### PR TITLE
[prismlauncher] update conflicts/make specs more consistent

### DIFF
--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -12,7 +12,7 @@
 %global commit_date %(date '+%Y%m%d')
 %global git_rel .%{commit_date}.%{shortcommit}
 
-%bcond_without qt6 1
+%bcond_without qt6
 
 # Change this variables if you want to use custom keys
 # Leave blank if you want to build Prism Launcher without MSA id or curseforge api key
@@ -45,8 +45,12 @@
 %global build_platform CentOS
 %endif
 
+%if %{with qt6}
 Name:           prismlauncher-nightly
-Version:        5.0
+%else
+Name:           prismlauncher-qt5-nightly
+%endif
+Version:        5.1
 Release:        0.1%{?git_rel}%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only
@@ -56,6 +60,7 @@ Source1:        https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbt
 Source2:        https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
 Source3:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
 Source4:        https://github.com/gulrak/filesystem/archive/%{filesystem_commit}/filesystem-%{filesystem_commit}.tar.gz
+
 BuildRequires:  cmake >= 3.15
 BuildRequires:  extra-cmake-modules
 BuildRequires:  gcc-c++
@@ -107,7 +112,13 @@ Recommends:     gamemoded
 Recommends:     gamemode
 %endif
 
-Conflicts:      prismlauncher
+Conflicts:     %{real_name}
+Conflicts:     %{real_name}-qt5
+%if %{with qt6}
+Conflicts:     %{real_name}-qt5-nightly
+%else
+Conflicts:     %{real_name}-nightly
+%endif
 
 %description
 A custom launcher for Minecraft that allows you to easily manage
@@ -146,9 +157,10 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 %install
 %cmake_install
 
-# this seems to be erroring out on older versions of fedora and epel
-# appstream-util validate-relax --nonet \
-#     %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%if 0%{?suse_version} > 1500 || 0%{?fedora} > 35
+appstream-util validate-relax --nonet \
+    %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%endif
 
 %check
 %ctest

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -45,8 +45,12 @@
 %global build_platform CentOS
 %endif
 
+%if %{with qt6}
+Name:           prismlauncher-nightly
+%else
 Name:           prismlauncher-qt5-nightly
-Version:        5.0
+%endif
+Version:        5.1
 Release:        0.1%{?git_rel}%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only
@@ -56,6 +60,7 @@ Source1:        https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbt
 Source2:        https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
 Source3:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
 Source4:        https://github.com/gulrak/filesystem/archive/%{filesystem_commit}/filesystem-%{filesystem_commit}.tar.gz
+
 BuildRequires:  cmake >= 3.15
 BuildRequires:  extra-cmake-modules
 BuildRequires:  gcc-c++
@@ -107,7 +112,13 @@ Recommends:     gamemoded
 Recommends:     gamemode
 %endif
 
-Conflicts:      prismlauncher
+Conflicts:     %{realname}
+Conflicts:     %{realname}-qt5
+%if %{with qt6}
+Conflicts:     %{realname}-qt5-nightly
+%else
+Conflicts:     %{realname}-nightly
+%endif
 
 %description
 A custom launcher for Minecraft that allows you to easily manage
@@ -146,9 +157,10 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 %install
 %cmake_install
 
-# this seems to be erroring out on older versions of fedora and epel
-# appstream-util validate-relax --nonet \
-#     %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%if 0%{?suse_version} > 1500 || 0%{?fedora} > 35
+appstream-util validate-relax --nonet \
+    %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%endif
 
 %check
 %ctest
@@ -174,4 +186,3 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 * Thu Oct 27 2022 seth <getchoo at tuta dot io> - 5.0-0.1.20221027.610b971
 - initial commit
-

--- a/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
+++ b/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
@@ -34,7 +34,11 @@
 %global build_platform CentOS
 %endif
 
+%if %{with qt6}
+Name:           prismlauncher
+%else
 Name:           prismlauncher-qt5
+%endif
 Version:        5.1
 Release:        1%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
@@ -93,7 +97,11 @@ Recommends:     gamemoded
 Recommends:     gamemode
 %endif
 
-Conflicts:      prismlauncher
+%if %{with qt6}
+Conflicts:     %{real_name}-qt5
+%else
+Conflicts:     %{real_name}
+%endif
 
 
 %description
@@ -123,8 +131,10 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 %install
 %cmake_install
 
+%if 0%{?suse_version} > 1500 || 0%{?fedora} > 35
 appstream-util validate-relax --nonet \
     %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%endif
 
 %check
 %ctest

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -1,6 +1,7 @@
 %global fancy_name PrismLauncher
+%global real_name prismlauncher
 %global repo https://github.com/%{fancy_name}/%{fancy_name}
-%bcond_without qt6 1
+%bcond_without qt6
 
 # Change this variables if you want to use custom keys
 # Leave blank if you want to build Prism Launcher without MSA id or curseforge api key
@@ -33,7 +34,11 @@
 %global build_platform CentOS
 %endif
 
+%if %{with qt6}
 Name:           prismlauncher
+%else
+Name:           prismlauncher-qt5
+%endif
 Version:        5.1
 Release:        1%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
@@ -92,6 +97,12 @@ Recommends:     gamemoded
 Recommends:     gamemode
 %endif
 
+%if %{with qt6}
+Conflicts:     %{real_name}-qt5
+%else
+Conflicts:     %{real_name}
+%endif
+
 %description
 A custom launcher for Minecraft that allows you to easily manage
 multiple installations of Minecraft at once (Fork of MultiMC)
@@ -119,8 +130,10 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 %install
 %cmake_install
 
+%if 0%{?suse_version} > 1500 || 0%{?fedora} > 35
 appstream-util validate-relax --nonet \
     %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%endif
 
 %check
 %ctest
@@ -129,10 +142,10 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 %files
 %doc README.md
 %license LICENSE COPYING.md
-%dir %{_datadir}/%{name}
+%dir %{_datadir}/%{real_name}
 %{_bindir}/prismlauncher
-%{_datadir}/%{name}/NewLaunch.jar
-%{_datadir}/%{name}/JavaCheck.jar
+%{_datadir}/%{real_name}/NewLaunch.jar
+%{_datadir}/%{real_name}/JavaCheck.jar
 %{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
 %{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg


### PR DESCRIPTION
the only thing affecting packaging here is adding proper conflicts so that none of the packages can be installed together. this might change later with a patch since it was suggested in the prism discord, but i'm a little lazy

the rest is just making the specs as consistent as possible between each other, just so they all look nice :p