### PR TITLE
add: prime-run

### DIFF
--- a/anda/misc/prime-run/anda.hcl
+++ b/anda/misc/prime-run/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+    arches = ["x86_64"]
 	rpm {
 		spec = "prime-run.spec"
 	}

--- a/anda/misc/prime-run/anda.hcl
+++ b/anda/misc/prime-run/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "prime-run.spec"
+	}
+}

--- a/anda/misc/prime-run/prime-run.sh
+++ b/anda/misc/prime-run/prime-run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export __NV_PRIME_RENDER_OFFLOAD=1
+export __GLX_VENDOR_LIBRARY_NAME=nvidia
+export __VK_LAYER_NV_optimus=NVIDIA_only
+export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json
+exec "$@"

--- a/anda/misc/prime-run/prime-run.spec
+++ b/anda/misc/prime-run/prime-run.spec
@@ -25,11 +25,11 @@ specific applications using the prime-run script.
 
 
 %install
-install -Dm755 %{SOURCE0} %{buildroot}%{_datadir}/prime-run
+install -Dm755 %{SOURCE0} %{buildroot}%{_bindir}/prime-run
 
 
 %files
-%{_datadir}/prime-run
+%{_bindir}/prime-run
 
 
 

--- a/anda/misc/prime-run/prime-run.spec
+++ b/anda/misc/prime-run/prime-run.spec
@@ -1,0 +1,36 @@
+Name:           prime-run
+Version:        0.0.1
+Release:        1%{?dist}
+Summary:        A simple script to run an application with NVIDIA PRIME GPU offloading
+
+License:        MIT
+URL:            https://terra.fyralabs.com
+Source0:        prime-run.sh
+
+# Bash script
+Requires:       bash
+
+%description
+A simple Bash script to force an application to run with PRIME GPU offloading. This is useful for
+laptops with NVIDIA Optimus technology, where the integrated GPU is switchable alongside the dedicated
+NVIDIA GPU. By default, the integrated GPU is used to save power, but this can be overridden for
+specific applications using the prime-run script.
+
+%prep
+
+
+%build
+
+
+%install
+install -Dm755 %{SOURCE0} %{buildroot}%{_datadir}/prime-run
+
+
+%files
+%{_datadir}/prime-run
+
+
+
+%changelog
+* Sun Mar 03 2024 Cappy Ishihara <cappy@cappuchino.xyz>
+- Initial release

--- a/anda/misc/prime-run/prime-run.spec
+++ b/anda/misc/prime-run/prime-run.spec
@@ -9,6 +9,8 @@ Source0:        prime-run.sh
 
 # Bash script
 Requires:       bash
+BuildArch:      noarch
+Supplements:    nvidia-driver
 
 %description
 A simple Bash script to force an application to run with PRIME GPU offloading. This is useful for

--- a/anda/misc/prime-run/prime-run.spec
+++ b/anda/misc/prime-run/prime-run.spec
@@ -1,5 +1,5 @@
 Name:           prime-run
-Version:        0.0.1
+Version:        1.0.0
 Release:        1%{?dist}
 Summary:        A simple script to run an application with NVIDIA PRIME GPU offloading
 
@@ -10,7 +10,6 @@ Source0:        prime-run.sh
 # Bash script
 Requires:       bash
 BuildArch:      noarch
-Supplements:    nvidia-driver
 
 %description
 A simple Bash script to force an application to run with PRIME GPU offloading. This is useful for


### PR DESCRIPTION
Simple bash script to force PRIME offloading. QoL for Arch Linux users moving to Fedora