### PR TITLE
[f40] fix: avstplg (#1510)

### DIFF
--- a/anda/system/avstplg/avstplg.spec
+++ b/anda/system/avstplg/avstplg.spec
@@ -13,8 +13,8 @@ Summary:        Set of tools designed to help develop and debug software and fir
 URL:            https://github.com/thesofproject/avsdk
 Source0:        https://github.com/thesofproject/avsdk/archive/%commit/avsdk-%commit.tar.gz
 
-Requires:       dotnet-runtime-6.0
-BuildRequires:  dotnet-sdk-6.0 make
+Requires:       dotnet-runtime-8.0
+BuildRequires:  dotnet-sdk-8.0 make
 
 %description
 Set of tools designed to help develop and debug software and firmware on Intel platforms with AudioDSP onboard.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: avstplg (#1510)](https://github.com/terrapkg/packages/pull/1510)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)