### PR TITLE
[f40] fix: anki (#1320)

### DIFF
--- a/anda/apps/anki/anki.spec
+++ b/anda/apps/anki/anki.spec
@@ -20,8 +20,10 @@ phrases in a foreign language) as easily, quickly and efficiently as possible.
 Anki is based on a theory called spaced repetition.
 
 %prep
+rm -rf *
 git clone https://github.com/ankitects/anki .
 git checkout %{version}
+%patch 0 -p1
 
 # See https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=anki
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: anki (#1320)](https://github.com/terrapkg/packages/pull/1320)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)