### PR TITLE
[f40] fix: elementary-settings-daemon (#1634)

### DIFF
--- a/anda/desktops/elementary/elementary-settings-daemon/elementary-settings-daemon.spec
+++ b/anda/desktops/elementary/elementary-settings-daemon/elementary-settings-daemon.spec
@@ -26,6 +26,8 @@ BuildRequires:  pkgconfig(granite) >= 5.3.0
 BuildRequires:  pkgconfig(libgeoclue-2.0)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(fwupd)
+BuildRequires:  pkgconfig(gexiv2)
+BuildRequires:  pkgconfig(packagekit-glib2)
 
 Requires:       xdg-desktop-portal
 
@@ -44,6 +46,8 @@ Requires:       xdg-desktop-portal
 
 %install
 %meson_install
+
+%find_lang %appname
 
 
 %check
@@ -64,7 +68,7 @@ appstream-util validate-relax --nonet \
 %systemd_preun %{appname}.check-for-firmware-updates.timer
 
 
-%files
+%files -f %appname.lang
 %license LICENSE
 %doc README.md
 
@@ -86,8 +90,6 @@ appstream-util validate-relax --nonet \
 %{_unitdir}/%{appname}.check-for-firmware-updates.timer
 
 %{_sysconfdir}/xdg/autostart/%appname.desktop
-
-%{_datadir}/icons/hicolor/*/apps/%{appname}.svg
 
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: elementary-settings-daemon (#1634)](https://github.com/terrapkg/packages/pull/1634)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)