### PR TITLE
[f40] fix: vala-panel (#1211)

### DIFF
--- a/anda/langs/vala/vala-panel/vala-panel.spec
+++ b/anda/langs/vala/vala-panel/vala-panel.spec
@@ -72,7 +72,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.valapanel.applica
 %{_datadir}/vala-panel/applets/*.plugin
 %dir %{_datadir}/vala-panel/images
 %{_datadir}/vala-panel/images/background.png
-%{_libdir}/girepository-1.0/ValaPanel-%version.typelib
+%{_libdir}/girepository-1.0/ValaPanel-*.typelib
 
 %files devel
 %doc README.md
@@ -82,7 +82,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.valapanel.applica
 %{_libdir}/libvalapanel.so
 %{_libdir}/pkgconfig/vala-panel.pc
 %{_datadir}/vala/vapi/vala-panel.*
-%{_datadir}/gir-1.0/ValaPanel-%version.gir
+%{_datadir}/gir-1.0/ValaPanel-*.gir
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: vala-panel (#1211)](https://github.com/terrapkg/packages/pull/1211)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)