### PR TITLE
[f40] fix: elementary-notifications (#1631)

### DIFF
--- a/anda/desktops/elementary/elementary-notifications/elementary-notifications.spec
+++ b/anda/desktops/elementary/elementary-notifications/elementary-notifications.spec
@@ -54,7 +54,6 @@ appstream-util validate-relax --nonet %buildroot%_datadir/metainfo/%appname.meta
 %{_bindir}/%{appname}.demo
 %{_datadir}/applications/%{appname}.demo.desktop
 
-%config %{_sysconfdir}/xdg/autostart/%{appname}.desktop
 %{_datadir}/glib-2.0/schemas/%{appname}.gschema.xml
 %{_metainfodir}/%{appname}.metainfo.xml
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: elementary-notifications (#1631)](https://github.com/terrapkg/packages/pull/1631)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)