### PR TITLE
[frawhide] patch: sbctl (#1023)

### DIFF
--- a/anda/tools/sbctl/sbctl.spec
+++ b/anda/tools/sbctl/sbctl.spec
@@ -7,6 +7,10 @@ License:        MIT
 URL:            https://github.com/Foxboron/sbctl
 Source0:        https://github.com/Foxboron/sbctl/releases/download/%{version}/sbctl-%{version}.tar.gz
 
+# Fixes https://github.com/Foxboron/sbctl/issues/293, allowing kernel-install to work properly with Fedora
+Patch1:         https://patch-diff.githubusercontent.com/raw/Foxboron/sbctl/pull/294.patch
+
+
 ExclusiveArch:  %{golang_arches}
 
 Requires:       binutils
@@ -25,7 +29,8 @@ needs to be signed in the boot chain.
 
 
 %prep
-%setup -q
+%autosetup -p1
+
 sed -i '/go build/d' Makefile
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f40` to `frawhide`:
 - [patch: sbctl (#1023)](https://github.com/terrapkg/packages/pull/1023)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)