### PR TITLE
[f40] ci: if package is labelled as large, use lg runners for x86 (#1387)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -42,7 +42,7 @@ jobs:
         pkg: ${{ fromJson(needs.manifest.outputs.build_matrix) }}
         version: ["40"]
       fail-fast: false
-    runs-on: ${{ matrix.pkg.arch == 'aarch64' && 'ARM64' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.pkg.arch == 'aarch64' && 'ARM64' || matrix.pkg.labels['large'] && 'x86-64-lg' || 'ubuntu-latest' }}
     container:
       image: ghcr.io/terrapkg/builder:f${{ matrix.version}}
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [ci: if package is labelled as large, use lg runners for x86 (#1387)](https://github.com/terrapkg/packages/pull/1387)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)