### PR TITLE
[f39] fix: make gala depend on libs with same epoch (#1158)

### DIFF
--- a/anda/desktops/elementary/gala/gala.spec
+++ b/anda/desktops/elementary/gala/gala.spec
@@ -3,7 +3,7 @@
 Name:           gala
 Summary:        Gala window manager
 Version:        7.1.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-3.0-or-later
 Epoch:          1
 
@@ -36,7 +36,7 @@ BuildRequires:  pkgconfig(mutter-clutter-13)
 BuildRequires:  pkgconfig(mutter-cogl-13)
 BuildRequires:  pkgconfig(mutter-cogl-pango-13)
 
-Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
 
 # gala provides a generic icon (apps/multitasking-view)
 Requires:       hicolor-icon-theme


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: make gala depend on libs with same epoch (#1158)](https://github.com/terrapkg/packages/pull/1158)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)