### PR TITLE
[f39] fix: elementary-capnet-assist (#1360)

### DIFF
--- a/anda/desktops/elementary/elementary-capnet-assist/elementary-capnet-assist.spec
+++ b/anda/desktops/elementary/elementary-capnet-assist/elementary-capnet-assist.spec
@@ -21,10 +21,13 @@ BuildRequires:  pkgconfig(gcr-ui-3)
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(gobject-2.0)
-BuildRequires:  pkgconfig(granite)
+BuildRequires:  pkgconfig(granite-7)
 BuildRequires:  pkgconfig(gtk+-3.0)
 BuildRequires:  pkgconfig(libhandy-1) >= 1.0.0
 BuildRequires:  pkgconfig(webkit2gtk-4.1)
+BuildRequires:  pkgconfig(gcr-4)
+BuildRequires:  pkgconfig(libadwaita-1)
+BuildRequires:  pkgconfig(webkitgtk-6.0)
 BuildRequires:  fdupes
 
 Requires:       NetworkManager


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: elementary-capnet-assist (#1360)](https://github.com/terrapkg/packages/pull/1360)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)