### PR TITLE
[f40] fix(anki-qt5): fix usage of %patch (#1386)

### DIFF
--- a/anda/apps/anki-qt5/anki-qt5.spec
+++ b/anda/apps/anki-qt5/anki-qt5.spec
@@ -22,7 +22,7 @@ Anki is based on a theory called spaced repetition.
 %prep
 git clone https://github.com/ankitects/anki .
 git checkout %version
-%patch1 -p1
+%patch 1 -p1
 
 # See https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=anki-qt5
 

--- a/anda/langs/python/protobuf/python3-protobuf.spec
+++ b/anda/langs/python/protobuf/python3-protobuf.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        5.27.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Protocol Buffers
 
 License:        BSD-3-Clause

--- a/anda/lib/libindicator/terra-libindicator.spec
+++ b/anda/lib/libindicator/terra-libindicator.spec
@@ -57,7 +57,7 @@ developing applications that use %{name}-gtk3.
 
 %prep
 %setup -q -c
-%patch1 -p1 -b .orig
+%patch 1 -p1 -b .orig
 # Remove all IDO references
 # This is only needed for tools/indicator-loader.c
 sed -i '6d' ./Makefile.am


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(anki-qt5): fix usage of %patch (#1386)](https://github.com/terrapkg/packages/pull/1386)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)