### PR TITLE
[f40] fix(update): crystal (#1571)

### DIFF
--- a/anda/langs/crystal/crystal/update.rhai
+++ b/anda/langs/crystal/crystal/update.rhai
@@ -1,1 +1,9 @@
-rpm.version(gh("crystal-lang/crystal"));
+let v = gh("crystal-lang/crystal");
+let url = `crystal-${v}-1-linux-x86_64-bundled.tar.gz`;
+
+if get(`https://github.com/crystal-lang/crystal/releases/expanded_assets/${v}`).contains(url) {
+  rpm.version(v);
+} else {
+  print(`crystal: ${v} (waiting for bundle)`);
+  terminate();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(update): crystal (#1571)](https://github.com/terrapkg/packages/pull/1571)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)