### PR TITLE
[f40] add: espanso-wayland espanso-x11 (#1098)

### DIFF
--- a/anda/tools/espanso-wayland/anda.hcl
+++ b/anda/tools/espanso-wayland/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "espanso-wayland.spec"
+	}
+}

--- a/anda/tools/espanso-wayland/espanso-wayland.spec
+++ b/anda/tools/espanso-wayland/espanso-wayland.spec
@@ -1,0 +1,42 @@
+Name:			espanso-wayland
+Version: 		2.2.1
+Release:		1%?dist
+Summary:		Cross-platform Text Expander written in Rust for Wayland
+License:		GPL-3.0
+URL:			https://espanso.org
+Source0:		https://github.com/espanso/espanso/archive/refs/tags/v%version.tar.gz
+Requires:		libxkbcommon dbus libnotify wxGTK wl-clipboard
+Conflicts:		espanso-x11
+BuildRequires:	anda-srpm-macros cargo-rpm-macros gcc gcc-c++
+BuildRequires:	pkgconfig(x11)
+BuildRequires:	pkgconfig(xtst)
+BuildRequires:	pkgconfig(xkbcommon)
+BuildRequires:	pkgconfig(dbus-1)
+BuildRequires:	wxGTK-devel
+
+%description
+A cross-platform Text Expander written in Rust. A text expander is a program
+that detects when you type a specific keyword and replaces it with something
+else.
+
+This package includes the Wayland version of espanso.
+
+
+%prep
+%autosetup -n espanso-%version
+cd espanso
+%cargo_prep_online
+
+%build
+cd espanso
+#cargo_build -n -f vendored-tls -f wayland
+
+%install
+cd espanso
+%cargo_install -n -f vendored-tls -f wayland
+
+%files
+%_bindir/espanso
+
+%changelog
+%autochangelog

--- a/anda/tools/espanso-wayland/update.rhai
+++ b/anda/tools/espanso-wayland/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("espanso/espanso"));

--- a/anda/tools/espanso-x11/anda.hcl
+++ b/anda/tools/espanso-x11/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "espanso-x11.spec"
+	}
+}

--- a/anda/tools/espanso-x11/espanso-x11.spec
+++ b/anda/tools/espanso-x11/espanso-x11.spec
@@ -1,0 +1,42 @@
+Name:			espanso-x11
+Version: 		2.2.1
+Release:		1%?dist
+Summary:		Cross-platform Text Expander written in Rust for X11
+License:		GPL-3.0
+URL:			https://espanso.org
+Source0:		https://github.com/espanso/espanso/archive/refs/tags/v%version.tar.gz
+Requires:		libxkbcommon dbus libnotify wxGTK xdotool xclip libxcb
+Conflicts:		espanso-wayland
+BuildRequires:	anda-srpm-macros cargo-rpm-macros gcc gcc-c++
+BuildRequires:	pkgconfig(x11)
+BuildRequires:	pkgconfig(xtst)
+BuildRequires:	pkgconfig(xkbcommon)
+BuildRequires:	pkgconfig(dbus-1)
+BuildRequires:	wxGTK-devel
+
+%description
+A cross-platform Text Expander written in Rust. A text expander is a program
+that detects when you type a specific keyword and replaces it with something
+else.
+
+This package includes the X11 version of espanso.
+
+
+%prep
+%autosetup -n espanso-%version
+cd espanso
+%cargo_prep_online
+
+%build
+cd espanso
+#cargo_build -n -f vendored-tls
+
+%install
+cd espanso
+%cargo_install -n -f vendored-tls
+
+%files
+%_bindir/espanso
+
+%changelog
+%autochangelog

--- a/anda/tools/espanso-x11/update.rhai
+++ b/anda/tools/espanso-x11/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("espanso/espanso"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: espanso-wayland espanso-x11 (#1098)](https://github.com/terrapkg/packages/pull/1098)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)