### PR TITLE
fix: submarine builds

### DIFF
--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -24,8 +24,11 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 (or a different system if you're brave.)
 
 %prep
-go install github.com/u-root/u-root@v0.14.0
 git clone --recurse-submodules --shallow-submodules -b v%version %url .
+
+pushd u-root
+go install
+popd
 
 %build
 export PATH=$PATH:$HOME/go/bin

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -4,7 +4,7 @@
 %global arch arm64
 %endif
 # do not strip binaries
-%global __os_install_post %{nil}
+%define __strip /bin/true
 %define debug_package %{nil}
 
 

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -3,6 +3,10 @@
 %elifarch aarch64
 %global arch arm64
 %endif
+# do not strip binaries
+%global __os_install_post %{nil}
+%define debug_package %{nil}
+
 
 Name:			submarine
 Version:		0.2.1

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -14,7 +14,7 @@ Release:		1%?dist
 Summary:		Experimental bootloader for ChomeOS's depthcharge
 License:		GPL-3.0
 URL:			https://github.com/FyraLabs/submarine
-BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git depthcharge-tools
+BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git depthcharge-tools uboot-tools
 
 %description
 An experimental bootloader for ChomeOS's depthcharge.
@@ -24,7 +24,7 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 (or a different system if you're brave.)
 
 %prep
-go install github.com/u-root/u-root@v0.11.0
+go install github.com/u-root/u-root@v0.14.0
 git clone --recurse-submodules --shallow-submodules -b v%version %url .
 
 %build
@@ -34,8 +34,14 @@ export PATH=$PATH:$HOME/go/bin
 %install
 mkdir -p %buildroot/boot %buildroot%_datadir/submarine
 install -Dm644 build/submarine-*.kpart %buildroot%_datadir/submarine/
+# Symlink the installed kpart to just submarine.kpart
+pushd %buildroot%_datadir/submarine/
+find . -name 'submarine-*.kpart' -exec ln -srf {} submarine.kpart \;
+popd
+
 install -Dm644 build/submarine-*.bin %buildroot%_datadir/submarine/
 
 %files
 %_datadir/submarine/submarine-*.kpart
+%_datadir/submarine/submarine.kpart
 %_datadir/submarine/submarine-*.bin


### PR DESCRIPTION
Finally fixes submarine builds to become bootable, also symlinks the kpart image as `submarine.kpart` for easy scripting access