### PR TITLE
[f40] fix: nvidia-patch (#1501)

### DIFF
--- a/anda/system/nvidia-patch/anda.hcl
+++ b/anda/system/nvidia-patch/anda.hcl
@@ -1,6 +1,8 @@
 project "pkg" {
     rpm {
         spec = "nvidia-patch.spec"
-        nightly = "1"
     }
+   	labels {
+		nightly = "1"
+	}
 }

--- a/anda/system/nvidia-patch/nvidia-patch.spec
+++ b/anda/system/nvidia-patch/nvidia-patch.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
-%global commit 564c0661a942f7163cb2cfa6cb1b14b4bcff3a30
+%global commit 87fe7b874b3db1489d7313c667130ef22c445bd7
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20240218
+%global commit_date 20240711
 
 
 %global patches %{_datadir}/src/nvidia-patch


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: nvidia-patch (#1501)](https://github.com/terrapkg/packages/pull/1501)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)