### PR TITLE
[f40] fix: elementary-greeter (#1119)

### DIFF
--- a/anda/desktops/elementary/elementary-greeter/elementary-greeter.spec
+++ b/anda/desktops/elementary/elementary-greeter/elementary-greeter.spec
@@ -11,7 +11,7 @@ URL:            https://github.com/elementary/greeter
 Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
 Source1:        40-%{appname}.conf
 
-Patch0:         https://github.com/elementary/greeter/commit/dbd9b6f9701f5992c3b3257c025b9cd80d041cc8.patch
+Patch0:         https://github.com/elementary/greeter/compare/7.0.0..42320c266395606b0c20782603e7407124c3f7a4.patch
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  gettext

--- a/anda/desktops/elementary/elementary-greeter/elementary-greeter.spec
+++ b/anda/desktops/elementary/elementary-greeter/elementary-greeter.spec
@@ -36,9 +36,9 @@ BuildRequires:  pkgconfig(granite) >= 5.0
 BuildRequires:  pkgconfig(gtk+-3.0)
 BuildRequires:  pkgconfig(libhandy-1)
 BuildRequires:  pkgconfig(liblightdm-gobject-1)
-BuildRequires:  pkgconfig(mutter-clutter-13)
-BuildRequires:  pkgconfig(mutter-cogl-13)
-BuildRequires:  pkgconfig(mutter-cogl-pango-13)
+BuildRequires:  pkgconfig(mutter-clutter-14)
+BuildRequires:  pkgconfig(mutter-cogl-14)
+BuildRequires:  pkgconfig(mutter-cogl-pango-14)
 BuildRequires:  pkgconfig(x11)
 
 Provides:       pantheon-greeter = %{version}-%{release}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: elementary-greeter (#1119)](https://github.com/terrapkg/packages/pull/1119)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)