### PR TITLE
[f40] fix: elementary-shortcut-overlay (#1361)

### DIFF
--- a/anda/desktops/elementary/elementary-shortcut-overlay/elementary-shortcut-overlay.spec
+++ b/anda/desktops/elementary/elementary-shortcut-overlay/elementary-shortcut-overlay.spec
@@ -49,7 +49,7 @@ desktop-file-validate \
     %{buildroot}/%{_datadir}/applications/%{appname}.desktop
 
 appstream-util validate-relax --nonet \
-    %{buildroot}/%{_datadir}/metainfo/%{appname}.appdata.xml
+    %{buildroot}/%{_datadir}/metainfo/%{appname}.metainfo.xml
 
 
 %files -f %{appname}.lang
@@ -59,7 +59,7 @@ appstream-util validate-relax --nonet \
 %{_bindir}/%{appname}
 
 %{_datadir}/applications/%{appname}.desktop
-%{_datadir}/metainfo/%{appname}.appdata.xml
+%{_datadir}/metainfo/%{appname}.metainfo.xml
 
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: elementary-shortcut-overlay (#1361)](https://github.com/terrapkg/packages/pull/1361)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)