### PR TITLE
add: micro-nightly

### DIFF
--- a/anda/apps/micro/anda.hcl
+++ b/anda/apps/micro/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "micro-nightly.spec"
+    }
+    labels {
+        nightly = "1"
+    }
+}

--- a/anda/apps/micro/micro-nightly.spec
+++ b/anda/apps/micro/micro-nightly.spec
@@ -1,9 +1,10 @@
-%global commit         2259fd10affd19be60400a1ac2c86b920f2c64c2
-%global shortcommit    %(c=%{commit}; echo ${c:0:7})
-%global compiledate    %(date "+%%B %%d, %%Y")
-
+# https://github.com/zyedidia/micro
 %global goipath        github.com/zyedidia/micro
-%global tag            nightly
+%global commit         2259fd10affd19be60400a1ac2c86b920f2c64c2
+
+%global shortcommit    %(c=%{commit}; echo ${c:0:7})
+%global commit_date    20240731
+%global compiledate    %(date "+%%B %%d, %%Y")
 
 %gometa -f
 
@@ -16,7 +17,7 @@ Micro is a terminal-based text editor that aims to be easy to use and intuitive,
 %global godocs         README.md
 
 Name:           %{goname}-%{tag}
-Version:        2.0.14~dev
+Version:        2.0.14~dev^%{commit_date}g%{shortcommit}
 Release:        %autorelease
 Summary:        A modern and intuitive terminal-based text editor
 License:        MIT AND Apache-2.0 AND MPL-2.0

--- a/anda/apps/micro/micro-nightly.spec
+++ b/anda/apps/micro/micro-nightly.spec
@@ -1,0 +1,73 @@
+%global commit         2259fd10affd19be60400a1ac2c86b920f2c64c2
+%global shortcommit    %(c=%{commit}; echo ${c:0:7})
+%global compiledate    %(date "+%%B %%d, %%Y")
+
+%global goipath        github.com/zyedidia/micro
+%global tag            nightly
+
+%gometa -f
+
+%global goname         micro
+
+%global common_description %{expand: 
+Micro is a terminal-based text editor that aims to be easy to use and intuitive, while also taking advantage of the full capabilities of modern terminals.}
+
+%global golicenses     LICENSE LICENSE-THIRD-PARTY
+%global godocs         README.md
+
+Name:           %{goname}-%{tag}
+Version:        2.0.14~dev
+Release:        %autorelease
+Summary:        A modern and intuitive terminal-based text editor
+License:        MIT AND Apache-2.0 AND MPL-2.0
+URL:            https://micro-editor.github.io
+Source0:        %{gosource}
+
+Recommends:     wl-clipboard xsel
+
+%description
+%{common_description}
+
+%prep
+%goprep
+# fix go build requires
+sed -i "s|github.com/zyedidia/json5|github.com/flynn/json5|" $(find . -name "*.go")
+
+%build
+%define build_version %(go run ./tools/build-version.go)
+export LDFLAGS="-X 'github.com/zyedidia/micro/internal/util.Version=%build_version' \
+                -X 'github.com/zyedidia/micro/internal/util.CommitHash=%{shortcommit}' \
+                -X 'github.com/zyedidia/micro/internal/util.CompileDate=%{compiledate}' \
+                -X 'github.com/zyedidia/micro/internal/util.Debug=OFF'"
+
+# for syntax highlighting
+export GOPATH='/usr/share/gocode/'
+export GO111MODULE=off
+go generate ./runtime
+
+for cmd in cmd/* ; do
+    %gobuild -o %{gobuilddir}/bin/$(basename $cmd) %{goipath}/$cmd
+done
+
+%generate_buildrequires
+%go_generate_buildrequires
+
+%install
+install -m 0755 -vd                     %{buildroot}%{_bindir}
+install -m 0755 -vp %{gobuilddir}/bin/* %{buildroot}%{_bindir}/
+
+mkdir -p %{buildroot}%{_mandir}/man1
+cp -p ./assets/packaging/micro.1 %{buildroot}%{_mandir}/man1/
+
+%check
+%gocheck -d cmd/micro/shellwords -d cmd/micro/terminfo
+
+%files
+%license %{golicenses}
+%doc %{godocs}
+%{_bindir}/*
+%{_mandir}/man1/micro.1.gz
+
+%changelog
+* Sat Aug  3 2024 davidusrex <dlunn@outlook.com>
+- Initial package

--- a/anda/apps/micro/update.rhai
+++ b/anda/apps/micro/update.rhai
@@ -1,5 +1,5 @@
 if filters.contains("nightly") {
-    #rpm.global("commit", gh_commit("zyedidia/micro", "nightly"));
+    rpm.global("commit", gh_commit("zyedidia/micro"));
     if rpm.changed() {
         rpm.release();
     }

--- a/anda/apps/micro/update.rhai
+++ b/anda/apps/micro/update.rhai
@@ -1,0 +1,6 @@
+if filters.contains("nightly") {
+    #rpm.global("commit", gh_commit("zyedidia/micro", "nightly"));
+    if rpm.changed() {
+        rpm.release();
+    }
+}  


### PR DESCRIPTION
Closes #1598 

Would it be possible to add a "tag" input to the `gh_commit` function in anda? What I'm trying to do is get the latest commit hash of the nightly tagged release instead of the latest commit hash of the main branch. That being said, it's probably not the end of the world if it can't be done.

I've had to compromise on how to handle versioning. The current maintainers of micro have taken the approach in the original developer's absence (the whole reason why I wanted to package this in the first place) to not bump the version number (current release version is 2.0.13, from Oct 2023) but instead to use its own convention for dev pre-release versions - appending "dev.(number of commits since last release version)" to the next release version number, i.e. the latest pre-release version is 2.0.14-dev.245

I've found out the hard way that this causes all sorts of problems with rpm, so what I've done is simply made %version = 2.0.14~dev. Also I have no idea where to even start with getting the commit count difference for update.rhai, seriously I spent like a week thinking about it lol

The downside to this is that the user won't know which commit their package is built against until they run the binary (the correct versioning scheme desired by micro is built into the binary). Please let me know if you would prefer appending the caret syntax to the rpm package version as well, i.e. 2.0.14~dev^20240731g2259fd1

I mentioned that the specfile failed to build in mock, would appreciate any and all help and advice on what I'm doing wrong.

Thanks so much!