### PR TITLE
[f40] feat(ci): add commit tracking to mg (#1537)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Notify Madoguchi (Success)
         if: success() && github.event_name == 'push'
-        run: ./.github/workflows/mg.sh true ${{matrix.pkg.pkg}} ${{matrix.version}} ${{matrix.pkg.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}}
+        run: ./.github/workflows/mg.sh true ${{matrix.pkg.pkg}} ${{matrix.version}} ${{matrix.pkg.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}} ${{github.sha}}
       - name: Notify Madoguchi (Failure)
         if: ( cancelled() || failure() ) && github.event_name == 'push'
-        run: ./.github/workflows/mg.sh false ${{matrix.pkg.pkg}} ${{matrix.version}} ${{matrix.pkg.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}}
+        run: ./.github/workflows/mg.sh false ${{matrix.pkg.pkg}} ${{matrix.version}} ${{matrix.pkg.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}} ${{github.sha}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@ on:
         required: false
         default: all
         type: string
-    
-
 
 jobs:
   parse:
@@ -28,18 +26,18 @@ jobs:
       - name: Parse Input
         id: parsing
         run: |
-            echo "${{ inputs.packages }}" | sed 's/ /\n/g' | sed 's/$/\//g' | jq -R . | jq -s . | jq -c . | sed 's/^/pkgs=/' >> $GITHUB_OUTPUT
-            echo "builder=${{ inputs.custom_builder }}" >> $GITHUB_OUTPUT
-            arch="${{ inputs.architecture }}"
-            # Convert to json array using jq
-            # if arch is not all, convert to array
-            if [ "$arch" != "all" ]; then
-              # jq, array with single element as string
-               arch=$(echo $arch | sed 's/,/\n/g')
-               echo "arch=$(echo $arch | jq -Rs 'split("\n")' | jq 'map(select(length > 0))' | jq -c .)" >> $GITHUB_OUTPUT
-            else
-               echo "arch=$(echo '["aarch64", "x86_64"]' | jq -c .)" >> $GITHUB_OUTPUT
-            fi
+          echo "${{ inputs.packages }}" | sed 's/ /\n/g' | sed 's/$/\//g' | jq -R . | jq -s . | jq -c . | sed 's/^/pkgs=/' >> $GITHUB_OUTPUT
+          echo "builder=${{ inputs.custom_builder }}" >> $GITHUB_OUTPUT
+          arch="${{ inputs.architecture }}"
+          # Convert to json array using jq
+          # if arch is not all, convert to array
+          if [ "$arch" != "all" ]; then
+            # jq, array with single element as string
+             arch=$(echo $arch | sed 's/,/\n/g')
+             echo "arch=$(echo $arch | jq -Rs 'split("\n")' | jq 'map(select(length > 0))' | jq -c .)" >> $GITHUB_OUTPUT
+          else
+             echo "arch=$(echo '["aarch64", "x86_64"]' | jq -c .)" >> $GITHUB_OUTPUT
+          fi
 
   build:
     needs: parse
@@ -102,7 +100,7 @@ jobs:
 
       - name: Notify Madoguchi (Success)
         if: success()
-        run: ./.github/workflows/mg.sh true ${{matrix.pkg}} ${{matrix.version}} ${{matrix.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}}
+        run: ./.github/workflows/mg.sh true ${{matrix.pkg}} ${{matrix.version}} ${{matrix.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}} ${{github.sha}}
       - name: Notify Madoguchi (Failure)
         if: cancelled() || failure()
-        run: ./.github/workflows/mg.sh false ${{matrix.pkg}} ${{matrix.version}} ${{matrix.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}}
+        run: ./.github/workflows/mg.sh false ${{matrix.pkg}} ${{matrix.version}} ${{matrix.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}} ${{github.sha}}

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Notify Madoguchi (Success)
         if: success()
-        run: ./.github/workflows/mg.sh true ${{matrix.pkg.pkg}} ${{matrix.version}} ${{matrix.pkg.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}}
+        run: ./.github/workflows/mg.sh true ${{matrix.pkg.pkg}} ${{matrix.version}} ${{matrix.pkg.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}} ${{github.sha}}
       - name: Notify Madoguchi (Failure)
         if: cancelled() || failure()
-        run: ./.github/workflows/mg.sh false ${{matrix.pkg.pkg}} ${{matrix.version}} ${{matrix.pkg.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}}
+        run: ./.github/workflows/mg.sh false ${{matrix.pkg.pkg}} ${{matrix.version}} ${{matrix.pkg.arch}} ${{github.run_id}} ${{secrets.MADOGUCHI_JWT}} ${{github.sha}}

--- a/.github/workflows/mg.sh
+++ b/.github/workflows/mg.sh
@@ -2,7 +2,7 @@ set -x
 
 dirs=$2
 dirs=${dirs/\/pkg/}
-export p="{\"id\":\"$5\",\"ver\":\"%v\",\"rel\":\"%r\",\"arch\":\"$4\",\"dirs\":\"$dirs\",\"succ\":$1}"
+export p="{\"id\":\"$5\",\"ver\":\"%v\",\"rel\":\"%r\",\"arch\":\"$4\",\"dirs\":\"$dirs\",\"succ\":$1,\"commit\":\"%6\"}"
 
 if [[ $1 == false ]]; then
 	d=${p/\%v/?}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [feat(ci): add commit tracking to mg (#1537)](https://github.com/terrapkg/packages/pull/1537)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)