### PR TITLE
fix building prismlauncher on aarch64 with newer tomlplusplus version

### DIFF
--- a/anda/games/prismlauncher-nightly/fix-disable-FLOAT16-in-toml.patch
+++ b/anda/games/prismlauncher-nightly/fix-disable-FLOAT16-in-toml.patch
@@ -1,0 +1,27 @@
+From c1763cc4b0871230a86e58aad07aacaf7b19182c Mon Sep 17 00:00:00 2001
+From: Sefa Eyeoglu <contact@scrumplex.net>
+Date: Tue, 15 Nov 2022 21:23:20 +0100
+Subject: [PATCH] fix: disable FLOAT16 in toml++
+
+Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0db05f98..8fc0d326 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,6 +70,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
+ 
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_DISABLE_DEPRECATED_BEFORE=0x050C00")
+ 
++# Fix aarch64 build for toml++
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTOML_ENABLE_FLOAT16=0")
++
+ # set CXXFLAGS for build targets
+ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS_RELEASE}")
+ 
+-- 
+2.38.1
+

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -7,7 +7,7 @@
 %global filesystem_commit cd6805e94dd5d6346be1b75a54cdc27787319dd2
 %global libnbtplusplus_commit 2203af7eeb48c45398139b583615134efd8d407f
 %global quazip_commit 6117161af08e366c37499895b00ef62f93adc345
-%global tomlplusplus_commit 4b166b69f28e70a416a1a04a98f365d2aeb90de8
+%global tomlplusplus_commit 0a90913abf9390b9e08ab6d3b40ac11634553f38
 
 %global commit_date %(date '+%Y%m%d')
 %global git_rel .%{commit_date}.%{shortcommit}
@@ -65,6 +65,7 @@ Source1:        https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbt
 Source2:        https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
 Source3:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
 Source4:        https://github.com/gulrak/filesystem/archive/%{filesystem_commit}/filesystem-%{filesystem_commit}.tar.gz
+Patch0:         fix-disable-FLOAT16-in-toml.patch
 
 BuildRequires:  cmake >= 3.15
 BuildRequires:  extra-cmake-modules

--- a/anda/games/prismlauncher-qt5-nightly/fix-disable-FLOAT16-in-toml.patch
+++ b/anda/games/prismlauncher-qt5-nightly/fix-disable-FLOAT16-in-toml.patch
@@ -1,0 +1,27 @@
+From c1763cc4b0871230a86e58aad07aacaf7b19182c Mon Sep 17 00:00:00 2001
+From: Sefa Eyeoglu <contact@scrumplex.net>
+Date: Tue, 15 Nov 2022 21:23:20 +0100
+Subject: [PATCH] fix: disable FLOAT16 in toml++
+
+Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0db05f98..8fc0d326 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,6 +70,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
+ 
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_DISABLE_DEPRECATED_BEFORE=0x050C00")
+ 
++# Fix aarch64 build for toml++
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTOML_ENABLE_FLOAT16=0")
++
+ # set CXXFLAGS for build targets
+ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS_RELEASE}")
+ 
+-- 
+2.38.1
+

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -7,7 +7,7 @@
 %global filesystem_commit cd6805e94dd5d6346be1b75a54cdc27787319dd2
 %global libnbtplusplus_commit 2203af7eeb48c45398139b583615134efd8d407f
 %global quazip_commit 6117161af08e366c37499895b00ef62f93adc345
-%global tomlplusplus_commit 4b166b69f28e70a416a1a04a98f365d2aeb90de8
+%global tomlplusplus_commit 0a90913abf9390b9e08ab6d3b40ac11634553f38
 
 %global commit_date %(date '+%Y%m%d')
 %global git_rel .%{commit_date}.%{shortcommit}
@@ -65,6 +65,7 @@ Source1:        https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbt
 Source2:        https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
 Source3:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
 Source4:        https://github.com/gulrak/filesystem/archive/%{filesystem_commit}/filesystem-%{filesystem_commit}.tar.gz
+Patch0:         fix-disable-FLOAT16-in-toml.patch
 
 BuildRequires:  cmake >= 3.15
 BuildRequires:  extra-cmake-modules

--- a/anda/games/prismlauncher-qt5/fix-disable-FLOAT16-in-toml.patch
+++ b/anda/games/prismlauncher-qt5/fix-disable-FLOAT16-in-toml.patch
@@ -1,0 +1,27 @@
+From c1763cc4b0871230a86e58aad07aacaf7b19182c Mon Sep 17 00:00:00 2001
+From: Sefa Eyeoglu <contact@scrumplex.net>
+Date: Tue, 15 Nov 2022 21:23:20 +0100
+Subject: [PATCH] fix: disable FLOAT16 in toml++
+
+Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0db05f98..8fc0d326 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,6 +70,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
+ 
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_DISABLE_DEPRECATED_BEFORE=0x050C00")
+ 
++# Fix aarch64 build for toml++
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTOML_ENABLE_FLOAT16=0")
++
+ # set CXXFLAGS for build targets
+ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS_RELEASE}")
+ 
+-- 
+2.38.1
+

