### PR TITLE
[f39] add hard dependency on Qt 4 CLI tools (we should patch this to use Qt 6 CLI tho) (#1270)

### DIFF
--- a/anda/misc/kwin-system76-scheduler-integration/kwin-system76-scheduler-integration.spec
+++ b/anda/misc/kwin-system76-scheduler-integration/kwin-system76-scheduler-integration.spec
@@ -8,7 +8,7 @@ Name:       kwin-system76-scheduler-integration
 %forgemeta
 
 Version:    0.1
-Release:    1%?dist
+Release:    2%?dist
 Summary:    Notify the System76 Scheduler which app has focus so it can be prioritized
 License:    MIT
 URL:        %forgeurl
@@ -16,7 +16,8 @@ Source0:    %forgesource
 Source1:    com.system76.Scheduler.dbusproxy.service
 Requires:   bash dbus-tools system76-scheduler kde-cli-tools systemd kf6-kconfig
 BuildRequires: systemd-rpm-macros
-
+# We require the Qt 4 package to provide the `qdbus` command
+Requires:   qt
 %description
 System76 Scheduler is a service which optimizes Linux's CPU scheduler and
 automatically assigns process priorities for improved desktop responsiveness.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add hard dependency on Qt 4 CLI tools (we should patch this to use Qt 6 CLI tho) (#1270)](https://github.com/terrapkg/packages/pull/1270)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)