### PR TITLE
add prismlauncher to Amusements/Games

### DIFF
--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -54,6 +54,11 @@ Version:        5.1
 Release:        0.1%{?git_rel}%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only
+%if 0%{?suse_version}
+Group:          Amusements/Games/Action/Other
+%else
+Group:          Amusements/Games
+%endif
 URL:            https://prismlauncher.org/
 Source0:        %{repo}/archive/%{commit}/%{fancy_name}-%{shortcommit}.tar.gz
 Source1:        https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
@@ -69,7 +74,7 @@ BuildRequires:  java-devel
 %if 0%{?suse_version}
 BuildRequires:  appstream-glib
 %else
-BuildRequires:	libappstream-glib
+BuildRequires:  libappstream-glib
 %endif
 
 BuildRequires:  desktop-file-utils
@@ -182,6 +187,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 
 %changelog
+* Thu Nov 10 2022 seth <getchoo at tuta dot io> - 5.1-0.1.20221110.e6d057f
+- add package to Amusements/Games
+
 * Sun Nov 06 2022 seth <getchoo at tuta dot io> - 5.0-0.1.20221105.9fb80a2
 - update installed files
 

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -54,6 +54,11 @@ Version:        5.1
 Release:        0.1%{?git_rel}%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only
+%if 0%{?suse_version}
+Group:          Amusements/Games/Action/Other
+%else
+Group:          Amusements/Games
+%endif
 URL:            https://prismlauncher.org/
 Source0:        %{repo}/archive/%{commit}/%{fancy_name}-%{shortcommit}.tar.gz
 Source1:        https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
@@ -69,7 +74,7 @@ BuildRequires:  java-devel
 %if 0%{?suse_version}
 BuildRequires:  appstream-glib
 %else
-BuildRequires:	libappstream-glib
+BuildRequires:  libappstream-glib
 %endif
 
 BuildRequires:  desktop-file-utils
@@ -182,6 +187,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 
 %changelog
+* Thu Nov 10 2022 seth <getchoo at tuta dot io> - 5.1-0.1.20221110.e6d057f
+- add package to Amusements/Games
+
 * Sun Nov 06 2022 seth <getchoo at tuta dot io> - 5.0-0.1.20221105.9fb80a2
 - update installed files
 

--- a/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
+++ b/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
@@ -40,9 +40,14 @@ Name:           prismlauncher
 Name:           prismlauncher-qt5
 %endif
 Version:        5.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only
+%if 0%{?suse_version}
+Group:          Amusements/Games/Action/Other
+%else
+Group:          Amusements/Games
+%endif
 URL:            https://prismlauncher.org/
 Source0:        %{repo}/releases/download/%{version}/%{fancy_name}-%{version}.tar.gz
 
@@ -54,7 +59,7 @@ BuildRequires:  java-devel
 %if 0%{?suse_version}
 BuildRequires:  appstream-glib
 %else
-BuildRequires:	libappstream-glib
+BuildRequires:  libappstream-glib
 %endif
 
 BuildRequires:  desktop-file-utils
@@ -154,6 +159,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 
 %changelog
+* Thu Nov 10 2022 seth <getchoo at tuta dot io> - 5.1-2
+- add package to Amusements/Games
+
 * Tue Nov 01 2022 root - 5.1-1
 - new version
 

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -40,9 +40,14 @@ Name:           prismlauncher
 Name:           prismlauncher-qt5
 %endif
 Version:        5.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only
+%if 0%{?suse_version}
+Group:          Amusements/Games/Action/Other
+%else
+Group:          Amusements/Games
+%endif
 URL:            https://prismlauncher.org/
 Source0:        %{repo}/releases/download/%{version}/%{fancy_name}-%{version}.tar.gz
 
@@ -54,7 +59,7 @@ BuildRequires:  java-devel
 %if 0%{?suse_version}
 BuildRequires:  appstream-glib
 %else
-BuildRequires:	libappstream-glib
+BuildRequires:  libappstream-glib
 %endif
 
 BuildRequires:  desktop-file-utils
@@ -154,6 +159,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 
 %changelog
+* Thu Nov 10 2022 seth <getchoo at tuta dot io> - 5.1-2
+- add package to Amusements/Games
+
 * Tue Nov 01 2022 root - 5.1-1
 - new version
 


### PR DESCRIPTION
fixes rpmlint warnings and makes the entries on repology look better