### PR TITLE
[f39] fix: anki-qt5 (#1505)

### DIFF
--- a/anda/apps/anki-qt5/anki-qt5.spec
+++ b/anda/apps/anki-qt5/anki-qt5.spec
@@ -20,6 +20,7 @@ phrases in a foreign language) as easily, quickly and efficiently as possible.
 Anki is based on a theory called spaced repetition.
 
 %prep
+rm -rf ./*
 git clone https://github.com/ankitects/anki .
 git checkout %version
 %patch 1 -p1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: anki-qt5 (#1505)](https://github.com/terrapkg/packages/pull/1505)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)