### PR TITLE
[f41] fix: use mold for linking and various other fixes (#1648)

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -7,6 +7,8 @@
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+# Use Mold as the linker
+%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 %global crate zed
 %global app_id dev.zed.Zed-Nightly

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -1,6 +1,10 @@
 %bcond_without check
-%global debug_package %{nil}
-%global ver 0.146.0
+
+%global ver 0.146.1
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+# Use Mold as the linker
+%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 %global crate zed
 %global app_id dev.zed.Zed-Preview

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -2,6 +2,8 @@
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+# Use Mold as the linker
+%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 %global crate zed
 %global app_id dev.zed.Zed


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: use mold for linking and various other fixes (#1648)](https://github.com/terrapkg/packages/pull/1648)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)