### PR TITLE
[f38] fix: nushell (#1314)

### DIFF
--- a/anda/langs/rust/nushell/nushell.spec
+++ b/anda/langs/rust/nushell/nushell.spec
@@ -16,7 +16,7 @@ Requires:		glibc openssl zlib
 %cargo_prep_online
 
 %build
-%{cargo_build -f extra,dataframe} --workspace
+%{cargo_build -f extra} --workspace
 
 %install
 mkdir -p %buildroot%_bindir


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f38`:
 - [fix: nushell (#1314)](https://github.com/terrapkg/packages/pull/1314)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)