### PR TITLE
add: amdctl

### DIFF
--- a/anda/tools/amdctl/0001-RPM-makefile-Remove-unused-Makefile-variables.patch
+++ b/anda/tools/amdctl/0001-RPM-makefile-Remove-unused-Makefile-variables.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paskal Sitepu <rmnscnce@ya.ru>
+Date: Sat, 4 Nov 2023 09:54:38 +0700
+Subject: [PATCH] (RPM) makefile: Remove unused Makefile variables
+
+Signed-off-by: Paskal Sitepu <rmnscnce@ya.ru>
+---
+ makefile | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/makefile b/makefile
+index 5ca6bab..0091429 100644
+--- a/makefile
++++ b/makefile
+@@ -1,5 +1,3 @@
+-CC=gcc
+-CFLAGS=-Wall -pedantic -Wextra -std=c99 -O2
+ all: amdctl
+ %.o: %.c
+        $(CC) -c -o $@ $< $(CFLAGS)
+-- 
+2.41.0

--- a/anda/tools/amdctl/amdctl.spec
+++ b/anda/tools/amdctl/amdctl.spec
@@ -1,0 +1,79 @@
+Name: amdctl
+Summary: Set P-State voltages and clock speeds on recent AMD CPUs on Linux
+License: GPLv3
+URL: https://github.com/kevinlekiller/%{name}
+
+Version: 0.11
+Release: 2%{?dist}
+Source0: https://github.com/kevinlekiller/%{name}/archive/refs/tags/v%{version}.tar.gz
+# Remove hardcoded CFLAGS and CC
+Patch0: 0001-RPM-makefile-Remove-unused-Makefile-variables.patch
+
+# `msr` is a builtin kernel module
+Requires: kernel-core systemd-udev coreutils
+BuildRequires: make gcc kernel-headers glibc-headers
+
+%description
+Tool for changing voltages and clock speeds for AMD processors with
+control over every power state and CPU core.
+
+%prep
+%setup -qn %{name}-%{version}
+patch -p1 -i %{PATCH0}
+
+%build
+%set_build_flags
+%make_build
+
+%install
+# install the 'amdctl' binary
+mkdir -p %{buildroot}/%{_bindir}
+install -m 0755 ./%{name} %{buildroot}/%{_bindir}/
+
+# add modules.load.d entry
+mkdir -p %{buildroot}/%{_modulesloaddir}/
+echo 'msr' > %{buildroot}/%{_modulesloaddir}/%{name}.conf
+
+# write the udev helper script
+mkdir -p %{buildroot}/%{_libexecdir}/%{name}/
+cat << 'EOF' > %{buildroot}/%{_libexecdir}/%{name}/udev-helper.sh
+#!/bin/sh
+echo 'on' > /sys/module/msr/parameters/allow_writes
+EOF
+chmod 0755 %{buildroot}/%{_libexecdir}/%{name}/udev-helper.sh
+
+# add udev rules to enable msr writes
+mkdir -p %{buildroot}/%{_udevrulesdir}/
+cat << 'EOF' > %{buildroot}/%{_udevrulesdir}/99-%{name}.rules
+DRIVER=="msr", RUN+="%{_libexecdir}/%{name}/udev-helper.sh"
+EOF
+
+%files
+%license LICENSE
+%doc README.md
+/%{_bindir}/%{name}
+/%{_libexecdir}/%{name}
+/%{_modulesloaddir}/%{name}.conf
+/%{_udevrulesdir}/99-%{name}.rules
+
+%changelog
+* Sat Nov 4 2023 <rmnscnce@ya.ru> - 0.11-1
+- Track upstream to 0.11
+
+* Fri Mar 18 2022 <rmnscnce@ya.ru> - 0.8-2
+- Clean up RPM spec file
+
+* Fri Mar 18 2022 <rmnscnce@ya.ru> - 0.8-1
+- Track upstream to 0.8
+
+* Mon Sep 13 2021 rmnscnce <rmnscnce@ya.ru> - 0.6.1-3
+- Wrap %%description
+
+* Mon Sep 13 2021 rmnscnce <rmnscnce@ya.ru> - 0.6.1-2
+- Fix missing executable bit for udev-helper.sh
+
+* Mon Sep 13 2021 rmnscnce <rmnscnce@ya.ru> - 0.6.1-1
+- Track upstream to 0.6.1
+
+* Mon May 24 2021 rmnscnce <rmnscnce@ya.ru> - 0.2-2.git+gb0ffbad
+- Initial packaging

--- a/anda/tools/amdctl/anda.hcl
+++ b/anda/tools/amdctl/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"] // Because of course
+	rpm {
+		spec = "amdctl.spec"
+	}
+}

--- a/anda/tools/amdctl/update.rhai
+++ b/anda/tools/amdctl/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("kevinlekiller/amdctl"));


### PR DESCRIPTION
Exclusive arch: x86_64

Rationale:
I want Terra users to have a way to tune their AMD CPU voltages and frequencies to their liking.