### PR TITLE
[f40] fix: submarine git pull (#1451)

### DIFF
--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -24,17 +24,21 @@ Submarine provides a minimal Linux environmemt that lives in a small partition
 (or a different system if you're brave.)
 
 %prep
-git clone --recurse-submodules --shallow-submodules -b v%version %url .
+git clone --recurse-submodules --shallow-submodules -b v%version %url %{name}-build
 
-pushd u-root
+pushd %{name}-build/u-root
 go install
 popd
 
+
 %build
+pushd %{name}-build
 export PATH=$PATH:$HOME/go/bin
 %make_build %arch
+popd
 
 %install
+pushd %{name}-build
 mkdir -p %buildroot/boot %buildroot%_datadir/submarine
 install -Dm644 build/submarine-*.kpart %buildroot%_datadir/submarine/
 # Symlink the installed kpart to just submarine.kpart
@@ -43,6 +47,8 @@ find . -name 'submarine-*.kpart' -exec ln -srf {} submarine.kpart \;
 popd
 
 install -Dm644 build/submarine-*.bin %buildroot%_datadir/submarine/
+
+popd
 
 %files
 %_datadir/submarine/submarine-*.kpart


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: submarine git pull (#1451)](https://github.com/terrapkg/packages/pull/1451)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)