### PR TITLE
chore(qtdbusmock): add README.md to %doc

### DIFF
--- a/anda/lib/qtdbusmock/qtdbusmock.spec
+++ b/anda/lib/qtdbusmock/qtdbusmock.spec
@@ -41,6 +41,7 @@ developing applications that use %{name}.
 %cmake_install
 
 %files
+%doc README.md
 %license COPYING
 %{_libdir}/libqtdbusmock.so.*
 %dir %{_datadir}/libqtdbusmock


### PR DESCRIPTION
Seeing whats up with this. Most likely a missing dependency.