### PR TITLE
[f40] fix(gcm-core): bump dotnet-sdk (#1163)

### DIFF
--- a/anda/tools/gcm-core/gcm-core.spec
+++ b/anda/tools/gcm-core/gcm-core.spec
@@ -18,7 +18,7 @@ Source0:        %{forgesource}
 Provides:       %{long_name} = %{version}-%{release}
 Provides:       %{long_name}-core = %{version}-%{release}
 
-BuildRequires:  dotnet-sdk-7.0
+BuildRequires:  dotnet-sdk-8.0
 # Require DPKG, so that we can use the `dpkg-architecture` command. which makes the build script happy.
 # TODO: Better solution: Patch out the debian-specific packaging code.
 BuildRequires:  dpkg-dev


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(gcm-core): bump dotnet-sdk (#1163)](https://github.com/terrapkg/packages/pull/1163)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)