### PR TITLE
chore: test unity-misc

### DIFF
--- a/anda/lib/libunity-misc/libunity-misc.spec
+++ b/anda/lib/libunity-misc/libunity-misc.spec
@@ -1,7 +1,7 @@
 Name:			libunity-misc
 Version:		4.0.5
 Release:		%autorelease
-Summary:		Misc Unity shell libs
+Summary:		Misc Unity shell libraries
 
 License:		LGPL-2.0 AND LGPL-2.0 AND GPL-2.0
 URL:			https://launchpad.net/libunity-misc


### PR DESCRIPTION
So for some reason, `unity-misc` isn't in Terra (38), yet Unity-shell is for some reason:
```
[me@fedora ~]$ dnf search unity-misc
Last metadata expiration check: 0:29:07 ago on Sun 11 Jun 2023 04:52:33 PM PDT.
No matches found.
[me@fedora ~]$ dnf info unity-misc
Last metadata expiration check: 0:31:09 ago on Sun 11 Jun 2023 04:52:33 PM PDT.
Error: No matching Packages to list

[me@fedora ~]$ dnf5 info unity-shell.x86_64
Updating and loading repositories:
Repositories loaded.
Available packages
Name           : unity-shell
Epoch          : 0
Version        : 7.7.0
Release        : 1.fc38
Architecture   : x86_64
Package size   : 2.2 MiB
Installed size : 9.2 MiB
Source         : unity-shell-7.7.0-1.fc38.src.rpm
Repository     : terra
Summary        : Unity is a shell that sings
URL            : https://launchpad.net/unity
License        : GPL-3.0-or-later
Description    : Unity is a desktop experience that sings. Designed by Canonical
....
```
This PR also functions as a test to make sure unity-misc can be built.