### PR TITLE
[f40] chore(rebuild): lomiri-url-dispatcher (#1174)

### DIFF
--- a/anda/desktops/lomiri-unity/lomiri-url-dispatcher/lomiri-url-dispatcher.spec
+++ b/anda/desktops/lomiri-unity/lomiri-url-dispatcher/lomiri-url-dispatcher.spec
@@ -4,7 +4,7 @@
 
 Name:           lomiri-url-dispatcher
 Version:        0.1.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A small library for handling URLs over dbus
 
 License:        LGPL-3.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [chore(rebuild): lomiri-url-dispatcher (#1174)](https://github.com/terrapkg/packages/pull/1174)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)