### PR TITLE
[f39] fix: armcord (#1311)

### DIFF
--- a/anda/apps/armcord/armcord.spec
+++ b/anda/apps/armcord/armcord.spec
@@ -9,7 +9,7 @@ URL:		https://github.com/ArmCord/ArmCord
 Group:		Applications/Internet
 Source1:	launch.sh
 Requires:	electron xdg-utils
-BuildRequires:	nodejs-npm git
+BuildRequires:	nodejs-npm git add-determinism
 Conflicts:	armcord-bin
 BuildArch:	noarch
 
@@ -18,6 +18,7 @@ ArmCord is a custom client designed to enhance your Discord experience
 while keeping everything lightweight.
 
 %prep
+rm -rf *
 git clone %url .
 git checkout v%version
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: armcord (#1311)](https://github.com/terrapkg/packages/pull/1311)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)