### PR TITLE
[f40] fix(update): zed-preview (#1485)

### DIFF
--- a/anda/devs/zed/preview/update.rhai
+++ b/anda/devs/zed/preview/update.rhai
@@ -5,6 +5,7 @@ for release in releases {
   }
   let tag = release.tag_name;
   tag.pop(4); // remove the "-pre" suffix
+  tag.crop(1); // remove "v"
   rpm.global("ver", tag);
   break;
   if rpm.changed() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(update): zed-preview (#1485)](https://github.com/terrapkg/packages/pull/1485)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)