### PR TITLE
fix: submarine git pull

### DIFF
--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -29,7 +29,7 @@ git clone --recurse-submodules --shallow-submodules -b v%version %url %{name}-bu
 pushd %{name}-build/u-root
 go install
 popd
-popd
+
 
 %build
 pushd %{name}-build

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -24,6 +24,7 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 (or a different system if you're brave.)
 
 %prep
+ls -la .
 git clone --recurse-submodules --shallow-submodules -b v%version %url .
 
 pushd u-root

--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -24,18 +24,21 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 (or a different system if you're brave.)
 
 %prep
-ls -la .
-git clone --recurse-submodules --shallow-submodules -b v%version %url .
+git clone --recurse-submodules --shallow-submodules -b v%version %url %{name}-build
 
-pushd u-root
+pushd %{name}-build/u-root
 go install
+popd
 popd
 
 %build
+pushd %{name}-build
 export PATH=$PATH:$HOME/go/bin
 %make_build %arch
+popd
 
 %install
+pushd %{name}-build
 mkdir -p %buildroot/boot %buildroot%_datadir/submarine
 install -Dm644 build/submarine-*.kpart %buildroot%_datadir/submarine/
 # Symlink the installed kpart to just submarine.kpart
@@ -44,6 +47,8 @@ find . -name 'submarine-*.kpart' -exec ln -srf {} submarine.kpart \;
 popd
 
 install -Dm644 build/submarine-*.bin %buildroot%_datadir/submarine/
+
+popd
 
 %files
 %_datadir/submarine/submarine-*.kpart


### PR DESCRIPTION
Fixes an issue on newer RPM versions, where we can't really do the `git pull` hack on the RPM builddir anymore, thanks to https://rpm-software-management.github.io/rpm/manual/dynamic_specs.html

It's a cool feature, but it breaks our current script