### PR TITLE
[f39] fix: Do not strip binaries in submarine (#1428)

### DIFF
--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -3,6 +3,10 @@
 %elifarch aarch64
 %global arch arm64
 %endif
+# do not strip binaries
+%define __strip /bin/true
+%define debug_package %{nil}
+
 
 Name:			submarine
 Version:		0.2.1
@@ -10,7 +14,7 @@ Release:		1%?dist
 Summary:		Experimental bootloader for ChomeOS's depthcharge
 License:		GPL-3.0
 URL:			https://github.com/FyraLabs/submarine
-BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git depthcharge-tools
+BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git depthcharge-tools uboot-tools
 
 %description
 An experimental bootloader for ChomeOS's depthcharge.
@@ -20,8 +24,11 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 (or a different system if you're brave.)
 
 %prep
-go install github.com/u-root/u-root@v0.11.0
 git clone --recurse-submodules --shallow-submodules -b v%version %url .
+
+pushd u-root
+go install
+popd
 
 %build
 export PATH=$PATH:$HOME/go/bin
@@ -30,8 +37,14 @@ export PATH=$PATH:$HOME/go/bin
 %install
 mkdir -p %buildroot/boot %buildroot%_datadir/submarine
 install -Dm644 build/submarine-*.kpart %buildroot%_datadir/submarine/
+# Symlink the installed kpart to just submarine.kpart
+pushd %buildroot%_datadir/submarine/
+find . -name 'submarine-*.kpart' -exec ln -srf {} submarine.kpart \;
+popd
+
 install -Dm644 build/submarine-*.bin %buildroot%_datadir/submarine/
 
 %files
 %_datadir/submarine/submarine-*.kpart
+%_datadir/submarine/submarine.kpart
 %_datadir/submarine/submarine-*.bin


### PR DESCRIPTION
# Backport

This will backport the following commits from `f40` to `f39`:
 - [fix: Do not strip binaries in submarine (#1428)](https://github.com/terrapkg/packages/pull/1428)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)