### PR TITLE
fix(dbgpkg): pop-launcher

### DIFF
--- a/anda/rust/pop-launcher/pop-launcher.spec
+++ b/anda/rust/pop-launcher/pop-launcher.spec
@@ -1,6 +1,6 @@
 %define _disable_source_fetch 0
 %bcond_without check
-%global debug_package %%{nil}
+%global debug_package %{nil}
 
 %global crate pop-launcher
 


### PR DESCRIPTION
Last time I incorrectly uncommented that so yeah I mean the macro escape thingy