### PR TITLE
misc fixes for prismlauncher{,-nightly}

### DIFF
--- a/anda/games/prismlauncher-nightly/0001-find-cmark-with-pkgconfig.patch
+++ b/anda/games/prismlauncher-nightly/0001-find-cmark-with-pkgconfig.patch
@@ -1,0 +1,79 @@
+From 5a38fc2c9a329e88c8337af541dfeccaeff1fefb Mon Sep 17 00:00:00 2001
+From: seth <getchoo@tuta.io>
+Date: Sun, 15 Jan 2023 14:47:49 -0500
+Subject: [PATCH] find cmark with pkgconfig
+
+Signed-off-by: seth <getchoo@tuta.io>
+---
+ cmake/Findcmark.cmake | 59 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 59 insertions(+)
+ create mode 100755 cmake/Findcmark.cmake
+
+diff --git a/cmake/Findcmark.cmake b/cmake/Findcmark.cmake
+new file mode 100755
+index 00000000..9858e5df
+--- /dev/null
++++ b/cmake/Findcmark.cmake
+@@ -0,0 +1,59 @@
++# SPDX-FileCopyrightText: 2019 Black Hat <bhat@encom.eu.org>
++# SPDX-License-Identifier: GPL-3.0-only
++
++#
++# CMake module to search for the cmark library
++#
++
++# first try to find cmark-config.cmake
++# path to a file not in the search path can be set with 'cmake -Dcmark_DIR=some/path/'
++find_package(cmark CONFIG QUIET)
++if(cmark_FOUND AND TARGET cmark::cmark)
++  # found it!
++  return()
++endif()
++
++find_package(PkgConfig QUIET)
++if(PKG_CONFIG_FOUND)
++  pkg_check_modules(PC_CMARK QUIET cmark)
++endif()
++
++if(NOT CMARK_INCLUDE_DIR)
++  find_path(CMARK_INCLUDE_DIR
++            NAMES cmark.h
++            PATHS
++            ${PC_CMARK_INCLUDEDIR}
++            ${PC_CMARK_INCLUDE_DIRS}
++            /usr/include
++            /usr/local/include)
++endif()
++
++if(NOT CMARK_LIBRARY)
++  find_library(CMARK_LIBRARY
++               NAMES cmark
++               HINTS
++               ${PC_CMARK_LIBDIR}
++               ${PC_CMARK_LIBRARY_DIRS}
++               /usr/lib
++               /usr/local/lib)
++endif()
++
++if(NOT TARGET cmark::cmark)
++  add_library(cmark::cmark UNKNOWN IMPORTED)
++  set_target_properties(cmark::cmark
++                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
++                                   ${CMARK_INCLUDE_DIR})
++  set_property(TARGET cmark::cmark APPEND
++               PROPERTY IMPORTED_LOCATION ${CMARK_LIBRARY})
++endif()
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(cmark
++                                  DEFAULT_MSG
++                                  CMARK_INCLUDE_DIR
++                                  CMARK_LIBRARY)
++
++mark_as_advanced(CMARK_LIBRARY CMARK_INCLUDE_DIR)
++
++set(CMARK_LIBRARIES ${CMARK_LIBRARY})
++set(CMARK_INCLUDE_DIRS ${CMARK_INCLUDE_DIR})
+-- 
+2.39.0
+

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -25,26 +25,14 @@
 %global min_qt_version 5.12
 %endif
 
-%global build_platform unknown
-
-%if 0%{?fedora}
-%global build_platform Fedora
-%endif
-
-%if 0%{?rhel}
-%global build_platform RedHat
-%endif
-
-%if 0%{?centos}
-%global build_platform CentOS
-%endif
+%global build_platform terra
 
 %if %{with qt6}
 Name:             prismlauncher-nightly
 %else
 Name:             prismlauncher-qt5-nightly
 %endif
-Version:          7.2^%{snapshot_info}
+Version:          8.0^%{snapshot_info}
 Release:          1%{?dist}
 Summary:          Minecraft launcher with ability to manage multiple instances
 License:          GPL-3.0-only AND Apache-2.0 AND LGPL-3.0-only AND GPL-3.0-or-later AND GPL-2.0-or-later AND ISC AND OFL-1.1 AND LGPL-2.1-only AND MIT AND BSD-2-Clause-FreeBSD AND BSD-3-Clause AND LGPL-3.0-or-later
