### PR TITLE
[el9] fix: switchboard-plug-mouse-touchpad (#1678)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-mouse-touchpad/switchboard-plug-mouse-touchpad.spec
+++ b/anda/desktops/elementary/switchboard-plug-mouse-touchpad/switchboard-plug-mouse-touchpad.spec
@@ -4,7 +4,7 @@
 
 %global plug_type hardware
 %global plug_name mouse-touchpad
-%global plug_rdnn io.elementary.switchboard.mouse-touchpad
+%global plug_rdnn io.elementary.settings.mouse-touchpad
 
 Name:           switchboard-plug-mouse-touchpad
 Summary:        Switchboard Mouse and Touchpad plug
@@ -18,13 +18,9 @@ Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  meson
-BuildRequires:  vala >= 0.22.0
 
-BuildRequires:  pkgconfig(glib-2.0) >= 2.32
-BuildRequires:  pkgconfig(granite)
-BuildRequires:  pkgconfig(gtk+-3.0)
-BuildRequires:  pkgconfig(switchboard-2.0)
-BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(switchboard-3)
 
 Requires:       switchboard%{?_isa}
 Supplements:    switchboard%{?_isa}
@@ -45,21 +41,21 @@ A switchboard plug to configure the behavior of mice and touchpads.
 %install
 %meson_install
 
-%find_lang %{plug_name}-plug
+%find_lang %{plug_rdnn}
 
 
 %check
 appstream-util validate-relax --nonet \
-    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
-%files -f %{plug_name}-plug.lang
+%files -f %{plug_rdnn}.lang
 %doc README.md
 %license COPYING
 
-%{_libdir}/switchboard/%{plug_type}/lib%{plug_name}.so
+%{_libdir}/switchboard-3/%{plug_type}/lib%{plug_name}.so
 
-%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el9`:
 - [fix: switchboard-plug-mouse-touchpad (#1678)](https://github.com/terrapkg/packages/pull/1678)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)