### PR TITLE
[f38] cros-keyboard-map (#1199)

### DIFF
--- a/anda/system/cros-keyboard-map/anda.hcl
+++ b/anda/system/cros-keyboard-map/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "cros-keyboard-map.spec"
+	}
+  labels {
+    nightly = "1"
+  }
+}

--- a/anda/system/cros-keyboard-map/cros-keyboard-map.spec
+++ b/anda/system/cros-keyboard-map/cros-keyboard-map.spec
@@ -1,0 +1,89 @@
+%global commit 1889baff16c08ddf2382d95ca18caa37001d5971
+%global commit_date 20240418
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global debug_package %{nil}
+%define __os_install_post %{nil}
+
+Name:           cros-keyboard-map
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+
+License:        BSD-3-Clause
+Summary:        Utility to generate keyd configurations for use on Chromebooks
+URL:            https://github.com/WeirdTreeThing/cros-keyboard-map
+Source0:        https://github.com/WeirdTreeThing/cros-keyboard-map/archive/%commit/cros-keyboard-map-%commit.tar.gz
+
+%{?systemd_requires}
+BuildRequires:  systemd-rpm-macros
+Requires:       keyd python3
+
+%description
+Set of tools designed to help develop and debug software and firmware on Intel platforms with AudioDSP onboard.
+
+Related to alsa-utils which is also set of utilities but targets AdvancedLinuxSoundArchitecture (ALSA) audience in more general fashion.
+
+%prep
+%autosetup -n cros-keyboard-map-%commit
+
+%install
+mkdir -p %buildroot/etc/cros-keyboard-map/configs
+install -Dm755 cros-keyboard-map.py %buildroot/etc/cros-keyboard-map/cros-keyboard-map.py
+cp configs/* %buildroot/etc/cros-keyboard-map/configs
+
+mkdir -p %buildroot/usr/bin
+tee %buildroot/usr/bin/um-generate-cros-keymap <<EOF
+if (grep -E "^(Nocturne|Atlas|Eve)$" /sys/class/dmi/id/product_name &> /dev/null)
+then
+	cp /etc/cros-keyboard-map/configs/cros-pixel.conf /etc/cros-keyboard-map/current.config
+elif (grep -E "^(Sarien|Arcada)$" /sys/class/dmi/id/product_name &> /dev/null)
+then
+	cp /etc/cros-keyboard-map/configs/cros-sarien.conf /etc/cros-keyboard-map/current.config
+else
+	python3 /etc/cros-keyboard-map/cros-keyboard-map.py --file /etc/cros-keyboard-map/current.config
+fi
+
+mkdir -p /etc/keyd
+if [[ -f /etc/keyd/default.conf ]]; then
+	rm /etc/keyd/default.conf
+fi
+ln -s /etc/cros-keyboard-map/current.config /etc/keyd/default.conf
+EOF
+
+mkdir -p %buildroot/etc/systemd/system
+tee %buildroot/etc/systemd/system/cros-keyboard-map.service <<EOF
+[Unit]
+Description=Generate chromebook keyboard layout
+Before=keyd.service
+After=tmp.mount
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /usr/bin/um-generate-cros-keymap
+
+[Install]
+WantedBy=sysinit.target
+EOF
+chmod +x %buildroot/usr/bin/um-generate-cros-keymap
+
+%post
+%systemd_post cros-keyboard-map.service
+%systemd_post keyd.service
+
+%preun
+%systemd_preun cros-keyboard-map.service
+%systemd_preun keyd.service
+
+%postun
+%systemd_postun_with_restart cros-keyboard-map.service
+%systemd_postun_with_restart keyd.service
+
+%files
+%doc README.md
+%license LICENSE
+/etc/cros-keyboard-map/*
+/etc/systemd/system/cros-keyboard-map.service
+/usr/bin/um-generate-cros-keymap
+
+%changelog
+* Sat May 4 2024 Owen-sz <owen@fyralabs.com>
+- Initial package.

--- a/anda/system/cros-keyboard-map/update.rhai
+++ b/anda/system/cros-keyboard-map/update.rhai
@@ -1,0 +1,7 @@
+if filters.contains("nightly") {
+  rpm.global("commit", gh_commit("WeirdTreeThing/cros-keyboard-map"));
+  if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `f40` to `f38`:
 - [Initial package (#1199)](https://github.com/terrapkg/packages/pull/1199)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)