### PR TITLE
adopt new policies for prismlauncher

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,3 +20,8 @@
 
 /anda/tools/melody @lleyton
 /anda/go/curlie @lleyton
+
+/anda/games/prismlauncher @getchoo
+/anda/games/prismlauncher-nightly @getchoo
+/anda/games/prismlauncher-qt5-nightly @getchoo
+/anda/games/prismlauncher-qt5 @getchoo

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -1,16 +1,13 @@
-%global fancy_name PrismLauncher
 %global real_name prismlauncher
-%global repo https://github.com/%{fancy_name}/%{fancy_name}
 
 %global commit 79d5beff8d45d9a66cfa91393167fc79d3a155a9
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global filesystem_commit cd6805e94dd5d6346be1b75a54cdc27787319dd2
 %global libnbtplusplus_commit 2203af7eeb48c45398139b583615134efd8d407f
 %global quazip_commit 6117161af08e366c37499895b00ef62f93adc345
 %global tomlplusplus_commit 0a90913abf9390b9e08ab6d3b40ac11634553f38
 
 %global commit_date %(date '+%Y%m%d')
-%global git_rel .%{commit_date}.%{shortcommit}
+%global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6
 
@@ -29,10 +26,6 @@
 
 %global build_platform unknown
 
-%if 0%{?suse_version}
-%global build_platform openSUSE
-%endif
-
 %if 0%{?fedora}
 %global build_platform Fedora
 %endif
@@ -45,85 +38,56 @@
 %global build_platform CentOS
 %endif
 
-%if %{with qt6}
-Name:           prismlauncher-nightly
-%else
-Name:           prismlauncher-qt5-nightly
-%endif
-Version:        6.0
-Release:        0.1%{?git_rel}%{?dist}
-Summary:        Minecraft launcher with ability to manage multiple instances
-License:        GPL-3.0-only
-%if 0%{?suse_version}
-Group:          Amusements/Games/Action/Other
-%else
-Group:          Amusements/Games
-%endif
-URL:            https://prismlauncher.org/
-Source0:        %{repo}/archive/%{commit}/%{fancy_name}-%{shortcommit}.tar.gz
-Source1:        https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
-Source2:        https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
-Source3:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
-Source4:        https://github.com/gulrak/filesystem/archive/%{filesystem_commit}/filesystem-%{filesystem_commit}.tar.gz
+Name:             prismlauncher-nightly
+Version:          6.0^%{snapshot_info}
+Release:          1%{?dist}
+Summary:          Minecraft launcher with ability to manage multiple instances
+License:          GPL-3.0-only
+Group:            Amusements/Games
+URL:              https://prismlauncher.org/
+Source0:          https://github.com/PrismLauncher/PrismLauncher/archive/%{commit}/%{real_name}-%{shortcommit}.tar.gz
+Source1:          https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
+Source2:          https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
+Source3:          https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
 
-BuildRequires:  cmake >= 3.15
-BuildRequires:  extra-cmake-modules
-BuildRequires:  gcc-c++
-BuildRequires:  java-devel
-
-%if 0%{?suse_version}
-BuildRequires:  appstream-glib
-%else
-BuildRequires:  libappstream-glib
-%endif
-
-BuildRequires:  desktop-file-utils
-BuildRequires:  cmake(Qt%{qt_version}Concurrent) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Core) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Gui) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Network) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Test) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
+BuildRequires:    cmake >= 3.15
+BuildRequires:    extra-cmake-modules
+BuildRequires:    gcc-c++
+BuildRequires:    java-devel >= 17
+BuildRequires:    desktop-file-utils
+BuildRequires:    libappstream-glib
+BuildRequires:    cmake(ghc_filesystem)
+BuildRequires:    cmake(Qt%{qt_version}Concurrent) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Core) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Gui) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Network) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Test) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
 
 %if %{with qt6}
-BuildRequires:  cmake(Qt6Core5Compat)
+BuildRequires:    cmake(Qt6Core5Compat)
 %endif
 
-BuildRequires:  pkgconfig(scdoc)
-BuildRequires:  zlib-devel
+BuildRequires:    pkgconfig(scdoc)
+BuildRequires:    pkgconfig(zlib)
 
-# Prism Launcher requires QuaZip >= 1.3
-%if 0%{?suse_version} >= 1550
-BuildRequires:  cmake(QuaZip-Qt%{qt_version})
-%endif
+Requires(post):   desktop-file-utils
+Requires(postun): desktop-file-utils
 
