### PR TITLE
fix(terra-release): disable repodata check to make mirroring work

### DIFF
--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -1,6 +1,6 @@
 Name:           terra-release
 Version:        40
-Release:        3
+Release:        4
 Summary:        Release package for Terra
 
 License:        MIT

--- a/anda/terra/release/terra.repo
+++ b/anda/terra/release/terra.repo
@@ -2,22 +2,24 @@
 name=Terra $releasever
 #baseurl=https://repos.fyralabs.com/terra$releasever
 metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever&arch=$basearch
+enabled=1
+countme=1
 metadata_expire=6h
+repo_gpgcheck=0
 type=rpm
 gpgcheck=1
 gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc
-repo_gpgcheck=1
-enabled=1
 enabled_metadata=1
 
 [terra-source]
 name=Terra $releasever - Source
 #baseurl=https://repos.fyralabs.com/terra$releasever-source
 metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-source&arch=$basearch
+enabled=0
+countme=1
 metadata_expire=6h
+repo_gpgcheck=0
 type=rpm
 gpgcheck=1
 gpgkey=https://repos.fyralabs.com/terra$releasever-source/key.asc
-repo_gpgcheck=1
-enabled=0
 enabled_metadata=0


### PR DESCRIPTION
This is done because not even Fedora enable this! This will cause issues when Terra mirrors are not syncing in real time, causing dnf to think Terra is broken when hashes don't match with tetsudou.