### PR TITLE
[f39] fix: gendesk (#1066)

### DIFF
--- a/anda/langs/go/gendesk/golang-github-xyproto-gendesk.spec
+++ b/anda/langs/go/gendesk/golang-github-xyproto-gendesk.spec
@@ -20,7 +20,7 @@ of information.}
 %global godocs          README.md
 
 Name:           %{goname}
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        Generate .desktop files and download .png icons
 
 License:        BSD-3-Clause


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: gendesk (#1066)](https://github.com/terrapkg/packages/pull/1066)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)