### PR TITLE
chore(gala): bump epoch

### DIFF
--- a/anda/desktops/elementary/gala/gala.spec
+++ b/anda/desktops/elementary/gala/gala.spec
@@ -3,8 +3,9 @@
 Name:           gala
 Summary:        Gala window manager
 Version:        7.1.3
-Release:        5%{?dist}
+Release:        1%{?dist}
 License:        GPL-3.0-or-later
+Epoch:          1
 
 URL:            https://github.com/elementary/gala
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz

--- a/anda/desktops/elementary/gala/gala.spec
+++ b/anda/desktops/elementary/gala/gala.spec
@@ -3,7 +3,7 @@
 Name:           gala
 Summary:        Gala window manager
 Version:        7.1.3
-Release:        2%{?dist}
+Release:        5%{?dist}
 License:        GPL-3.0-or-later
 
 URL:            https://github.com/elementary/gala


### PR DESCRIPTION
make it so that gala version is higher than 7.1.3-4.20240113.git1550761.fc40 (in fedora)