### PR TITLE
[el9] fix: discord* (#1743)

### DIFF
--- a/anda/apps/discord-canary-openasar/discord-canary-openasar.spec
+++ b/anda/apps/discord-canary-openasar/discord-canary-openasar.spec
@@ -34,6 +34,7 @@ sed "s@Discord Canary@Discord Canary OpenAsar@g" a > discord-canary.desktop
 
 %install
 rm -rf $RPM_BUILD_ROOT
+mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_datadir}/discord-canary-openasar
 cp -rv * %{buildroot}%{_datadir}/discord-canary-openasar
 mkdir -p %{buildroot}%{_datadir}/applications/
@@ -42,9 +43,11 @@ ln -s %_datadir/discord-canary-openasar/discord-canary.desktop %{buildroot}%{_da
 ln -s %_datadir/discord-canary-openasar/discord.png %{buildroot}%{_datadir}/pixmaps/discord-canary-openasar.png
 cp -v %{SOURCE1} %{buildroot}%{_datadir}/discord-canary-openasar/resources/app.asar
 chmod o+w %{buildroot}%{_datadir}/discord-canary-openasar/resources -R
+ln -s %_datadir/discord-canary-openasar/DiscordCanary %buildroot%_bindir/discord-canary-openasar
 
 
 %files
+%_bindir/discord-canary-openasar
 %{_datadir}/discord-canary-openasar/
 %{_datadir}/applications/discord-canary-openasar.desktop
 %{_datadir}/pixmaps/discord-canary-openasar.png

--- a/anda/apps/discord-canary/discord-canary.spec
+++ b/anda/apps/discord-canary/discord-canary.spec
@@ -16,9 +16,8 @@ Requires:       glibc GConf2 nspr >= 4.13 nss >= 3.27 libX11 >= 1.6 libXtst >= 1
 Group:          Applications/Internet
 ExclusiveArch:  x86_64
 %description
-Imagine a place where you can belong to a school club, a gaming group, or a
-worldwide art community. Where just you and a handful of friends can spend time
-together. A place that makes it easy to talk every day and hang out more often.
+All-in-one voice and text chat for gamers that's free, secure, and works on
+both your desktop and phone.
 
 %prep
 %autosetup -n DiscordCanary
@@ -27,14 +26,17 @@ together. A place that makes it easy to talk every day and hang out more often.
 
 %install
 rm -rf $RPM_BUILD_ROOT
+mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_datadir}/discord-canary
 cp -rv * %{buildroot}%{_datadir}/discord-canary
 mkdir -p %{buildroot}%{_datadir}/applications/
 mkdir -p %{buildroot}%{_datadir}/pixmaps
 ln -s %_datadir/discord-canary/discord-canary.desktop %{buildroot}%{_datadir}/applications/
 ln -s %_datadir/discord-canary/discord.png %{buildroot}%{_datadir}/pixmaps/discord-canary.png
+ln -s %_datadir/discord/DiscordCanary %buildroot%_bindir/discord-canary
 
 %files
+%_bindir/discord-canary
 %{_datadir}/discord-canary/
 %{_datadir}/applications/discord-canary.desktop
 %{_datadir}/pixmaps/discord-canary.png

--- a/anda/apps/discord-openasar/discord-openasar.spec
+++ b/anda/apps/discord-openasar/discord-openasar.spec
@@ -34,6 +34,7 @@ sed "s@Discord@Discord OpenAsar@g" a > discord.desktop
 
 %install
 rm -rf $RPM_BUILD_ROOT
+mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_datadir}/discord-openasar
 cp -rv * %{buildroot}%{_datadir}/discord-openasar
 mkdir -p %{buildroot}%{_datadir}/applications/
@@ -42,9 +43,11 @@ ln -s %_datadir/discord-openasar/discord.desktop %{buildroot}%{_datadir}/applica
 ln -s %_datadir/discord-openasar/discord.png %{buildroot}%{_datadir}/pixmaps/discord-openasar.png
 cp -v %{SOURCE1} %{buildroot}%{_datadir}/discord-openasar/resources/app.asar
 chmod o+w %{buildroot}%{_datadir}/discord-openasar/resources -R
+ln -s %_datadir/discord-openasar/Discord %buildroot%_bindir/discord-openasar
 
 
 %files
+%_bindir/discord-openasar
 %{_datadir}/discord-openasar/
 %{_datadir}/applications/discord-openasar.desktop
 %{_datadir}/pixmaps/discord-openasar.png

