### PR TITLE
[f40] fix(neovide)!: requires neovim > 0.9.5 (#1286)

### DIFF
--- a/anda/devs/neovide/neovide.spec
+++ b/anda/devs/neovide/neovide.spec
@@ -2,12 +2,13 @@
 
 Name:		neovide
 Version:	0.13.0
-Release:	1%?dist
+Release:	2%?dist
 Summary:	No Nonsense Neovim Client in Rust
 License:	MIT
 URL:		https://neovide.dev/
 Source0:	https://github.com/neovide/neovide/archive/refs/tags/%version.tar.gz
-Requires:	neovim fontconfig freetype libglvnd
+Requires:	fontconfig freetype libglvnd
+Requires:	neovim > 0.9.5
 BuildRequires:	anda-srpm-macros cargo-rpm-macros >= 24 cmake gtk3 python3 SDL2
 BuildRequires:	fontconfig-devel freetype-devel libX11-xcb libX11-devel libstdc++-static libstdc++-devel
 ExclusiveArch:	x86_64


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(neovide)!: requires neovim &gt; 0.9.5 (#1286)](https://github.com/terrapkg/packages/pull/1286)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)