### PR TITLE
[frawhide] bump: submarine (#1446)

### DIFF
--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -10,7 +10,7 @@
 
 Name:			submarine
 Version:		0.2.1
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Experimental bootloader for ChomeOS's depthcharge
 License:		GPL-3.0
 URL:			https://github.com/FyraLabs/submarine


### PR DESCRIPTION
# Backport

This will backport the following commits from `f40` to `frawhide`:
 - [bump: submarine (#1446)](https://github.com/terrapkg/packages/pull/1446)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)