### PR TITLE
[f40] fix: sbctl (#1248)

### DIFF
--- a/anda/tools/sbctl/sbctl.spec
+++ b/anda/tools/sbctl/sbctl.spec
@@ -7,10 +7,6 @@ License:        MIT
 URL:            https://github.com/Foxboron/sbctl
 Source0:        https://github.com/Foxboron/sbctl/releases/download/%{version}/sbctl-%{version}.tar.gz
 
-# Fixes https://github.com/Foxboron/sbctl/issues/293, allowing kernel-install to work properly with Fedora
-Patch1:         https://patch-diff.githubusercontent.com/raw/Foxboron/sbctl/pull/294.patch
-
-
 ExclusiveArch:  %{golang_arches}
 
 Requires:       binutils


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: sbctl (#1248)](https://github.com/terrapkg/packages/pull/1248)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)