### PR TITLE
[frawhide] fix: nushell (#1152)

### DIFF
--- a/anda/langs/rust/nushell/nushell.spec
+++ b/anda/langs/rust/nushell/nushell.spec
@@ -19,7 +19,8 @@ Requires:		glibc openssl zlib
 %{cargo_build -f extra,dataframe} --workspace
 
 %install
-%cargo_install -f extra,dataframe
+mkdir -p %buildroot%_bindir
+cp target/rpm/nu* %buildroot%_bindir/
 rm -rf .cargo
 
 %post


### PR DESCRIPTION
# Backport

This will backport the following commits from `f39` to `frawhide`:
 - [fix: nushell (#1152)](https://github.com/terrapkg/packages/pull/1152)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)