### PR TITLE
[f40] fix: apparmor (#1472)

### DIFF
--- a/anda/lib/apparmor/apparmor.spec
+++ b/anda/lib/apparmor/apparmor.spec
@@ -3,7 +3,7 @@
 %bcond_with tests
 
 Name:           apparmor
-Version:        4.0.0~alpha3
+Version:        4.0.1
 Release:        2%{?dist}
 Summary:        AppArmor userspace components
 
@@ -11,8 +11,8 @@ Summary:        AppArmor userspace components
 %global normver %(echo %version | sed 's/~/-/')
 
 License:        GPL-2.0
-URL:            https://launchpad.net/apparmor
-Source0:        %{url}/%{baseversion}/%normver/+download/%{name}-%{version}.tar.gz
+URL:            https://gitlab.com/apparmor/apparmor
+Source0:        %url/-/archive/v%version/apparmor-v%version.tar.gz
 Source1:        apparmor.preset
 Patch01:        0001-fix-avahi-daemon-authselect-denial-in-fedora.patch
 
@@ -32,6 +32,7 @@ BuildRequires:  gettext
 BuildRequires:  pam-devel
 BuildRequires:  httpd-devel
 BuildRequires:  systemd-rpm-macros
+BuildRequires:  autoconf-archive
 BuildRequires:  gawk
 BuildRequires:  which
 %if %{with tests}
@@ -138,7 +139,7 @@ confinement policies when running virtual hosts in the webserver by using the
 changehat abilities exposed through libapparmor.
 
 %prep
-%autosetup -p1 -n %{name}-%{version}
+%autosetup -p1 -n %name-v%version
 sed -i 's/@VERSION@/%normver/g' libraries/libapparmor/swig/python/setup.py.in
 sed -i 's/${VERSION}/%normver/g' utils/Makefile
 
@@ -265,7 +266,6 @@ make -C utils check
 %doc parser/README
 %doc parser/*.[1-9].html
 %doc common/apparmor.css
-%doc parser/techdoc.pdf
 %{_sbindir}/apparmor_parser
 %{_bindir}/aa-enabled
 %{_bindir}/aa-exec
@@ -276,8 +276,8 @@ make -C utils check
 %{_presetdir}/70-apparmor.preset
 %{_prefix}/lib/apparmor
 %dir %{_sysconfdir}/apparmor
+%config(noreplace) %{_sysconfdir}/apparmor.d/
 %config(noreplace) %{_sysconfdir}/apparmor/parser.conf
-%{_sharedstatedir}/apparmor
 %{_mandir}/man1/aa-enabled.1.gz
 %{_mandir}/man1/aa-exec.1.gz
 %{_mandir}/man1/aa-features-abi.1.gz

--- a/anda/lib/apparmor/update.rhai
+++ b/anda/lib/apparmor/update.rhai
@@ -1,4 +1,1 @@
-let html = get("https://launchpad.net/apparmor");
-let v = find("Latest version is ([\\d.\\w\\-]+)", html, 1);
-v.replace('-', '~');
-rpm.version(v);
+rpm.version(gitlab_tag("4484878"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: apparmor (#1472)](https://github.com/terrapkg/packages/pull/1472)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)