### PR TITLE
[f39] fix(envision): use better versioning (#1496)

### DIFF
--- a/anda/apps/envision/envision.spec
+++ b/anda/apps/envision/envision.spec
@@ -3,7 +3,7 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           envision
-Version:        %commit_date.%commit
+Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        UI for building, configuring and running Monado, the open source OpenXR runtime
 License:        AGPL-3.0-or-later


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix(envision): use better versioning (#1496)](https://github.com/terrapkg/packages/pull/1496)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)