### PR TITLE
chore: rename libindicator

### DIFF
--- a/anda/desktops/unity-shell/unity-shell.spec
+++ b/anda/desktops/unity-shell/unity-shell.spec
@@ -19,7 +19,7 @@ BuildRequires:	pkgconfig(zeitgeist-2.0)
 BuildRequires:	libappstream-glib-devel
 BuildRequires:	libdbusmenu-devel
 BuildRequires:	bamf-devel
-BuildRequires:	libindicator-gtk3-devel
+BuildRequires:	newer-libindicator-gtk3-devel
 BuildRequires:	json-glib-devel
 BuildRequires:	libnotify-devel
 BuildRequires:	libsigc++20-devel
@@ -45,7 +45,7 @@ Requires:	pam
 Requires:	bamf-daemon
 Requires:	unity-gtk-module-common
 Requires:	compiz9
-Requires:	libindicator-gtk3
+Requires:	newer-libindicator-gtk3
 Recommends:	unity-greeter
 Recommends:	unity-scope-home
 

--- a/anda/desktops/unityx-shell/unityx-shell.spec
+++ b/anda/desktops/unityx-shell/unityx-shell.spec
@@ -26,7 +26,7 @@ BuildRequires: zeitgeist-devel
 BuildRequires: libappstream-glib-devel
 BuildRequires: libdbusmenu-devel
 BuildRequires: bamf-devel
-BuildRequires: libindicator-gtk3-devel
+BuildRequires: newer-libindicator-gtk3-devel
 BuildRequires: json-glib-devel
 BuildRequires: libnotify-devel
 BuildRequires: libsigc++20-devel
@@ -61,7 +61,7 @@ Requires:      geis-devel
 Requires:      unity-settings-daemon
 Requires:      unity-gtk3-module
 Requires:      unity-gtk2-module
-Requires:      libindicator-gtk3
+Requires:      newer-libindicator-gtk3
 Requires:      plotinus%{?_isa} = %{version}-%{release}
 Requires:      bamf-daemon
 Requires:      xbindkeys

--- a/anda/lib/libindicator/anda.hcl
+++ b/anda/lib/libindicator/anda.hcl
@@ -1,5 +1,0 @@
-project pkg {
-	rpm {
-		spec = "libindicator.spec"
-	}
-}

--- a/anda/lib/newer-libindicator/anda.hcl
+++ b/anda/lib/newer-libindicator/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "newer-libindicator.spec"
+	}
+}

--- a/anda/lib/newer-libindicator/newer-libindicator.spec
+++ b/anda/lib/newer-libindicator/newer-libindicator.spec
@@ -1,4 +1,4 @@
-Name:			libindicator
+Name:			newer-libindicator
 Version:		16.10.0
 Release:		%autorelease
 Summary:		Shared functions for Ayatana indicators


### PR DESCRIPTION
So, the libindicator in Fedora uses an extremely old 12.10 series, while this rpm is much more newer using the 16.10 series. In fact I even used the same spec file from Fedora as they are extremely close.