### PR TITLE
fix(unity-settings-daemon): remove rpmlint warning

### DIFF
--- a/anda/lib/unity-settings-daemon/unity-settings-daemon.spec
+++ b/anda/lib/unity-settings-daemon/unity-settings-daemon.spec
@@ -61,7 +61,7 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 
 # Requires internet so manually installing manpage
 rm -rf man
-sed -i '/man\/Makefile/d' ./configure.ac
+sed -i '/man\/Makefile/d' "configure.ac"
 sed -i '/man/d' Makefile.am
 
 %build


### PR DESCRIPTION
For some reason rpmlint thinks we are running `configure` but we are only editing part of `configure.ac`.