### PR TITLE
[prismlauncher(-qt5)-nightly] add patch to find cmark correctly

### DIFF
--- a/anda/games/prismlauncher-nightly/0001-find-cmark-with-pkgconfig.patch
+++ b/anda/games/prismlauncher-nightly/0001-find-cmark-with-pkgconfig.patch
@@ -1,0 +1,79 @@
+From 5a38fc2c9a329e88c8337af541dfeccaeff1fefb Mon Sep 17 00:00:00 2001
+From: seth <getchoo@tuta.io>
+Date: Sun, 15 Jan 2023 14:47:49 -0500
+Subject: [PATCH] find cmark with pkgconfig
+
+Signed-off-by: seth <getchoo@tuta.io>
+---
+ cmake/Findcmark.cmake | 59 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 59 insertions(+)
+ create mode 100755 cmake/Findcmark.cmake
+
+diff --git a/cmake/Findcmark.cmake b/cmake/Findcmark.cmake
+new file mode 100755
+index 00000000..9858e5df
+--- /dev/null
++++ b/cmake/Findcmark.cmake
+@@ -0,0 +1,59 @@
++# SPDX-FileCopyrightText: 2019 Black Hat <bhat@encom.eu.org>
++# SPDX-License-Identifier: GPL-3.0-only
++
++#
++# CMake module to search for the cmark library
++#
++
++# first try to find cmark-config.cmake
++# path to a file not in the search path can be set with 'cmake -Dcmark_DIR=some/path/'
++find_package(cmark CONFIG QUIET)
++if(cmark_FOUND AND TARGET cmark::cmark)
++  # found it!
++  return()
++endif()
++
++find_package(PkgConfig QUIET)
++if(PKG_CONFIG_FOUND)
++  pkg_check_modules(PC_CMARK QUIET cmark)
++endif()
++
++if(NOT CMARK_INCLUDE_DIR)
++  find_path(CMARK_INCLUDE_DIR
++            NAMES cmark.h
++            PATHS
++            ${PC_CMARK_INCLUDEDIR}
++            ${PC_CMARK_INCLUDE_DIRS}
++            /usr/include
++            /usr/local/include)
++endif()
++
++if(NOT CMARK_LIBRARY)
++  find_library(CMARK_LIBRARY
++               NAMES cmark
++               HINTS
++               ${PC_CMARK_LIBDIR}
++               ${PC_CMARK_LIBRARY_DIRS}
++               /usr/lib
++               /usr/local/lib)
++endif()
++
++if(NOT TARGET cmark::cmark)
++  add_library(cmark::cmark UNKNOWN IMPORTED)
++  set_target_properties(cmark::cmark
++                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
++                                   ${CMARK_INCLUDE_DIR})
++  set_property(TARGET cmark::cmark APPEND
++               PROPERTY IMPORTED_LOCATION ${CMARK_LIBRARY})
++endif()
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(cmark
++                                  DEFAULT_MSG
++                                  CMARK_INCLUDE_DIR
++                                  CMARK_LIBRARY)
++
++mark_as_advanced(CMARK_LIBRARY CMARK_INCLUDE_DIR)
++
++set(CMARK_LIBRARIES ${CMARK_LIBRARY})
++set(CMARK_INCLUDE_DIRS ${CMARK_INCLUDE_DIR})
+-- 
+2.39.0
+

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -49,6 +49,7 @@ Source0:          https://github.com/PrismLauncher/PrismLauncher/archive/%{commi
 Source1:          https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
 Source2:          https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
 Source3:          https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
+Patch0:           0001-find-cmark-with-pkgconfig.patch
 
 BuildRequires:    cmake >= 3.15
 BuildRequires:    extra-cmake-modules
@@ -97,7 +98,7 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 
 
 %prep
-%autosetup -n PrismLauncher-%{commit}
+%autosetup -p1 -n PrismLauncher-%{commit}
 
 tar -xzf %{SOURCE1} -C libraries
 tar -xvf %{SOURCE2} -C libraries
@@ -178,6 +179,9 @@ fi
 
 
 %changelog
+* Sun Jan 15 2023 seth <getchoo at tuta dot io> - 7.0^20230115.f1247d2-1
+- add 0001-find-cmark-with-pkgconfig.patch
+
 * Fri Jan 13 2023 seth <getchoo at tuta dot io> - 7.0^20230113.3de681d-1
 - add cmark as a build dep
 

