### PR TITLE
[f38] chore(wingpanel): bump epoch to 1 (#1144)

### DIFF
--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -9,6 +9,7 @@ Summary:        Stylish top panel
 Version:        3.0.5
 Release:        1%{?dist}
 License:        GPL-2.0-or-later
+Epoch:          1
 
 URL:            https://github.com/elementary/wingpanel
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [chore(wingpanel): bump epoch to 1 (#1144)](https://github.com/terrapkg/packages/pull/1144)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)