### PR TITLE
fix(update): switchboard-plug-datetime

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-datetime/switchboard-plug-datetime.spec
+++ b/anda/desktops/elementary/switchboard-plug-datetime/switchboard-plug-datetime.spec
@@ -8,7 +8,7 @@
 
 Name:           switchboard-plug-datetime
 Summary:        Switchboard Date & Time Plug
-Version:        elementary/switchboard.plug.datetime
+Version:        2.2.0
 Release:        1%{?dist}
 License:        GPL-3.0-or-later
 

--- a/anda/desktops/elementary/switchboard-plug-datetime/update.rhai
+++ b/anda/desktops/elementary/switchboard-plug-datetime/update.rhai
@@ -1,1 +1,1 @@
-rpm.version("elementary/switchboard-plug-datetime");
+rpm.version(gh("elementary/switchboard-plug-datetime"));


### PR DESCRIPTION
oops forgot `gh()`