### PR TITLE
[f40] fix: gamescope package (#1593)

### DIFF
--- a/anda/games/gamescope/anda.hcl
+++ b/anda/games/gamescope/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "terra-gamescope.spec"
     }
+    labels {
+        multilib = 1
+    }
 }

--- a/anda/games/gamescope/terra-gamescope.spec
+++ b/anda/games/gamescope/terra-gamescope.spec
@@ -89,8 +89,10 @@ BuildRequires:  git
 # libliftoff hasn't bumped soname, but API/ABI has changed for 0.2.0 release
 Requires:       libliftoff%{?_isa} >= %{libliftoff_minver}
 Requires:       xorg-x11-server-Xwayland
-Requires:       gamescope-libs = %{version}-%{release}
-Requires:       gamescope-libs(x86-32) = %{version}-%{release}
+Requires:       %{name}-libs = %{version}-%{release}
+%ifarch %{ix86}
+Requires:       %{name}-libs(x86-32) = %{version}-%{release}
+%endif
 Recommends:     mesa-dri-drivers
 Recommends:     mesa-vulkan-drivers
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: gamescope package (#1593)](https://github.com/terrapkg/packages/pull/1593)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)