### PR TITLE
[f40] fix: starship (#1252)

### DIFF
--- a/anda/langs/rust/starship/rust-starship.spec
+++ b/anda/langs/rust/starship/rust-starship.spec
@@ -5,14 +5,14 @@
 
 Name:           rust-starship
 Version:        1.19.0
-Release:        1%?dist
+Release:        %autorelease
 Summary:        Minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄🌌️
 
 License:        ISC
 URL:            https://crates.io/crates/starship
 Source:         %{crates_source}
 # Automatically generated patch to strip dependencies and normalize metadata
-Patch0:         starship-fix-metadata-auto.diff
+Patch:          starship-fix-metadata-auto.diff
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
@@ -175,10 +175,10 @@ use the "starship-battery" feature of the "%{crate}" crate.
 %cargo_prep_online
 
 %build
-%{cargo_build}
+%cargo_build
 
 %install
-%{cargo_install}
+%cargo_install
 
 %if %{with check}
 %check

--- a/anda/langs/rust/starship/starship-fix-metadata-auto.diff
+++ b/anda/langs/rust/starship/starship-fix-metadata-auto.diff
@@ -1,5 +1,5 @@
---- starship-1.18.1/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ starship-1.18.1/Cargo.toml	2024-03-24T13:14:24.022475+00:00
+--- starship-1.19.0/Cargo.toml	1970-01-01T00:00:01+00:00
++++ starship-1.19.0/Cargo.toml	2024-05-16T10:47:19.540098+00:00
 @@ -263,18 +263,3 @@
  ]
  default-features = false
@@ -8,7 +8,7 @@
 -version = "0.2.0"
 -
 -[target."cfg(windows)".dependencies.windows]
--version = "0.54.0"
+-version = "0.56.0"
 -features = [
 -    "Win32_Foundation",
 -    "Win32_UI_Shell",


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: starship (#1252)](https://github.com/terrapkg/packages/pull/1252)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)