### PR TITLE
[el9] fix: switchboard-plug-notifications (#1679)

### DIFF
--- a/anda/desktops/elementary/switchboard-plug-notifications/switchboard-plug-notifications.spec
+++ b/anda/desktops/elementary/switchboard-plug-notifications/switchboard-plug-notifications.spec
@@ -4,7 +4,7 @@
 
 %global plug_type personal
 %global plug_name notifications
-%global plug_rdnn io.elementary.switchboard.notifications
+%global plug_rdnn io.elementary.settings.notifications
 
 Name:           switchboard-plug-notifications
 Summary:        Switchboard Notifications plug
@@ -18,12 +18,9 @@ Source0:        %{url}/archive/%{version}/%{srcname}-%{version}.tar.gz
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  meson
-BuildRequires:  vala >= 0.22.0
 
-BuildRequires:  pkgconfig(glib-2.0) >= 2.32
-BuildRequires:  pkgconfig(granite)
-BuildRequires:  pkgconfig(gtk+-3.0) >= 3.12
-BuildRequires:  pkgconfig(switchboard-2.0)
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(switchboard-3)
 
 Requires:       gala%{?_isa}
 Requires:       switchboard%{?_isa}
@@ -48,21 +45,21 @@ related to the Notifications plugin for Gala.
 
 %install
 %meson_install
-%find_lang %{plug_name}-plug
+%find_lang %{plug_rdnn}
 
 
 %check
 appstream-util validate-relax --nonet \
-    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+    %{buildroot}/%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
-%files -f %{plug_name}-plug.lang
+%files -f %{plug_rdnn}.lang
 %doc README.md
 %license COPYING
 
-%{_libdir}/switchboard/%{plug_type}/lib%{plug_name}.so
+%{_libdir}/switchboard-3/%{plug_type}/lib%{plug_name}.so
 
-%{_datadir}/metainfo/%{plug_rdnn}.appdata.xml
+%{_datadir}/metainfo/%{plug_rdnn}.metainfo.xml
 
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el9`:
 - [fix: switchboard-plug-notifications (#1679)](https://github.com/terrapkg/packages/pull/1679)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)