### PR TITLE
[f39] fix: terra-libplacebo (#1411)

### DIFF
--- a/anda/lib/placebo/terra-libplacebo.spec
+++ b/anda/lib/placebo/terra-libplacebo.spec
@@ -68,7 +68,7 @@ developing applications that use %{name}.
 %files
 %license LICENSE
 %doc README.md
-%{_libdir}/libplacebo.so.338
+%{_libdir}/libplacebo.so.*
 
 %files devel
 %{_includedir}/*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: terra-libplacebo (#1411)](https://github.com/terrapkg/packages/pull/1411)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)