### PR TITLE
[f39] fix: update OpenTabletDriver to .NET 8 (#1816)

### DIFF
--- a/anda/system/opentabletdriver/opentabletdriver.spec
+++ b/anda/system/opentabletdriver/opentabletdriver.spec
@@ -5,6 +5,7 @@
 # We aren't using Mono but RPM expected Mono
 %global __requires_exclude_from ^/usr/lib/opentabletdriver/.*$
 %global __os_install_post %{nil}
+%global dotnet_runtime_version 8.0
 
 Name: opentabletdriver
 Version: 0.6.4.0
@@ -12,13 +13,14 @@ Release: 1%{?dist}
 Summary: A cross-platform open source tablet driver
 License: LGPLv3
 URL: https://github.com/OpenTabletDriver/OpenTabletDriver
+Packager: Cappy Ishihara <cappy@fyralabs.com>
 %define otddir OpenTabletDriver-%{version}
 
-BuildRequires: dotnet-sdk-6.0 git jq systemd-rpm-macros
+BuildRequires: dotnet-sdk-%{dotnet_runtime_version}
+BuildRequires: git jq systemd-rpm-macros
 
-Requires: dotnet-runtime-6.0
+Requires: dotnet-runtime-%{dotnet_runtime_version}
 Requires: libevdev.so.2()(64bit)
-Requires: gtk3
 Requires: gtk3
 Requires: udev
 Suggests: libX11
@@ -28,12 +30,16 @@ Suggests: libXrandr
 OpenTabletDriver is an open source, cross platform, user mode tablet driver. The goal of OpenTabletDriver is to be cross platform as possible with the highest compatibility in an easily configurable graphical user interface.
 
 %prep
+mkdir -p %{otddir}
+cd %{otddir}
 git clone -b v%version %url .
 
 %build
+cd %{otddir}
 ./eng/linux/package.sh --output bin
 
 %install
+cd %{otddir}
 export DONT_STRIP=1
 PREFIX="%{_prefix}" ./eng/linux/package.sh --package Generic --build false
 mkdir -p "%{buildroot}"

--- a/anda/system/opentabletdriver/update.rhai
+++ b/anda/system/opentabletdriver/update.rhai
@@ -1,1 +1,3 @@
+# todo: Check latest .NET runtime version from Fedora repos and set macros accordingly
+
 rpm.version(gh("OpenTabletDriver/OpenTabletDriver"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: update OpenTabletDriver to .NET 8 (#1816)](https://github.com/terrapkg/packages/pull/1816)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)