@@ -54,6 +42,7 @@ Source0:          https://github.com/PrismLauncher/PrismLauncher/archive/%{commi
 Source1:          https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
 Source2:          https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
 Source3:          https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
+Patch0:           0001-find-cmark-with-pkgconfig.patch
 
 BuildRequires:    cmake >= 3.15
 BuildRequires:    extra-cmake-modules
@@ -75,6 +64,9 @@ BuildRequires:    cmake(Qt6Core5Compat)
 %endif
 
 BuildRequires:    pkgconfig(libcmark)
+%if 0%{fedora} < 38
+BuildRequires:    cmark
+%endif
 BuildRequires:    pkgconfig(scdoc)
 BuildRequires:    pkgconfig(zlib)
 
@@ -93,8 +85,6 @@ Recommends:       xrandr
 Recommends:       flite
 # Prism supports enabling gamemode
 Suggests:         gamemode
-
-Recommends:       terra-fractureiser-detector
 
 Conflicts:        %{real_name}
 Conflicts:        %{real_name}-qt5
@@ -125,7 +115,6 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 
 %build
-export Launcher_BUILD_PLATFORM=terra
 %cmake \
   -DLauncher_QT_VERSION_MAJOR="%{qt_version}" \
   -DLauncher_BUILD_PLATFORM="%{build_platform}" \
@@ -147,9 +136,6 @@ export Launcher_BUILD_PLATFORM=terra
 %check
 %ctest
 
-appstream-util validate-relax --nonet %buildroot%_metainfodir/org.prismlauncher.PrismLauncher.metainfo.xml
-desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
-
 
 %files
 %doc README.md
@@ -168,6 +154,10 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 
 %changelog
+* Wed Jul 26 2023 seth <getchoo at tuta dot io> - 8.0^20230726.4f00012-1
+- remove terra-fractureiser-detector from recommends, use proper build platform,
+  and add patches for epel/older fedora versions
+
 * Sun Jul 23 2023 seth <getchoo at tuta dot io> - 8.0^20230722.273d75f-1
 - update submodules, version, & use autorelease
 

--- a/anda/games/prismlauncher-nightly/update.rhai
+++ b/anda/games/prismlauncher-nightly/update.rhai
@@ -4,5 +4,5 @@ if filters.contains("nightly") {
 	let sha = req.get().json().sha;
 	rpm.global("commit", sha);
 	rpm.release();
-	rpm.version(`${gh("PrismLauncher/PrismLauncher")}^%{snapshot_info}`);
+	// rpm.version(`${gh("PrismLauncher/PrismLauncher")}^%{snapshot_info}`);
 }

