### PR TITLE
fix: don't run zed tests by default

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -3,7 +3,7 @@
 %global commit_date 20240731
 %global ver 0.147.0
 
-%bcond_without check
+%bcond_with check
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -1,4 +1,4 @@
-%bcond_without check
+%bcond_with check
 
 %global ver 0.146.3
 # Exclude input files from mangling

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -1,4 +1,4 @@
-%bcond_without check
+%bcond_with check
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$


### PR DESCRIPTION
Currently, the x86-64-lg CI is borked, and the standard GitHub runners fail to work because of lack of disk space. This lack of disk space issue seems to happen during the test phase. I'll switch it off of the large runners after I verify with a manual build.

For now, we're going to disable running tests by default. Obviously this isn't ideal (esp for nightly), but we don't have much other of a choice and upstream is generally pretty good about QAing.