### PR TITLE
[frawhide] chore(gala): bump epoch (#1133)

### DIFF
--- a/anda/desktops/elementary/gala/gala.spec
+++ b/anda/desktops/elementary/gala/gala.spec
@@ -3,8 +3,9 @@
 Name:           gala
 Summary:        Gala window manager
 Version:        7.1.3
-Release:        2%{?dist}
+Release:        1%{?dist}
 License:        GPL-3.0-or-later
+Epoch:          1
 
 URL:            https://github.com/elementary/gala
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `f40` to `frawhide`:
 - [chore(gala): bump release (#1133)](https://github.com/terrapkg/packages/pull/1133)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)