### PR TITLE
[f39] fix: specify bootstrap image for mock configs (#1442)

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,5 +1,5 @@
 Name:           terra-mock-configs
-Version:        8
+Version:        9
 Release:        1%{?dist}
 Summary:        Mock configs for Terra repos
 

--- a/anda/terra/mock-configs/terra.tpl
+++ b/anda/terra/mock-configs/terra.tpl
@@ -4,6 +4,7 @@ config_opts['macros']['%dist'] = '.fc{{ releasever }}'
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['package_manager'] = 'dnf5'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:{{ releasever }}'
 config_opts['mirrored'] = True
 config_opts['plugin_conf']['root_cache_enable'] = True
 config_opts['plugin_conf']['yum_cache_enable'] = True


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: specify bootstrap image for mock configs (#1442)](https://github.com/terrapkg/packages/pull/1442)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)