### PR TITLE
[f41] add: gamescope-legacy (#1912)

### DIFF
--- a/anda/games/gamescope-legacy/0001-cstdint.patch
+++ b/anda/games/gamescope-legacy/0001-cstdint.patch
@@ -1,0 +1,36 @@
+From 5529e8ac8f3232ec6233e33286834548e1d8018d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Franti=C5=A1ek=20Zatloukal?= <fzatlouk@redhat.com>
+Date: Sun, 8 Oct 2023 22:10:33 +0200
+Subject: [PATCH] <cstdint>
+
+---
+ src/reshade/source/effect_parser_stmt.cpp | 1 +
+ src/reshade/source/effect_token.hpp       | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/reshade/source/effect_parser_stmt.cpp b/src/reshade/source/effect_parser_stmt.cpp
+index 7829729..f126be2 100644
+--- a/src/reshade/source/effect_parser_stmt.cpp
++++ b/src/reshade/source/effect_parser_stmt.cpp
+@@ -9,6 +9,7 @@
+ #include <cctype> // std::toupper
+ #include <cassert>
+ #include <functional>
++#include <limits>
+ #include <string_view>
+ 
+ struct on_scope_exit
+diff --git a/src/reshade/source/effect_token.hpp b/src/reshade/source/effect_token.hpp
+index 072d439..e4bb633 100644
+--- a/src/reshade/source/effect_token.hpp
++++ b/src/reshade/source/effect_token.hpp
+@@ -5,6 +5,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 
+-- 
+2.41.0

--- a/anda/games/gamescope-legacy/anda.hcl
+++ b/anda/games/gamescope-legacy/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "gamescope-legacy.spec"
+    }
+    labels {
+        multilib = 1
+    }
+}

