### PR TITLE
[f40] fix: wingpanel (#1116)

### DIFF
--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -18,7 +18,7 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  meson
-BuildRequires:  vala-nightly
+BuildRequires:  vala >= 0.24.0
 
 BuildRequires:  mesa-libEGL-devel
 

--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -18,7 +18,7 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  meson
-BuildRequires:  vala >= 0.24.0
+BuildRequires:  vala-nightly
 
 BuildRequires:  mesa-libEGL-devel
 

--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -28,9 +28,9 @@ BuildRequires:  pkgconfig(gee-0.8)
 BuildRequires:  pkgconfig(glib-2.0) >= 2.32
 BuildRequires:  pkgconfig(granite) >= 5.4.0
 BuildRequires:  pkgconfig(gtk+-3.0) >= 3.10
-BuildRequires:  pkgconfig(mutter-clutter-13)
-BuildRequires:  pkgconfig(mutter-cogl-13)
-BuildRequires:  pkgconfig(mutter-cogl-pango-13)
+BuildRequires:  pkgconfig(mutter-clutter-14)
+BuildRequires:  pkgconfig(mutter-cogl-14)
+BuildRequires:  pkgconfig(mutter-cogl-pango-14)
 
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 

--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -12,7 +12,7 @@ License:        GPL-2.0-or-later
 
 URL:            https://github.com/elementary/wingpanel
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
-Patch0:         https://github.com/elementary/wingpanel/commit/d6009d9f0d5c7479172093447ccceccba86ff1f3.patch
+Patch0:         https://github.com/elementary/wingpanel/compare/23a3eb7c2448b4f35398116df7d01b075361ef1f..5d22d436b45decfb2a50d9a7c27f2c961f1dd39f.patch
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  gettext

--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -12,7 +12,7 @@ License:        GPL-2.0-or-later
 
 URL:            https://github.com/elementary/wingpanel
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
-Patch0:         https://github.com/elementary/wingpanel/compare/7.1.3..5c68c1f4816ec60dcb12599626bd8b3d7a74f3a8.patch
+Patch0:         https://github.com/elementary/wingpanel/compare/3.0.5..5c68c1f4816ec60dcb12599626bd8b3d7a74f3a8.patch
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  gettext

--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -12,7 +12,7 @@ License:        GPL-2.0-or-later
 
 URL:            https://github.com/elementary/wingpanel
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
-Patch0:         https://github.com/elementary/wingpanel/compare/23a3eb7c2448b4f35398116df7d01b075361ef1f..5d22d436b45decfb2a50d9a7c27f2c961f1dd39f.patch
+Patch0:         https://github.com/elementary/wingpanel/compare/7.1.3..5c68c1f4816ec60dcb12599626bd8b3d7a74f3a8.patch
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  gettext

--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -12,7 +12,7 @@ License:        GPL-2.0-or-later
 
 URL:            https://github.com/elementary/wingpanel
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
-Patch0:         https://github.com/elementary/wingpanel/compare/3.0.5..5c68c1f4816ec60dcb12599626bd8b3d7a74f3a8.patch
+Patch0:         https://github.com/elementary/wingpanel/compare/3.0.5..5d22d436b45decfb2a50d9a7c27f2c961f1dd39f.patch
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  gettext

--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -22,7 +22,7 @@ BuildRequires:  vala >= 0.24.0
 
 BuildRequires:  mesa-libEGL-devel
 
-BuildRequires:  pkgconfig(gala)
+BuildRequires:  pkgconfig(gala) >= 7.1.3-2
 BuildRequires:  pkgconfig(gdk-x11-3.0)
 BuildRequires:  pkgconfig(gee-0.8)
 BuildRequires:  pkgconfig(glib-2.0) >= 2.32


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: wingpanel (#1116)](https://github.com/terrapkg/packages/pull/1116)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)