### PR TITLE
fix(lomiri): add missing dependency

### DIFF
--- a/anda/desktops/lomiri/lomiri.spec
+++ b/anda/desktops/lomiri/lomiri.spec
@@ -55,6 +55,8 @@ BuildRequires: qt5-qtbase-private-devel
 BuildRequires: qt5-qtdeclarative-devel
 BuildRequires: systemd-rpm-macros
 Recommends:    lomiri-session
+# Most of these are for other libs that rpm doesn't find
+Requires:      libusermetrics
 Requires:      deviceinfo
 Requires:      lomiri-system-settings
 Requires:      qmenumodel


### PR DESCRIPTION
A missing one!
```
[2023-06-17:12:23:09.930] file:///usr/share/lomiri//Greeter/IntegratedLightDMImpl.qml:18:1: plugin cannot be loaded for module "LightDM.IntegratedLightDM": Cannot load library /usr/lib64/lomiri/qml/LightDM/IntegratedLightDM/libIntegratedLightDM-qml.so: (libusermetricsoutput.so.1: cannot open shared object file: No such file or directory)
```