### PR TITLE
[f39] fix(gala): devel requires correct package with epoch (#1137)

### DIFF
--- a/anda/desktops/elementary/gala/gala.spec
+++ b/anda/desktops/elementary/gala/gala.spec
@@ -62,7 +62,7 @@ This package contains the shared libraries.
 
 %package        devel
 Summary:        Gala window manager development files
-Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description    devel
 Gala is Pantheon's Window Manager, part of the elementary project.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix(gala): devel requires correct package with epoch (#1137)](https://github.com/terrapkg/packages/pull/1137)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)