### PR TITLE
[f40] fix(ci): mg.sh should use new ci5 endpoint (#1607)

### DIFF
--- a/.github/workflows/mg.sh
+++ b/.github/workflows/mg.sh
@@ -17,5 +17,5 @@ for f in anda-build/rpm/rpms/*; do
 	r=$(lesspipe.sh $f | grep -E "Release\s*: " | sed "s@Release\s*: @@")
 	d=${p/\%v/$v}
 	d=${d/\%r/$r}
-	curl -H "Authorization: Bearer $6" https://madoguchi.fyralabs.com/ci/terra$3/builds/$n -X PUT -H "Content-Type: application/json" -d $d --fail-with-body
+	curl -H "Authorization: Bearer $6" https://madoguchi.fyralabs.com/ci5/terra$3/builds/$n -X PUT -H "Content-Type: application/json" -d $d --fail-with-body
 done


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(ci): mg.sh should use new ci5 endpoint (#1607)](https://github.com/terrapkg/packages/pull/1607)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)