### PR TITLE
fix nightly packages providing the "stable" package

### DIFF
--- a/anda/vala/vala-language-server-nightly/vala-language-server-nightly.spec
+++ b/anda/vala/vala-language-server-nightly/vala-language-server-nightly.spec
@@ -46,8 +46,6 @@ Recommends:     gobject-introspection-devel
 Suggests:       gnome-builder
 
 Conflicts:      vala-language-server
-Provides:       vala-language-server = %version
-Provides:       vala-language-server%{?_isa} = %version
 
 %description
 Provides code intelligence for Vala (and also Genie).

--- a/anda/vala/vala-nightly/vala-nightly.spec
+++ b/anda/vala/vala-nightly/vala-nightly.spec
@@ -39,11 +39,7 @@ Requires: libvala%{?_isa} = %{version}-%{release}
 # For GLib-2.0 and GObject-2.0 .gir files
 Requires: gobject-introspection-devel
 
-Provides: vala(api) = %{api_ver}
-
 Conflicts:      vala
-Provides:       vala = %version
-Provides:       vala%{?_isa} = %version
 
 %description
 Vala is a new programming language that aims to bring modern programming
@@ -65,8 +61,6 @@ type system.
 Summary:        Vala compiler library
 
 Conflicts:      libvala
-Provides:       libvala = %version
-Provides:       libvala%{?_isa} = %version
 
 %description -n libvala-nightly
 Vala is a new programming language that aims to bring modern programming
@@ -82,8 +76,6 @@ Summary:        Development files for libvala
 Requires:       libvala%{?_isa} = %{version}-%{release}
 
 Conflicts:      libvala-devel
-Provides:       libvala-devel = %version
-Provides:       libvala-devel%{?_isa} = %version
 
 %description -n libvala-nightly-devel
 Vala is a new programming language that aims to bring modern programming
@@ -102,7 +94,6 @@ Requires:       %{name} = %{version}-%{release}
 Requires:       devhelp
 
 Conflicts:      vala-doc
-Provides:       vala-doc = %version
 
 %description    doc
 Vala is a new programming language that aims to bring modern programming
@@ -118,8 +109,6 @@ Summary:        Vala documentation generator
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 Conflicts:      valadoc
-Provides:       valadoc = %version
-Provides:       valadoc%{?_isa} = %version
 
 %description -n valadoc-nightly
 Valadoc is a documentation generator for generating API documentation from Vala
@@ -131,8 +120,6 @@ Summary:        Development files for valadoc
 Requires:       valadoc%{?_isa} = %{version}-%{release}
 
 Conflicts:      valadoc-devel
-Provides:       valadoc-devel = %version
-Provides:       valadoc-devel%{?_isa} = %version
 
 %description -n valadoc-nightly-devel
 Valadoc is a documentation generator for generating API documentation from Vala


### PR DESCRIPTION
For example, when installing `vala` DNF seems to consider all packages that provide `vala`, instead of just named packages. Nightly packages will have a version higher than the stable package, causing them to be automatically installed. I wish there was a way to do a soft-provides, such that DNF will not automatically consider it, but will "allow" it if the package is explicity installed (and the user installs something that has that provided package as a dep.) This will do though.