### PR TITLE
[f41] bump: keyd (#1815)

### DIFF
--- a/anda/tools/keyd/keyd.spec
+++ b/anda/tools/keyd/keyd.spec
@@ -1,25 +1,25 @@
 Name:			keyd
-Version:		2.4.3
-Release:		3%?dist
+Version:		2.5.0
+Release:		1%?dist
 Summary:		Key remapping daemon for linux
 URL:			https://github.com/rvaiya/keyd
 License:		MIT
-Source0:		%url/archive/refs/tags/v%version.tar.gz
 Suggests:		python3 python3-xlib
-BuildRequires:	gcc mold make kernel-headers systemd-rpm-macros
+BuildRequires:	gcc mold make kernel-headers systemd-rpm-macros git-core
 
 %description
 keyd provides a flexible system wide daemon which remaps keys using kernel
 level input primitives (evdev, uinput).
 
 %prep
-%autosetup
+rm -rf ./*
+git clone --depth 1 -b v%version %url .
 
 %build
 %make_build
 
 %install
-%make_install
+%make_install PREFIX=%_prefix
 install -Dm644 keyd.service %buildroot%_unitdir/keyd.service
 
 %post


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [bump: keyd (#1815)](https://github.com/terrapkg/packages/pull/1815)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)