--- a/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
+++ b/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
@@ -41,7 +41,7 @@ Name:           prismlauncher
 Name:           prismlauncher-qt5
 %endif
 Version:        5.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only
 %if 0%{?suse_version}
@@ -166,6 +166,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 
 %changelog
+* Tue Nov 15 2022 seth <getchoo at tuta dot io> - 5.2-2
+- use newer version of toml++
+
 * Tue Nov 15 2022 root - 5.2-1
 - new version
 

--- a/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
+++ b/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
@@ -1,6 +1,7 @@
 %global fancy_name PrismLauncher
 %global real_name prismlauncher
 %global repo https://github.com/%{fancy_name}/%{fancy_name}
+%global tomlplusplus_commit 0a90913abf9390b9e08ab6d3b40ac11634553f38
 %bcond_with qt6
 
 # Change this variables if you want to use custom keys
@@ -50,6 +51,8 @@ Group:          Amusements/Games
 %endif
 URL:            https://prismlauncher.org/
 Source0:        %{repo}/releases/download/%{version}/%{fancy_name}-%{version}.tar.gz
+Source1:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
+Patch0:         fix-disable-FLOAT16-in-toml.patch
 
 BuildRequires:  cmake >= 3.15
 BuildRequires:  extra-cmake-modules
@@ -116,6 +119,10 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 
 %prep
 %autosetup -n %{fancy_name}-%{version}
+
+tar -xzf %{SOURCE1} -C libraries
+rm -rf libraries/tomlplusplus/*
+mv -f libraries/tomlplusplus-%{tomlplusplus_commit}/* libraries/tomlplusplus
 
 # Do not set RPATH
 sed -i "s|\$ORIGIN/||" CMakeLists.txt

--- a/anda/games/prismlauncher/fix-disable-FLOAT16-in-toml.patch
+++ b/anda/games/prismlauncher/fix-disable-FLOAT16-in-toml.patch
@@ -1,0 +1,27 @@
+From c1763cc4b0871230a86e58aad07aacaf7b19182c Mon Sep 17 00:00:00 2001
+From: Sefa Eyeoglu <contact@scrumplex.net>
+Date: Tue, 15 Nov 2022 21:23:20 +0100
+Subject: [PATCH] fix: disable FLOAT16 in toml++
+
+Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0db05f98..8fc0d326 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,6 +70,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
+ 
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_DISABLE_DEPRECATED_BEFORE=0x050C00")
+ 
++# Fix aarch64 build for toml++
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTOML_ENABLE_FLOAT16=0")
++
+ # set CXXFLAGS for build targets
+ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS_RELEASE}")
+ 
+-- 
+2.38.1
+

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -1,6 +1,7 @@
 %global fancy_name PrismLauncher
 %global real_name prismlauncher
 %global repo https://github.com/%{fancy_name}/%{fancy_name}
+%global tomlplusplus_commit 0a90913abf9390b9e08ab6d3b40ac11634553f38
 %bcond_without qt6
 
 # Change this variables if you want to use custom keys
@@ -50,6 +51,8 @@ Group:          Amusements/Games
 %endif
 URL:            https://prismlauncher.org/
 Source0:        %{repo}/releases/download/%{version}/%{fancy_name}-%{version}.tar.gz
+Source1:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
+Patch0:         fix-disable-FLOAT16-in-toml.patch
 
 BuildRequires:  cmake >= 3.15
 BuildRequires:  extra-cmake-modules
@@ -116,6 +119,10 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 
 %prep
 %autosetup -n %{fancy_name}-%{version}
+
+tar -xzf %{SOURCE1} -C libraries
+rm -rf libraries/tomlplusplus/*
+mv -f libraries/tomlplusplus-%{tomlplusplus_commit}/* libraries/tomlplusplus
 
 # Do not set RPATH
 sed -i "s|\$ORIGIN/||" CMakeLists.txt

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -41,7 +41,7 @@ Name:           prismlauncher
 Name:           prismlauncher-qt5
 %endif
 Version:        5.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only
 %if 0%{?suse_version}
@@ -166,6 +166,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 
 %changelog
+* Tue Nov 15 2022 seth <getchoo at tuta dot io> - 5.2-2
+- use newer version of toml++
+
 * Tue Nov 15 2022 root - 5.2-1
 - new version
 


### PR DESCRIPTION
this PR fixes building on aarch64 for the stable releases, as well as bumping the tomlplusplus version in nightly builds. all of them use [this patch](https://github.com/flathub/org.prismlauncher.PrismLauncher/blob/master/0002-fix-disable-FLOAT16-in-toml.patch) from Scrumplex that addresses issues found in the revision of tomlplusplus used upstream (see https://github.com/marzer/tomlplusplus/issues/178)

[build on copr](https://copr.fedorainfracloud.org/coprs/g3tchoo/prismlauncher/build/5041814/)