### PR TITLE
[f39] add: openbangla-keyboard (#1203)

### DIFF
--- a/anda/misc/openbangla-keyboard/anda.hcl
+++ b/anda/misc/openbangla-keyboard/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  rpm {
+    spec = "openbangla-keyboard-nightly.spec"
+  }
+  labels { nightly = "1" }
+}

--- a/anda/misc/openbangla-keyboard/openbangla-keyboard-nightly.spec
+++ b/anda/misc/openbangla-keyboard/openbangla-keyboard-nightly.spec
@@ -1,0 +1,84 @@
+%global ver 2.0.0
+%global commit c7aeeda40f528d647af0a019984897543ebb6d5e
+%global commit_date 20240505
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           openbangla-keyboard-nightly
+Version:        %ver^%commit_date.%shortcommit
+Release:        1%?dist
+Summary:        An OpenSource, Unicode compliant Bengali Input Method 
+License:        GPL-3.0-or-later
+URL:            https://openbangla.github.io/
+Source0:        https://github.com/OpenBangla/OpenBangla-Keyboard/archive/%commit.tar.gz
+Source1:        https://github.com/OpenBangla/riti/archive/master.tar.gz
+BuildRequires:  cmake anda-srpm-macros rust-packaging git-core gcc-c++
+BuildRequires:  qt5-qtbase-devel pkgconfig(ibus-1.0) fcitx5-devel pkgconfig(libzstd)
+Requires:       qt5-qtbase hicolor-icon-theme zstd
+Requires:       openbangla-im = %version-%release
+Provides:       openbangla-keyboard = %version-%release
+Conflicts:      openbangla-keyboard
+
+%description
+OpenBangla Keyboard is an open source, Unicode compliant, Bangla input method for GNU/Linux systems.
+It’s a full-fledged Bangla input method with typing automation tools, includes many famous typing
+methods such as Avro Phonetic, Probhat, Munir Optima, National (Jatiya) etc.
+
+
+%package -n ibus-openbangla
+Summary:    OpenBangla Keyboard for IBus
+Requires:   ibus
+Requires:   openbangla-keyboard = %version-%release
+Provides:   openbangla-im = %version-%release
+Conflicts:  openbangla-im
+
+%description -n ibus-openbangla
+OpenBangla Keyboard for IBus.
+
+
+%package -n fcitx5-openbangla
+Summary:    OpenBangla Keyboard for Fcitx5
+Requires:   fcitx5
+Requires:   openbangla-keyboard = %version-%release
+Provides:   openbangla-im = %version-%release
+Conflicts:  openbangla-im
+
+%description -n fcitx5-openbangla
+OpenBangla Keyboard for Fcitx5.
+
+
+%prep
+%autosetup -n OpenBangla-Keyboard-%commit
+rmdir src/engine/riti
+tar xf %SOURCE1 -C src/engine/
+mv src/engine/riti-master src/engine/riti
+
+%build
+if [[ -d build ]]; then rm -rf build; fi
+%cmake -DENABLE_FCITX=YES -DENABLE_IBUS=YES
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%doc README.adoc
+%license LICENSE
+%_bindir/openbangla-gui
+%_datadir/applications/openbangla-keyboard.desktop
+%_datadir/icons/hicolor/*/apps/openbangla-keyboard.png
+%_datadir/metainfo/io.github.openbangla.keyboard.metainfo.xml
+%_datadir/openbangla-keyboard/
+%_datadir/pixmaps/openbangla-keyboard.png
+
+%files -n ibus-openbangla
+%_libexecdir/ibus-engine-openbangla
+%_datadir/ibus/component/openbangla.xml
+
+%files -n fcitx5-openbangla
+%_libdir/fcitx5/openbangla.so
+%_datadir/fcitx5/addon/openbangla.conf
+%_datadir/fcitx5/inputmethod/openbangla.conf
+
+
+%changelog
+%autochangelog

--- a/anda/misc/openbangla-keyboard/update.rhai
+++ b/anda/misc/openbangla-keyboard/update.rhai
@@ -1,0 +1,8 @@
+if filters.contains("nightly") {
+	rpm.global("commit", get("https://api.github.com/repos/OpenBangla/OpenBangla-Keyboard/commits/develop").json().sha);
+	if rpm.changed() {
+		rpm.global("ver", gh("OpenBangla/OpenBangla-Keyboard"));
+		rpm.global("commit_date", date());
+		rpm.release();
+	}
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add: openbangla-keyboard (#1203)](https://github.com/terrapkg/packages/pull/1203)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)