### PR TITLE
[f38] fix: armcord-bin (#1312)

### DIFF
--- a/anda/apps/armcord-bin/armcord-bin.spec
+++ b/anda/apps/armcord-bin/armcord-bin.spec
@@ -26,6 +26,7 @@ Source2:		https://raw.githubusercontent.com/ArmCord/ArmCord/v%version/README.md
 Requires:		electron xdg-utils
 ExclusiveArch:	x86_64 aarch64 armv7l
 Conflicts:		armcord
+BuildRequires:	add-determinism
 
 %description
 ArmCord is a custom client designed to enhance your Discord experience


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [fix: armcord-bin (#1312)](https://github.com/terrapkg/packages/pull/1312)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)