--- a/anda/games/gamescope-legacy/gamescope-legacy.spec
+++ b/anda/games/gamescope-legacy/gamescope-legacy.spec
@@ -1,0 +1,129 @@
+%global libliftoff_minver 0.4.1
+%global reshade_commit 4245743a8c41abbe3dc73980c1810fe449359bf1
+%global reshade_shortcommit %(c=%{reshade_commit}; echo ${c:0:7})
+%global _default_patch_fuzz 2
+
+
+# =============================================================================
+# IMPORTANT: This package should *not* have an update script, at least not one that
+# tracks upstream Gamescope from Valve. This package is intended to be a legacy
+# build for Polaris and older GPUs from AMD, and should not be updated to the
+# latest version.
+# 
+# This package however, should be obsoleted once https://github.com/ValveSoftware/gamescope/issues/1218
+# is finally resolved, and Gamescope's Wayland backend has a fallback for GPUs without Vulkan DRM modifiers.
+# =============================================================================
+
+
+Name:           gamescope-legacy
+Version:        3.14.2
+Release:        1%{?dist}
+Summary:        Legacy builds of gamescope, a micro-compositor for video games on Wayland
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+License:        BSD
+URL:            https://github.com/ValveSoftware/gamescope
+Source0:        %{url}/archive/%{version}/gamescope-%{version}.tar.gz
+# Create stb.pc to satisfy dependency('stb')
+Source1:        stb.pc
+Source2:        https://github.com/Joshua-Ashton/reshade/archive/%{reshade_commit}/reshade-%{reshade_shortcommit}.tar.gz
+
+Patch0:         0001-cstdint.patch
+
+# https://hhd.dev/
+Patch1:         v2-0001-always-send-ctrl-1-2-to-steam-s-wayland-session.patch
+
+# ChimeraOS
+Patch2:         legacy-720p.patch
+
+BuildRequires:  meson >= 0.54.0
+BuildRequires:  ninja-build
+BuildRequires:  cmake
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  glm-devel
+BuildRequires:  google-benchmark-devel
+BuildRequires:  libXmu-devel
+BuildRequires:  libXcursor-devel
+BuildRequires:  pkgconfig(libdisplay-info)
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xdamage)
+BuildRequires:  pkgconfig(xcomposite)
+BuildRequires:  pkgconfig(xrender)
+BuildRequires:  pkgconfig(xext)
+BuildRequires:  pkgconfig(xfixes)
+BuildRequires:  pkgconfig(xxf86vm)
+BuildRequires:  pkgconfig(xtst)
+BuildRequires:  pkgconfig(xres)
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(vulkan)
+BuildRequires:  pkgconfig(wayland-scanner)
+BuildRequires:  pkgconfig(wayland-server)
+BuildRequires:  pkgconfig(wayland-protocols) >= 1.17
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(sdl2)
+BuildRequires:  pkgconfig(libpipewire-0.3)
+BuildRequires:  pkgconfig(libavif)
+BuildRequires:  (pkgconfig(wlroots) >= 0.17.0 with pkgconfig(wlroots) < 0.18)
+BuildRequires:  (pkgconfig(libliftoff) >= 0.4.1 with pkgconfig(libliftoff) < 0.5)
+BuildRequires:  pkgconfig(libcap)
+BuildRequires:  pkgconfig(hwdata)
+BuildRequires:  spirv-headers-devel
+# Enforce the the minimum EVR to contain fixes for all of:
+# CVE-2021-28021 CVE-2021-42715 CVE-2021-42716 CVE-2022-28041 CVE-2023-43898
+# CVE-2023-45661 CVE-2023-45662 CVE-2023-45663 CVE-2023-45664 CVE-2023-45666
+# CVE-2023-45667
+BuildRequires:  stb_image-devel >= 2.28^20231011gitbeebb24-12
+# Header-only library: -static is for tracking per guidelines
+BuildRequires:  stb_image-static
+BuildRequires:  stb_image_resize-devel
+BuildRequires:  stb_image_resize-static
+BuildRequires:  stb_image_write-devel
+BuildRequires:  stb_image_write-static
+BuildRequires:  vkroots-devel
+BuildRequires:  /usr/bin/glslangValidator
+
+# libliftoff hasn't bumped soname, but API/ABI has changed for 0.2.0 release
+Requires:       libliftoff%{?_isa} >= %{libliftoff_minver}
+Requires:       xorg-x11-server-Xwayland
+
+Requires:       terra-gamescope-libs
+Requires:       terra-gamescope-libs(x86-32)
+
+Recommends:     mesa-dri-drivers
+Recommends:     mesa-vulkan-drivers
+
+%description
+%{name} is the micro-compositor optimized for running video games on Wayland. This is a legacy build primarily intended for use by Polaris GPUs.
+
+%prep
+%autosetup -p1 -a2 -N -n gamescope-%{version}
+# Install stub pkgconfig file
+mkdir -p pkgconfig
+cp %{SOURCE1} pkgconfig/stb.pc
+
+# Replace spirv-headers include with the system directory
+sed -i 's^../thirdparty/SPIRV-Headers/include/spirv/^/usr/include/spirv/^' src/meson.build
+
+# Push in reshade from sources instead of submodule
+rm -rf src/reshade && mv reshade-%{reshade_commit} src/reshade
+
+%autopatch -p1
+
+%build
+export PKG_CONFIG_PATH=pkgconfig
+%meson -Dpipewire=enabled -Denable_gamescope_wsi_layer=false -Denable_openvr_support=false -Dforce_fallback_for=[]
+%meson_build
+
+%install
+%meson_install
+# Rename to not conflict with the base package
+mv %{buildroot}%{_bindir}/gamescope %{buildroot}%{_bindir}/gamescope-legacy
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/gamescope-legacy
+
+%changelog
+%autochangelog
+

