### PR TITLE
fix: move submarine kpart away from /boot

### DIFF
--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -27,9 +27,9 @@ git clone --recurse-submodules --shallow-submodules -b v%version %url .
 
 %install
 mkdir -p %buildroot/boot %buildroot%_datadir/submarine
-install -Dm644 build/submarine-*.kpart %buildroot/boot/
+install -Dm644 build/submarine-*.kpart %buildroot%_datadir/submarine/
 install -Dm644 build/submarine-*.bin %buildroot%_datadir/submarine/
 
 %files
-/boot/submarine-*.kpart
+%_datadir/submarine/submarine-*.kpart
 %_datadir/submarine/submarine-*.bin

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -10,7 +10,7 @@ Release:		1%?dist
 Summary:		Experimental bootloader for ChomeOS's depthcharge
 License:		GPL-3.0
 URL:			https://github.com/FyraLabs/submarine
-BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git golang-github-u-root
+BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git
 
 %description
 An experimental bootloader for ChomeOS's depthcharge.
@@ -20,6 +20,7 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 (or a different system if you're brave.)
 
 %prep
+go install github.com/u-root/u-root@v0.11.0
 git clone --recurse-submodules --shallow-submodules -b v%version %url .
 
 %build

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -21,10 +21,10 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 
 %prep
 go install github.com/u-root/u-root@v0.11.0
-export PATH=$PATH:$HOME/go/bin
 git clone --recurse-submodules --shallow-submodules -b v%version %url .
 
 %build
+export PATH=$PATH:$HOME/go/bin
 %make_build %arch
 
 %install

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -10,7 +10,7 @@ Release:		1%?dist
 Summary:		Experimental bootloader for ChomeOS's depthcharge
 License:		GPL-3.0
 URL:			https://github.com/FyraLabs/submarine
-BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git
+BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git depthcharge-tools
 
 %description
 An experimental bootloader for ChomeOS's depthcharge.

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:			submarine
-Version:		0.1.0
+Version:		0.2.0
 Release:		1%?dist
 Summary:		Experimental bootloader for ChomeOS's depthcharge
 License:		GPL-3.0

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -21,6 +21,7 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 
 %prep
 go install github.com/u-root/u-root@v0.11.0
+export PATH=$PATH:$HOME/go/bin
 git clone --recurse-submodules --shallow-submodules -b v%version %url .
 
 %build

--- a/anda/system/submarine/update.rhai
+++ b/anda/system/submarine/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("FyraLabs/submarine"));
+rpm.version(gh_tag("FyraLabs/submarine"));


### PR DESCRIPTION
there's no need to have this in boot, an external program will write the bootloader kpart onto a parition