### PR TITLE
[f39] fix: ruffle (#1834)

### DIFF
--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -59,7 +59,7 @@ EOF
 %install
 cd desktop
 %cargo_install
-install -Dm644 assets/logo.svg %buildroot%_iconsdir/hicolor/scalable/apps/ruffle_desktop.svg
+install -Dm644 assets/icon.svg %buildroot%_iconsdir/hicolor/scalable/apps/ruffle_desktop.svg
 install -Dm644 ../ruffle_desktop.desktop %buildroot%_datadir/applications/ruffle_desktop.desktop
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: ruffle (#1834)](https://github.com/terrapkg/packages/pull/1834)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)