### PR TITLE
[f39] fix: add parted and gdisk to deps (#1287)

### DIFF
--- a/anda/tools/buildsys/katsu/katsu.spec
+++ b/anda/tools/buildsys/katsu/katsu.spec
@@ -2,12 +2,12 @@
 
 Name:			katsu
 Version:		0.4.0
-Release:		1%?dist
+Release:		2%?dist
 Summary:		The vicious image builder
 License:		MIT
 URL:			https://github.com/FyraLabs/katsu
 Source0:		%url/archive/refs/tags/v%version.tar.gz
-Requires:		xorriso dracut limine grub2 systemd-devel squashfs-tools
+Requires:		xorriso dracut limine grub2 systemd-devel squashfs-tools parted gdisk
 Requires:		dracut-live dracut-config-generic dracut-config-rescue grub2-tools-extra dracut-squash
 BuildRequires:	cargo rust-packaging pkgconfig(libudev) clang-devel
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: add parted and gdisk to deps (#1287)](https://github.com/terrapkg/packages/pull/1287)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)