### PR TITLE
[f39] fix: switchboard-plug-datetime (#1676)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-datetime/switchboard-plug-datetime.spec
+++ b/anda/desktops/elementary/switchboard-plug-datetime/switchboard-plug-datetime.spec
@@ -4,7 +4,7 @@
 
 %global plug_type system
 %global plug_name datetime
-%global plug_rdnn io.elementary.switchboard.datetime
+%global plug_rdnn io.elementary.settings.datetime
 
 Name:           switchboard-plug-datetime
 Summary:        Switchboard Date & Time Plug
@@ -18,11 +18,8 @@ Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  meson
-BuildRequires:  vala
 BuildRequires:  fdupes
 
-BuildRequires:  pkgconfig(granite)
-BuildRequires:  pkgconfig(libadwaita-1)
 BuildRequires:  switchboard-devel
 
 Requires:       switchboard%{?_isa}
@@ -44,24 +41,24 @@ Supplements:    switchboard%{?_isa}
 %install
 %meson_install
 %fdupes %buildroot%_datadir/locale/
-%find_lang %{plug_name}-plug
+%find_lang %{plug_rdnn}
 
-# remove the specified stock icon from appdata (invalid in libappstream-glib)
-sed -i '/icon type="stock"/d' %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+# remove the specified stock icon from metainfo (invalid in libappstream-glib)
+sed -i '/icon type="stock"/d' %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
 %check
 appstream-util validate-relax --nonet \
-    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
-%files -f %{plug_name}-plug.lang
+%files -f %{plug_rdnn}.lang
 %doc README.md
 %license COPYING
 
-%{_libdir}/switchboard/%{plug_type}/lib%{plug_name}.so
+%{_libdir}/switchboard-3/%{plug_type}/lib%{plug_name}.so
 
-%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: switchboard-plug-datetime (#1676)](https://github.com/terrapkg/packages/pull/1676)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)