### PR TITLE
[f40] add: mugshot (#1466)

### DIFF
--- a/anda/apps/mugshot/anda.hcl
+++ b/anda/apps/mugshot/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+    rpm {
+        spec = "mugshot.spec"
+    }
+}

--- a/anda/apps/mugshot/mugshot.spec
+++ b/anda/apps/mugshot/mugshot.spec
@@ -1,0 +1,62 @@
+%global app org.bluesabre.Mugshot
+%global _description %{expand:
+Mugshot is a lightweight user configuration utility for Linux designed for simplicity and ease of
+use. Quickly update your personal profile and sync your updates across applications.}
+
+
+Name:           python-mugshot
+Version:        0.4.3
+Release:        1%?dist
+Summary:        User Management Utility for Linux
+License:        GPL-3.0
+URL:            https://github.com/bluesabre/mugshot
+Source0:        %url/archive/refs/tags/mugshot-%version.tar.gz
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-distutils-extra
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  glib2
+BuildRequires:  desktop-file-utils
+BuildRequires:  libappstream-glib
+
+%description %_description
+
+%package -n mugshot
+Requires:       util-linux-user
+Requires:       python3-cairo
+Requires:       python3-pexpect
+Requires:       python3-gobject
+Summary:        User Management Utility for Linux
+
+%description -n mugshot %_description
+
+%prep
+%autosetup -n mugshot-mugshot-%version
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files -L 'mugshot*'
+install -Dm644 data/glib-2.0/schemas/%{lower:%app}.gschema.xml %buildroot%_datadir/glib-2.0/schemas/
+
+%find_lang mugshot
+
+%check
+#pyproject_check_import
+desktop-file-validate %buildroot%_datadir/applications/%app.desktop
+appstream-util validate-relax --nonet %buildroot%_metainfodir/mugshot.appdata.xml
+
+%files -n mugshot -f %{pyproject_files} -f mugshot.lang
+%doc README.md NEWS
+%license COPYING
+%_bindir/mugshot
+%_datadir/glib-2.0/schemas/%{lower:%app}.gschema.xml
+%_datadir/applications/%app.desktop
+%_datadir/mugshot/
+%_metainfodir/mugshot.appdata.xml
+%_mandir/man1/mugshot.1.gz
+%_iconsdir/hicolor/*/apps/mugshot.svg

--- a/anda/apps/mugshot/update.rhai
+++ b/anda/apps/mugshot/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("bluesabre/mugshot"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: mugshot (#1466)](https://github.com/terrapkg/packages/pull/1466)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)