### PR TITLE
[f40] fix: gendesk (#1404)

### DIFF
--- a/anda/langs/go/gendesk/golang-github-xyproto-gendesk.spec
+++ b/anda/langs/go/gendesk/golang-github-xyproto-gendesk.spec
@@ -27,6 +27,7 @@ License:        BSD-3-Clause
 URL:            %{gourl}
 Source:         %{gosource}
 BuildRequires:  git-core gcc
+Provides:       gendesk
 
 %description %{common_description}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: gendesk (#1404)](https://github.com/terrapkg/packages/pull/1404)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)