### PR TITLE
fix(lomiri): depend on device-info

### DIFF
--- a/anda/desktops/lomiri/lomiri.spec
+++ b/anda/desktops/lomiri/lomiri.spec
@@ -55,6 +55,7 @@ BuildRequires: qt5-qtbase-private-devel
 BuildRequires: qt5-qtdeclarative-devel
 BuildRequires: systemd-rpm-macros
 Recommends:    lomiri-session
+Requires:      deviceinfo
 Requires:      lomiri-system-settings
 Requires:      qmenumodel
 Requires:      xorg-x11-server-Xwayland


### PR DESCRIPTION
Since https://gitlab.com/ubports/development/core/lomiri/-/commit/b90e5eb02b76231589a35d213bef3d1837fbe4aa but primarilly for a rebuild of course.