### PR TITLE
[f40] fix: elementary-music (#1641)

### DIFF
--- a/anda/desktops/elementary/elementary-music/elementary-music.spec
+++ b/anda/desktops/elementary/elementary-music/elementary-music.spec
@@ -41,6 +41,7 @@ BuildRequires:  pkgconfig(libpeas-1.0)
 BuildRequires:  pkgconfig(libpeas-gtk-1.0)
 BuildRequires:  pkgconfig(taglib_c)
 BuildRequires:  pkgconfig(zeitgeist-2.0)
+BuildRequires:  pkgconfig(libadwaita-1)
 
 Requires:       hicolor-icon-theme
 
@@ -99,7 +100,6 @@ appstream-util validate-relax --nonet \
 %{_datadir}/glib-2.0/schemas/%{appname}.gschema.xml
 %{_datadir}/icons/hicolor/*/apps/%{appname}.svg
 %{_datadir}/metainfo/%{appname}.metainfo.xml
-%{_datadir}/locale/*/LC_MESSAGES/%{appname}.mo
 
 %files devel
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: elementary-music (#1641)](https://github.com/terrapkg/packages/pull/1641)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)