--- a/anda/games/prismlauncher-qt5-nightly/0001-find-cmark-with-pkgconfig.patch
+++ b/anda/games/prismlauncher-qt5-nightly/0001-find-cmark-with-pkgconfig.patch
@@ -1,0 +1,79 @@
+From 5a38fc2c9a329e88c8337af541dfeccaeff1fefb Mon Sep 17 00:00:00 2001
+From: seth <getchoo@tuta.io>
+Date: Sun, 15 Jan 2023 14:47:49 -0500
+Subject: [PATCH] find cmark with pkgconfig
+
+Signed-off-by: seth <getchoo@tuta.io>
+---
+ cmake/Findcmark.cmake | 59 +++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 59 insertions(+)
+ create mode 100755 cmake/Findcmark.cmake
+
+diff --git a/cmake/Findcmark.cmake b/cmake/Findcmark.cmake
+new file mode 100755
+index 00000000..9858e5df
+--- /dev/null
++++ b/cmake/Findcmark.cmake
+@@ -0,0 +1,59 @@
++# SPDX-FileCopyrightText: 2019 Black Hat <bhat@encom.eu.org>
++# SPDX-License-Identifier: GPL-3.0-only
++
++#
++# CMake module to search for the cmark library
++#
++
++# first try to find cmark-config.cmake
++# path to a file not in the search path can be set with 'cmake -Dcmark_DIR=some/path/'
++find_package(cmark CONFIG QUIET)
++if(cmark_FOUND AND TARGET cmark::cmark)
++  # found it!
++  return()
++endif()
++
++find_package(PkgConfig QUIET)
++if(PKG_CONFIG_FOUND)
++  pkg_check_modules(PC_CMARK QUIET cmark)
++endif()
++
++if(NOT CMARK_INCLUDE_DIR)
++  find_path(CMARK_INCLUDE_DIR
++            NAMES cmark.h
++            PATHS
++            ${PC_CMARK_INCLUDEDIR}
++            ${PC_CMARK_INCLUDE_DIRS}
++            /usr/include
++            /usr/local/include)
++endif()
++
++if(NOT CMARK_LIBRARY)
++  find_library(CMARK_LIBRARY
++               NAMES cmark
++               HINTS
++               ${PC_CMARK_LIBDIR}
++               ${PC_CMARK_LIBRARY_DIRS}
++               /usr/lib
++               /usr/local/lib)
++endif()
++
++if(NOT TARGET cmark::cmark)
++  add_library(cmark::cmark UNKNOWN IMPORTED)
++  set_target_properties(cmark::cmark
++                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
++                                   ${CMARK_INCLUDE_DIR})
++  set_property(TARGET cmark::cmark APPEND
++               PROPERTY IMPORTED_LOCATION ${CMARK_LIBRARY})
++endif()
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(cmark
++                                  DEFAULT_MSG
++                                  CMARK_INCLUDE_DIR
++                                  CMARK_LIBRARY)
++
++mark_as_advanced(CMARK_LIBRARY CMARK_INCLUDE_DIR)
++
++set(CMARK_LIBRARIES ${CMARK_LIBRARY})
++set(CMARK_INCLUDE_DIRS ${CMARK_INCLUDE_DIR})
+-- 
+2.39.0
+

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -25,26 +25,14 @@
 %global min_qt_version 5.12
 %endif
 
-%global build_platform unknown
-
-%if 0%{?fedora}
-%global build_platform Fedora
-%endif
-
-%if 0%{?rhel}
-%global build_platform RedHat
-%endif
-
-%if 0%{?centos}
-%global build_platform CentOS
-%endif
+%global build_platform terra
 
 %if %{with qt6}
 Name:             prismlauncher-nightly
 %else
 Name:             prismlauncher-qt5-nightly
 %endif
-Version:          7.2^%{snapshot_info}
+Version:          8.0^%{snapshot_info}
 Release:          1%{?dist}
 Summary:          Minecraft launcher with ability to manage multiple instances
 License:          GPL-3.0-only AND Apache-2.0 AND LGPL-3.0-only AND GPL-3.0-or-later AND GPL-2.0-or-later AND ISC AND OFL-1.1 AND LGPL-2.1-only AND MIT AND BSD-2-Clause-FreeBSD AND BSD-3-Clause AND LGPL-3.0-or-later
@@ -54,6 +42,7 @@ Source0:          https://github.com/PrismLauncher/PrismLauncher/archive/%{commi
 Source1:          https://github.com/PrismLauncher/libnbtplusplus/archive/%{libnbtplusplus_commit}/libnbtplusplus-%{libnbtplusplus_commit}.tar.gz
 Source2:          https://github.com/stachenov/quazip/archive/%{quazip_commit}/quazip-%{quazip_commit}.tar.gz
 Source3:          https://github.com/marzer/tomlplusplus/archive/%{tomlplusplus_commit}/tomlplusplus-%{tomlplusplus_commit}.tar.gz
+Patch0:           0001-find-cmark-with-pkgconfig.patch
 
 BuildRequires:    cmake >= 3.15
 BuildRequires:    extra-cmake-modules
@@ -75,6 +64,9 @@ BuildRequires:    cmake(Qt6Core5Compat)
 %endif
 
 BuildRequires:    pkgconfig(libcmark)
+%if 0%{fedora} < 38
+BuildRequires:    cmark
+%endif
 BuildRequires:    pkgconfig(scdoc)
 BuildRequires:    pkgconfig(zlib)
 
@@ -91,8 +83,6 @@ Requires:         java-1.8.0-openjdk
 Recommends:       xrandr
 # libflite needed for using narrator in minecraft
 Recommends:       flite
-
-Recommends:       terra-fractureiser-detector
 # Prism supports enabling gamemode
 Suggests:         gamemode
 
