### PR TITLE
fix: obsoletes appcenter

### DIFF
--- a/anda/desktops/elementary/appcenter/elementary-appcenter.spec
+++ b/anda/desktops/elementary/appcenter/elementary-appcenter.spec
@@ -6,6 +6,9 @@ Version:        7.3.0
 Release:        1%{?dist}
 License:        GPL-3.0
 
+Provides:       appcenter = %{version}-%{release}
+Obsoletes:      appcenter < 7.2.1-2
+
 URL:            https://github.com/elementary/appcenter
 Source0:        %url/archive/%{version}/appcenter-%{version}.tar.gz
 


### PR DESCRIPTION
We'll need to obsolete the appcenter package in Ultramarine Linux.