### PR TITLE
[f40] fix(zed*): add cargo clean to make for more disk space (#1805)

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -79,6 +79,8 @@ script/generate-licenses
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
+%__cargo clean
+
 install -Dm644 %app_id.desktop %{buildroot}%{_datadir}/applications/%app_id.desktop
 install -Dm644 crates/zed/resources/app-icon-nightly.png %{buildroot}%{_datadir}/pixmaps/%app_id.png
 

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -75,6 +75,8 @@ script/generate-licenses
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
+%__cargo clean
+
 install -Dm644 %app_id.desktop %{buildroot}%{_datadir}/applications/%app_id.desktop
 install -Dm644 crates/zed/resources/app-icon-preview.png %{buildroot}%{_datadir}/pixmaps/%app_id.png
 

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -75,6 +75,8 @@ script/generate-licenses
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
+%__cargo clean
+
 install -Dm644 %app_id.desktop %{buildroot}%{_datadir}/applications/%app_id.desktop
 install -Dm644 crates/zed/resources/app-icon.png %{buildroot}%{_datadir}/pixmaps/%app_id.png
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(zed*): add cargo clean to make for more disk space (#1805)](https://github.com/terrapkg/packages/pull/1805)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)