### PR TITLE
[f41] fix: disable large runners for zed (#1800)

### DIFF
--- a/anda/devs/zed/nightly/anda.hcl
+++ b/anda/devs/zed/nightly/anda.hcl
@@ -4,6 +4,5 @@ project pkg {
   }
   labels {
     nightly = 1
-    large = 1
   }
 }

--- a/anda/devs/zed/preview/anda.hcl
+++ b/anda/devs/zed/preview/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
   rpm {
     spec = "zed-preview.spec"
   }
-  labels {
-    large = 1
-  }
 }

--- a/anda/devs/zed/stable/anda.hcl
+++ b/anda/devs/zed/stable/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
   rpm {
     spec = "zed.spec"
   }
-  labels {
-    large = 1
-  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: disable large runners for zed (#1800)](https://github.com/terrapkg/packages/pull/1800)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)