### PR TITLE
[f39] fix: use correct file ext for mock configurations (#1775)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           cp -v mock-configs/terra.tpl /etc/mock/templates/terra.tpl
 
       - name: Build with Andaman
-        run: anda build anda/${{ matrix.pkg }}pkg --package rpm -c mock-configs/terra-${{ matrix.version }}-${{ matrix.arch }}.pkg
+        run: anda build anda/${{ matrix.pkg }}pkg --package rpm -c mock-configs/terra-${{ matrix.version }}-${{ matrix.arch }}.cfg
 
       - name: Generating artifact name
         id: art

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -37,7 +37,7 @@ jobs:
           cp -v mock-configs/terra.tpl /etc/mock/templates/terra.tpl
 
       - name: Build with Andaman
-        run: anda build ${{ matrix.pkg.pkg }} --package rpm -c mock-configs/terra-${{ matrix.version }}-${{ matrix.pkg.arch }}.pkg
+        run: anda build ${{ matrix.pkg.pkg }} --package rpm -c mock-configs/terra-${{ matrix.version }}-${{ matrix.pkg.arch }}.cfg
 
       - name: Generating artifact name
         id: art


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: use correct file ext for mock configurations (#1775)](https://github.com/terrapkg/packages/pull/1775)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)