### PR TITLE
[f39] fix: vala-panel-appmenu (#1359)

### DIFF
--- a/anda/langs/vala/vala-panel-appmenu/vala-panel-appmenu.spec
+++ b/anda/langs/vala/vala-panel-appmenu/vala-panel-appmenu.spec
@@ -118,9 +118,9 @@ Vala appmenu support for Java Swing applications.
 %{_datadir}/glib-2.0/schemas/org.valapanel.appmenu.gschema.xml
 %{_datadir}/vala-panel/applets/org.valapanel.appmenu.plugin
 %{_datadir}/vala/vapi/appmenu-glib-translator.*
-%{_datadir}/gir-1.0/AppmenuGLibTranslator-%version.gir
+%{_datadir}/gir-1.0/AppmenuGLibTranslator-*.gir
 %{_includedir}/appmenu-glib-translator/importer.h
-%{_libdir}/girepository-1.0/AppmenuGLibTranslator-%version.typelib
+%{_libdir}/girepository-1.0/AppmenuGLibTranslator-*.typelib
 %{_libdir}/libappmenu-glib-translator.*
 
 %files -n vala-panel-appmenu-gtk-module


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: vala-panel-appmenu (#1359)](https://github.com/terrapkg/packages/pull/1359)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)