### PR TITLE
[f40] feat: require hydrogen icon theme (#1584)

### DIFF
--- a/anda/lib/libhelium/libhelium.spec
+++ b/anda/lib/libhelium/libhelium.spec
@@ -1,10 +1,12 @@
+%global ver 1.8.12-10
+%global sanitized_ver %(echo %{ver} | sed -E 's/-/~/g')
 Summary:        The Application Framework for tauOS apps
 Name:           libhelium
-Version:        1.8.12.10
+Version:        %{sanitized_ver}
 Release:        1%?dist
 License:        GPL-3.0
 URL:            https://github.com/tau-OS/libhelium
-Source0:        https://github.com/tau-OS/libhelium/archive/refs/tags/%{version}.tar.gz
+Source0:        https://github.com/tau-OS/libhelium/archive/refs/tags/%{ver}.tar.gz
 
 BuildRequires:  sass
 BuildRequires:  meson
@@ -21,6 +23,7 @@ Requires: gtk4 >= 4.4
 Requires: glib2 >= 2.66.0
 Requires: libgee >= 0.20
 Requires: tau-helium >= 1.1.25
+Requires: tau-hydrogen
 
 %description
 The Application Framework for tauOS apps
@@ -34,7 +37,7 @@ This package contains the libraries and header files that are needed
 for writing applications with libhelium.
 
 %prep
-%autosetup -n libhelium-%{version}
+%autosetup -n libhelium-%{ver}
 
 %build
 %meson \

--- a/anda/lib/libhelium/update.rhai
+++ b/anda/lib/libhelium/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("tau-OS/libhelium"));
+rpm.global("ver",gh("tau-OS/libhelium"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [feat: require hydrogen icon theme (#1584)](https://github.com/terrapkg/packages/pull/1584)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)