### PR TITLE
[f40] fix: use raboneko user for backports (#1044)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,24 @@
+name: Automatic backport/sync action
+
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport/sync PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@v9.3.0
+        with:
+          github_token: ${{ secrets.RABONEKO_BACKPORT_GITHUB_TOKEN }}
+          auto_backport_label_prefix: sync-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: use raboneko user for backports (#1044)](https://github.com/terrapkg/packages/pull/1044)

<!--- Backport version: 9.4.5 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)