### PR TITLE
[f40] fix: granite-7 (#1216)

### DIFF
--- a/anda/desktops/elementary/granite-7/granite-7.spec
+++ b/anda/desktops/elementary/granite-7/granite-7.spec
@@ -82,6 +82,7 @@ desktop-file-validate \
 
 %{_datadir}/metainfo/granite-7.metainfo.xml
 %{_datadir}/icons/hicolor/*/apps/io.elementary.granite-7.svg
+%{_datadir}/themes/Granite/
 
 
 %files devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: granite-7 (#1216)](https://github.com/terrapkg/packages/pull/1216)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)