### PR TITLE
[f38] fix: click (#1220)

### DIFF
--- a/anda/misc/click/click.spec
+++ b/anda/misc/click/click.spec
@@ -11,7 +11,6 @@ URL:            https://gitlab.com/ubports/development/core/click
 Source0:        %{url}/-/archive/%commit/click-%commit.tar.gz
 
 BuildRequires: automake libtool
-BuildRequires: pkgconfig
 BuildRequires: make
 BuildRequires: g++
 BuildRequires: gcc
@@ -63,6 +62,7 @@ Provides HTML and Manpage (documentation) for Click.
 NOCONFIGURE=1 \
 ./autogen.sh
 
+export CFLAGS="$CFLAGS -Wno-implicit-function-declaration"
 %configure
 %make_build
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [fix: click (#1220)](https://github.com/terrapkg/packages/pull/1220)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)