### PR TITLE
[f39] feat(comps): add &#x60;helium&#x60; group (#1280)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -73,4 +73,16 @@
       <packagereq type="default">pantheon-tweaks</packagereq>
     </packagelist>
   </group>
+  <group>
+    <id>helium</id>
+    <name>Helium Theme and libhelium</name>
+    <description>The Application Framework and Theme for tauOS.</description>
+    <default>false</default>
+    <uservisible>true</uservisible>
+    <packagelist>
+      <packagereq type="default">libhelium</packagereq>
+      <packagereq type="default">tau-helium</packagereq>
+      <packagereq type="default">tau-hydrogen</packagereq>
+    </packagelist>
+  </group>
 </comps>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [feat(comps): add &#x60;helium&#x60; group (#1280)](https://github.com/terrapkg/packages/pull/1280)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)