### PR TITLE
Fix AppImageLauncher package

### DIFF
--- a/anda/lib/argagg/anda.hcl
+++ b/anda/lib/argagg/anda.hcl
@@ -1,0 +1,5 @@
+project "pkg" {
+    rpm {
+        spec = "argagg.spec"
+    }
+}

--- a/anda/lib/argagg/argagg.spec
+++ b/anda/lib/argagg/argagg.spec
@@ -1,0 +1,106 @@
+%global debug_package %{nil}
+
+Name:           argagg
+Version:        0.4.6
+Release:        1%{?dist}
+Summary:        Simple C++ command line argument/option parser
+
+License:        MIT
+URL:            https://github.com/vietjtnguyen/argagg/
+Source0:        https://github.com/vietjtnguyen/argagg/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+
+BuildRequires:  cmake
+BuildRequires:  doxygen
+
+%description
+This is yet another C++ command line argument/option parser. It was written as
+a simple and idiomatic alternative to other frameworks like getopt, Boost
+program options, TCLAP, and others. The goal is to achieve the majority of
+argument parsing needs in a simple manner with an easy to use API. It operates
+as a single pass over all arguments, recognizing flags prefixed by - (short) or
+-- (long) and aggregating them into easy to access structures with lots of
+convenience functions. It defers processing types until you access them, so the
+result structures end up just being pointers into the original command line
+argument C-strings. argagg supports POSIX recommended argument syntax
+conventions.
+
+%package        devel
+Summary:        Development files for %{name}
+
+%description    devel
+The %{name}-devel package contains the header files for developing applications
+that use %{name}.
+
+%package        doc
+Summary:        Developer documentation for %{name}
+
+%description    doc
+The %{name}-doc package contains the documentation for developing applications
+that use %{name}.
+
+%prep
+%setup -q
+
+%build
+# ignore doctest warnings
+%cmake -DOXYGEN=ON
+# enter cmake build directory
+pushd redhat-linux-build
+mkdir share
+popd
+%cmake_build -t docs
+
+
+%install
+%cmake_install
+
+ls -la redhat-linux-build/share
+
+%files
+
+%files devel
+%{_includedir}/*
+
+%files doc
+%doc %{_datadir}/doc/%{name}
+
+%changelog
+* Fri May 26 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Updated version to 0.4.6
+
+* Fri Apr 28 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Updated version to 0.4.5
+
+* Tue Apr 25 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Updated version to 0.4.4
+
+* Tue Apr 25 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Updated version to 0.4.3
+
+* Tue Apr 25 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Updated version to 0.4.2
+
+* Sun Mar 05 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Updated description
+- Remove dependence on empty root package
+
+* Sun Feb 19 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Disabled creation of debuginfo package
+
+* Mon Feb 13 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Fixed License field and doc subpackage description typo
+
+* Sat Feb 11 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Updated version to 0.2.2
+
+* Fri Feb 10 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Separated documentation into a separate package
+
+* Fri Feb 10 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Packaged version 0.2.1
+
+* Mon Jan 30 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Added missing files specification for empty parent package
+
+* Sun Jan 29 2017 Viet The Nguyen <vietjtnguyen@gmail.com>
+- Initial packaging

--- a/anda/lib/libappimageupdate/anda.hcl
+++ b/anda/lib/libappimageupdate/anda.hcl
@@ -1,0 +1,5 @@
+project "pkg" {
+    rpm {
+        spec = "libappimageupdate.spec"
+    }
+}

--- a/anda/lib/libappimageupdate/libappimageupdate.spec
+++ b/anda/lib/libappimageupdate/libappimageupdate.spec
@@ -23,6 +23,12 @@ BuildRequires:  cmake3
 BuildRequires:  gcc-c++
 BuildRequires:  libappimage-devel curl-devel libX11-devel zlib-devel fuse-devel librsvg2-devel cairo-devel git-core
 BuildRequires:  nlohmann-json-devel
+BuildRequires:  pkgconfig(libgcrypt)
+BuildRequires:  pkgconfig(gpgme)
+BuildRequires:  pkgconfig(Qt5)
+BuildRequires:  openssl-devel
+BuildRequires:  inotify-tools-devel
+BuildRequires:  argagg-devel
 
 %description
 Implements functionality for dealing with AppImage files. It is written in C++ and is using Boost.

--- a/anda/lib/libappimageupdate/libappimageupdate.spec
+++ b/anda/lib/libappimageupdate/libappimageupdate.spec
@@ -48,7 +48,7 @@ git submodule update --init --recursive
 
 %build
 # add include path for argagg
-%cmake -DBUILD_QT_UI=OFF \
+%cmake -DBUILD_QT_UI=ON \
     -DBUILD_LIBAPPIMAGEUPDATE_ONLY=ON \
     -DUSE_SYSTEM_LIBAPPIMAGE=ON
 %cmake_build

--- a/anda/lib/libappimageupdate/libappimageupdate.spec
+++ b/anda/lib/libappimageupdate/libappimageupdate.spec
@@ -72,4 +72,4 @@ git submodule update --init --recursive
 
 %changelog
 * Tue Oct 25 2022 Cappy Ishihara <cappy@cappuchino.xyz>
-- 
+- Initial build

--- a/anda/lib/libappimageupdate/libappimageupdate.spec
+++ b/anda/lib/libappimageupdate/libappimageupdate.spec
@@ -1,0 +1,80 @@
+%global git_commit af298b7aebfab4bcee7490a86f0471cc22db248b
+
+%global commit_short %(c=%{git_commit}; echo ${c:0:7})
+
+%global libver  2.0.0-alpha-1-20220124.git%{commit_short}
+
+# replace - with ~
+%global libver_format %(v=%{libver}; sed 's/-/~/g' <<< $v)
+
+Name:           libappimageupdate
+
+Version:        %{libver_format}
+Release:        1%{?dist}
+Summary:        AppImageUpdate lets you update AppImages in a decentral way using information embedded in the AppImage itself.
+
+License:        MIT
+URL:            https://github.com/AppImageCommunity/AppImageUpdate
+#Source0:        %{url}/archive/refs/%{libver}.tar.gz
+Source0:        %{url}/archive/%{git_commit}.tar.gz
+
+BuildRequires:  make
+BuildRequires:  cmake3
+BuildRequires:  gcc-c++
+BuildRequires:  libappimage-devel curl-devel libX11-devel zlib-devel fuse-devel librsvg2-devel cairo-devel git-core
+BuildRequires:  nlohmann-json-devel
+
+%description
+Implements functionality for dealing with AppImage files. It is written in C++ and is using Boost.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+
+%prep
+%autosetup -n AppImageUpdate-%{git_commit}
+
+git init .
+git remote add origin %{url}
+git fetch origin
+git checkout %{git_commit} --force
+git pull origin %{git_commit} --force
+git submodule update --init --recursive
+
+%build
+# add include path for argagg
+%cmake -DBUILD_QT_UI=OFF \
+    -DBUILD_LIBAPPIMAGEUPDATE_ONLY=ON \
+    -DUSE_SYSTEM_LIBAPPIMAGE=ON
+%cmake_build
+
+
+%install
+%cmake_install
+
+%{?ldconfig_scriptlets}
+
+
+%files
+%{_libdir}/*.so
+%{_libdir}/*.a
+# what is this?
+%exclude %{_bindir}/validate
+
+%files devel
+%{_includedir}/*
+%{_prefix}/lib/cmake/AppImageUpdate/
+
+
+
+
+
+
+%changelog
+* Tue Oct 25 2022 Cappy Ishihara <cappy@cappuchino.xyz>
+- 

--- a/anda/lib/libappimageupdate/libappimageupdate.spec
+++ b/anda/lib/libappimageupdate/libappimageupdate.spec
@@ -70,11 +70,6 @@ git submodule update --init --recursive
 %{_includedir}/*
 %{_prefix}/lib/cmake/AppImageUpdate/
 
-
-
-
-
-
 %changelog
 * Tue Oct 25 2022 Cappy Ishihara <cappy@cappuchino.xyz>
 - 

--- a/anda/lib/nlohmann-json/anda.hcl
+++ b/anda/lib/nlohmann-json/anda.hcl
@@ -1,0 +1,5 @@
+project "pkg" {
+    rpm {
+        spec = "nlohmann-json.spec"
+    }
+}

--- a/anda/lib/nlohmann-json/nlohmann-json.spec
+++ b/anda/lib/nlohmann-json/nlohmann-json.spec
@@ -1,0 +1,102 @@
+%global debug_package %{nil}
+
+Name: nlohmann-json
+Version: 3.11.2
+Release: 1%{?dist}
+
+Summary: JSON for Modern C++ (c++11) ("single header file")
+
+
+%define desc %{expand:There are myriads of JSON libraries out there, and each may even have its reason to exist. 
+Our class had these design goals:
+- intuitive syntax.
+- Trivial integration.
+- Serious testing
+}
+
+License: MIT
+Url: https://github.com/nlohmann/json
+
+Source: https://github.com/nlohmann/json/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires: cmake gcc-c++
+
+%description
+%{desc}
+
+%package devel
+Summary: JSON for Modern C++ (c++11) ("single header file")
+Group: Development/C++
+
+%description devel
+%{desc}
+
+This package contains the single header C++ file and CMake dependency files.
+
+%prep
+%autosetup -n json-%{version}
+
+%build
+%cmake
+
+
+%install
+%cmake_install
+
+%files devel
+%{_includedir}/nlohmann
+%{_datadir}/cmake/nlohmann_json/
+%{_datadir}/pkgconfig/nlohmann_json.pc
+
+%changelog
+* Mon Dec 26 2022 Cappy Ishihara <cappy@cappuchino.xyz> - 3.11.2-1.um37
+- Rebuild for Terra, dependency of libappimageupdate
+
+* Fri Dec 10 2021 Ilya Kurdyukov <ilyakurdyukov@altlinux.org> 3.10.4-alt1.1
+- Fixed build for Elbrus.
+
+* Mon Nov 15 2021 Paul Wolneykien <manowar@altlinux.org> 3.10.4-alt1
+- new version 3.10.4
+
+* Thu Sep 16 2021 Ivan A. Melnikov <iv@altlinux.org> 3.10.2-alt2
+- Disable slower tests on %%mips and riscv64 to avoid timeouts.
+
+* Tue Sep 14 2021 Paul Wolneykien <manowar@altlinux.org> 3.10.2-alt1
+- Updated to v3.10.2.
+
+* Wed Apr 28 2021 Arseny Maslennikov <arseny@altlinux.org> 3.8.0-alt3.1
+- NMU: spec: adapted to new cmake macros.
+
+* Thu Sep 10 2020 Ivan A. Melnikov <iv@altlinux.org> 3.8.0-alt3
+- Skip test-unicode on mips*, as it timeouts.
+
+* Fri Jul 03 2020 Paul Wolneykien <manowar@altlinux.org> 3.8.0-alt2
+- Added the test data bundle.
+- Fix: Run the tests with CMake.
+- Skip the cmake_fetch_content test.
+
+* Thu Jul 02 2020 Paul Wolneykien <manowar@altlinux.org> 3.8.0-alt1
+- Freshed up to v3.8.0.
+
+* Tue Mar 31 2020 Paul Wolneykien <manowar@altlinux.org> 3.7.2-alt2
+- Run the auto-tests.
+- Package CMake dependency files.
+- This is now an arch package'nlohmann-json' providing nlohmann-json-devel
+  and replacing json-cpp.
+- Fixed project lincense: MIT.
+
+* Tue Mar 31 2020 Paul Wolneykien <manowar@altlinux.org> 3.7.2-alt1
+- Upstream version 3.7.2.
+- Also install %_includedir/nlohmann/json.hpp symlink.
+
+* Mon Nov 26 2018 Pavel Vainerman <pv@altlinux.ru> 3.4.0-alt1
+- new version
+
+* Sun Mar 19 2017 Pavel Vainerman <pv@altlinux.ru> 2.1.1-alt1
+- new version
+
+* Tue Nov 08 2016 Pavel Vainerman <pv@altlinux.ru> 2.0.7-alt1
+- new version
+
+* Sun Oct 30 2016 Pavel Vainerman <pv@altlinux.ru> 2.0.6-alt0.1
+- initial commit 

--- a/anda/tools/appimagelauncher/appimagelauncher.spec
+++ b/anda/tools/appimagelauncher/appimagelauncher.spec
@@ -57,6 +57,38 @@ popd
 %cmake_install
 
 
+%post
+echo "Installing AppImageLauncher as interpreter for AppImages"
+# as there's no _real_ package that we could use as a dependency to take care of the kernel module,
+# we need to make sure that the kernel module is loaded manually
+modprobe -v binfmt_misc
+
+(set -x; systemctl restart systemd-binfmt)
+
+
+%postun
+
+echo "Removing AppImageLauncher as interpreter for AppImages"
+(set -x; systemctl restart systemd-binfmt)
+
+update_notifier="/usr/share/update-notifier/notify-reboot-required"
+if [ -x "$update_notifier" ]; then
+    "$update_notifier"
+fi
+
+cat <<EOF
+#####################################################
+#                                                   #
+#  NOTE: you need to reboot your computer in order  #
+#  to complete the uninstallation                   #
+#                                                   #
+#  (If you see this message during an upgrade:      #
+#  don't worry, you do not have to take any         #
+#  action, no reboot required!)                     #
+#                                                   #
+#####################################################
+EOF
+
 %files
 %{_datadir}/appimagelauncher
 %{_datadir}/applications/appimagelauncher.desktop

--- a/anda/tools/appimagelauncher/appimagelauncher.spec
+++ b/anda/tools/appimagelauncher/appimagelauncher.spec
@@ -1,12 +1,9 @@
 %global git_commit 0f918015fa418affec32435d1c61c6ae473f2af5
 %global git_shortcommit %(c=%{git_commit}; echo ${c:0:7})
 
-# exclude libappimageupdate* from provides
-%global __requires_exclude ^libappimageupdate.*$
-
 Name:           appimagelauncher
 Version:        2.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Helper application for Linux distributions serving as a kind of "entry point" for running and integrating AppImages
 
 License:        MIT
@@ -27,6 +24,7 @@ BuildRequires:  qt5-linguist
 BuildRequires:  libcurl-devel
 BuildRequires:  boost-devel
 BuildRequires:  libappimage-devel
+BuildRequires:  libappimageupdate-devel
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  librsvg2-devel
 
@@ -75,5 +73,8 @@ popd
 %{_mandir}/man1/AppImageLauncher.1.gz
 
 %changelog
+* Mon Dec 26 2022 Cappy Ishihara <cappy@cappuchino.xyz>
+- Bumped release, added missing dependency
+
 * Tue Oct 25 2022 Cappy Ishihara <cappy@cappuchino.xyz>
 - Initial Release


### PR DESCRIPTION
This PR adds `libappimageupdate` and fixes AppImageLauncher, adding back postinstall and postuninstall scripts and fixes the libappimageupdate dependency.