### PR TITLE
[f38] fix(gala): devel requires correct package with epoch (#1137)

### DIFF
--- a/anda/desktops/elementary/gala/gala.spec
+++ b/anda/desktops/elementary/gala/gala.spec
@@ -61,7 +61,7 @@ This package contains the shared libraries.
 
 %package        devel
 Summary:        Gala window manager development files
-Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description    devel
 Gala is Pantheon's Window Manager, part of the elementary project.

--- a/anda/desktops/elementary/gala/gala.spec
+++ b/anda/desktops/elementary/gala/gala.spec
@@ -5,6 +5,7 @@ Summary:        Gala window manager
 Version:        7.1.3
 Release:        1%{?dist}
 License:        GPL-3.0-or-later
+Epoch:          1
 
 URL:            https://github.com/elementary/gala
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [fix(gala): devel requires correct package with epoch (#1137)](https://github.com/terrapkg/packages/pull/1137)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)