### PR TITLE
fix: actually install the kwin package (kwin-system76-scheduler-integration)

### DIFF
--- a/anda/others/kwin-system76-scheduler-integration/kwin-system76-scheduler-integration.spec
+++ b/anda/others/kwin-system76-scheduler-integration/kwin-system76-scheduler-integration.spec
@@ -2,7 +2,7 @@
 
 Name:			kwin-system76-scheduler-integration
 Version:		0.1
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Notify the System76 Scheduler which app has focus so it can be prioritized
 License:		MIT
 URL:			https://github.com/maxiberta/kwin-system76-scheduler-integration
@@ -10,7 +10,7 @@ Source0:		%url/archive/refs/tags/%version.tar.gz
 Source1:		system76-scheduler-dbus-proxy.sh
 Source2:		com.system76.Scheduler.dbusproxy.service
 Requires:		bash dbus-tools system76-scheduler kde-cli-tools systemd kf5-kconfig-core qt
-BuildRequires:	kf5-kpackage systemd-rpm-macros
+BuildRequires: systemd-rpm-macros
 
 %description
 System76 Scheduler is a service which optimizes Linux's CPU scheduler and
@@ -23,13 +23,13 @@ via D-Bus, so it is prioritized.
 %autosetup
 
 %build
-kpackagetool5 --type=KWin/Script -i .
 
 %install
+mkdir -p %buildroot%_datadir/kwin/scripts/kwin-system76-scheduler-integration/
+cp -r * %buildroot%_datadir/kwin/scripts/kwin-system76-scheduler-integration/
 install -Dm755 %SOURCE1 %buildroot/usr/local/bin/system76-scheduler-dbus-proxy.sh
 install -Dm644 %SOURCE2 %buildroot%_userunitdir/com.system76.Scheduler.dbusproxy.service
-mkdir -p %buildroot%_datadir/kwin-system76-scheduler-integration
-cp -r $HOME/.local/share/kwin-system76-scheduler-integration %buildroot%_datadir/kwin-system76-scheduler-integration
+install -Dm644 metadata.desktop %buildroot%_datadir/kservices5/kwin-system76-scheduler-integration.desktop
 
 %post
 %systemd_user_post com.system76.Scheduler.dbusproxy.service
@@ -42,8 +42,8 @@ cp -r $HOME/.local/share/kwin-system76-scheduler-integration %buildroot%_datadir
 %files
 %config %_userunitdir/com.system76.Scheduler.dbusproxy.service
 /usr/local/bin/system76-scheduler-dbus-proxy.sh
-%_datadir/kwin-system76-scheduler-integration/
-
+%_datadir/kwin/scripts/kwin-system76-scheduler-integration/
+%_datadir/kservices5/kwin-system76-scheduler-integration.desktop
 
 %changelog
 %autochangelog


### PR DESCRIPTION
Everything seems to work, but I still need to figure out how to get the kwin script to be enabled by default... you'd think the kservices5 file would do it, but I guess not?