### PR TITLE
[f39] Add metainfo for xpadneo driver (#1328)

### DIFF
--- a/anda/system/xpadneo/io.github.xpadneo.metainfo.xml
+++ b/anda/system/xpadneo/io.github.xpadneo.metainfo.xml
@@ -1,0 +1,26 @@
+<component type="driver">
+  <id>io.github.xpadneo</id>
+  <name>xpadneo</name>
+  <pkgname>xpadneo</pkgname>
+  <summary>Advanced Linux Driver for Xbox One Wireless Controller (shipped with Xbox One S)</summary>
+  <description>
+    <p>
+    Wireless Drivers for the Xbox One and Series S|X controllers.
+
+    Across all models, xpadneo won't support audio features of the controllers because the firmware doesn't support audio in Bluetooth mode. In the future, xpadneo may support audio when USB and dongle support will be added.
+    </p>
+  </description>
+  <url type="homepage">https://atar-axis.github.io/xpadneo/</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <!-- gplv3 -->
+  <project_license>GPL-3.0</project_license>
+
+  <developer id="atar-axis.github.io">
+    <name>Florian Dollinger</name>
+  </developer>
+
+  <provides>
+  <!-- /devices/virtual/misc/uhid/0005:045E:02FD.0008/input/input27 -->
+    <modalias>usb:v045Ep02FDd0008dc00dsc00dp00ic03isc00ip00in00</modalias>
+  </provides>
+</component>

--- a/anda/system/xpadneo/xpadneo.spec
+++ b/anda/system/xpadneo/xpadneo.spec
@@ -12,6 +12,7 @@ License:  GPL-3.0
 URL:      https://github.com/atar-axis/xpadneo
 Source0:  %url/archive/v%version/%name-%version.tar.gz
 Source1:  modules-load-d-xpadneo.conf
+Source2:  io.github.xpadneo.metainfo.xml
 
 %global   srcname hid-%name
 
@@ -69,6 +70,7 @@ done
 install -Dm644 hid-xpadneo/etc-modprobe.d/xpadneo.conf %{buildroot}%{_modprobedir}/60-xpadneo.conf
 install -Dm644 %{SOURCE1} %{buildroot}%{_modulesloaddir}/xpadneo.conf
 install -Dm644 hid-xpadneo/etc-udev-rules.d/60-xpadneo.rules %{buildroot}%{_udevrulesdir}/60-xpadneo.rules
+install -Dm644 %{SOURCE2} %{buildroot}%{_datadir}/metainfo/io.github.xpadneo.metainfo.xml
 
 %files
 %doc NEWS.md docs/README.md docs/CONFIGURATION.md
@@ -76,6 +78,7 @@ install -Dm644 hid-xpadneo/etc-udev-rules.d/60-xpadneo.rules %{buildroot}%{_udev
 %{_modprobedir}/60-xpadneo.conf
 %{_modulesloaddir}/xpadneo.conf
 %{_udevrulesdir}/60-xpadneo.rules
+%{_datadir}/metainfo/io.github.xpadneo.metainfo.xml
 
 %changelog
 * Wed Oct 12 2022 Jan DrÃ¶gehoff <sentrycraft123@gmail.com> - 0.9.5-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [Add metainfo for xpadneo driver (#1328)](https://github.com/terrapkg/packages/pull/1328)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)