### PR TITLE
[f40] fix: switchboard-plug-wacom (#1412)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-wacom/switchboard-plug-wacom.spec
+++ b/anda/desktops/elementary/switchboard-plug-wacom/switchboard-plug-wacom.spec
@@ -4,7 +4,7 @@
 
 %global plug_type hardware
 %global plug_name wacom
-%global plug_rdnn io.elementary.switchboard.wacom
+%global plug_rdnn io.elementary.settings.wacom
 
 Name:           switchboard-plug-wacom
 Summary:        Switchboard Wacom Plug
@@ -25,7 +25,7 @@ BuildRequires:  pkgconfig(libwacom)
 BuildRequires:  pkgconfig(gudev-1.0)
 BuildRequires:  pkgconfig(x11)
 BuildRequires:  pkgconfig(xi)
-BuildRequires:  switchboard-devel
+BuildRequires:  pkgconfig(switchboard-3)
 
 Requires:       switchboard%{?_isa}
 Supplements:    switchboard%{?_isa}
@@ -45,22 +45,18 @@ Supplements:    switchboard%{?_isa}
 %install
 %meson_install
 
-%find_lang %{plug_name}-plug
+%find_lang %{plug_rdnn}
 
 
 %check
 appstream-util validate-relax --nonet \
-    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
-%files -f %{plug_name}-plug.lang
+%files -f %{plug_rdnn}.lang
 %doc README.md
 %license COPYING
 
-%{_libdir}/switchboard/%{plug_type}/lib%{plug_name}.so
+%{_libdir}/switchboard-3/%{plug_type}/lib%{plug_name}.so
 
-%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
-
-%changelog
-* Tue Jun 13 2023 windowsboy111 <windowsboy111@fyralabs.com> - 1.0.1-1
-- Initial package.
+%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: switchboard-plug-wacom (#1412)](https://github.com/terrapkg/packages/pull/1412)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)