### PR TITLE
Fix dependency issue with gala and gnome-disk-utility

### DIFF
--- a/anda/desktops/elementary/pantheon-session-settings/pantheon-session-settings.spec
+++ b/anda/desktops/elementary/pantheon-session-settings/pantheon-session-settings.spec
@@ -13,7 +13,8 @@ BuildArch:      noarch
 
 Requires:       elementary-settings-daemon
 Requires:       gala
-#Requires:       gnome-disk-utility
+# Gala has a hard runtime dependency on... GNOME Disks' DBus service!?!
+Requires:       gnome-disk-utility
 Requires:       gnome-keyring
 Requires:       gnome-session
 #Requires:       gnome-session-xsession  # this pulls in gnome-shell


### PR DESCRIPTION
The previous dependency hell fix was making Pantheon sessions unbootable... After some debugging, I figured out that elementary, in their infinite wisdom, made Gala have a hard runtime dependency on... GNOME Disks. its DBus service specifically.

This finally makes Pantheon bootable again.