### PR TITLE
[f40] add: gamescope-session (#1555)

### DIFF
--- a/anda/games/gamescope-session/anda.hcl
+++ b/anda/games/gamescope-session/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "gamescope-session.spec"
+    }
+    labels {
+        nightly = 1
+    }
+}

--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,0 +1,35 @@
+%define debug_package %nil
+
+%global commit 4aa204e6ef332457d277488ffa61959f2dcde470
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20240719
+
+Name:           gamescope-session
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        ChimeraOS session on Gamescope
+License:        MIT
+URL:            https://github.com/ChimeraOS/gamescope-session
+Source0:        %url/archive/%commit.tar.gz
+BuildRequires:  systemd-rpm-macros
+
+%description
+Gamescope session plus based on Valve's gamescope.
+
+%prep
+%autosetup -n gamescope-session-%commit
+
+%build
+
+%install
+mkdir -p %buildroot
+cp -r usr %buildroot/
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/export-gpu
+%_bindir/gamescope-session-plus
+%_userunitdir/gamescope-session-plus@.service
+%_datadir/gamescope-session-plus/device-quirks
+%_datadir/gamescope-session-plus/gamescope-session-plus

--- a/anda/games/gamescope-session/update.rhai
+++ b/anda/games/gamescope-session/update.rhai
@@ -1,0 +1,7 @@
+if filters.contains("nightly") {
+    rpm.global("commit", gh_commit("ChimeraOS/gamescope-session"));
+    if rpm.changed() {
+        rpm.release();
+        rpm.global("commit_date", date());
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: gamescope-session (#1555)](https://github.com/terrapkg/packages/pull/1555)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)