### PR TITLE
[f38] fix: kotlin-native (#1275)

### DIFF
--- a/anda/langs/kotlin/kotlin-native/kotlin-native.spec
+++ b/anda/langs/kotlin/kotlin-native/kotlin-native.spec
@@ -9,7 +9,7 @@ ExclusiveArch:  x86_64
 
 License:        ASL 2.0
 URL:            https://kotlinlang.org/docs/reference/native-overview.html
-Source0:        https://github.com/JetBrains/kotlin/releases/download/v%{version}/kotlin-native-linux-x86_64-%{version}.tar.gz 
+Source0:        https://github.com/JetBrains/kotlin/releases/download/v%version/kotlin-native-prebuilt-linux-x86_64-%version.tar.gz
 
 BuildRequires:  tar
 BuildRequires:  sed
@@ -28,7 +28,7 @@ Kotlin compiler and native implementation of the Kotlin standard library.
 
 
 %prep
-tar -xf %{SOURCE0} && cd kotlin-native-linux-x86_64-%{version}
+tar -xf %{SOURCE0} && cd kotlin-native-prebuilt-linux-x86_64-%{version}
 sed -i "s|\(DIR *= *\).*|\1%{_bindir}|" bin/*
 sed -i "s|\(KONAN_HOME *= *\).*|\1%{_datadir}/%{name}|" bin/*
 
@@ -36,7 +36,7 @@ sed -i "s|\(KONAN_HOME *= *\).*|\1%{_datadir}/%{name}|" bin/*
 %build
 
 %install
-rm -rf %{buildroot} && mkdir -p %{buildroot}%{_bindir}/ && cd kotlin-native-linux-x86_64-%{version}
+rm -rf %{buildroot} && mkdir -p %{buildroot}%{_bindir}/ && cd kotlin-native-prebuilt-linux-x86_64-%{version}
 install -m 0755 bin/cinterop %{buildroot}%{_bindir}/
 install -m 0755 bin/generate-platform %{buildroot}%{_bindir}/
 install -m 0755 bin/jsinterop %{buildroot}%{_bindir}/
@@ -79,65 +79,5 @@ kotlinc-native test.kt -o test
 
 
 %changelog
-* Mon Apr 03 2023 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.8.20
-* Thu Feb 02 2023 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.8.10
-* Wed Dec 28 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.8.0
-* Wed Nov 09 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.7.21
-* Thu Sep 29 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.7.20
-* Fri Jul 08 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.7.10
-* Mon Jun 13 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.7.0
-* Mon Jun 13 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.6.21
-* Thu Jun 09 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.7.0
-* Wed Apr 20 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.6.21
-* Mon Apr 04 2022 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.6.20
-* Tue Dec 14 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.6.10
-* Fri Dec 10 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.6.0
-* Mon Nov 29 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.5.32
-* Tue Nov 16 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.6.0
-* Mon Sep 20 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.5.31
-* Tue Aug 24 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.5.30
-* Tue Jul 13 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.5.21
-* Thu Jun 24 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.5.20
-* Mon May 24 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.5.10
-* Wed May 05 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.5.0
-* Tue Mar 30 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.4.32
-* Fri Feb 26 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.4.31
-* Wed Feb 03 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.4.30
-* Mon Jan 18 2021 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.4.30-RC
-* Mon Dec 07 2020 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.4.21
-* Thu Nov 19 2020 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.4.20
-* Thu Sep 10 2020 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.4.10
-* Fri Aug 14 2020 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.4.0
-* Sat Apr 18 2020 Gonçalo Silva <goncalossilva@gmail.com>
-- Update to 1.3.72
-* Mon Apr 13 2020 Gonçalo Silva <goncalossilva@gmail.com>
+%autochangelog
 - Kotlin/Native 1.3.71


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [fix: kotlin-native (#1275)](https://github.com/terrapkg/packages/pull/1275)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)