### PR TITLE
[f41] fix: switchboard-plug-about (#1674)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-about/switchboard-plug-about.spec
+++ b/anda/desktops/elementary/switchboard-plug-about/switchboard-plug-about.spec
@@ -3,8 +3,8 @@
 %global srcname switchboard-plug-about
 
 %global plug_type hardware
-%global plug_name about
-%global plug_rdnn io.elementary.switchboard.about
+%global plug_name system
+%global plug_rdnn io.elementary.settings.system
 
 Name:           switchboard-plug-about
 Summary:        Switchboard System Information plug
@@ -15,26 +15,19 @@ License:        GPL-3.0-or-later
 URL:            https://github.com/elementary/switchboard-plug-about
 Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
 
-Patch0:         https://github.com/elementary/switchboard-plug-about/compare/6.2.0..72d7da13da2824812908276751fd3024db2dd0f8.patch
-
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  meson
-BuildRequires:  vala >= 0.22.0
 BuildRequires:  fdupes
 
-BuildRequires:  pkgconfig(appstream) >= 0.12.10
 BuildRequires:  pkgconfig(fwupd)
-BuildRequires:  pkgconfig(gio-2.0)
-BuildRequires:  pkgconfig(glib-2.0) >= 2.64.0
-BuildRequires:  pkgconfig(gobject-2.0)
-BuildRequires:  pkgconfig(granite)
-BuildRequires:  pkgconfig(gtk+-3.0)
+BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(libgtop-2.0)
-BuildRequires:  pkgconfig(libhandy-1)
-BuildRequires:  pkgconfig(switchboard-2.0)
-BuildRequires:  pkgconfig(gudev-1.0)
+BuildRequires:  pkgconfig(switchboard-3)
 BuildRequires:  pkgconfig(udisks2)
+BuildRequires:  pkgconfig(gudev-1.0)
+BuildRequires:  pkgconfig(packagekit-glib2)
+BuildRequires:  pkgconfig(polkit-gobject-1)
 
 Requires:       switchboard%{?_isa}
 Supplements:    switchboard%{?_isa}
@@ -57,24 +50,25 @@ This switchboard plug shows system information.
 %install
 %meson_install
 %fdupes %buildroot%_datadir/locale/
-%find_lang %{plug_name}-plug
+%find_lang %{plug_rdnn}
 
-# remove the specified stock icon from appdata (invalid in libappstream-glib)
-sed -i '/icon type="stock"/d' %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+mv %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml{.in,}
+# remove the specified stock icon from metainfo (invalid in libappstream-glib)
+sed -i '/icon type="stock"/d' %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
 %check
 appstream-util validate-relax --nonet \
-    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
-%files -f %{plug_name}-plug.lang
+%files -f %{plug_rdnn}.lang
 %doc README.md
 %license COPYING
 
-%{_libdir}/switchboard/%{plug_type}/lib%{plug_name}.so
+%{_libdir}/switchboard-3/%{plug_type}/lib%{plug_name}.so
 
-%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: switchboard-plug-about (#1674)](https://github.com/terrapkg/packages/pull/1674)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)