### PR TITLE
[f39] add zed-preview (#1397)

### DIFF
--- a/anda/devs/zed/preview/anda.hcl
+++ b/anda/devs/zed/preview/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "zed-preview.spec"
+  }
+  labels {
+    large = 1
+  }
+}

--- a/anda/devs/zed/preview/update.rhai
+++ b/anda/devs/zed/preview/update.rhai
@@ -1,0 +1,10 @@
+let releases = "https://api.github.com/repos/zed-industries/zed/releases".get().json_arr();
+for release in releases {
+  if !release.prerelease {
+    continue;
+  }
+  let tag = release.tag_name;
+  tag.pop(4); // remove the "-pre" suffix
+  rpm.global("ver", tag);
+  terminate();
+}

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -1,0 +1,91 @@
+%bcond_without check
+%global debug_package %{nil}
+%global ver 0.142.1
+
+%global crate zed
+%global app_id dev.zed.Zed-Preview
+
+Name:           zed-preview
+Version:        %ver
+Release:        pre1%?dist
+Summary:        Zed is a high-performance, multiplayer code editor
+
+License:        MIT
+URL:            https://zed.dev/
+Source0:        https://github.com/zed-industries/zed/archive/refs/tags/v%{ver}-pre.tar.gz
+
+Conflicts:      zed
+Provides:       zed
+
+BuildRequires:  cargo-rpm-macros >= 24
+BuildRequires:  anda-srpm-macros
+BuildRequires:  gcc
+BuildRequires:  g++
+BuildRequires:  clang
+BuildRequires:  mold
+BuildRequires:  alsa-lib-devel
+BuildRequires:  fontconfig-devel
+BuildRequires:  wayland-devel
+BuildRequires:  libxkbcommon-x11-devel
+BuildRequires:  openssl-devel
+BuildRequires:  libzstd-devel
+BuildRequires:  perl-FindBin
+BuildRequires:  perl-IPC-Cmd
+BuildRequires:  perl-File-Compare
+BuildRequires:  perl-File-Copy
+BuildRequires:  perl-lib
+BuildRequires:  vulkan-loader
+
+%description
+Code at the speed of thought - Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
+
+%prep
+%autosetup -n %{crate}-%{ver}-pre -p1
+%cargo_prep_online
+
+export DO_STARTUP_NOTIFY="true"
+export APP_ID="%app_id"
+export APP_ICON="%app_id"
+export APP_NAME="Zed Preview"
+export APP_CLI="zed"
+export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed Preview from Terra."
+export ZED_RELEASE_CHANNEL=preview
+export BRANDING_LIGHT="#99c1f1"
+export BRANDING_DARK="#1a5fb4"
+
+echo "StartupWMClass=$APP_ID" >> crates/zed/resources/zed.desktop.in
+envsubst < "crates/zed/resources/zed.desktop.in" > $APP_ID.desktop # from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zed-git#n52
+
+envsubst < "crates/zed/resources/flatpak/zed.metainfo.xml.in" > $APP_ID.metainfo.xml
+
+%build
+export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed Preview from Terra."
+echo "preview" > crates/zed/RELEASE_CHANNEL
+
+%cargo_build -- --package zed --package cli
+script/generate-licenses
+
+%install
+install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
+install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
+
+install -Dm644 %app_id.desktop %{buildroot}%{_datadir}/applications/%app_id.desktop
+install -Dm644 crates/zed/resources/app-icon-preview.png %{buildroot}%{_datadir}/pixmaps/%app_id.png
+
+install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
+
+%if %{with check}
+%check
+%cargo_test
+%endif
+
+%files
+%{_libexecdir}/zed-editor
+%{_bindir}/zed
+%{_datadir}/applications/%app_id.desktop
+%{_datadir}/pixmaps/%app_id.png
+%{_metainfodir}/%app_id.metainfo.xml
+%license assets/licenses.md
+
+%changelog
+%autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add zed-preview (#1397)](https://github.com/terrapkg/packages/pull/1397)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)