### PR TITLE
[f39] add: libbacktrace (#1872)

### DIFF
--- a/anda/lib/backtrace/anda.hcl
+++ b/anda/lib/backtrace/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "libbacktrace-nightly.spec"
+    }
+    labels {
+        nightly = 1
+    }
+}

--- a/anda/lib/backtrace/libbacktrace-nightly.spec
+++ b/anda/lib/backtrace/libbacktrace-nightly.spec
@@ -1,0 +1,69 @@
+%global debug_package %nil
+
+%global commit 86885d14049fab06ef8a33aac51664230ca09200
+%global shortcommit %(c=%commit; echo ${c:0:7})
+%global commit_date 20240806
+
+%global _desc %{expand:
+A C library that may be linked into a C/C++ program to produce symbolic backtraces.
+}
+
+Name:           libbacktrace-nightly
+Version:        1.0^%commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Library to produce symbolic backtraces
+License:        BSD-3-Clause
+URL:            https://github.com/ianlancetaylor/libbacktrace
+Source0:		%url/archive/%commit.tar.gz
+Packager:       madonuko <mado@fyralabs.com>
+BuildRequires:  gcc make
+BuildRequires:  automake
+BuildRequires:  libtool
+BuildRequires:  pkgconfig(liblzma)
+BuildRequires:  pkgconfig(libunwind)
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(zlib)
+
+%description %_desc
+
+%package devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description devel %_desc
+This package contains the development files for the %name package.
+
+%prep
+%autosetup -n libbacktrace-%commit
+
+%build
+autoreconf -fiv
+%configure \
+  --disable-static \
+  --enable-shared \
+  --with-system-libunwind \
+  --enable-silent-rules
+%make_build
+
+%check
+# btest_dwz fails
+%make_build check ||:
+
+%install
+%make_install
+
+find %{buildroot} -type f -name "*.la" -delete -print
+
+%files
+%doc README.md
+%license LICENSE
+%_includedir/backtrace-supported.h
+%_includedir/backtrace.h
+%_libdir/libbacktrace.so
+
+%files devel
+%_libdir/libbacktrace.so.*
+
+%changelog
+* Sat Aug 10 2024 madonuko <mado@fyralabs.com>
+- Initial package

--- a/anda/lib/backtrace/update.rhai
+++ b/anda/lib/backtrace/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("ianlancetaylor/libbacktrace"));
+if rpm.changed() {
+    rpm.global("commit_date", date());
+    rpm.release();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add: libbacktrace (#1872)](https://github.com/terrapkg/packages/pull/1872)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)