### PR TITLE
[f38] fix: reset author and sign during backport (#1069)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,9 @@
+{
+  "repoOwner": "terrapkg",
+  "repoName": "packages",
+  "resetAuthor": true,
+  "targetBranchChoices": ["f38", "f39", "f40", "frawhide"],
+  "branchLabelMapping": {
+    "^sync-(.+)$": "$1"
+  }
+}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,6 +9,18 @@ jobs:
     name: Backport/sync PR
     runs-on: ubuntu-latest
     steps:
+      - name: Install SSH signing key
+        run: |
+          mkdir -p ${{ runner.temp }}
+          echo "${{ secrets.SSH_SIGNING_KEY }}" > ${{ runner.temp }}/signing_key
+          chmod 0700 ${{ runner.temp }}/signing_key
+
+      - name: Setup Raboneko Signing
+        run: |
+          git config --global gpg.format "ssh"
+          git config --global user.signingkey "${{ runner.temp }}/signing_key"
+          git config --global commit.gpgsign true
+
       - name: Backport Action
         uses: sorenlouv/backport-github-action@v9.3.0
         with:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [fix: reset author and sign during backport (#1069)](https://github.com/terrapkg/packages/pull/1069)

<!--- Backport version: 9.4.5 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)