-%if 0%{?suse_version}
-Requires:       %{!?with_qt6:lib}qt%{qt_version}-%{!?with_qt6:qt}imageformats
-Requires:       libQt%{qt_version}Svg%{qt_version}
-%else
-Requires:       qt%{qt_version}-qtimageformats
-Requires:       qt%{qt_version}-qtsvg
-%endif
+Requires:         qt%{qt_version}-qtimageformats
+Requires:         qt%{qt_version}-qtsvg
+Requires:         javapackages-filesystem
+Requires:         java-headless >= 17
+Requires:         java-1.8.0-openjdk-headless
 
-Recommends:     java-openjdk-headless
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-Recommends:     xrandr
-
+Recommends:       xrandr
 # Prism supports enabling gamemode
-%if 0%{?suse_version}
-Recommends:     gamemoded
-%else
-Recommends:     gamemode
-%endif
+Suggests:         gamemode
 
-Conflicts:      %{real_name}
-Conflicts:      %{real_name}-qt5
-%if %{with qt6}
-Conflicts:      %{real_name}-qt5-nightly
-%else
-Conflicts:      %{real_name}-nightly
-%endif
+Conflicts:        prismlauncher
+Conflicts:        prismlauncher-qt5
 
 
 %description
@@ -132,20 +96,20 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 
 
 %prep
-%autosetup -n %{fancy_name}-%{commit}
+%autosetup -n PrismLauncher-%{commit}
 
-tar -xvf %{SOURCE1} -C libraries
+tar -xzf %{SOURCE1} -C libraries
 tar -xvf %{SOURCE2} -C libraries
 tar -xvf %{SOURCE3} -C libraries
-tar -xvf %{SOURCE4} -C libraries
-rmdir libraries/{quazip/,libnbtplusplus}
-mv -f libraries/quazip-%{quazip_commit} libraries/quazip
+
+rmdir libraries/{libnbtplusplus,quazip,tomlplusplus}/
 mv -f libraries/libnbtplusplus-%{libnbtplusplus_commit} libraries/libnbtplusplus
