### PR TITLE
feat: use mirror network for Terra

### DIFF
--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -1,6 +1,6 @@
 Name:           terra-release
 Version:        40
-Release:        1
+Release:        2
 Summary:        Release package for Terra
 
 License:        MIT

--- a/anda/terra/release/terra.repo
+++ b/anda/terra/release/terra.repo
@@ -1,9 +1,9 @@
 [terra]
 name=Terra $releasever
-baseurl=https://repos.fyralabs.com/terra$releasever
+#baseurl=https://repos.fyralabs.com/terra$releasever
+metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever&arch=$basearch
 metadata_expire=6h
 type=rpm
-skip_if_unavailable=True
 gpgcheck=1
 gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc
 repo_gpgcheck=1
@@ -12,10 +12,10 @@ enabled_metadata=1
 
 [terra-source]
 name=Terra $releasever - Source
-baseurl=https://repos.fyralabs.com/terra$releasever-source
+#baseurl=https://repos.fyralabs.com/terra$releasever-source
+metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever&arch=$basearch
 metadata_expire=6h
 type=rpm
-skip_if_unavailable=True
 gpgcheck=1
 gpgkey=https://repos.fyralabs.com/terra$releasever-source/key.asc
 repo_gpgcheck=1


### PR DESCRIPTION
While we do have tetsudou configs for 39, those were mainly for testing. We could backport to 39 if needed.. but 40 is current anyways so maybe not?