### PR TITLE
[f40] fix: don&#x27;t delete lock file in cargo_prep_online (#1353)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -1,5 +1,5 @@
 Name:           anda-srpm-macros
-Version:        0.1.6
+Version:        0.1.7
 Release:        1%{?dist}
 Summary:        SRPM macros for extra Fedora packages
 

--- a/anda/terra/srpm-macros/macros.cargo_extra
+++ b/anda/terra/srpm-macros/macros.cargo_extra
@@ -30,7 +30,6 @@ verbose = true\
 directory = "%{cargo_registry}"\
 \
 EOF\
-%{__rm} -f Cargo.lock \
 %{__rm} -f Cargo.toml.orig \
 )
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: don&#x27;t delete lock file in cargo_prep_online (#1353)](https://github.com/terrapkg/packages/pull/1353)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)