### PR TITLE
[f39] fix(codium): remove &#x60;--unity-launch&#x60; from .desktop (#1851)

### DIFF
--- a/anda/devs/codium/codium.spec
+++ b/anda/devs/codium/codium.spec
@@ -52,7 +52,7 @@ cat <<EOF > vscodium-bin.desktop
 Name=VSCodium
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
-Exec=/usr/bin/codium --no-sandbox --unity-launch %F
+Exec=/usr/bin/codium --no-sandbox %F
 Icon=vscodium
 Type=Application
 StartupNotify=false


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix(codium): remove &#x60;--unity-launch&#x60; from .desktop (#1851)](https://github.com/terrapkg/packages/pull/1851)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)