### PR TITLE
[f38] chore(ci): get rid of cache buildroot (#1014)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -54,13 +54,6 @@ jobs:
       - name: Set up git repository
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Cache buildroot
-        id: br-cache
-        uses: actions/cache@v3
-        with:
-          path: /var/cache
-          key: ${{ runner.os }}-br-${{ matrix.version }}-${{ matrix.pkg.arch }}
-
       - name: Include custom build template instead of package default
         run: |
           cp -v anda/terra/mock-configs/terra.tpl /etc/mock/templates/terra.tpl


### PR DESCRIPTION
# Backport

This will backport the following commits from `f39` to `f38`:
 - [chore(ci): get rid of cache buildroot (#1014)](https://github.com/terrapkg/packages/pull/1014)

<!--- Backport version: 9.4.5 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)