### PR TITLE
[f40] fix: nim (#1552)

### DIFF
--- a/anda/langs/nim/nim/nim.spec
+++ b/anda/langs/nim/nim/nim.spec
@@ -12,6 +12,7 @@ Source2:		nimgrep.1
 Source3:		nimble.1
 Source4:		nimsuggest.1
 BuildRequires:	gcc mold git-core gcc-c++ nodejs openssl-devel pkgconfig(bash-completion) gc-devel pcre-devel
+BuildRequires:  redhat-rpm-config
 Requires:		gcc
 
 
@@ -136,8 +137,8 @@ rm -rf %buildroot%_bindir/empty.txt
 %_includedir/cycle.h
 %_includedir/nimbase.h
 %_datadir/nim
-%bash_completion_dir/nim
-%bash_completion_dir/nimble
+%bash_completions_dir/nim
+%bash_completions_dir/nimble
 
 %files tools
 %license copying.txt


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: nim (#1552)](https://github.com/terrapkg/packages/pull/1552)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)