### PR TITLE
[f39] fix: elementary-terminal (#1551)

### DIFF
--- a/anda/desktops/elementary/elementary-terminal/elementary-terminal.spec
+++ b/anda/desktops/elementary/elementary-terminal/elementary-terminal.spec
@@ -90,16 +90,9 @@ appstream-util validate-relax --nonet \
 %{_datadir}/glib-2.0/schemas/%{appname}.gschema.xml
 %{_datadir}/%{appname}/
 %{_datadir}/metainfo/%{appname}.appdata.xml
+%{_mandir}/man1/%{appname}.1.gz
 
 %files fish
 %doc README.md
 %license COPYING
 %{_datadir}/fish/vendor_conf.d/pantheon_terminal_process_completion_notifications.fish
-
-
-%changelog
-* Thu Nov 17 2022 windowsboy111 <wboy111@outlook.com> - 6.1.1-1
-- new version
-
-* Sat Oct 15 2022 windowsboy111 <windowsboy111@fyralabs.com>
-- Repackaged for Terra


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: elementary-terminal (#1551)](https://github.com/terrapkg/packages/pull/1551)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)