### PR TITLE
[prismlauncher-nightly] bump version to 7.0

### DIFF
--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -39,7 +39,7 @@
 %endif
 
 Name:             prismlauncher-nightly
-Version:          6.0^%{snapshot_info}
+Version:          7.0^%{snapshot_info}
 Release:          1%{?dist}
 Summary:          Minecraft launcher with ability to manage multiple instances
 License:          GPL-3.0-only

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -39,7 +39,7 @@
 %endif
 
 Name:             prismlauncher-qt5-nightly
-Version:          6.0^%{snapshot_info}
+Version:          7.0^%{snapshot_info}
 Release:          1%{?dist}
 Summary:          Minecraft launcher with ability to manage multiple instances
 License:          GPL-3.0-only


### PR DESCRIPTION
upstream bumped the version in https://github.com/PrismLauncher/PrismLauncher/commit/4f3786c2e11f266a06e5a8281bfa16087c5dd42e

Signed-off-by: seth <getchoo@tuta.io>