### PR TITLE
[f40] fix: anda (#1336)

### DIFF
--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -19,6 +19,8 @@ BuildRequires:  rust-packaging >= 21
 BuildRequires:  anda-srpm-macros
 BuildRequires:  openssl-devel
 BuildRequires:  git-core
+BuildRequires:  libgit2-devel
+BuildRequires:  libssh2-devel
 
 Requires:       mock
 Requires:       rpm-build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: anda (#1336)](https://github.com/terrapkg/packages/pull/1336)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)