### PR TITLE
[prismlauncher-nightly] bump commit

### DIFF
--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -2,7 +2,7 @@
 %global real_name prismlauncher
 %global repo https://github.com/%{fancy_name}/%{fancy_name}
 
-%global commit 68b7aa0a4d124b231ba351ae8d37ea6c55b333a2
+%global commit b60fe08d44fbf70bff1555ab0e0cee0a00172ac8
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global filesystem_commit cd6805e94dd5d6346be1b75a54cdc27787319dd2
 %global libnbtplusplus_commit 2203af7eeb48c45398139b583615134efd8d407f

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -2,7 +2,7 @@
 %global real_name prismlauncher
 %global repo https://github.com/%{fancy_name}/%{fancy_name}
 
-%global commit 30607c34a153fd32085712e18827983772d77f7b
+%global commit b60fe08d44fbf70bff1555ab0e0cee0a00172ac8
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global filesystem_commit cd6805e94dd5d6346be1b75a54cdc27787319dd2
 %global libnbtplusplus_commit 2203af7eeb48c45398139b583615134efd8d407f


### PR DESCRIPTION
not really sure what's going on, but it looks like auto updates are no longer working for the nightly packages. since the script still works for me locally and each check after discord-ptb fails, i'm guessing maybe there's some rate limiting going on here. is there any way to solve this?