### PR TITLE
[f39] fix: don&#x27;t run zed tests by default (#1786)

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -3,7 +3,7 @@
 %global commit_date 20240619
 %global ver 0.142.0
 
-%bcond_without check
+%bcond_with check
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -1,4 +1,4 @@
-%bcond_without check
+%bcond_with check
 
 %global ver 0.146.2
 # Exclude input files from mangling

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -1,4 +1,4 @@
-%bcond_without check
+%bcond_with check
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: don&#x27;t run zed tests by default (#1786)](https://github.com/terrapkg/packages/pull/1786)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)