### PR TITLE
fix(ayatana-indicator-session): include systemd session

### DIFF
--- a/anda/indicators/ayatana-indicator-session/ayatana-indicator-session.spec
+++ b/anda/indicators/ayatana-indicator-session/ayatana-indicator-session.spec
@@ -17,6 +17,7 @@ BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  pkgconfig(dbustest-1)
 BuildRequires:  pkgconfig(gee-0.8)
 BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  intltool
 
 %description
@@ -45,7 +46,7 @@ This package contains the development header files for %{name}.
 %files -f %{name}.lang
 %license COPYING
 %{_sysconfdir}/xdg/autostart/ayatana-indicator-session.desktop
-#{_userunitdir}/ayatana-indicator-session.service
+%{_userunitdir}/ayatana-indicator-session.service
 %dir %{_libexecdir}/ayatana-indicator-session
 %{_libexecdir}/ayatana-indicator-session/ayatana-indicator-session-service
 %{_datadir}/ayatana/indicators/org.ayatana.indicator.session


### PR DESCRIPTION
The systemd file got removed for some reason.