### PR TITLE
[f38] fix(nim-nightly): fixed package name (#1082)

### DIFF
--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -5,9 +5,9 @@
 %global commit_date 20240322
 %global debug_package %nil
 
-Name:			nim-nighlty
+Name:			nim-nightly
 Version:		%ver^%commit_date.%shortcommit
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Imperative, multi-paradigm, compiled programming language
 License:		MIT and BSD
 URL:			https://nim-lang.org
@@ -19,6 +19,9 @@ Source4:		nimsuggest.1
 BuildRequires:	gcc mold git gcc-c++ nodejs openssl-devel pkgconfig(bash-completion) gc-devel pcre pcre-devel
 Requires:		redhat-rpm-config gcc
 Conflicts:		choosenim
+# somehow wrong name and never noticed
+Provides:		nim-nightly = %version-%release
+Obsoletes:		nim-nighlty < 2.1.1^20240404.9e1b170-2
 
 
 %description
@@ -29,6 +32,9 @@ order of priority).
 
 %package tools
 Summary:	Tools for Nim programming language
+Provides:	nim-nightly-tools = %version-%release
+Obsoletes:	nim-nighlty-tools < 2.1.1^20240404.9e1b170-2
+
 %description tools
 Nim is a compiled, garbage-collected systems programming language with a
 design that focuses on efficiency, expressiveness, and elegance (in that
@@ -41,6 +47,8 @@ This package provides various tools, which help Nim programmers.
 %package doc
 Summary:	Documentation for Nim programming language
 BuildArch:	noarch
+Provides:	nim-nightly-doc = %version-%release
+Obsoletes:	nim-nighlty-doc < 2.1.1^20240404.9e1b170-2
 %description doc
 Nim is a compiled, garbage-collected systems programming language with a
 design that focuses on efficiency, expressiveness, and elegance (in that


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [fix(nim-nightly): fixed package name (#1082)](https://github.com/terrapkg/packages/pull/1082)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)