### PR TITLE
[f40] bump: crystal (#1489)

### DIFF
--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -1,7 +1,7 @@
 %define debug_package %nil
 
 Name:			crystal
-Version:		1.12.2
+Version:		1.13.0
 Release:		1%?dist
 Summary:		The Crystal Programming Language
 License:		Apache-2.0

--- a/anda/langs/crystal/crystal/update.rhai
+++ b/anda/langs/crystal/crystal/update.rhai
@@ -1,2 +1,1 @@
-let html = get("https://crystal-lang.org/");
-rpm.version(find("Latest release: <strong>(.+?)</strong>", html, 1))
+rpm.version(gh("crystal-lang/crystal"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [bump: crystal (#1489)](https://github.com/terrapkg/packages/pull/1489)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)