### PR TITLE
bump prismlauncher-nightly version to future tag

### DIFF
--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -50,7 +50,7 @@ Name:           prismlauncher-nightly
 %else
 Name:           prismlauncher-qt5-nightly
 %endif
-Version:        5.1
+Version:        6.0
 Release:        0.1%{?git_rel}%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -50,7 +50,7 @@ Name:           prismlauncher-nightly
 %else
 Name:           prismlauncher-qt5-nightly
 %endif
-Version:        5.1
+Version:        6.0
 Release:        0.1%{?git_rel}%{?dist}
 Summary:        Minecraft launcher with ability to manage multiple instances
 License:        GPL-3.0-only


### PR DESCRIPTION
the next tag for prismlauncher is [6.0](https://github.com/PrismLauncher/PrismLauncher/milestone/2)