### PR TITLE
[f40] fix: nushell (#1493)

### DIFF
--- a/anda/langs/rust/nushell/nushell.spec
+++ b/anda/langs/rust/nushell/nushell.spec
@@ -4,19 +4,20 @@ Release:		1%?dist
 Summary:		A new type of shell
 License:		MIT
 URL:			https://www.nushell.sh/
-Source0:		https://github.com/nushell/nushell/archive/refs/tags/%version.tar.gz
-BuildRequires:	anda-srpm-macros rust-packaging openssl-devel
+BuildRequires:	anda-srpm-macros rust-packaging git-core
+BuildRequires:  openssl-devel-engine
 Requires:		glibc openssl zlib
 
 %description
 %summary.
 
 %prep
-%autosetup
+rm -rf ./*
+git clone https://github.com/nushell/nushell -b %version --depth 1 .
 %cargo_prep_online
 
 %build
-%{cargo_build -f extra} --workspace
+%{cargo_build} --workspace
 
 %install
 mkdir -p %buildroot%_bindir

--- a/anda/langs/rust/nushell/nushell.spec
+++ b/anda/langs/rust/nushell/nushell.spec
@@ -5,7 +5,7 @@ Summary:		A new type of shell
 License:		MIT
 URL:			https://www.nushell.sh/
 BuildRequires:	anda-srpm-macros rust-packaging git-core
-BuildRequires:  openssl-devel-engine
+BuildRequires:  openssl-devel
 Requires:		glibc openssl zlib
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: nushell (#1493)](https://github.com/terrapkg/packages/pull/1493)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)