### PR TITLE
[el9] fix: switchboard-plug-useraccounts (#1673)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-useraccounts/switchboard-plug-useraccounts.spec
+++ b/anda/desktops/elementary/switchboard-plug-useraccounts/switchboard-plug-useraccounts.spec
@@ -4,7 +4,7 @@
 
 %global plug_type system
 %global plug_name useraccounts
-%global plug_rdnn io.elementary.switchboard.useraccounts
+%global plug_rdnn io.elementary.settings.useraccounts
 
 Name:           switchboard-plug-useraccounts
 Summary:        Switchboard User Accounts Plug
@@ -18,17 +18,10 @@ Source0:        %url/archive/%version/%srcname-%version.tar.gz
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  meson >= 0.46.1
-BuildRequires:  vala
 
 BuildRequires:  pkgconfig(accountsservice)
-BuildRequires:  gobject-introspection-devel
-BuildRequires:  gnome-desktop3-devel
-BuildRequires:  pkgconfig(granite) >= 0.5
-BuildRequires:  pkgconfig(libhandy-1) >= 0.90.0
-BuildRequires:  pkgconfig(polkit-gobject-1)
+BuildRequires:  pkgconfig(gnome-desktop-4)
 BuildRequires:  pkgconfig(pwquality)
-BuildRequires:  polkit-devel
-BuildRequires:  gtk3-devel
 BuildRequires:  switchboard-devel
 
 Requires:       switchboard%?_isa
@@ -48,21 +41,21 @@ Supplements:    switchboard%?_isa
 
 %install
 %meson_install
-%find_lang %plug_name-plug
+%find_lang %plug_rdnn
 
 
 %check
 appstream-util validate-relax --nonet \
-    %buildroot/%_datadir/metainfo/%plug_rdnn.appdata.xml
+    %buildroot/%_datadir/metainfo/%plug_rdnn.metainfo.xml
 
 
-%files -f %plug_name-plug.lang
+%files -f %plug_rdnn.lang
 %doc README.md
 %license COPYING
 
-%_libdir/switchboard/%plug_type/lib%plug_name.so
-%_libdir/switchboard/system/pantheon-useraccounts/guest-session-toggle
-%_datadir/metainfo/%plug_rdnn.appdata.xml
+%_libdir/switchboard-3/%plug_type/lib%plug_name.so
+%_libdir/switchboard-3/system/useraccounts/guest-session-toggle
+%_datadir/metainfo/%plug_rdnn.metainfo.xml
 %_datadir/polkit-1/actions/%plug_rdnn.policy
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el9`:
 - [fix: switchboard-plug-useraccounts (#1673)](https://github.com/terrapkg/packages/pull/1673)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)