### PR TITLE
Add elementary-files-portal to comps.xml

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -33,6 +33,7 @@
       <packagereq type="mandatory">wingpanel-indicator-session</packagereq>
       <packagereq type="mandatory">wingpanel-indicator-sound</packagereq>
       <packagereq type="mandatory">xdg-desktop-portal-pantheon</packagereq>
+      <packagereq type="mandatory">elementary-files-portal</packagereq>
       <packagereq type="default">elementary-appcenter</packagereq>
       <packagereq type="default">elementary-calculator</packagereq>
       <packagereq type="default">elementary-calendar</packagereq>


### PR DESCRIPTION
This pull request adds the necessary package requirement for elementary-files-portal to the comps.xml file. This change ensures that the elementary-files-portal package is included as a mandatory dependency in the system.

This fixes an issue where the file picker portal would not work on Pantheon installs, becuase the portal package is not installed