### PR TITLE
[f40] fix: switchboard-plug-parental-controls (#1670)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-parental-controls/switchboard-plug-parental-controls.spec
+++ b/anda/desktops/elementary/switchboard-plug-parental-controls/switchboard-plug-parental-controls.spec
@@ -3,8 +3,8 @@
 %global srcname switchboard-plug-parental-controls
 
 %global plug_type system
-%global plug_name parental-controls
-%global plug_rdnn io.elementary.switchboard.parental-controls
+%global plug_name screentime-limits
+%global plug_rdnn io.elementary.settings.screentime-limits
 
 Name:           switchboard-plug-parental-controls
 Summary:        Switchboard Screen Time & Limits Plug
@@ -25,12 +25,8 @@ BuildRequires:  pkgconfig(accountsservice)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(flatpak)
 BuildRequires:  pkgconfig(glib-2.0)
-BuildRequires:  pkgconfig(granite)
-BuildRequires:  pkgconfig(libhandy-1) >= 0.90.0
-BuildRequires:  pkgconfig(malcontent-0)
-BuildRequires:  pkgconfig(polkit-gobject-1)
-BuildRequires:  polkit-devel
 BuildRequires:  switchboard-devel
+BuildRequires:  rpm_macro(_unitdir)
 
 Requires:       switchboard%{?_isa}
 Supplements:    switchboard%{?_isa}
@@ -51,24 +47,25 @@ Supplements:    switchboard%{?_isa}
 %install
 %meson_install
 %fdupes %buildroot%_datadir/locale/
-%find_lang %{plug_name}-plug
+%find_lang %{plug_rdnn}
 
 # remove the specified stock icon from appdata (invalid in libappstream-glib)
-sed -i '/icon type="stock"/d' %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+sed -i '/icon type="stock"/d' %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
 %check
 appstream-util validate-relax --nonet \
-    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
-%files -f %{plug_name}-plug.lang
+%files -f %{plug_rdnn}.lang
 %doc README.md
 %license COPYING
 
-%{_libdir}/switchboard/%{plug_type}/lib%{plug_name}.so
+%{_libdir}/switchboard-3/%{plug_type}/lib%{plug_name}.so
 
-%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
+%_iconsdir/hicolor/*/apps/%plug_rdnn.svg
 
 %_sysconfdir/pantheon-parental-controls/daemon.conf
 %_bindir/pantheon-parental-controls-daemon
@@ -76,8 +73,8 @@ appstream-util validate-relax --nonet \
 %_datadir/applications/pantheon-parental-controls-client.desktop
 %_datadir/dbus-1/system-services/org.pantheon.ParentalControls.service
 %_datadir/dbus-1/system.d/org.pantheon.ParentalControls.conf
-%_datadir/polkit-1/actions/io.elementary.switchboard.screentime-limits.policy
-/usr/lib/systemd/system/pantheon-parental-controls.service
+%_datadir/polkit-1/actions/%plug_rdnn.policy
+%_unitdir/pantheon-parental-controls.service
 
 %changelog
 * Tue Jun 13 2023 windowsboy111 <windowsboy111@fyralabs.com> - 6.0.1-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: switchboard-plug-parental-controls (#1670)](https://github.com/terrapkg/packages/pull/1670)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)