### PR TITLE
[f40] fix(elementary-appcenter): add patch for appstream 1.0 (#1153)

### DIFF
--- a/anda/desktops/elementary/appcenter/elementary-appcenter.spec
+++ b/anda/desktops/elementary/appcenter/elementary-appcenter.spec
@@ -3,7 +3,7 @@
 Name:           elementary-appcenter
 Summary:        Software Center from elementary
 Version:        7.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-3.0
 
 Provides:       appcenter = %{version}-%{release}
@@ -11,6 +11,8 @@ Obsoletes:      appcenter < 7.2.1-2
 
 URL:            https://github.com/elementary/appcenter
 Source0:        %url/archive/%{version}/appcenter-%{version}.tar.gz
+
+Patch0:         pr2099.patch
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  gettext

--- a/anda/desktops/elementary/appcenter/pr2099.patch
+++ b/anda/desktops/elementary/appcenter/pr2099.patch
@@ -1,0 +1,311 @@
+commit fce55d9373bfb82953191b32e276a2129ffcb8c1
+Author: Marius Meisenzahl <meisenzahl@users.noreply.github.com>
+Date:   Wed Feb 7 00:14:43 2024 +0100
+
+    Add support for AppStream 1.0 (#2099)
+
+diff --git a/src/Core/FlatpakBackend.vala b/src/Core/FlatpakBackend.vala
+index 98931505..10f2baab 100644
+--- a/src/Core/FlatpakBackend.vala
++++ b/src/Core/FlatpakBackend.vala
+@@ -400,8 +400,13 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
+ 
+         var category_array = new GLib.GenericArray<AppStream.Category> ();
+         category_array.add (category);
++#if HAS_APPSTREAM_1_0
++        AppStream.utils_sort_components_into_categories (user_appstream_pool.get_components ().as_array (), category_array, false);
++        AppStream.utils_sort_components_into_categories (system_appstream_pool.get_components ().as_array (), category_array, false);
++#else
+         AppStream.utils_sort_components_into_categories (user_appstream_pool.get_components (), category_array, false);
+         AppStream.utils_sort_components_into_categories (system_appstream_pool.get_components (), category_array, false);
++#endif
+         components = category.get_components ();
+ 
+         var apps = new Gee.TreeSet<AppCenterCore.Package> ();
+@@ -417,13 +422,21 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
+         var apps = new Gee.TreeSet<AppCenterCore.Package> ();
+         var comps = user_appstream_pool.search (query);
+         if (category == null) {
++#if HAS_APPSTREAM_1_0
++            comps.as_array ().foreach ((comp) => {
++#else
+             comps.foreach ((comp) => {
++#endif
+                 var packages = get_packages_for_component_id (comp.get_id ());
+                 apps.add_all (packages);
+             });
+         } else {
+             var cat_packages = get_applications_for_category (category);
++#if HAS_APPSTREAM_1_0
++            comps.as_array ().foreach ((comp) => {
++#else
+             comps.foreach ((comp) => {
++#endif
+                 var packages = get_packages_for_component_id (comp.get_id ());
+                 foreach (var package in packages) {
+                     if (package in cat_packages) {
+@@ -435,13 +448,21 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
+ 
+         comps = system_appstream_pool.search (query);
+         if (category == null) {
++#if HAS_APPSTREAM_1_0
++            comps.as_array ().foreach ((comp) => {
++#else
+             comps.foreach ((comp) => {
++#endif
+                 var packages = get_packages_for_component_id (comp.get_id ());
+                 apps.add_all (packages);
+             });
+         } else {
+             var cat_packages = get_applications_for_category (category);
++#if HAS_APPSTREAM_1_0
++            comps.as_array ().foreach ((comp) => {
++#else
+             comps.foreach ((comp) => {
++#endif
+                 var packages = get_packages_for_component_id (comp.get_id ());
+                 foreach (var package in packages) {
+                     if (package in cat_packages) {
+@@ -510,7 +531,11 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
+                 continue;
+             }
+ 
++#if HAS_APPSTREAM_1_0
++            if (package.component.get_developer ().get_name () == author) {
++#else
+             if (package.component.developer_name == author) {
++#endif
+                 package_ids.add (package.component.id);
+ 
+                 AppCenterCore.Package? user_package = null;
+@@ -1095,7 +1120,11 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
+             warning ("Errors found in flatpak appdata, some components may be incomplete/missing: %s", e.message);
+         } finally {
+             var comp_validator = ComponentValidator.get_default ();
++#if HAS_APPSTREAM_1_0
++            user_appstream_pool.get_components ().as_array ().foreach ((comp) => {
++#else
+             user_appstream_pool.get_components ().foreach ((comp) => {
++#endif
+                 if (!comp_validator.validate (comp)) {
+                     return;
+                 }
+@@ -1133,7 +1162,11 @@ public class AppCenterCore.FlatpakBackend : Backend, Object {
+             warning ("Errors found in flatpak appdata, some components may be incomplete/missing: %s", e.message);
+         } finally {
+             var comp_validator = ComponentValidator.get_default ();
++#if HAS_APPSTREAM_1_0
++            system_appstream_pool.get_components ().as_array ().foreach ((comp) => {
++#else
+             system_appstream_pool.get_components ().foreach ((comp) => {
++#endif
+                 if (!comp_validator.validate (comp)) {
+                     return;
+                 }
+diff --git a/src/Core/Package.vala b/src/Core/Package.vala
+index 0f9a90c4..ed141292 100644
+--- a/src/Core/Package.vala
++++ b/src/Core/Package.vala
+@@ -306,7 +306,11 @@ public class AppCenterCore.Package : Object {
+                 return _author;
+             }
+ 
++#if HAS_APPSTREAM_1_0
++            _author = component.get_developer ().get_name ();
++#else
+             _author = component.developer_name;
++#endif
+ 
+             if (_author == null) {
+                 var project_group = component.project_group;
+@@ -677,7 +681,11 @@ public class AppCenterCore.Package : Object {
+             }
+ 
+             try {
++#if HAS_APPSTREAM_1_0
++                description = AppStream.markup_convert (description, TEXT);
++#else
+                 description = AppStream.markup_convert_simple (description);
++#endif
+             } catch (Error e) {
+                 warning ("Failed to convert description to markup: %s", e.message);
+             }
+@@ -919,7 +927,11 @@ public class AppCenterCore.Package : Object {
+     }
+ 
+     public AppStream.Release? get_newest_release () {
++#if HAS_APPSTREAM_1_0
++        var releases = component.get_releases_plain ().get_entries ();
++#else
+         var releases = component.get_releases ();
++#endif
+         releases.sort_with_data ((a, b) => {
+             if (a.get_version () == null || b.get_version () == null) {
+                 if (a.get_version () != null) {
+diff --git a/src/Core/PackageKitBackend.vala b/src/Core/PackageKitBackend.vala
+index 09da4074..a108831e 100644
+--- a/src/Core/PackageKitBackend.vala
++++ b/src/Core/PackageKitBackend.vala
+@@ -275,7 +275,11 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
+         } finally {
+             var new_package_list = new Gee.HashMap<string, Package> ();
+             var comp_validator = ComponentValidator.get_default ();
++#if HAS_APPSTREAM_1_0
++            appstream_pool.get_components ().as_array ().foreach ((comp) => {
++#else
+             appstream_pool.get_components ().foreach ((comp) => {
++#endif
+                 if (!comp_validator.validate (comp)) {
+                     return;
+                 }
+@@ -317,7 +321,12 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
+             component.set_id (id);
+             component.set_origin (Package.APPCENTER_PACKAGE_ORIGIN);
+ 
+-#if HAS_APPSTREAM_0_15
++#if HAS_APPSTREAM_1_0
++            var components = new AppStream.ComponentBox (AppStream.ComponentBoxFlags.NONE);
++            components.add (component);
++
++            appstream_pool.add_components (components);
++#elif HAS_APPSTREAM_0_15
+             var components = new GenericArray<AppStream.Component> ();
+             components.add (component);
+ 
+@@ -430,7 +439,11 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
+                 break;
+             }
+ 
++#if HAS_APPSTREAM_1_0
++            if (package.component.get_developer ().get_name () == author) {
++#else
+             if (package.component.developer_name == author) {
++#endif
+                 packages.add (package);
+             }
+         }
+@@ -447,7 +460,11 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
+ 
+         var category_array = new GLib.GenericArray<AppStream.Category> ();
+         category_array.add (category);
++#if HAS_APPSTREAM_1_0
++        AppStream.utils_sort_components_into_categories (appstream_pool.get_components ().as_array (), category_array, true);
++#else
+         AppStream.utils_sort_components_into_categories (appstream_pool.get_components (), category_array, true);
++#endif
+         components = category.get_components ();
+ 
+         var apps = new Gee.TreeSet<AppCenterCore.Package> ();
+@@ -465,7 +482,11 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
+         var apps = new Gee.TreeSet<AppCenterCore.Package> ();
+         var comps = appstream_pool.search (query);
+         if (category == null) {
++#if HAS_APPSTREAM_1_0
++            comps.as_array ().foreach ((comp) => {
++#else
+             comps.foreach ((comp) => {
++#endif
+                 var package = get_package_for_component_id (comp.get_id ());
+                 if (package != null) {
+                     apps.add (package);
+@@ -473,7 +494,11 @@ public class AppCenterCore.PackageKitBackend : Backend, Object {
+             });
+         } else {
+             var cat_packages = get_applications_for_category (category);
++#if HAS_APPSTREAM_1_0
++            comps.as_array ().foreach ((comp) => {
++#else
+             comps.foreach ((comp) => {
++#endif
+                 var package = get_package_for_component_id (comp.get_id ());
+                 if (package != null && package in cat_packages) {
+                     apps.add (package);
+diff --git a/src/Views/AppInfoView.vala b/src/Views/AppInfoView.vala
+index 5a3a361a..bef37f0e 100644
+--- a/src/Views/AppInfoView.vala
++++ b/src/Views/AppInfoView.vala
+@@ -310,8 +310,16 @@ public class AppCenter.Views.AppInfoView : AppCenter.AbstractAppContainer {
+                 oars_flowbox.add (uncurated);
+             }
+ #endif
++
++#if HAS_APPSTREAM_1_0
++            var active_locale = "en-US";
++            if (package_component.get_context () != null) {
++                active_locale = package_component.get_context ().get_locale () ?? "en-US";
++            }
++#else
+             var active_locale = package_component.get_active_locale ();
+-            if (active_locale != "en_US") {
++#endif
++            if (active_locale != "en_US" && active_locale != "en-US") {
+                 var percent_translated = package_component.get_language (
+                     // Expects language without locale
+                     active_locale.split ("_")[0]
+@@ -492,7 +500,11 @@ public class AppCenter.Views.AppInfoView : AppCenter.AbstractAppContainer {
+             }
+         }
+ 
++#if HAS_APPSTREAM_1_0
++        screenshots = package_component.get_screenshots_all ();
++#else
+         screenshots = package_component.get_screenshots ();
++#endif
+ 
+         if (screenshots.length > 0) {
+             screenshot_carousel = new Hdy.Carousel () {
+@@ -1030,7 +1042,11 @@ public class AppCenter.Views.AppInfoView : AppCenter.AbstractAppContainer {
+             get_app_download_size.begin ();
+ 
+             Idle.add (() => {
++#if HAS_APPSTREAM_1_0
++                var releases = package.component.get_releases_plain ().get_entries ();
++#else
+                 var releases = package.component.get_releases ();
++#endif
+ 
+                 foreach (unowned var release in releases) {
+                     if (release.get_version () == null) {
+@@ -1049,7 +1065,11 @@ public class AppCenter.Views.AppInfoView : AppCenter.AbstractAppContainer {
+ 
+                         release_carousel.add (release_row);
+ 
++#if HAS_APPSTREAM_1_0
++                        if (package.installed && AppStream.vercmp_simple (release.get_version (), package.get_version ()) <= 0) {
++#else
+                         if (package.installed && AppStream.utils_compare_versions (release.get_version (), package.get_version ()) <= 0) {
++#endif
+                             break;
+                         }
+                     }
+diff --git a/src/Widgets/ReleaseRow.vala b/src/Widgets/ReleaseRow.vala
+index 3b487914..36fcbc76 100644
+--- a/src/Widgets/ReleaseRow.vala
++++ b/src/Widgets/ReleaseRow.vala
+@@ -116,7 +116,11 @@ public class AppCenter.Widgets.ReleaseRow : Gtk.Box {
+     private string format_release_description (string? description ) {
+         if (description != null) {
+             try {
++#if HAS_APPSTREAM_1_0
++                var markup = AppStream.markup_convert (description, TEXT);
++#else
+                 var markup = AppStream.markup_convert_simple (description);
++#endif
+ 
+                 if (markup.strip () != "") {
+                     return markup;
+diff --git a/src/meson.build b/src/meson.build
+index d3d558ef..df69a0bf 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -78,6 +78,10 @@ if appstream.version().version_compare('>=0.16')
+     args += '--define=HAS_APPSTREAM_0_16'
+ endif
+ 
++if appstream.version().version_compare('>=1.0')
++    args += '--define=HAS_APPSTREAM_1_0'
++endif
++
+ if get_option('packagekit_backend')
+     appcenter_files += files(
+         'Core/PackageKitBackend.vala',


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(elementary-appcenter): add patch for appstream 1.0 (#1153)](https://github.com/terrapkg/packages/pull/1153)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)