### PR TITLE
[el9] feat(envision): update by nightly (#1764)

### DIFF
--- a/anda/apps/envision/anda.hcl
+++ b/anda/apps/envision/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "envision.spec"
     }
+    labels {
+        nightly = 1
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el9`:
 - [feat(envision): update by nightly (#1764)](https://github.com/terrapkg/packages/pull/1764)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)