### PR TITLE
[f41] fix: switchboard-plug-sound (#1672)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-sound/switchboard-plug-sound.spec
+++ b/anda/desktops/elementary/switchboard-plug-sound/switchboard-plug-sound.spec
@@ -4,7 +4,7 @@
 
 %global plug_type system
 %global plug_name sound
-%global plug_rdnn io.elementary.switchboard.sound
+%global plug_rdnn io.elementary.settings.sound
 
 Name:           switchboard-plug-sound
 Summary:        Switchboard Sound Plug
@@ -18,18 +18,12 @@ Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  meson
-BuildRequires:  vala >= 0.34.1
 BuildRequires:  fdupes
 
 BuildRequires:  pkgconfig(glib-2.0)
-BuildRequires:  pkgconfig(granite)
-BuildRequires:  pkgconfig(gtk+-3.0)
 BuildRequires:  pkgconfig(libcanberra)
-BuildRequires:  pkgconfig(libcanberra-gtk)
 BuildRequires:  pkgconfig(libpulse)
-BuildRequires:  pkgconfig(libhandy-1)
-BuildRequires:  pkgconfig(libpulse-mainloop-glib)
-BuildRequires:  pkgconfig(switchboard-2.0)
+BuildRequires:  pkgconfig(switchboard-3)
 
 Requires:       switchboard%{?_isa}
 Supplements:    switchboard%{?_isa}
@@ -50,9 +44,9 @@ A sound plug for Switchboard.
 %install
 %meson_install
 %fdupes %buildroot%_datadir/locale/
-%find_lang %{plug_name}-plug
+%find_lang %{plug_rdnn}
 
-# remove the specified stock icon from appdata (invalid in libappstream-glib)
+# remove the specified stock icon from metainfo (invalid in libappstream-glib)
 sed -i '/icon type="stock"/d' %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
@@ -60,13 +54,14 @@ sed -i '/icon type="stock"/d' %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.met
 appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
-%files -f %{plug_name}-plug.lang
+%files -f %{plug_rdnn}.lang
 %doc README.md
 %license COPYING
 
-%{_libdir}/switchboard/%{plug_type}/lib%{plug_name}.so
+%{_libdir}/switchboard-3/%{plug_type}/lib%{plug_rdnn}.so
 
 %{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
+%{_datadir}/glib-2.0/schemas/%{plug_name}.gschema.xml
 
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: switchboard-plug-sound (#1672)](https://github.com/terrapkg/packages/pull/1672)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)