### PR TITLE
[el9] add: libaudec (#1873)

### DIFF
--- a/anda/lib/audec/anda.hcl
+++ b/anda/lib/audec/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "libaudec.spec"
+    }
+}

--- a/anda/lib/audec/libaudec.patch
+++ b/anda/lib/audec/libaudec.patch
@@ -1,0 +1,12 @@
+diff -uraN libaudec-v0.2.2/meson.build omv-libaudec-v0.2.2/meson.build
+--- libaudec-v0.2.2/meson.build	2020-05-16 13:50:13.000000000 +0200
++++ omv-libaudec-v0.2.2/meson.build	2020-07-20 12:41:48.461809598 +0200
+@@ -212,8 +212,6 @@
+   install: not meson.is_subproject(),
+   )
+ 
+-subdir('tests')
+-
+ summary = [
+   '',
+   '------',

--- a/anda/lib/audec/libaudec.spec
+++ b/anda/lib/audec/libaudec.spec
@@ -1,0 +1,51 @@
+%global _desc %{expand:
+libaudec (lib audio decoder) is a wrapper library over ffmpeg, sndfile and
+libsamplerate for reading and resampling audio files.
+}
+
+Name:           libaudec
+Version:        0.3.4
+Release:        1%?dist
+Summary:        libaudec (lib audio decoder) is a wrapper library over ffmpeg, sndfile and libsamplerate for reading and resampling audio files
+License:        AGPL-3.0-or-later
+URL:            https://git.sr.ht/~alextee/libaudec
+Source0:        %url/archive/v%version.tar.gz
+Patch0:         libaudec.patch
+BuildRequires:  cmake meson ninja-build gcc
+BuildRequires:  pkgconfig(samplerate)
+BuildRequires:  pkgconfig(sndfile)
+BuildRequires:  ffmpeg-free-devel
+
+%description %_desc
+
+%package devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description devel %_desc
+This package contains the development files for the %name package.
+
+%prep
+%setup -q -n libaudec-v%{version}
+%ifarch %{ix86} %{arm}
+%autopatch -p1
+rm -r tests
+%endif
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+%files
+%doc README.md
+%license COPYING COPYING.GPL3
+%_bindir/audec
+
+%files devel
+%_includedir/audec/audec.h
+%_libdir/libaudec.a
+%_libdir/pkgconfig/audec.pc
+%_libdir/libaudec.so


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el9`:
 - [add: libaudec (#1873)](https://github.com/terrapkg/packages/pull/1873)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)