### PR TITLE
[f39] fix: albius (#1373)

### DIFF
--- a/anda/langs/go/albius/albius.spec
+++ b/anda/langs/go/albius/albius.spec
@@ -4,7 +4,7 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           albius
-Version:        %date.%shortcommit
+Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        A Linux installer backend with support for SquashFS and OCI installations
 License:        GPL-3.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: albius (#1373)](https://github.com/terrapkg/packages/pull/1373)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)