@@ -125,7 +115,6 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 
 %build
-export Launcher_BUILD_PLATFORM=terra
 %cmake \
   -DLauncher_QT_VERSION_MAJOR="%{qt_version}" \
   -DLauncher_BUILD_PLATFORM="%{build_platform}" \
@@ -147,9 +136,6 @@ export Launcher_BUILD_PLATFORM=terra
 %check
 %ctest
 
-appstream-util validate-relax --nonet %buildroot%_metainfodir/org.prismlauncher.PrismLauncher.metainfo.xml
-desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
-
 
 %files
 %doc README.md
@@ -168,6 +154,10 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.Pri
 
 
 %changelog
+* Wed Jul 26 2023 seth <getchoo at tuta dot io> - 8.0^20230726.4f00012-1
+- remove terra-fractureiser-detector from recommends, use proper build platform,
+  and add patches for epel/older fedora versions
+
 * Sun Jul 23 2023 seth <getchoo at tuta dot io> - 8.0^20230722.273d75f-1
 - update submodules, version, & use autorelease
 

--- a/anda/games/prismlauncher-qt5-nightly/update.rhai
+++ b/anda/games/prismlauncher-qt5-nightly/update.rhai
@@ -4,5 +4,5 @@ if filters.contains("nightly") {
 	let sha = req.get().json().sha;
 	rpm.global("commit", sha);
 	rpm.release();
-	rpm.version(`${gh("PrismLauncher/PrismLauncher")}^%{snapshot_info}`);
+	// rpm.version(`${gh("PrismLauncher/PrismLauncher")}^%{snapshot_info}`);
 }

--- a/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
+++ b/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
@@ -1,4 +1,5 @@
 %global real_name prismlauncher
+%global nice_name PrismLauncher
 %bcond_with qt6
 
 # Change this variables if you want to use custom keys
@@ -14,19 +15,7 @@
 %global min_qt_version 5.12
 %endif
 
-%global build_platform unknown
-
-%if 0%{?fedora}
-%global build_platform Fedora
-%endif
-
-%if 0%{?rhel}
-%global build_platform RedHat
-%endif
-
-%if 0%{?centos}
-%global build_platform CentOS
-%endif
+%global build_platform terra
 
 %if %{with qt6}
 Name:             prismlauncher
@@ -34,7 +23,7 @@ Name:             prismlauncher
 Name:             prismlauncher-qt5
 %endif
 Version:          7.2
-Release:          1%{?dist}
+Release:          2%{?dist}
 Summary:          Minecraft launcher with ability to manage multiple instances
 # see COPYING.md for more information
 # each file in the source also contains a SPDX-License-Identifier header that declares its license
@@ -80,7 +69,6 @@ Recommends:       xrandr
 # libflite needed for using narrator in minecraft
 Recommends:       flite
 
-Recommends:       terra-fractureiser-detector
 # Prism supports enabling gamemode
 Suggests:         gamemode
 
@@ -103,7 +91,6 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 
 %build
-export Launcher_BUILD_PLATFORM=terra
 %cmake \
   -DLauncher_QT_VERSION_MAJOR="%{qt_version}" \
   -DLauncher_BUILD_PLATFORM="%{build_platform}" \
@@ -125,27 +112,27 @@ export Launcher_BUILD_PLATFORM=terra
 %check
 %ctest
 
-appstream-util validate-relax --nonet %buildroot%_metainfodir/org.prismlauncher.PrismLauncher.metainfo.xml
-desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
-
 
 %files
 %doc README.md
 %license LICENSE COPYING.md
-%dir %{_datadir}/PrismLauncher
+%dir %{_datadir}/%{nice_name}
 %{_bindir}/prismlauncher
