### PR TITLE
[f40] add: mkfstab (#1303)

### DIFF
--- a/anda/langs/nim/mkfstab/anda.hcl
+++ b/anda/langs/nim/mkfstab/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "mkfstab.spec"
+    }
+}

--- a/anda/langs/nim/mkfstab/mkfstab.spec
+++ b/anda/langs/nim/mkfstab/mkfstab.spec
@@ -1,0 +1,26 @@
+Name:           mkfstab
+Version:        0.1.1
+Release:        1%?dist
+Summary:        An alternative to genfstab: generate output suitable for addition to /etc/fstab
+License:        MIT
+URL:            https://github.com/Ultramarine-Linux/mkfstab
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildRequires:  nim anda-srpm-macros
+
+%description
+An alternative to genfstab from Arch Linux. This is a dead simple but faster implementation of genfstab.
+
+%prep
+%autosetup
+
+%build
+nimble setup -y
+nim c %nim_c src/%name
+
+%install
+install -Dpm755 src/%name %buildroot%_bindir/%name
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/%name

--- a/anda/langs/nim/mkfstab/update.rhai
+++ b/anda/langs/nim/mkfstab/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Ultramarine-Linux/mkfstab"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: mkfstab (#1303)](https://github.com/terrapkg/packages/pull/1303)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)