--- a/anda/games/gamescope-legacy/legacy-720p.patch
+++ b/anda/games/gamescope-legacy/legacy-720p.patch
@@ -1,0 +1,33 @@
+From 072ebb67cd4a88fd0f5db22a92a46f8316f28a46 Mon Sep 17 00:00:00 2001
+From: Matthew Anderson <ruinairas1992@gmail.com>
+Date: Tue, 25 Jul 2023 18:05:05 -0500
+Subject: [PATCH] Set default to native resolution of display if Steam tries to
+ force 720p/800p
+
+You can select 720p/800p still in game or via Steam's resolution setting
+Steam > Settings > Display > Resolution
+
+This effectively reverts the changes Valve made a year ago forcing us to
+720p.
+---
+ src/steamcompmgr.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/steamcompmgr.cpp b/src/steamcompmgr.cpp
+index 52dd8d1cf..5b0fa6e52 100644
+--- a/src/steamcompmgr.cpp
++++ b/src/steamcompmgr.cpp
+@@ -5202,6 +5202,13 @@ handle_property_notify(xwayland_ctx_t *ctx, XPropertyEvent *ev)
+ 			size_t server_idx = size_t{ xwayland_mode_ctl[ 0 ] };
+ 			int width = xwayland_mode_ctl[ 1 ];
+ 			int height = xwayland_mode_ctl[ 2 ];
++
++			if ( g_nOutputWidth != 1280 && width == 1280 )
++			{
++				width = g_nOutputWidth;
++				height = g_nOutputHeight;
++			}
++
+ 			bool allowSuperRes = !!xwayland_mode_ctl[ 3 ];
+ 
+ 			if ( !allowSuperRes )

--- a/anda/games/gamescope-legacy/stb.pc
+++ b/anda/games/gamescope-legacy/stb.pc
@@ -1,0 +1,7 @@
+prefix=/usr
+includedir=${prefix}/include/stb
+
+Name: stb
+Description: Single-file public domain libraries for C/C++
+Version: 0.1.0
+Cflags: -I${includedir}

--- a/anda/games/gamescope-legacy/v2-0001-always-send-ctrl-1-2-to-steam-s-wayland-session.patch
+++ b/anda/games/gamescope-legacy/v2-0001-always-send-ctrl-1-2-to-steam-s-wayland-session.patch
@@ -1,0 +1,39 @@
+From 35e001dc59a44227d670c667a85a6ef5472eee58 Mon Sep 17 00:00:00 2001
+From: antheas <git@antheas.dev>
+Date: Sat, 20 Jul 2024 01:23:19 +0300
+Subject: [PATCH v2] always send ctrl+1/2 to steam's wayland session
+
+---
+ src/wlserver.cpp | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/wlserver.cpp b/src/wlserver.cpp
+index 1852be9..7de737d 100644
+--- a/src/wlserver.cpp
++++ b/src/wlserver.cpp
+@@ -369,7 +369,12 @@ static void wlserver_handle_key(struct wl_listener *listener, void *data)
+ 		keysym == XKB_KEY_XF86AudioLowerVolume ||
+ 		keysym == XKB_KEY_XF86AudioRaiseVolume ||
+ 		keysym == XKB_KEY_XF86PowerOff;
+-	if ( ( event->state == WL_KEYBOARD_KEY_STATE_PRESSED || event->state == WL_KEYBOARD_KEY_STATE_RELEASED ) && forbidden_key )
++
++	// Check for steam keys (ctrl + 1/2)
++	bool is_steamshortcut = (keyboard->wlr->modifiers.depressed & WLR_MODIFIER_CTRL) && (keysym == XKB_KEY_1 ||
++																						 keysym == XKB_KEY_2);
++
++	if ( ( event->state == WL_KEYBOARD_KEY_STATE_PRESSED || event->state == WL_KEYBOARD_KEY_STATE_RELEASED ) && (forbidden_key || is_steamshortcut) )
+ 	{
+ 		// Always send volume+/- to root server only, to avoid it reaching the game.
+ 		struct wlr_surface *old_kb_surf = wlserver.kb_focus_surface;
+@@ -378,6 +383,9 @@ static void wlserver_handle_key(struct wl_listener *listener, void *data)
+ 		{
+ 			wlserver_keyboardfocus( new_kb_surf, false );
+ 			wlr_seat_set_keyboard( wlserver.wlr.seat, keyboard->wlr );
++			// Send modifiers to steam for it to work
++			if (is_steamshortcut)
++				wlr_seat_keyboard_notify_modifiers(wlserver.wlr.seat, &keyboard->wlr->modifiers);
+ 			wlr_seat_keyboard_notify_key( wlserver.wlr.seat, event->time_msec, event->keycode, event->state );
+ 			wlserver_keyboardfocus( old_kb_surf, false );
+ 			return;
+-- 
+2.45.2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: gamescope-legacy (#1912)](https://github.com/terrapkg/packages/pull/1912)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)