### PR TITLE
[f39] add: flow-control-nightly (#1528)

### DIFF
--- a/anda/devs/flow/anda.hcl
+++ b/anda/devs/flow/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "flow-control-nightly.spec"
+    }
+    labels {
+        nightly = 1
+    }
+}

--- a/anda/devs/flow/flow-control-nightly.spec
+++ b/anda/devs/flow/flow-control-nightly.spec
@@ -1,0 +1,30 @@
+%global commit 787bf3c6585701ec718c740ccb424794c39a2b43
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20240714
+
+Name:           flow-control-nightly
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        A programmer's text editor 
+License:        MIT
+URL:            https://github.com/neurocyte/flow
+Source0:        %url/archive/%commit.tar.gz
+BuildRequires:  zig
+Provides:       flow = %version-%release
+
+%description
+%summary.
+
+%prep
+%autosetup -n flow-%commit
+
+%build
+zig build -Doptimize=ReleaseFast --release=fast
+
+%install
+install -Dpm755 zig-out/bin/flow %buildroot%_bindir/flow
+
+%files
+%doc README.md help.md
+%license LICENSE
+%_bindir/flow

--- a/anda/devs/flow/update.rhai
+++ b/anda/devs/flow/update.rhai
@@ -1,0 +1,7 @@
+if filters.contains("nightly") {
+    rpm.global("commit", gh_commit("neurocyte/flow"));
+    if rpm.changed() {
+        rpm.release();
+        rpm.global("commit_date", date());
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add: flow-control-nightly (#1528)](https://github.com/terrapkg/packages/pull/1528)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)