-mv -f libraries/tomlplusplus-%{tomlplusplus_commit}/* libraries/tomlplusplus
-mv -f libraries/filesystem-%{filesystem_commit}/* libraries/filesystem
+mv -f libraries/quazip-%{quazip_commit} libraries/quazip
+mv -f libraries/tomlplusplus-%{tomlplusplus_commit} libraries/tomlplusplus
 
 # Do not set RPATH
 sed -i "s|\$ORIGIN/||" CMakeLists.txt
+
 
 %build
 %cmake \
@@ -160,17 +124,40 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 %cmake_build
 
+
 %install
 %cmake_install
 
-%if 0%{?suse_version} > 1500 || 0%{?fedora} > 35
-appstream-util validate-relax --nonet \
-    %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
-%endif
 
 %check
 %ctest
+
+appstream-util validate-relax --nonet \
+    %{buildroot}%{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
+
 desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
+
+
+%post
+/usr/bin/update-desktop-database &> /dev/null || :
+/bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
+/bin/touch --no-create %{_datadir}/mime/packages &>/dev/null || :
+
+
+%postun
+/usr/bin/update-desktop-database &> /dev/null || :
+
+if [ $1 -eq 0 ] ; then
+    /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null
+    /usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+		/usr/bin/update-mime-database %{_datadir}/mime &> /dev/null || :
+fi
+
+
+%posttrans
+/usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+/usr/bin/update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
+
 
 %files
 %doc README.md
@@ -180,13 +167,17 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 %{_datadir}/%{real_name}/NewLaunch.jar
 %{_datadir}/%{real_name}/JavaCheck.jar
 %{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
-%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
 %{_datadir}/mime/packages/modrinth-mrpack-mime.xml
 %{_mandir}/man?/prismlauncher.*
 
 
 %changelog
+* Mon Dec 05 2022 seth <getchoo at tuta dot io> - 6.0^20221204.79d5bef-1
+- revise file to better follow fedora packaging guidelines and add java 8 as a
+  dependency
+
 * Thu Nov 10 2022 seth <getchoo at tuta dot io> - 5.1-0.1.20221110.e6d057f
 - add package to Amusements/Games
 

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -1,16 +1,13 @@
-%global fancy_name PrismLauncher
 %global real_name prismlauncher
-%global repo https://github.com/%{fancy_name}/%{fancy_name}
 
 %global commit 79d5beff8d45d9a66cfa91393167fc79d3a155a9
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global filesystem_commit cd6805e94dd5d6346be1b75a54cdc27787319dd2
 %global libnbtplusplus_commit 2203af7eeb48c45398139b583615134efd8d407f
 %global quazip_commit 6117161af08e366c37499895b00ef62f93adc345
 %global tomlplusplus_commit 0a90913abf9390b9e08ab6d3b40ac11634553f38
 
 %global commit_date %(date '+%Y%m%d')
-%global git_rel .%{commit_date}.%{shortcommit}
+%global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_with qt6
 
@@ -29,10 +26,6 @@
 
 %global build_platform unknown
 
-%if 0%{?suse_version}
-%global build_platform openSUSE
-%endif
-
 %if 0%{?fedora}
 %global build_platform Fedora
 %endif
@@ -45,85 +38,57 @@
 %global build_platform CentOS
 %endif
 
-%if %{with qt6}
-Name:           prismlauncher-nightly
-%else
-Name:           prismlauncher-qt5-nightly
-%endif
-Version:        6.0
-Release:        0.1%{?git_rel}%{?dist}
-Summary:        Minecraft launcher with ability to manage multiple instances
-License:        GPL-3.0-only
-%if 0%{?suse_version}
-Group:          Amusements/Games/Action/Other
-%else
-Group:          Amusements/Games
-%endif
-URL:            https://prismlauncher.org/
-Source0:        %{repo}/archive/%{commit}/%{fancy_name}-%{shortcommit}.tar.gz
-Source1:        https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
-Source2:        https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
-Source3:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
-Source4:        https://github.com/gulrak/filesystem/archive/%{filesystem_commit}/filesystem-%{filesystem_commit}.tar.gz
+Name:             prismlauncher-qt5-nightly
+Version:          6.0^%{snapshot_info}
+Release:          1%{?dist}
+Summary:          Minecraft launcher with ability to manage multiple instances
+License:          GPL-3.0-only
+Group:            Amusements/Games
+URL:              https://prismlauncher.org/
+Source0:          https://github.com/PrismLauncher/PrismLauncher/archive/%{commit}/%{real_name}-%{shortcommit}.tar.gz
+Source1:          https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
+Source2:          https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
+Source3:          https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
 
-BuildRequires:  cmake >= 3.15
-BuildRequires:  extra-cmake-modules
-BuildRequires:  gcc-c++
-BuildRequires:  java-devel
-
-%if 0%{?suse_version}
-BuildRequires:  appstream-glib
-%else
-BuildRequires:  libappstream-glib
-%endif
-
-BuildRequires:  desktop-file-utils
-BuildRequires:  cmake(Qt%{qt_version}Concurrent) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Core) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Gui) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Network) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Test) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
+BuildRequires:    cmake >= 3.15
+BuildRequires:    extra-cmake-modules
+BuildRequires:    gcc-c++
+BuildRequires:    java-devel >= 17
+BuildRequires:    desktop-file-utils
+BuildRequires:    libappstream-glib
+BuildRequires:    cmake(ghc_filesystem)
+BuildRequires:    cmake(Qt%{qt_version}Concurrent) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Core) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Gui) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Network) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Test) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
 
 %if %{with qt6}
-BuildRequires:  cmake(Qt6Core5Compat)
+BuildRequires:    cmake(Qt6Core5Compat)
 %endif
 
-BuildRequires:  pkgconfig(scdoc)
-BuildRequires:  zlib-devel
+BuildRequires:    pkgconfig(scdoc)
+BuildRequires:    pkgconfig(zlib)
 
-# Prism Launcher requires QuaZip >= 1.3
-%if 0%{?suse_version} >= 1550
-BuildRequires:  cmake(QuaZip-Qt%{qt_version})
-%endif
+Requires(post):   desktop-file-utils
+Requires(postun): desktop-file-utils
 
-%if 0%{?suse_version}
-Requires:       %{!?with_qt6:lib}qt%{qt_version}-%{!?with_qt6:qt}imageformats
-Requires:       libQt%{qt_version}Svg%{qt_version}
-%else
-Requires:       qt%{qt_version}-qtimageformats
-Requires:       qt%{qt_version}-qtsvg
-%endif
+Requires:         qt%{qt_version}-qtimageformats
+Requires:         qt%{qt_version}-qtsvg
+Requires:         javapackages-filesystem
+Requires:         java-headless >= 17
+Requires:         java-1.8.0-openjdk-headless
 
-Recommends:     java-openjdk-headless
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-Recommends:     xrandr
-
+Recommends:       xrandr
 # Prism supports enabling gamemode
-%if 0%{?suse_version}
-Recommends:     gamemoded
-%else
-Recommends:     gamemode
-%endif
+Suggests:         gamemode
 
-Conflicts:      %{real_name}
-Conflicts:      %{real_name}-qt5
-%if %{with qt6}
-Conflicts:      %{real_name}-qt5-nightly
-%else
-Conflicts:      %{real_name}-nightly
-%endif
+Conflicts:        prismlauncher
+Conflicts:        prismlauncher-qt5
+Conflicts:        primslauncher-nightly
 
 
 %description
@@ -132,20 +97,20 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 
 
 %prep
-%autosetup -n %{fancy_name}-%{commit}
+%autosetup -n PrismLauncher-%{commit}
 
-tar -xvf %{SOURCE1} -C libraries
+tar -xzf %{SOURCE1} -C libraries
 tar -xvf %{SOURCE2} -C libraries
 tar -xvf %{SOURCE3} -C libraries
-tar -xvf %{SOURCE4} -C libraries
-rmdir libraries/{quazip/,libnbtplusplus}
-mv -f libraries/quazip-%{quazip_commit} libraries/quazip
+
+rmdir libraries/{libnbtplusplus,quazip,tomlplusplus}/
 mv -f libraries/libnbtplusplus-%{libnbtplusplus_commit} libraries/libnbtplusplus
-mv -f libraries/tomlplusplus-%{tomlplusplus_commit}/* libraries/tomlplusplus
-mv -f libraries/filesystem-%{filesystem_commit}/* libraries/filesystem
+mv -f libraries/quazip-%{quazip_commit} libraries/quazip
+mv -f libraries/tomlplusplus-%{tomlplusplus_commit} libraries/tomlplusplus
 
 # Do not set RPATH
 sed -i "s|\$ORIGIN/||" CMakeLists.txt
+
 
 %build
 %cmake \
@@ -160,17 +125,40 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 %cmake_build
 
+
 %install
 %cmake_install
 
-%if 0%{?suse_version} > 1500 || 0%{?fedora} > 35
-appstream-util validate-relax --nonet \
-    %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
-%endif
 
 %check
 %ctest
+
+appstream-util validate-relax --nonet \
+    %{buildroot}%{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
+
 desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
+
+
+%post
+/usr/bin/update-desktop-database &> /dev/null || :
+/bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
+/bin/touch --no-create %{_datadir}/mime/packages &>/dev/null || :
+
+
+%postun
+/usr/bin/update-desktop-database &> /dev/null || :
+
+if [ $1 -eq 0 ] ; then
+    /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null
+    /usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+		/usr/bin/update-mime-database %{_datadir}/mime &> /dev/null || :
+fi
+
+
+%posttrans
+/usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+/usr/bin/update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
+
 
 %files
 %doc README.md
@@ -180,13 +168,17 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 %{_datadir}/%{real_name}/NewLaunch.jar
 %{_datadir}/%{real_name}/JavaCheck.jar
 %{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
-%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
 %{_datadir}/mime/packages/modrinth-mrpack-mime.xml
 %{_mandir}/man?/prismlauncher.*
 
 
 %changelog
+* Mon Dec 05 2022 seth <getchoo at tuta dot io> - 6.0^20221204.79d5bef-1
+- revise file to better follow fedora packaging guidelines and add java 8 as a
+  dependency
+
 * Thu Nov 10 2022 seth <getchoo at tuta dot io> - 5.1-0.1.20221110.e6d057f
 - add package to Amusements/Games
 

--- a/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
+++ b/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
@@ -1,6 +1,4 @@
-%global fancy_name PrismLauncher
-%global real_name prismlauncher
-%global repo https://github.com/%{fancy_name}/%{fancy_name}
+%define real_name prismlauncher
 %global tomlplusplus_commit 0a90913abf9390b9e08ab6d3b40ac11634553f38
 %bcond_with qt6
 
@@ -19,10 +17,6 @@
 
 %global build_platform unknown
 
-%if 0%{?suse_version}
-%global build_platform openSUSE
-%endif
-
 %if 0%{?fedora}
 %global build_platform Fedora
 %endif
@@ -35,81 +29,54 @@
 %global build_platform CentOS
 %endif
 
-%if %{with qt6}
-Name:           prismlauncher
-%else
-Name:           prismlauncher-qt5
-%endif
-Version:        5.2
-Release:        2%{?dist}
-Summary:        Minecraft launcher with ability to manage multiple instances
-License:        GPL-3.0-only
-%if 0%{?suse_version}
-Group:          Amusements/Games/Action/Other
-%else
-Group:          Amusements/Games
-%endif
-URL:            https://prismlauncher.org/
-Source0:        %{repo}/releases/download/%{version}/%{fancy_name}-%{version}.tar.gz
-Source1:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
-Patch0:         fix-disable-FLOAT16-in-toml.patch
+Name:             prismlauncher-qt5
+Version:          5.2
+Release:          3%{?dist}
+Summary:          Minecraft launcher with ability to manage multiple instances
+License:          GPL-3.0-only
+Group:            Amusements/Games
+URL:              https://prismlauncher.org/
+Source0:          https://github.com/PrismLauncher/PrismLauncher/releases/download/%{version}/%{real_name}-%{version}.tar.gz
+Source1:          https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
+Patch0:           fix-disable-FLOAT16-in-toml.patch
 
-BuildRequires:  cmake >= 3.15
-BuildRequires:  extra-cmake-modules
-BuildRequires:  gcc-c++
-BuildRequires:  java-devel
-
-%if 0%{?suse_version}
-BuildRequires:  appstream-glib
-%else
-BuildRequires:  libappstream-glib
-%endif
-
-BuildRequires:  desktop-file-utils
-BuildRequires:  cmake(Qt%{qt_version}Concurrent) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Core) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Gui) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Network) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Test) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
+BuildRequires:    cmake >= 3.15
+BuildRequires:    extra-cmake-modules
+BuildRequires:    gcc-c++
+BuildRequires:    java-devel >= 17
+BuildRequires:    desktop-file-utils
+BuildRequires:    libappstream-glib
+BuildRequires:    cmake(ghc_filesystem)
+BuildRequires:    cmake(Qt%{qt_version}Concurrent) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Core) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Gui) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Network) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Test) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
 
 %if %{with qt6}
-BuildRequires:  cmake(Qt6Core5Compat)
+BuildRequires:    cmake(Qt6Core5Compat)
 %endif
 
-BuildRequires:  pkgconfig(scdoc)
-BuildRequires:  zlib-devel
+BuildRequires:    pkgconfig(scdoc)
+BuildRequires:    pkgconfig(zlib)
 
-# Prism Launcher requires QuaZip >= 1.3
-%if 0%{?suse_version} >= 1550
-BuildRequires:  cmake(QuaZip-Qt%{qt_version})
-%endif
+Requires(post):   desktop-file-utils
+Requires(postun): desktop-file-utils
 
-%if 0%{?suse_version}
-Requires:       %{!?with_qt6:lib}qt%{qt_version}-%{!?with_qt6:qt}imageformats
-Requires:       libQt%{qt_version}Svg%{qt_version}
-%else
-Requires:       qt%{qt_version}-qtimageformats
-Requires:       qt%{qt_version}-qtsvg
-%endif
+Requires:         qt%{qt_version}-qtimageformats
+Requires:         qt%{qt_version}-qtsvg
+Requires:         javapackages-filesystem
+Requires:         java-headless >= 17
+Requires:         java-1.8.0-openjdk-headless
 
-Recommends:     java-openjdk-headless
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-Recommends:     xrandr
-
+Recommends:       xrandr
 # Prism supports enabling gamemode
-%if 0%{?suse_version}
-Recommends:     gamemoded
-%else
-Recommends:     gamemode
-%endif
+Suggests:         gamemode
 
-%if %{with qt6}
-Conflicts:      %{real_name}-qt5
-%else
-Conflicts:      %{real_name}
-%endif
+Conflicts:        prismlauncher
 
 
 %description
@@ -118,7 +85,7 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 
 
 %prep
-%autosetup -n %{fancy_name}-%{version}
+%autosetup -n PrismLauncher-%{version}
 
 tar -xzf %{SOURCE1} -C libraries
 rm -rf libraries/tomlplusplus/*
@@ -126,6 +93,7 @@ mv -f libraries/tomlplusplus-%{tomlplusplus_commit}/* libraries/tomlplusplus
 
 # Do not set RPATH
 sed -i "s|\$ORIGIN/||" CMakeLists.txt
+
 
 %build
 %cmake \
@@ -140,17 +108,36 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 %cmake_build
 
+
 %install
 %cmake_install
 
-%if 0%{?suse_version} > 1500 || 0%{?fedora} > 35
-appstream-util validate-relax --nonet \
-    %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
-%endif
 
 %check
 %ctest
+
+appstream-util validate-relax --nonet \
+    %{buildroot}%{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
+
 desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
+
+
+%post
+/usr/bin/update-desktop-database &> /dev/null || :
+/bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
+
+
+%postun
+/usr/bin/update-desktop-database &> /dev/null || :
+if [ $1 -eq 0 ] ; then
+    /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null
+    /usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+fi
+
+
+%posttrans
+/usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+
 
 %files
 %doc README.md
@@ -160,32 +147,33 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 %{_datadir}/%{real_name}/NewLaunch.jar
 %{_datadir}/%{real_name}/JavaCheck.jar
 %{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
-%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
 %{_mandir}/man?/prismlauncher.*
 
 
 %changelog
-* Tue Nov 15 2022 seth <getchoo at tuta dot io> - 5.2-2
-- use newer version of toml++
+* Mon Dec 05 2022 seth <getchoo at tuta dot io> - 5.2-3
+- revise file to better follow fedora packaging guidelines and add java 8 as a
+  dependency
 
-* Tue Nov 15 2022 root - 5.2-1
-- new version
+* Tue Nov 15 2022 seth <getchoo at tuta dot io> - 5.2-2
+- use newer version of toml++ to fix issues on aarch64
+
+* Tue Nov 15 2022 seth <getchoo at tuta dot io> - 5.2-1
+- update to 5.2
 
 * Thu Nov 10 2022 seth <getchoo at tuta dot io> - 5.1-2
 - add package to Amusements/Games
 
-* Tue Nov 01 2022 root - 5.1-1
-- new version
-
-* Wed Oct 19 2022 seth <getchoo at tuta dot io> - 5.0-4
-- fix opensuse deps
+* Tue Nov 01 2022 seth <getchoo at tuta dot io> - 5.1-1
+- update to 5.1
 
 * Wed Oct 19 2022 seth <getchoo at tuta dot io> - 5.0-3
 - add missing deps and build with qt6 by default
 
 * Wed Oct 19 2022 seth <getchoo at tuta dot io> - 5.0-2
-- add change-jars-path.patch and allow for building on opensuse
+- add change-jars-path.patch to allow for package-specific jar path
 
 * Wed Oct 19 2022 seth <getchoo at tuta dot io> - 5.0-1
 - update to version 5.0
@@ -198,63 +186,3 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 * Tue Oct 18 2022 Cappy Ishihara <cappy@cappuchino.xyz> - 1.4.2-1
 - Repackaged as Prism Launcher
-
-* Thu Sep 08 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.4.2-1
-- Update to 1.4.2
-
-* Fri Jul 29 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.4.1-1
-- Update to 1.4.1
-
-* Sat Jul 23 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.4.0-2
-- Recommend gamemode
-
-* Sat Jul 23 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.4.0-1
-- Update to 1.4.0
-
-* Wed Jun 15 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.3.2-2
-- Fixing OpenSuse Tumbleweed compilation
-
-* Sun Jun 12 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.3.2-1
-- Update to 1.3.2
-
-* Mon May 30 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.3.1-1
-- Update to 1.3.1
-
-* Mon May 23 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.3.0-1
-- Update to 1.3.0
-
-* Sat May 14 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.2.2-1
-- Update to 1.2.2
-
-* Mon Apr 25 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.2.1-2
-- Correct dependencies for openSUSE
-
-* Wed Apr 20 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.2.1-1
-- Update to 1.2.1
-
-* Tue Apr 19 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.2.0-1
-- Update to 1.2.0
-
-* Tue Apr 19 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.1.1-3
-- Correct dependencies for openSuse
-
-* Wed Apr 06 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.1.1-2
-- Add missing dependencies
-
-* Mon Mar 28 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.1.1-1
-- Update to 1.1.1
-
-* Wed Mar 16 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.1.0-1
-- Update to 1.1.0
-
-* Mon Jan 24 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.0.5-2
-- remove explicit dependencies, correct dependencies to work on OpenSuse
-
-* Sun Jan 09 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.0.5-1
-- Update to 1.0.5
-
-* Sun Jan 09 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.0.4-2
-- rework spec
-
-* Fri Jan 7 2022 getchoo <getchoo at tuta dot io> - 1.0.4-1
-- Initial polymc spec

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -1,6 +1,3 @@
-%global fancy_name PrismLauncher
-%global real_name prismlauncher
-%global repo https://github.com/%{fancy_name}/%{fancy_name}
 %global tomlplusplus_commit 0a90913abf9390b9e08ab6d3b40ac11634553f38
 %bcond_without qt6
 
@@ -19,10 +16,6 @@
 
 %global build_platform unknown
 
-%if 0%{?suse_version}
-%global build_platform openSUSE
-%endif
-
 %if 0%{?fedora}
 %global build_platform Fedora
 %endif
@@ -35,81 +28,52 @@
 %global build_platform CentOS
 %endif
 
-%if %{with qt6}
-Name:           prismlauncher
-%else
-Name:           prismlauncher-qt5
-%endif
-Version:        5.2
-Release:        2%{?dist}
-Summary:        Minecraft launcher with ability to manage multiple instances
-License:        GPL-3.0-only
-%if 0%{?suse_version}
-Group:          Amusements/Games/Action/Other
-%else
-Group:          Amusements/Games
-%endif
-URL:            https://prismlauncher.org/
-Source0:        %{repo}/releases/download/%{version}/%{fancy_name}-%{version}.tar.gz
-Source1:        https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
-Patch0:         fix-disable-FLOAT16-in-toml.patch
+Name:             prismlauncher
+Version:          5.2
+Release:          3%{?dist}
+Summary:          Minecraft launcher with ability to manage multiple instances
+License:          GPL-3.0-only
+Group:            Amusements/Games
+URL:              https://prismlauncher.org/
+Source0:          https://github.com/PrismLauncher/PrismLauncher/releases/download/%{version}/%{name}-%{version}.tar.gz
+Source1:          https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
+Patch0:           fix-disable-FLOAT16-in-toml.patch
 
-BuildRequires:  cmake >= 3.15
-BuildRequires:  extra-cmake-modules
-BuildRequires:  gcc-c++
-BuildRequires:  java-devel
-
-%if 0%{?suse_version}
-BuildRequires:  appstream-glib
-%else
-BuildRequires:  libappstream-glib
-%endif
-
-BuildRequires:  desktop-file-utils
-BuildRequires:  cmake(Qt%{qt_version}Concurrent) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Core) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Gui) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Network) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Test) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
-BuildRequires:  cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
+BuildRequires:    cmake >= 3.15
+BuildRequires:    extra-cmake-modules
+BuildRequires:    gcc-c++
+BuildRequires:    java-devel >= 17
+BuildRequires:    desktop-file-utils
+BuildRequires:    libappstream-glib
+BuildRequires:    cmake(ghc_filesystem)
+BuildRequires:    cmake(Qt%{qt_version}Concurrent) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Core) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Gui) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Network) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Test) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
 
 %if %{with qt6}
-BuildRequires:  cmake(Qt6Core5Compat)
+BuildRequires:    cmake(Qt6Core5Compat)
 %endif
 
-BuildRequires:  pkgconfig(scdoc)
-BuildRequires:  zlib-devel
+BuildRequires:    pkgconfig(scdoc)
+BuildRequires:    pkgconfig(zlib)
 
-# Prism Launcher requires QuaZip >= 1.3
-%if 0%{?suse_version} >= 1550
-BuildRequires:  cmake(QuaZip-Qt%{qt_version})
-%endif
+Requires(post):   desktop-file-utils
+Requires(postun): desktop-file-utils
 
-%if 0%{?suse_version}
-Requires:       %{!?with_qt6:lib}qt%{qt_version}-%{!?with_qt6:qt}imageformats
-Requires:       libQt%{qt_version}Svg%{qt_version}
-%else
-Requires:       qt%{qt_version}-qtimageformats
-Requires:       qt%{qt_version}-qtsvg
-%endif
+Requires:         qt%{qt_version}-qtimageformats
+Requires:         qt%{qt_version}-qtsvg
+Requires:         javapackages-filesystem
+Requires:         java-headless >= 17
+Requires:         java-1.8.0-openjdk-headless
 
-Recommends:     java-openjdk-headless
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-Recommends:     xrandr
-
+Recommends:       xrandr
 # Prism supports enabling gamemode
-%if 0%{?suse_version}
-Recommends:     gamemoded
-%else
-Recommends:     gamemode
-%endif
-
-%if %{with qt6}
-Conflicts:      %{real_name}-qt5
-%else
-Conflicts:      %{real_name}
-%endif
+Suggests:         gamemode
 
 
 %description
@@ -118,7 +82,7 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 
 
 %prep
-%autosetup -n %{fancy_name}-%{version}
+%autosetup -n PrismLauncher-%{version}
 
 tar -xzf %{SOURCE1} -C libraries
 rm -rf libraries/tomlplusplus/*
@@ -126,6 +90,7 @@ mv -f libraries/tomlplusplus-%{tomlplusplus_commit}/* libraries/tomlplusplus
 
 # Do not set RPATH
 sed -i "s|\$ORIGIN/||" CMakeLists.txt
+
 
 %build
 %cmake \
@@ -140,52 +105,73 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 %cmake_build
 
+
 %install
 %cmake_install
 
-%if 0%{?suse_version} > 1500 || 0%{?fedora} > 35
-appstream-util validate-relax --nonet \
-    %{buildroot}%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
-%endif
 
 %check
 %ctest
+
+appstream-util validate-relax --nonet \
+    %{buildroot}%{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
+
 desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
+
+
+%post
+/usr/bin/update-desktop-database &> /dev/null || :
+/bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
+
+
+%postun
+/usr/bin/update-desktop-database &> /dev/null || :
+if [ $1 -eq 0 ] ; then
+    /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null
+    /usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+fi
+
+
+%posttrans
+/usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
+
 
 %files
 %doc README.md
 %license LICENSE COPYING.md
-%dir %{_datadir}/%{real_name}
+%dir %{_datadir}/%{name}
 %{_bindir}/prismlauncher
-%{_datadir}/%{real_name}/NewLaunch.jar
-%{_datadir}/%{real_name}/JavaCheck.jar
+%{_datadir}/%{name}/NewLaunch.jar
+%{_datadir}/%{name}/JavaCheck.jar
 %{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
-%{_datadir}/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml
+%{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
 %{_mandir}/man?/prismlauncher.*
 
 
 %changelog
-* Tue Nov 15 2022 seth <getchoo at tuta dot io> - 5.2-2
-- use newer version of toml++
+* Mon Dec 05 2022 seth <getchoo at tuta dot io> - 5.2-3
+- revise file to better follow fedora packaging guidelines and add java 8 as a
+  dependency
 
-* Tue Nov 15 2022 root - 5.2-1
-- new version
+
+* Tue Nov 15 2022 seth <getchoo at tuta dot io> - 5.2-2
+- use newer version of toml++ to fix issues on aarch64
+
+* Tue Nov 15 2022 seth <getchoo at tuta dot io> - 5.2-1
+- update to 5.2
 
 * Thu Nov 10 2022 seth <getchoo at tuta dot io> - 5.1-2
 - add package to Amusements/Games
 
-* Tue Nov 01 2022 root - 5.1-1
-- new version
-
-* Wed Oct 19 2022 seth <getchoo at tuta dot io> - 5.0-4
-- fix opensuse deps
+* Tue Nov 01 2022 seth <getchoo at tuta dot io> - 5.1-1
+- update to 5.1
 
 * Wed Oct 19 2022 seth <getchoo at tuta dot io> - 5.0-3
 - add missing deps and build with qt6 by default
 
 * Wed Oct 19 2022 seth <getchoo at tuta dot io> - 5.0-2
-- add change-jars-path.patch and allow for building on opensuse
+- add change-jars-path.patch to allow for package-specific jar path
 
 * Wed Oct 19 2022 seth <getchoo at tuta dot io> - 5.0-1
 - update to version 5.0
@@ -198,63 +184,3 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 * Tue Oct 18 2022 Cappy Ishihara <cappy@cappuchino.xyz> - 1.4.2-1
 - Repackaged as Prism Launcher
-
-* Thu Sep 08 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.4.2-1
-- Update to 1.4.2
-
-* Fri Jul 29 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.4.1-1
-- Update to 1.4.1
-
-* Sat Jul 23 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.4.0-2
-- Recommend gamemode
-
-* Sat Jul 23 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.4.0-1
-- Update to 1.4.0
-
-* Wed Jun 15 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.3.2-2
-- Fixing OpenSuse Tumbleweed compilation
-
-* Sun Jun 12 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.3.2-1
-- Update to 1.3.2
-
-* Mon May 30 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.3.1-1
-- Update to 1.3.1
-
-* Mon May 23 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.3.0-1
-- Update to 1.3.0
-
-* Sat May 14 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.2.2-1
-- Update to 1.2.2
-
-* Mon Apr 25 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.2.1-2
-- Correct dependencies for openSUSE
-
-* Wed Apr 20 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.2.1-1
-- Update to 1.2.1
-
-* Tue Apr 19 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.2.0-1
-- Update to 1.2.0
-
-* Tue Apr 19 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.1.1-3
-- Correct dependencies for openSuse
-
-* Wed Apr 06 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.1.1-2
-- Add missing dependencies
-
-* Mon Mar 28 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.1.1-1
-- Update to 1.1.1
-
-* Wed Mar 16 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.1.0-1
-- Update to 1.1.0
-
-* Mon Jan 24 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.0.5-2
-- remove explicit dependencies, correct dependencies to work on OpenSuse
-
-* Sun Jan 09 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.0.5-1
-- Update to 1.0.5
-
-* Sun Jan 09 2022 Jan Drögehoff <sentrycraft123@gmail.com> - 1.0.4-2
-- rework spec
-
-* Fri Jan 7 2022 getchoo <getchoo at tuta dot io> - 1.0.4-1
-- Initial polymc spec


### PR DESCRIPTION
some changes include:

- more closely following fedora packaging guidelines by using pkgconfig for zlib and the system version of `filesystem`
- adding java 8 as a dependency for older versions of minecraft
- changing the versioning system for nightly packages to the way described [here](https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_snapshots)
- adding myself to the CODEOWNERS file 

amazing work on the new documentation by the way! 😄