### PR TITLE
[f39] fix: apparmor (#1175)

### DIFF
--- a/anda/lib/apparmor/apparmor.spec
+++ b/anda/lib/apparmor/apparmor.spec
@@ -4,14 +4,15 @@
 
 Name:           apparmor
 Version:        4.0.0~alpha3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        AppArmor userspace components
 
 %define baseversion %(echo %{version} | cut -d. -f-2)
+%global normver %(echo %version | sed 's/~/-/')
 
 License:        GPL-2.0
 URL:            https://launchpad.net/apparmor
-Source0:        %{url}/%{baseversion}/%(echo %version | sed 's/~/-/')/+download/%{name}-%{version}.tar.gz
+Source0:        %{url}/%{baseversion}/%normver/+download/%{name}-%{version}.tar.gz
 Source1:        apparmor.preset
 Patch01:        0001-fix-avahi-daemon-authselect-denial-in-fedora.patch
 
@@ -138,6 +139,8 @@ changehat abilities exposed through libapparmor.
 
 %prep
 %autosetup -p1 -n %{name}-%{version}
+sed -i 's/@VERSION@/%normver/g' libraries/libapparmor/swig/python/setup.py.in
+sed -i 's/${VERSION}/%normver/g' utils/Makefile
 
 %build
 export PYTHON=%{__python3}
@@ -149,7 +152,7 @@ pushd libraries/libapparmor
 %configure \
     --with-python \
 
-%make_build
+%make_build VERSION=%normver
 popd
 
 %make_build -C binutils


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: apparmor (#1175)](https://github.com/terrapkg/packages/pull/1175)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)