### PR TITLE
[f40] fix: terra source mirror (#1240)

### DIFF
--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -1,6 +1,6 @@
 Name:           terra-release
 Version:        40
-Release:        2
+Release:        3
 Summary:        Release package for Terra
 
 License:        MIT

--- a/anda/terra/release/terra.repo
+++ b/anda/terra/release/terra.repo
@@ -13,7 +13,7 @@ enabled_metadata=1
 [terra-source]
 name=Terra $releasever - Source
 #baseurl=https://repos.fyralabs.com/terra$releasever-source
-metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever&arch=$basearch
+metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-source&arch=$basearch
 metadata_expire=6h
 type=rpm
 gpgcheck=1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: terra source mirror (#1240)](https://github.com/terrapkg/packages/pull/1240)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)