### PR TITLE
[f40] fix: ruff (#1455)

### DIFF
--- a/anda/langs/python/ruff/python3-ruff.spec
+++ b/anda/langs/python/ruff/python3-ruff.spec
@@ -6,7 +6,7 @@ Release:		1%?dist
 Summary:		An extremely fast Python linter, written in Rust
 License:		MIT
 URL:			https://beta.ruff.rs/
-Source0:		https://github.com/astral-sh/ruff/archive/refs/tags/v%{version}.tar.gz
+Source0:		https://github.com/astral-sh/ruff/archive/refs/tags/%{version}.tar.gz
 BuildRequires:	python3-installer python3-pip maturin cargo
 Provides:		python3.11dist(ruff) = %{version}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: ruff (#1455)](https://github.com/terrapkg/packages/pull/1455)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)