### PR TITLE
[f39] add: google-black-cursor-theme (#1274)

### DIFF
--- a/anda/themes/google-black-cursor-theme/anda.hcl
+++ b/anda/themes/google-black-cursor-theme/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "google-black-cursor-theme.spec"
+	}
+}

--- a/anda/themes/google-black-cursor-theme/google-black-cursor-theme.spec
+++ b/anda/themes/google-black-cursor-theme/google-black-cursor-theme.spec
@@ -1,0 +1,36 @@
+Name:		google-black-cursor-theme
+Version:	2.0.0
+Release:	1%{?dist}
+URL:		https://github.com/ful1e5/Google_Cursor
+Source0:	%{url}/releases/download/v%{version}/GoogleDot-Black.tar.gz
+Source1:	https://raw.githubusercontent.com/ful1e5/Google_Cursor/v%{version}/README.md
+Source2:	https://raw.githubusercontent.com/ful1e5/Google_Cursor/v%{version}/LICENSE
+License:	GPL-3.0
+Summary:	An opensource cursor theme inspired by Google. 
+BuildArch:	noarch
+BuildRequires:	rpm_macro(fdupes)
+
+%description
+An opensource cursor theme inspired by Google.
+
+%prep
+tar xf %{SOURCE0}
+
+%build
+
+%install
+mkdir -p %{buildroot}/%{_datadir}/icons/
+mv Google* %{buildroot}/%{_datadir}/icons/
+mkdir -p %{buildroot}/%{_datadir}/{doc,licenses}/%{name}/
+cp %{SOURCE1} %{buildroot}/%{_datadir}/doc/%{name}/README.md
+cp %{SOURCE2} %{buildroot}/%{_datadir}/licenses/%{name}/LICENSE
+%fdupes %buildroot%_datadir/icons/
+
+%files
+%doc README.md
+%license LICENSE
+%{_datadir}/icons/Google*
+
+%changelog
+* Tue May 21 2024 matteodev8 <me@matteodev.xyz> - 2.0.0
+- Initial package (mostly copied from bibata-cursor-theme)

--- a/anda/themes/google-black-cursor-theme/update.rhai
+++ b/anda/themes/google-black-cursor-theme/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("ful1e5/Google_Cursor"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add: google-black-cursor-theme (#1274)](https://github.com/terrapkg/packages/pull/1274)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)