### PR TITLE
[f39] fix(ci): mg.sh typo (#1621)

### DIFF
--- a/.github/workflows/mg.sh
+++ b/.github/workflows/mg.sh
@@ -2,7 +2,7 @@ set -x
 
 dirs=$2
 dirs=${dirs/\/pkg/}
-export p="{\"id\":\"$5\",\"ver\":\"%v\",\"rel\":\"%r\",\"arch\":\"$4\",\"dirs\":\"$dirs\",\"succ\":$1,\"commit\":\"%6\"}"
+export p="{\"id\":\"$5\",\"ver\":\"%v\",\"rel\":\"%r\",\"arch\":\"$4\",\"dirs\":\"$dirs\",\"succ\":$1,\"commit\":\"$6\"}"
 
 if [[ $1 == false ]]; then
 	d=${p/\%v/?}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix(ci): mg.sh typo (#1621)](https://github.com/terrapkg/packages/pull/1621)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)