### PR TITLE
[f39] fix(wingpanel): proper devel and libs reference with epoch (#1148)

### DIFF
--- a/anda/desktops/elementary/wingpanel/wingpanel.spec
+++ b/anda/desktops/elementary/wingpanel/wingpanel.spec
@@ -33,7 +33,7 @@ BuildRequires:  pkgconfig(mutter-clutter-13)
 BuildRequires:  pkgconfig(mutter-cogl-13)
 BuildRequires:  pkgconfig(mutter-cogl-pango-13)
 
-Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
 
 # wingpanel ayatana appindicator support was abandoned by upstream
 # wingpanel-indicator-ayatana-2.0.3-10.fc32 retired for fedora 33+
@@ -44,8 +44,8 @@ Obsoletes:      wingpanel-indicator-ayatana < 2.0.3-11
 
 %package        libs
 Summary:        Stylish top panel (shared library)
-Enhances:       %{name} = %{version}-%{release}
-Enhances:       %{name}-devel = %{version}-%{release}
+Enhances:       %{name} = %{epoch}:%{version}-%{release}
+Enhances:       %{name}-devel = %{epoch}:%{version}-%{release}
 
 %description    libs %{common_description}
 
@@ -54,7 +54,7 @@ This package contains the shared library.
 
 %package        devel
 Summary:        Stylish top panel (development files)
-Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description    devel %{common_description}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f40` to `f39`:
 - [fix(wingpanel): proper devel and libs reference with epoch (#1148)](https://github.com/terrapkg/packages/pull/1148)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)