--- a/anda/apps/discord-ptb-openasar/discord-ptb-openasar.spec
+++ b/anda/apps/discord-ptb-openasar/discord-ptb-openasar.spec
@@ -34,6 +34,7 @@ sed "s@Discord Ptb@Discord Ptb OpenAsar@g" a > discord-ptb.desktop
 
 %install
 rm -rf $RPM_BUILD_ROOT
+mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_datadir}/discord-ptb-openasar
 cp -rv * %{buildroot}%{_datadir}/discord-ptb-openasar
 mkdir -p %{buildroot}%{_datadir}/applications/
@@ -44,9 +45,11 @@ install discord-ptb.desktop %{buildroot}%{_datadir}/applications/discord-ptb-ope
 install discord.png %{buildroot}%{_datadir}/pixmaps/discord-ptb-openasar.png
 cp -v %{SOURCE1} %{buildroot}%{_datadir}/discord-ptb-openasar/resources/app.asar
 chmod o+w %{buildroot}%{_datadir}/discord-ptb-openasar/resources -R
+ln -s %_datadir/discord-ptb-openasar/Discord %buildroot%_bindir/discord-ptb-openasar
 
 
 %files
+%_bindir/discord-ptb-openasar
 %{_datadir}/discord-ptb-openasar/
 %{_datadir}/applications/discord-ptb-openasar.desktop
 %{_datadir}/pixmaps/discord-ptb-openasar.png

--- a/anda/apps/discord-ptb/discord-ptb.spec
+++ b/anda/apps/discord-ptb/discord-ptb.spec
@@ -20,9 +20,8 @@ Requires:       libXtst >= 1.2
 Group:          Applications/Internet
 ExclusiveArch:  x86_64
 %description
-Imagine a place where you can belong to a school club, a gaming group, or a
-worldwide art community. Where just you and a handful of friends can spend time
-together. A place that makes it easy to talk every day and hang out more often.
+All-in-one voice and text chat for gamers that's free, secure, and works on
+both your desktop and phone.
 
 %prep
 %autosetup -n DiscordPTB
@@ -31,14 +30,17 @@ together. A place that makes it easy to talk every day and hang out more often.
 
 %install
 rm -rf $RPM_BUILD_ROOT
+mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_datadir}/discord-ptb
 cp -rv * %{buildroot}%{_datadir}/discord-ptb
 mkdir -p %{buildroot}%{_datadir}/applications/
 mkdir -p %{buildroot}%{_datadir}/pixmaps
 ln -s %_datadir/discord-ptb/discord-ptb.desktop %{buildroot}%{_datadir}/applications/
 ln -s %_datadir/discord-ptb/discord.png %{buildroot}%{_datadir}/pixmaps/discord-ptb.png
+ln -s %_datadir/discord-ptb/Discord %buildroot%_bindir/discord-ptb
 
 %files
+%_bindir/discord-ptb
 %{_datadir}/discord-ptb/
 %{_datadir}/applications/discord-ptb.desktop
 %{_datadir}/pixmaps/discord-ptb.png

--- a/anda/apps/discord/discord.spec
+++ b/anda/apps/discord/discord.spec
@@ -20,9 +20,8 @@ Requires:		libXtst >= 1.2
 Group:			Applications/Internet
 ExclusiveArch:	x86_64
 %description
-Imagine a place where you can belong to a school club, a gaming group, or a
-worldwide art community. Where just you and a handful of friends can spend time
-together. A place that makes it easy to talk every day and hang out more often.
+All-in-one voice and text chat for gamers that's free, secure, and works on
+both your desktop and phone.
 
 %prep
 %autosetup -n Discord
@@ -31,14 +30,17 @@ together. A place that makes it easy to talk every day and hang out more often.
 
 %install
 rm -rf $RPM_BUILD_ROOT
+mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_datadir}/discord
 cp -rv * %{buildroot}%{_datadir}/discord
 mkdir -p %{buildroot}%{_datadir}/applications/
 mkdir -p %{buildroot}%{_datadir}/pixmaps
 ln -s %_datadir/discord/discord.desktop %{buildroot}%{_datadir}/applications/discord.desktop
 ln -s %_datadir/discord/discord.png %{buildroot}%{_datadir}/pixmaps/discord.png
+ln -s %_datadir/discord/Discord %buildroot%_bindir/discord
 
 %files
+%_bindir/discord
 %{_datadir}/discord/
 %{_datadir}/applications/discord.desktop
 %{_datadir}/pixmaps/discord.png


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el9`:
 - [fix: discord* (#1743)](https://github.com/terrapkg/packages/pull/1743)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)