### PR TITLE
[f41] fix: gamescope (#1842)

### DIFF
--- a/anda/games/gamescope/terra-gamescope.spec
+++ b/anda/games/gamescope/terra-gamescope.spec
@@ -15,9 +15,9 @@ URL:            https://github.com/ValveSoftware/gamescope
 Source0:        stb.pc
 
 # https://github.com/ChimeraOS/gamescope
-Patch0:         chimeraos.patch
+#Patch0:         chimeraos.patch
 # https://hhd.dev/
-Patch1:         disable-steam-touch-click-atom.patch
+#Patch1:         disable-steam-touch-click-atom.patch
 # https://github.com/ValveSoftware/gamescope/pull/1281
 # Patch2:         deckhd.patch
 # https://github.com/ValveSoftware/gamescope/issues/1398


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: gamescope (#1842)](https://github.com/terrapkg/packages/pull/1842)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)