### PR TITLE
[f40] fix(voicevox): try to use large runners (#1865)

### DIFF
--- a/anda/apps/voicevox/voicevox.spec
+++ b/anda/apps/voicevox/voicevox.spec
@@ -4,6 +4,10 @@
 # do not strip binaries
 %define __strip /bin/true
 
+# do not perform compression in cpio
+%define _source_payload w0.ufdio
+%define _binary_payload w0.gzdio
+
 # Exclude private libraries
 %global __requires_exclude libffmpeg.so
 %global __provides_exclude_from %{_datadir}/%{name}/.*\\.so


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(voicevox): try to use large runners (#1865)](https://github.com/terrapkg/packages/pull/1865)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)