### PR TITLE
[f41] add: ruffle (#1754)

### DIFF
--- a/anda/apps/ruffle/anda.hcl
+++ b/anda/apps/ruffle/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "ruffle-nightly.spec"
+    }
+}

--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -1,0 +1,64 @@
+%global ver 2024-07-29
+%global goodver %(echo %ver | sed 's/-//g')
+%global __brp_mangle_shebangs %{nil}
+%bcond_without mold
+
+%global _description %{expand:
+Ruffle is an Adobe Flash Player emulator written in the Rust programming
+language. Ruffle targets both the desktop and the web using WebAssembly.}
+
+Name:           ruffle-nightly
+Version:        %goodver
+Release:        1%?dist
+Summary:        A Flash Player emulator written in Rust
+License:        Apache-2.0 OR MIT
+URL:            https://ruffle.rs/
+Source0:        https://github.com/ruffle-rs/ruffle/archive/refs/tags/nightly-%ver.tar.gz
+Provides:       ruffle
+BuildRequires:  cargo-rpm-macros >= 24
+BuildRequires:  anda-srpm-macros
+BuildRequires:  gcc-c++ cmake java
+BuildRequires:  java-latest-openjdk-headless
+BuildRequires:  pkgconfig(alsa)
+BuildRequires:  pkgconfig(gtk+-3.0)
+BuildRequires:  pkgconfig(libudev)
+BuildRequires:  pkgconfig(xcb-cursor)
+Packager:       madonuko <mado@fyralabs.com>
+
+%description %_description
+
+%files
+%doc README.md
+%license LICENSE.md
+%license LICENSE.dependencies
+%_bindir/ruffle_desktop
+
+%package        devel
+Summary:        %{summary}
+BuildArch:      noarch
+
+%description    devel %{_description}
+
+This package contains library source intended for building other packages which
+use the "%{crate}" crate.
+
+%files          devel
+%license %{crate_instdir}/LICENSE.md
+%doc %{crate_instdir}/CONTRIBUTING.md
+%doc %{crate_instdir}/README.md
+%{crate_instdir}/
+
+%prep
+%autosetup -n ruffle-nightly-%ver
+%cargo_prep_online
+
+%build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+cd desktop
+%cargo_install
+
+%changelog
+* Mon Jul 29 2024 madonuko <mado@fyralabs.com>
+- Initial package

--- a/anda/apps/ruffle/update.rhai
+++ b/anda/apps/ruffle/update.rhai
@@ -1,0 +1,13 @@
+let releases = "https://api.github.com/repos/ruffle-rs/ruffle/releases".get().json_arr();
+for release in releases {
+  let tag = release.tag_name;
+  if !tag.starts_with("nightly-") {
+    continue;
+  }
+  tag.crop(8); // remove "nightly-"
+  rpm.global("ver", tag);
+  break;
+}
+if rpm.changed() {
+  rpm.release();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: ruffle (#1754)](https://github.com/terrapkg/packages/pull/1754)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)