### PR TITLE
[f40] feat: use mirror network for Terra (#1237)

### DIFF
--- a/anda/terra/release/terra.repo
+++ b/anda/terra/release/terra.repo
@@ -1,9 +1,9 @@
 [terra]
 name=Terra $releasever
+#baseurl=https://repos.fyralabs.com/terra$releasever
 metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever&arch=$basearch
 metadata_expire=6h
 type=rpm
-skip_if_unavailable=True
 gpgcheck=1
 gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc
 repo_gpgcheck=1
@@ -12,10 +12,10 @@ enabled_metadata=1
 
 [terra-source]
 name=Terra $releasever - Source
-metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-source&arch=$basearch
+#baseurl=https://repos.fyralabs.com/terra$releasever-source
+metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever&arch=$basearch
 metadata_expire=6h
 type=rpm
-skip_if_unavailable=True
 gpgcheck=1
 gpgkey=https://repos.fyralabs.com/terra$releasever-source/key.asc
 repo_gpgcheck=1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [feat: use mirror network for Terra (#1237)](https://github.com/terrapkg/packages/pull/1237)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)