### PR TITLE
[f40] fix(switchboard-plug-about): pull in various patches (#1155)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-about/switchboard-plug-about.spec
+++ b/anda/desktops/elementary/switchboard-plug-about/switchboard-plug-about.spec
@@ -9,11 +9,13 @@
 Name:           switchboard-plug-about
 Summary:        Switchboard System Information plug
 Version:        6.2.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        GPL-3.0-or-later
 
 URL:            https://github.com/elementary/switchboard-plug-about
 Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
+
+Patch0:         https://github.com/elementary/switchboard-plug-about/compare/6.2.0..72d7da13da2824812908276751fd3024db2dd0f8.patch
 
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(switchboard-plug-about): pull in various patches (#1155)](https://github.com/terrapkg/packages/pull/1155)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)