### PR TITLE
fix: espanso

### DIFF
--- a/anda/tools/espanso-wayland/espanso-wayland.spec
+++ b/anda/tools/espanso-wayland/espanso-wayland.spec
@@ -13,6 +13,7 @@ BuildRequires:	pkgconfig(xtst)
 BuildRequires:	pkgconfig(xkbcommon)
 BuildRequires:	pkgconfig(dbus-1)
 BuildRequires:	wxGTK-devel
+BuildRequires:	openssl-devel
 
 %description
 A cross-platform Text Expander written in Rust. A text expander is a program
@@ -29,7 +30,7 @@ cd espanso
 
 %build
 cd espanso
-%cargo_build -n -f vendored-tls -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-migrate,espanso-modulo,espanso-package,espanso-path,espanso-render,espanso-ui}
+%cargo_build -n -f vendored-tls,"wayland" -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-migrate,espanso-modulo,espanso-package,espanso-path,espanso-render,espanso-ui}
 
 %install
 mkdir -p %buildroot%_bindir

--- a/anda/tools/espanso-x11/espanso-x11.spec
+++ b/anda/tools/espanso-x11/espanso-x11.spec
@@ -13,6 +13,7 @@ BuildRequires:	pkgconfig(xtst)
 BuildRequires:	pkgconfig(xkbcommon)
 BuildRequires:	pkgconfig(dbus-1)
 BuildRequires:	wxGTK-devel
+BuildRequires:	openssl-devel
 
 %description
 A cross-platform Text Expander written in Rust. A text expander is a program
@@ -29,7 +30,7 @@ cd espanso
 
 %build
 cd espanso
-%cargo_build -n -f vendored-tls -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-migrate,espanso-modulo,espanso-package,espanso-path,espanso-render,espanso-ui}
+%cargo_build -n -f vendored-tls,"default" -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-migrate,espanso-modulo,espanso-package,espanso-path,espanso-render,espanso-ui}
 
 %install
 mkdir -p %buildroot%_bindir


### PR DESCRIPTION
Fixes Espanso build so that the GUI library is actually included in the binary. (this time with 100% less GH signing shenanigans)

Thanks,
Elliott