### PR TITLE
[f40] add tarballs to .gitignore (#1655)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 anda-build/
+**/*.tar*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add tarballs to .gitignore (#1655)](https://github.com/terrapkg/packages/pull/1655)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)