### PR TITLE
[f40] prismlauncher: move JREs to weak deps, add java 21 for snapshots (#1040)

### DIFF
--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -76,8 +76,9 @@ Requires(postun): desktop-file-utils
 Requires:         qt%{qt_version}-qtimageformats
 Requires:         qt%{qt_version}-qtsvg
 Requires:         javapackages-filesystem
-Requires:         java-17-openjdk
-Requires:         java-1.8.0-openjdk
+Recommends:       java-21-openjdk
+Recommends:       java-17-openjdk
+Suggests:         java-1.8.0-openjdk
 
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
 Recommends:       xrandr

--- a/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
+++ b/anda/games/prismlauncher-qt5-nightly/prismlauncher-qt5-nightly.spec
@@ -76,8 +76,9 @@ Requires(postun): desktop-file-utils
 Requires:         qt%{qt_version}-qtimageformats
 Requires:         qt%{qt_version}-qtsvg
 Requires:         javapackages-filesystem
-Requires:         java-17-openjdk
-Requires:         java-1.8.0-openjdk
+Recommends:       java-21-openjdk
+Recommends:       java-17-openjdk
+Suggests:         java-1.8.0-openjdk
 
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
 Recommends:       xrandr

--- a/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
+++ b/anda/games/prismlauncher-qt5/prismlauncher-qt5.spec
@@ -23,7 +23,7 @@ Name:             prismlauncher
 Name:             prismlauncher-qt5
 %endif
 Version:          8.2
-Release:          1%?dist
+Release:          2%?dist
 Summary:          Minecraft launcher with ability to manage multiple instances
 # see COPYING.md for more information
 # each file in the source also contains a SPDX-License-Identifier header that declares its license
@@ -61,8 +61,9 @@ Requires(postun): desktop-file-utils
 Requires:         qt%{qt_version}-qtimageformats
 Requires:         qt%{qt_version}-qtsvg
 Requires:         javapackages-filesystem
-Requires:         java-17-openjdk
-Requires:         java-1.8.0-openjdk
+Recommends:       java-21-openjdk
+Recommends:       java-17-openjdk
+Suggests:         java-1.8.0-openjdk
 
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
 Recommends:       xrandr
@@ -131,6 +132,9 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 
 %changelog
+* Wed Apr 03 2024 seth <getchoo at tuta dot io> - 8.2-2
+- move JREs to weak deps, add java 21 for snapshots
+
 * Wed Jul 26 2023 seth <getchoo at tuta dot io> - 7.2-2
 - remove terra-fractureiser-detector from recommends, use proper build platform
 

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -23,7 +23,7 @@ Name:             prismlauncher
 Name:             prismlauncher-qt5
 %endif
 Version:          8.2
-Release:          1%?dist
+Release:          2%?dist
 Summary:          Minecraft launcher with ability to manage multiple instances
 # see COPYING.md for more information
 # each file in the source also contains a SPDX-License-Identifier header that declares its license
@@ -61,8 +61,9 @@ Requires(postun): desktop-file-utils
 Requires:         qt%{qt_version}-qtimageformats
 Requires:         qt%{qt_version}-qtsvg
 Requires:         javapackages-filesystem
-Requires:         java-17-openjdk
-Requires:         java-1.8.0-openjdk
+Recommends:       java-21-openjdk
+Recommends:       java-17-openjdk
+Suggests:         java-1.8.0-openjdk
 
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
 Recommends:       xrandr
@@ -131,6 +132,9 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
 
 %changelog
+* Wed Apr 03 2024 seth <getchoo at tuta dot io> - 8.2-2
+- move JREs to weak deps, add java 21 for snapshots
+
 * Wed Jul 26 2023 seth <getchoo at tuta dot io> - 7.2-2
 - remove terra-fractureiser-detector from recommends, use proper build platform
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [prismlauncher: move JREs to weak deps, add java 21 for snapshots (#1040)](https://github.com/terrapkg/packages/pull/1040)

<!--- Backport version: 9.4.5 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)