### PR TITLE
fix(click): use autorelease

### DIFF
--- a/anda/others/click/click.spec
+++ b/anda/others/click/click.spec
@@ -4,7 +4,7 @@
 
 Name:           click
 Version:        0.5.0
-Release:        2%?dist
+Release:        %autorelease
 Summary:        An app building method
 License:        LGPL-3.0
 URL:            https://gitlab.com/ubports/development/core/click


### PR DESCRIPTION
For some reason `python3-lomiri-click` isn't available!
```
[me@archlinux ~]$ sudo dnf upgrade
[sudo] password for me: 
Last metadata expiration check: 1:37:27 ago on Mon 26 Jun 2023 02:25:15 PM PDT.
Dependencies resolved.

 Problem 1: cannot install the best update candidate for package python3-lomiri-click-0.5.0-1.fc38.x86_64
  - nothing provides click(aarch-64) = 0.5.0-2.fc38 needed by python3-lomiri-click-0.5.0-2.fc38.noarch from terra
 Problem 2: problem with installed package python3-lomiri-click-0.5.0-1.fc38.x86_64
  - package python3-lomiri-click-0.5.0-1.fc38.x86_64 from @System requires click(x86-64) = 0.5.0-1.fc38, but none of the providers can be installed
  - package python3-lomiri-click-0.5.0-1.fc38.x86_64 from terra requires click(x86-64) = 0.5.0-1.fc38, but none of the providers can be installed
  - cannot install both click-0.5.0-2.fc38.x86_64 from terra and click-0.5.0-1.fc38.x86_64 from @System
  - cannot install the best update candidate for package click-0.5.0-1.fc38.x86_64
  - nothing provides click(aarch-64) = 0.5.0-2.fc38 needed by python3-lomiri-click-0.5.0-2.fc38.noarch from terra
```

```
[me@archlinux ~]$ sudo dnf install click-0.5.0-2.fc38.x86_64
Last metadata expiration check: 1:38:35 ago on Mon 26 Jun 2023 02:25:15 PM PDT.
Error: 
 Problem: problem with installed package python3-lomiri-click-0.5.0-1.fc38.x86_64
  - package python3-lomiri-click-0.5.0-1.fc38.x86_64 from @System requires click(x86-64) = 0.5.0-1.fc38, but none of the providers can be installed
  - package python3-lomiri-click-0.5.0-1.fc38.x86_64 from terra requires click(x86-64) = 0.5.0-1.fc38, but none of the providers can be installed
  - cannot install both click-0.5.0-2.fc38.x86_64 from terra and click-0.5.0-1.fc38.x86_64 from @System
  - conflicting requests
  - nothing provides click(aarch-64) = 0.5.0-2.fc38 needed by python3-lomiri-click-0.5.0-2.fc38.noarch from terra
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
[me@archlinux ~]$ sudo dnf install --allowerasing click-0.5.0-2.fc38.x86_64 python3-lomiri-click-0.5.0-2.fc38.x86_64
Last metadata expiration check: 1:39:00 ago on Mon 26 Jun 2023 02:25:15 PM PDT.
No match for argument: python3-lomiri-click-0.5.0-2.fc38.x86_64
Error: Unable to find a match: python3-lomiri-click-0.5.0-2.fc38.x86_64
```