### PR TITLE
[f41] fix: gamescope-session (#1755)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -30,6 +30,7 @@ cp -r usr %buildroot/
 %license LICENSE
 %_bindir/export-gpu
 %_bindir/gamescope-session-plus
+%_libexecdir/gamescope-sdl-workaround
 %_userunitdir/gamescope-session-plus@.service
 %_datadir/gamescope-session-plus/device-quirks
 %_datadir/gamescope-session-plus/gamescope-session-plus


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: gamescope-session (#1755)](https://github.com/terrapkg/packages/pull/1755)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)