### PR TITLE
Create runner.temp before use

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,7 +24,9 @@ jobs:
           ssh-key: ${{ secrets.SSH_AUTHENTICATION_KEY }}
     
       - name: Install SSH signing key
-        run: echo "${{ secrets.SSH_SIGNING_KEY }}" > ${{ runner.temp }}/signing_key
+        run: |
+          mkdir -p ${{ runner.temp }}
+          echo "${{ secrets.SSH_SIGNING_KEY }}" > ${{ runner.temp }}/signing_key
 
       - name: Run Update
         run: bash ./update.sh


### PR DESCRIPTION
I'm pretty sure it should, but GitHub doesn't create the runner.temp directory before use. So let's do that here