--- a/anda/games/prismlauncher-qt5-nightly/0001-find-cmark-with-pkgconfig.patch
+++ b/anda/games/prismlauncher-qt5-nightly/0001-find-cmark-with-pkgconfig.patch
@@ -1,0 +1,79 @@
+From 5a38fc2c9a329e88c8337af541dfeccaeff1fefb Mon Sep 17 00:00:00 2001
+From: seth <getchoo@tuta.io>
+Date: Sun, 15 Jan 2023 14:47:49 -0500
+Subject: [PATCH] find cmark with pkgconfig
+
+Signed-off-by: seth <getchoo@tuta.io>
+---
+ cmake/Findcmark.cmake | 59 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 59 insertions(+)
+ create mode 100755 cmake/Findcmark.cmake
+
+diff --git a/cmake/Findcmark.cmake b/cmake/Findcmark.cmake
+new file mode 100755
+index 00000000..9858e5df
+--- /dev/null
++++ b/cmake/Findcmark.cmake
+@@ -0,0 +1,59 @@
++# SPDX-FileCopyrightText: 2019 Black Hat <bhat@encom.eu.org>
++# SPDX-License-Identifier: GPL-3.0-only
++
++#
++# CMake module to search for the cmark library
++#
++
++# first try to find cmark-config.cmake
++# path to a file not in the search path can be set with 'cmake -Dcmark_DIR=some/path/'
++find_package(cmark CONFIG QUIET)
++if(cmark_FOUND AND TARGET cmark::cmark)
++  # found it!
++  return()
++endif()
++
++find_package(PkgConfig QUIET)
++if(PKG_CONFIG_FOUND)
++  pkg_check_modules(PC_CMARK QUIET cmark)
++endif()
++
++if(NOT CMARK_INCLUDE_DIR)
++  find_path(CMARK_INCLUDE_DIR
++            NAMES cmark.h
++            PATHS
++            ${PC_CMARK_INCLUDEDIR}
++            ${PC_CMARK_INCLUDE_DIRS}
++            /usr/include
++            /usr/local/include)
++endif()
++
++if(NOT CMARK_LIBRARY)
++  find_library(CMARK_LIBRARY
++               NAMES cmark
++               HINTS
++               ${PC_CMARK_LIBDIR}
++               ${PC_CMARK_LIBRARY_DIRS}
++               /usr/lib
++               /usr/local/lib)
++endif()
++
++if(NOT TARGET cmark::cmark)
++  add_library(cmark::cmark UNKNOWN IMPORTED)
++  set_target_properties(cmark::cmark
++                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
++                                   ${CMARK_INCLUDE_DIR})
++  set_property(TARGET cmark::cmark APPEND
++               PROPERTY IMPORTED_LOCATION ${CMARK_LIBRARY})
++endif()
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(cmark
++                                  DEFAULT_MSG
++                                  CMARK_INCLUDE_DIR
++                                  CMARK_LIBRARY)
++
++mark_as_advanced(CMARK_LIBRARY CMARK_INCLUDE_DIR)
++
++set(CMARK_LIBRARIES ${CMARK_LIBRARY})
++set(CMARK_INCLUDE_DIRS ${CMARK_INCLUDE_DIR})
+-- 
+2.39.0
+

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -49,6 +49,7 @@ Source0:          https://github.com/PrismLauncher/PrismLauncher/archive/%{commi
 Source1:          https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
 Source2:          https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
 Source3:          https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
+Patch0:           0001-find-cmark-with-pkgconfig.patch
 
 BuildRequires:    cmake >= 3.15
 BuildRequires:    extra-cmake-modules
@@ -98,7 +99,7 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 
 
 %prep
-%autosetup -n PrismLauncher-%{commit}
+%autosetup -p1 -n PrismLauncher-%{commit}
 
 tar -xzf %{SOURCE1} -C libraries
 tar -xvf %{SOURCE2} -C libraries
@@ -179,6 +180,9 @@ fi
 
 
 %changelog
+* Sun Jan 15 2023 seth <getchoo at tuta dot io> - 7.0^20230115.f1247d2-1
+- add 0001-find-cmark-with-pkgconfig.patch
+
 * Fri Jan 13 2023 seth <getchoo at tuta dot io> - 7.0^20230113.3de681d-1
 - add cmark as a build dep
 


### PR DESCRIPTION
took me a while to figure this out, but it looks like fedora's `cmark-devel` package is at version that doesn't support cmake properly. this adds a patch that will remedy this issue with a new cmake config file sourced from [neochat](https://invent.kde.org/network/neochat/-/blob/3f8d2a11d0e00e35a743996b7f3e71c9a401de81/cmake/Findcmark.cmake)