### PR TITLE
[frawhide] ci: custom runner option for custom build workflow call (#1419)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,16 @@ on:
       packages:
         description: "Packages to Build"
         required: true
+      custom_builder:
+        description: "Custom Builder"
+        required: false
+        default: ""
 
 jobs:
   parse:
     outputs:
       pkgs: ${{ steps.parsing.outputs.pkgs }}
+      builder: ${{ inputs.custom_builder }}
     runs-on: "ubuntu-latest"
     steps:
       - name: Parse Input
@@ -22,9 +27,9 @@ jobs:
       matrix:
         pkg: ${{ fromJson(needs.parse.outputs.pkgs) }}
         version: ["rawhide"]
-        arch: ["x86_64", "aarch64"]
+        arch: ${{ output.builder == "x86-64-lg" && ["x86_64"] || ["x86_64", "aarch64"] }}
       fail-fast: false
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ARM64' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ARM64' || output.builder && output.builder || 'ubuntu-latest' }}
     container:
       image: ghcr.io/terrapkg/builder:f${{ matrix.version }}
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `f40` to `frawhide`:
 - [ci: custom runner option for custom build workflow call (#1419)](https://github.com/terrapkg/packages/pull/1419)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)