### PR TITLE
[f39] fix: only run backport action if merged (#1054)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,6 +8,7 @@ jobs:
   backport:
     name: Backport/sync PR
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged
     steps:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@v9.3.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: only run backport action if merged (#1054)](https://github.com/terrapkg/packages/pull/1054)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)