### PR TITLE
[f39] bump: terra-mock-configs (#1659)

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -37,6 +37,9 @@ cp -v *.cfg %{buildroot}%{_sysconfdir}/mock/
 %config %{_sysconfdir}/mock/terra-*-i386.cfg
 
 %changelog
+* Fri Jul 26 2024 madonuko <mado@fyralabs.com> - 1:1.1.0-1
+- Include mock files for Terra 41
+
 * Mon Jul 22 2024 Lleyton Gray <lleyton@fyralabs.com> - 1:1.0.0-1
 - Migrate to pulling configs from an external repository
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [bump: terra-mock-configs (#1659)](https://github.com/terrapkg/packages/pull/1659)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)