### PR TITLE
Add blank spec to address Anda bug

### DIFF
--- a/anda/tools/lorax/anda.hcl
+++ b/anda/tools/lorax/anda.hcl
@@ -1,6 +1,6 @@
 project pkg {
     rpm {
-        spec = ""
+        spec = "lorax.spec"
         enable_scm = true
 
         scm_opts = {


### PR DESCRIPTION
There's a bug in Anda where the `spec` option is not ignored when `enable_scm` is set, this is a temporary fix for that