-%{_datadir}/PrismLauncher/NewLaunch.jar
-%{_datadir}/PrismLauncher/JavaCheck.jar
+%{_datadir}/%{nice_name}/NewLaunch.jar
+%{_datadir}/%{nice_name}/JavaCheck.jar
+%{_datadir}/%{nice_name}/qtlogging.ini
 %{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
 %{_datadir}/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
 %{_datadir}/mime/packages/modrinth-mrpack-mime.xml
 %{_datadir}/qlogging-categories%{qt_version}/prismlauncher.categories
-%{_datadir}/PrismLauncher/qtlogging.ini
 %{_mandir}/man?/prismlauncher.*
 %{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
 
 
 %changelog
+* Wed Jul 26 2023 seth <getchoo at tuta dot io> - 7.2-2
+- remove terra-fractureiser-detector from recommends, use proper build platform
+
 * Thu Jun 08 2023 seth <getchoo@tuta.io> - 6.3-3
 - specify jdk 17 + cleanup outdated patches/scriptlets
 

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -1,4 +1,5 @@
 %global real_name prismlauncher
+%global nice_name PrismLauncher
 %bcond_without qt6
 
 # Change this variables if you want to use custom keys
@@ -14,19 +15,7 @@
 %global min_qt_version 5.12
 %endif
 
-%global build_platform unknown
-
-%if 0%{?fedora}
-%global build_platform Fedora
-%endif
-
-%if 0%{?rhel}
-%global build_platform RedHat
-%endif
-
-%if 0%{?centos}
-%global build_platform CentOS
-%endif
+%global build_platform terra
 
 %if %{with qt6}
 Name:             prismlauncher
@@ -34,7 +23,7 @@ Name:             prismlauncher
 Name:             prismlauncher-qt5
 %endif
 Version:          7.2
-Release:          1%{?dist}
+Release:          2%{?dist}
 Summary:          Minecraft launcher with ability to manage multiple instances
 # see COPYING.md for more information
 # each file in the source also contains a SPDX-License-Identifier header that declares its license
@@ -80,7 +69,6 @@ Recommends:       xrandr
 # libflite needed for using narrator in minecraft
 Recommends:       flite
 
-Recommends:       terra-fractureiser-detector
 # Prism supports enabling gamemode
 Suggests:         gamemode
 
@@ -103,7 +91,6 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 
 %build
-export Launcher_BUILD_PLATFORM=terra
 %cmake \
   -DLauncher_QT_VERSION_MAJOR="%{qt_version}" \
   -DLauncher_BUILD_PLATFORM="%{build_platform}" \
@@ -125,27 +112,27 @@ export Launcher_BUILD_PLATFORM=terra
 %check
 %ctest
 
-appstream-util validate-relax --nonet %buildroot%_metainfodir/org.prismlauncher.PrismLauncher.metainfo.xml
-desktop-file-validate %{buildroot}%{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
-
 
 %files
 %doc README.md
 %license LICENSE COPYING.md
-%dir %{_datadir}/PrismLauncher
+%dir %{_datadir}/%{nice_name}
 %{_bindir}/prismlauncher
-%{_datadir}/PrismLauncher/NewLaunch.jar
-%{_datadir}/PrismLauncher/JavaCheck.jar
+%{_datadir}/%{nice_name}/NewLaunch.jar
+%{_datadir}/%{nice_name}/JavaCheck.jar
+%{_datadir}/%{nice_name}/qtlogging.ini
 %{_datadir}/applications/org.prismlauncher.PrismLauncher.desktop
 %{_datadir}/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
 %{_datadir}/mime/packages/modrinth-mrpack-mime.xml
 %{_datadir}/qlogging-categories%{qt_version}/prismlauncher.categories
-%{_datadir}/PrismLauncher/qtlogging.ini
 %{_mandir}/man?/prismlauncher.*
 %{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml
 
 
 %changelog
+* Wed Jul 26 2023 seth <getchoo at tuta dot io> - 7.2-2
+- remove terra-fractureiser-detector from recommends, use proper build platform
+
 * Thu Jun 08 2023 seth <getchoo@tuta.io> - 6.3-3
 - specify jdk 17 + cleanup outdated patches/scriptlets
 


### PR DESCRIPTION
this fixes a few things, namely

- correctly setting the build platform and removing the previous conditionals
- adding support for fedora < 38/epel back
  - the cmark changes weren't backported, see https://github.com/terrapkg/packages/pull/510
  - these are only required for -nightly builds as the release tarball bundles cmark
- using macros for file name paths
- bumping the version for -nightly builds to 8.0 to follow upstream
- removed some manual scriptlet tests
  - these are done automatically on fedora and won't work on epel anyways
- removing terra-fractureiser-detector from recommends
  - this really isn't required anymore as fractureiser has been purged by all major mod distributors
