### PR TITLE
[f39] fix: anki-bin (#1521)

### DIFF
--- a/anda/apps/anki-bin/anki-bin.spec
+++ b/anda/apps/anki-bin/anki-bin.spec
@@ -1,18 +1,26 @@
+%global xurl https://files.pythonhosted.org/packages/51/5f/6f52b958fe38a36a0799c01fbd56a742ebdfcf41f89438dbee998b8ce692/anki-24.06.3-cp39-abi3-manylinux_2_28_x86_64.whl
+%global aurl https://files.pythonhosted.org/packages/df/bb/b0bfbc6a06a598b0b614d18dd8c4f40827828649f9742f1f44a4e44d6a2c/anki-24.06.3-cp39-abi3-manylinux_2_31_aarch64.whl
+%global qurl https://files.pythonhosted.org/packages/21/2a/d8e22a9521be04ef29a30d21a2c3008783ab03b6f07cc14696a040f747a4/aqt-24.06.3-py3-none-any.whl
+
 Name:			anki-bin
 Version:		24.06.3
 Release:		1%?dist
 Summary:		Flashcard program for using space repetition learning (Installed with wheel)
 License:		AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
 URL:			https://apps.ankiweb.net/
-BuildRequires:	python3-pip rpm_macro(fdupes)
+BuildRequires:	python3-pip rpm_macro(fdupes) cargo
 Requires:		python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
 Requires:		python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
 Requires:		python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
 Requires:       libxcrypt-compat hicolor-icon-theme sox mpv 
 ExclusiveArch:	x86_64
 Conflicts:		anki
-Source0:		https://files.pythonhosted.org/packages/cp39/a/anki/anki-%{version}-cp39-abi3-manylinux_2_28_%{_arch}.whl
-Source1:		https://files.pythonhosted.org/packages/py3/a/aqt/aqt-%{version}-py3-none-any.whl
+%ifarch x86_64
+Source0:		%xurl
+%elifarch aarch64
+Source0:        %aurl
+%endif
+Source1:		%qurl
 Source2:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/runanki.py
 Source3:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.desktop
 Source4:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.png

--- a/anda/apps/anki-bin/update.rhai
+++ b/anda/apps/anki-bin/update.rhai
@@ -1,1 +1,15 @@
-rpm.version(gh("ankitects/anki"));
+let aarch64_regex = `<a href="https://files\.pythonhosted\.org/packages/(..)/(..)/(.{60})/anki-([\d.]+)-cp(\d+)-abi3-manylinux_.+?_aarch64.whl">`;
+let html = get("https://pypi.org/project/anki/");
+let relevant = find(aarch64_regex, html, 0);
+let ver = find(aarch64_regex, relevant, 4);
+rpm.version(ver);
+if rpm.changed() {
+    rpm.release();
+    rpm.global("aurl", find(`"(.+)"`, relevant, 1));
+    let cp = find(aarch64_regex, relevant, 5);
+    let x86_64_regex = `<a href="https://files\.pythonhosted\.org/packages/(..)/(..)/(.{60})/anki-${ver}-cp${cp}-abi3-manylinux_.+?_x86_64.whl">`;
+    let relevant1 = find(x86_64_regex, html, 0);
+    rpm.global("xurl", find(`"(.+)"`, relevant1, 1));
+    let qhtml = get("https://pypi.org/project/aqt/");
+    rpm.global("qurl", find(`<a href="(https://files\.pythonhosted\.org/packages/../../.{60}/aqt-${ver}-py3-none.any.whl)">`, qhtml, 1));
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: anki-bin (#1521)](https://github.com/terrapkg/packages/pull/1521)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)