### PR TITLE
[f38] fix: arrpc (#1104)

### DIFF
--- a/anda/misc/arrpc/arrpc.spec
+++ b/anda/misc/arrpc/arrpc.spec
@@ -1,4 +1,5 @@
 %define debug_package %nil
+%define __strip /bin/true
 %global commit c6e23e7eb733ad396d3eebc328404cc656fed581
 
 Name:			arrpc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [fix: arrpc (#1104)](https://github.com/terrapkg/packages/pull/1104)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)