### PR TITLE
[f39] chore(rebuild): libappimage (#1172)

### DIFF
--- a/anda/lib/libappimage/libappimage.spec
+++ b/anda/lib/libappimage/libappimage.spec
@@ -7,7 +7,7 @@ Name:           libappimage
 
 
 Version:        %{libver_format}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Implements functionality for dealing with AppImage files
 
 License:        MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [chore(rebuild): libappimage (#1172)](https://github.com/terrapkg/packages/pull/1172)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)