### PR TITLE
[f38] add: albius (#1263)

### DIFF
--- a/anda/langs/go/albius/albius.spec
+++ b/anda/langs/go/albius/albius.spec
@@ -1,0 +1,38 @@
+%define debug_package %nil
+%global commit 688ca6ae29de89174794a48be61ecd0fb1111c96
+%global commit_date 20240430
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           albius
+Version:        %date.%shortcommit
+Release:        1%?dist
+Summary:        A Linux installer backend with support for SquashFS and OCI installations
+License:        GPL-3.0
+URL:            https://github.com/Vanilla-OS/Albius
+Source0:        %url/archive/%commit/albius-%commit.tar.gz
+BuildRequires:  go anda-srpm-macros btrfs-progs-devel pkgconfig(devmapper) pkgconfig(gpgme) lvm2 gcc
+
+%description
+Albius is a Linux installer backend originally designed for Vanilla OS,
+but capable of handling any Linux distribution that uses either Squashfs
+or OCI images for distributing the base system. Albius is written entirely
+in Go and uses a recipe system (see "recipes" subsection) for describing
+operations, mountpoints and options.
+
+%prep
+%autosetup -n Albius-%commit
+go mod download
+
+%build
+mkdir -p build/bin
+go build -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -s -w" -buildmode=pie -o build/bin/albius .
+
+%install
+mkdir -p %{buildroot}%{_bindir}/
+install -pm755 build/bin/albius %{buildroot}%{_bindir}/
+
+%files
+%_bindir/albius
+
+%changelog
+%autochangelog

--- a/anda/langs/go/albius/anda.hcl
+++ b/anda/langs/go/albius/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "albius.spec"
+  }
+}

--- a/anda/langs/go/albius/update.rhai
+++ b/anda/langs/go/albius/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Vanilla-OS/Albius"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [add: albius (#1263)](https://github.com/terrapkg/packages/pull/1263)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)