### PR TITLE
Revisting terra-mesa

### DIFF
--- a/anda/system/terra-mesa/Mesa-MLAA-License-Clarification-Email.txt
+++ b/anda/system/terra-mesa/Mesa-MLAA-License-Clarification-Email.txt
@@ -1,0 +1,117 @@
+
+Subject: RE: Question about Mesa MLAA license
+From: Jorge Jimenez <iryoku@gmail.com>
+Date: 01/08/2013 12:50 PM
+To: Tom Callaway <tcallawa@redhat.com>
+CC: "jorge@iryoku.com" <jorge@iryoku.com>
+
+Yes to both questions.
+ 
+Thanks,
+Jorge
+ 
+From: Tom Callaway <tcallawa@redhat.com>
+Sent: January 8, 2013 6:49 PM
+To: Jorge Jimenez <iryoku@gmail.com>
+CC: jorge@iryoku.com
+Subject: Re: Question about Mesa MLAA license
+ 
+On 01/08/2013 12:39 PM, Jorge Jimenez wrote:
+> Hi Tom,
+>
+> What we meant with that is that we made an exception for clause 2.
+> Instead of clause 2, in the case of the Mesa project, you have to name
+> the technique Jimenez's MLAA in the config options of Mesa. We did that
+> just to allow them to solve license issues. This exception should be for
+> the Mesa project, and any project using Mesa, like Fedora.
+>
+> We want to widespread usage of our MLAA, so we want to avoid any kind of
+> license complications. Hope current one is good for Fedora, if not
+> please tell, and we'll see what we can do!
+
+Okay, a few more questions:
+
+* If Fedora decides to simply reproduce the quoted statement:
+"Uses Jimenez's MLAA. Copyright (C) 2010 by Jorge Jimenez, Belen Masia,
+Jose I. Echevarria, Fernando Navarro and Diego Gutierrez."
+
+Specifically, if this is done as part of documentation included with
+Mesa, is that sufficient to meet clause 2 even if the Mesa config option
+is not set as described in your exception?
+
+* Currently, the Mesa config option for MLAA says: "Morphological
+anti-aliasing based on Jimenez\' MLAA. 0 to disable, 8 for default
+quality". Is this in compliance with your exception?
+
+Thanks again,
+
+~tom
+
+==
+Fedora Project
+
+Subject: RE: Question about Mesa MLAA license
+From: Jorge Jimenez <iryoku@gmail.com>
+Date: 01/08/2013 12:39 PM
+To: "jorge@iryoku.com" <jorge@iryoku.com>, Tom Callaway <tcallawa@redhat.com>
+
+Hi Tom,
+ 
+What we meant with that is that we made an exception for clause 2. 
+Instead of clause 2, in the case of the Mesa project, you have to name 
+the technique Jimenez's MLAA in the config options of Mesa. We did that 
+just to allow them to solve license issues. This exception should be for 
+the Mesa project, and any project using Mesa, like Fedora.
+ 
+We want to widespread usage of our MLAA, so we want to avoid any kind of 
+license complications. Hope current one is good for Fedora, if not 
+please tell, and we'll see what we can do!
+ 
+Cheers,
+Jorge
+ 
+From: Tom Callaway <tcallawa@redhat.com>
+Sent: January 8, 2013 6:30 PM
+To: jorge@iryoku.com
+Subject: Question about Mesa MLAA license
+ 
+Jorge,
+
+Thanks for all of your fantastic graphics work! I have been auditing
+Fedora (a popular distribution of Linux) for license compliance and I
+came across your MLAA code in Mesa.
+
+The license says:
+
+ *    2. Redistributions in binary form must reproduce the following
+statement:
+ *
+ *       "Uses Jimenez's MLAA. Copyright (C) 2010 by Jorge Jimenez, Belen Masia,
+ *        Jose I. Echevarria, Fernando Navarro and Diego Gutierrez."
+ *
+ *       Only for use in the Mesa project, this point 2 is filled by naming the
+ *       technique Jimenez's MLAA in the Mesa config options.
+
+That wording is unclear. When you say "Only for use in the Mesa
+project...", it seems like you could either be saying:
+
+- This code may only be used as part of Mesa.
+
+OR
+
+- In Mesa, you can comply with clause 2 by simply selecting "Jimenez's
+MLAA" in the Mesa config options.
+
+*****
+
+If the first item is true, then we may have to remove the MLAA code from
+Fedora's copy of Mesa. However, looking at the license on your SMAA
+code, I do not believe it to be the case. Please let me know either way!
+
+Thanks in advance,
+
+Tom Callaway
+Fedora Legal
+
+==
+Fedora Project

--- a/anda/system/terra-mesa/anda.hcl
+++ b/anda/system/terra-mesa/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "terra-mesa.spec"
+    }
+    labels {
+        multilib = 1
+    }
+}

--- a/anda/system/terra-mesa/terra-mesa.spec
+++ b/anda/system/terra-mesa/terra-mesa.spec
@@ -1,11 +1,6 @@
 %global srcname mesa
 %global ver 24.2.0
 
-# define macro for providing srcname and ver
-# %replace_pkg subpackage
-%define replace_pkg() \
-Provides:       %{srcname}-%1 \
-Provides:       %{srcname}-%1%{?_isa}
 Source0:        https://archive.mesa3d.org/%{srcname}-%{ver}.tar.xz
 
 ## START: Set by rpmautospec
@@ -87,9 +82,19 @@ Source0:        https://archive.mesa3d.org/%{srcname}-%{ver}.tar.xz
 Name:           terra-%{srcname}
 Summary:        Mesa graphics libraries
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        %autorelease
+Release:        1.terra%{?dist}
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
+
+
+# define macro for providing srcname and ver
+# %replace_pkg subpackage
+%define replace_pkg() \
+Requires:       terra-mesa-filesystem = %{version}-%{release} \
+Provides:       %{srcname}-%1 \
+Provides:       %{srcname}-%1%{?_isa} \
+Conflicts:      %{srcname}-%1
+
 
 # src/gallium/auxiliary/postprocess/pp_mlaa* have an ... interestingly worded license.
 # Source1 contains email correspondence clarifying the license terms.

--- a/anda/system/terra-mesa/terra-mesa.spec
+++ b/anda/system/terra-mesa/terra-mesa.spec
@@ -552,6 +552,7 @@ popd
 %endif
 %files dri-drivers
 %dir %{_datadir}/drirc.d
+%{_libdir}/libgallium*.so
 %{_datadir}/drirc.d/00-mesa-defaults.conf
 %{_libdir}/dri/kms_swrast_dri.so
 %{_libdir}/dri/swrast_dri.so

--- a/anda/system/terra-mesa/terra-mesa.spec
+++ b/anda/system/terra-mesa/terra-mesa.spec
@@ -1,0 +1,715 @@
+%global srcname mesa
+%global ver 24.2.0
+
+# define macro for providing srcname and ver
+# %replace_pkg subpackage
+%define replace_pkg() \
+Provides:       %{srcname}-%1 \
+Provides:       %{srcname}-%1%{?_isa}
+Source0:        https://archive.mesa3d.org/%{srcname}-%{ver}.tar.xz
+
+## START: Set by rpmautospec
+## (rpmautospec version 0.6.3)
+## RPMAUTOSPEC: autorelease, autochangelog
+%define autorelease(e:s:pb:n) %{?-p:0.}%{lua:
+    release_number = 2;
+    base_release_number = tonumber(rpm.expand("%{?-b*}%{!?-b:1}"));
+    print(release_number + base_release_number - 1);
+}%{?-e:.%{-e*}}%{?-s:.%{-s*}}%{!?-n:%{?dist}}
+## END: Set by rpmautospec
+
+# Switches
+
+%ifnarch s390x
+%global with_hardware 1
+%global with_radeonsi 1
+%global with_vmware 1
+%global with_vulkan_hw 1
+%global with_vdpau 1
+%global with_va 1
+%if !0%{?rhel}
+%global with_r300 1
+%global with_r600 1
+%global with_nine 1
+%global with_nvk %{with vulkan_hw}
+%global with_omx 1
+%global with_opencl 1
+%endif
+%global base_vulkan ,amd
+%endif
+
+%ifnarch %{ix86}
+%if !0%{?rhel}
+%global with_teflon 1
+%endif
+%endif
+
+%ifarch %{ix86} x86_64
+%global with_crocus 1
+%global with_i915   1
+%global with_iris   1
+%global with_xa     1
+%global with_intel_clc 1
+%global intel_platform_vulkan ,intel,intel_hasvk
+%endif
+%ifarch x86_64
+%global with_intel_vk_rt 1
+%endif
+
+%ifarch aarch64 x86_64 %{ix86}
+%if !0%{?rhel}
+%global with_lima      1
+%global with_vc4       1
+%endif
+%global with_etnaviv   1
+%global with_freedreno 1
+%global with_panfrost  1
+%global with_tegra     1
+%global with_v3d       1
+%global with_xa        1
+%global extra_platform_vulkan ,broadcom,freedreno,panfrost,imagination-experimental
+%endif
+
+%if !0%{?rhel}
+%global with_libunwind 1
+%global with_lmsensors 1
+%endif
+
+%ifarch %{valgrind_arches}
+%bcond_without valgrind
+%else
+%bcond_with valgrind
+%endif
+
+%global vulkan_drivers swrast%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan}%{?with_nvk:,nouveau}
+
+
+Name:           terra-%{srcname}
+Summary:        Mesa graphics libraries
+Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
+Release:        %autorelease
+License:        MIT AND BSD-3-Clause AND SGI-B-2.0
+URL:            http://www.mesa3d.org
+
+# src/gallium/auxiliary/postprocess/pp_mlaa* have an ... interestingly worded license.
+# Source1 contains email correspondence clarifying the license terms.
+# Fedora opts to ignore the optional part of clause 2 and treat that code as 2 clause BSD.
+Source1:        Mesa-MLAA-License-Clarification-Email.txt
+#Patch10:        https://src.fedoraproject.org/rpms/mesa/raw/e89544b7a4d811a64ca23b402add29524cc6f704/f/gnome-shell-glthread-disable.patch
+# Patch11:        https://src.fedoraproject.org/rpms/mesa/raw/e89544b7a4d811a64ca23b402add29524cc6f704/f/0001-llvmpipe-Init-eglQueryDmaBufModifiersEXT-num_modifie.patch
+#Patch12:        https://src.fedoraproject.org/rpms/mesa/raw/e89544b7a4d811a64ca23b402add29524cc6f704/f/0001-Revert-ac-radeonsi-remove-has_syncobj-has_fence_to_h.patch
+# s390x: fix build
+# Patch100:       https://src.fedoraproject.org/rpms/mesa/raw/e89544b7a4d811a64ca23b402add29524cc6f704/f/fix-egl-on-s390x.patch
+BuildRequires:  meson >= 1.3.0
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  gettext
+%if 0%{?with_hardware}
+BuildRequires:  kernel-headers
+%endif
+# We only check for the minimum version of pkgconfig(libdrm) needed so that the
+# SRPMs for each arch still have the same build dependencies. See:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1859515
+BuildRequires:  pkgconfig(libdrm) >= 2.4.97
+%if 0%{?with_libunwind}
+BuildRequires:  pkgconfig(libunwind)
+%endif
+BuildRequires:  pkgconfig(expat)
+BuildRequires:  pkgconfig(zlib) >= 1.2.3
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(libselinux)
+BuildRequires:  pkgconfig(wayland-scanner)
+BuildRequires:  pkgconfig(wayland-protocols) >= 1.8
+BuildRequires:  pkgconfig(wayland-client) >= 1.11
+BuildRequires:  pkgconfig(wayland-server) >= 1.11
+BuildRequires:  pkgconfig(wayland-egl-backend) >= 3
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xext)
+BuildRequires:  pkgconfig(xdamage) >= 1.1
+BuildRequires:  pkgconfig(xfixes)
+BuildRequires:  pkgconfig(xcb-glx) >= 1.8.1
+BuildRequires:  pkgconfig(xxf86vm)
+BuildRequires:  pkgconfig(xcb)
+BuildRequires:  pkgconfig(x11-xcb)
+BuildRequires:  pkgconfig(xcb-dri2) >= 1.8
+BuildRequires:  pkgconfig(xcb-dri3)
+BuildRequires:  pkgconfig(xcb-present)
+BuildRequires:  pkgconfig(xcb-sync)
+BuildRequires:  pkgconfig(xshmfence) >= 1.1
+BuildRequires:  pkgconfig(dri2proto) >= 2.8
+BuildRequires:  pkgconfig(glproto) >= 1.4.14
+BuildRequires:  pkgconfig(xcb-xfixes)
+BuildRequires:  pkgconfig(xcb-randr)
+BuildRequires:  pkgconfig(xrandr) >= 1.3
+BuildRequires:  bison
+BuildRequires:  flex
+%if 0%{?with_lmsensors}
+BuildRequires:  lm_sensors-devel
+%endif
+%if 0%{?with_vdpau}
+BuildRequires:  pkgconfig(vdpau) >= 1.1
+%endif
+%if 0%{?with_va}
+BuildRequires:  pkgconfig(libva) >= 0.38.0
+%endif
+%if 0%{?with_omx}
+BuildRequires:  pkgconfig(libomxil-bellagio)
+%endif
+BuildRequires:  pkgconfig(libelf)
+BuildRequires:  pkgconfig(libglvnd) >= 1.3.2
+BuildRequires:  llvm-devel >= 7.0.0
+%if 0%{?with_teflon}
+BuildRequires:  flatbuffers-devel
+BuildRequires:  flatbuffers-compiler
+BuildRequires:  xtensor-devel
+%endif
+%if 0%{?with_opencl} || 0%{?with_nvk} || 0%{?with_intel_clc}
+BuildRequires:  clang-devel
+BuildRequires:  bindgen
+BuildRequires:  rust-packaging
+BuildRequires:  pkgconfig(libclc)
+BuildRequires:  pkgconfig(SPIRV-Tools)
+BuildRequires:  pkgconfig(LLVMSPIRVLib)
+%endif
+%if 0%{?with_opencl} || 0%{?with_nvk}
+BuildRequires:  cbindgen
+BuildRequires:  (crate(paste) >= 1.0.14 with crate(paste) < 2)
+BuildRequires:  (crate(proc-macro2) >= 1.0.56 with crate(proc-macro2) < 2)
+BuildRequires:  (crate(quote) >= 1.0.25 with crate(quote) < 2)
+BuildRequires:  (crate(syn/clone-impls) >= 2.0.15 with crate(syn/clone-impls) < 3)
+BuildRequires:  (crate(unicode-ident) >= 1.0.6 with crate(unicode-ident) < 2)
+%endif
+%if %{with valgrind}
+BuildRequires:  pkgconfig(valgrind)
+%endif
+BuildRequires:  python3-devel
+BuildRequires:  python3-mako
+BuildRequires:  python3-pyyaml
+%if 0%{?with_intel_clc}
+BuildRequires:  python3-ply
+%endif
+BuildRequires:  python3-pycparser
+BuildRequires:  vulkan-headers
+BuildRequires:  glslang
+%if 0%{?with_vulkan_hw}
+BuildRequires:  pkgconfig(vulkan)
+%endif
+%description
+%{summary}.
+%package filesystem
+%replace_pkg filesystem
+Summary:        Mesa driver filesystem
+Provides:       mesa-dri-filesystem = %{?epoch:%{epoch}:}%{version}-%{release}
+%description filesystem
+%{summary}.
+%package libGL
+%replace_pkg libGL
+Summary:        Mesa libGL runtime libraries
+Requires:       %{name}-libglapi%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libglvnd-glx%{?_isa} >= 1:1.3.2
+Recommends:     %{name}-dri-drivers%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+%description libGL
+%{summary}.
+%package libGL-devel
+%replace_pkg libGL-devel
+Summary:        Mesa libGL development package
+Requires:       %{name}-libGL%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libglvnd-devel%{?_isa} >= 1:1.3.2
+Provides:       libGL-devel
+Provides:       libGL-devel%{?_isa}
+Recommends:     gl-manpages
+%description libGL-devel
+%{summary}.
+%package libEGL
+%replace_pkg libEGL
+Summary:        Mesa libEGL runtime libraries
+Requires:       libglvnd-egl%{?_isa} >= 1:1.3.2
+Requires:       %{name}-libgbm%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       %{name}-libglapi%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Recommends:     %{name}-dri-drivers%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+%description libEGL
+%{summary}.
+%package libEGL-devel
+%replace_pkg libEGL-devel
+Summary:        Mesa libEGL development package
+Requires:       %{name}-libEGL%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libglvnd-devel%{?_isa} >= 1:1.3.2
+Requires:       %{srcname}-khr-devel%{?_isa}
+Provides:       libEGL-devel
+Provides:       libEGL-devel%{?_isa}
+%description libEGL-devel
+%{summary}.
+%package dri-drivers
+%replace_pkg dri-drivers
+Summary:        Mesa-based DRI drivers
+Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       %{name}-libglapi%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+%if 0%{?with_va}
+Recommends:     %{name}-va-drivers%{?_isa}
+%endif
+%description dri-drivers
+%{summary}.
+%if 0%{?with_omx}
+%package omx-drivers
+%replace_pkg omx-drivers
+Summary:        Mesa-based OMX drivers
+Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+%description omx-drivers
+%{summary}.
+%endif
+%if 0%{?with_va}
+%package        va-drivers
+%replace_pkg va-drivers
+Provides:       %{srcname}-va-drivers = %{?epoch:%{epoch}:}%{version}-%{release}
+Summary:        Mesa-based VA-API video acceleration drivers
+Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Obsoletes:      %{name}-vaapi-drivers < 22.2.0-5
+%description va-drivers
+%{summary}.
+%endif
+%if 0%{?with_vdpau}
+%package        vdpau-drivers
+%replace_pkg vdpau-drivers
+Summary:        Mesa-based VDPAU drivers
+Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+%description vdpau-drivers
+%{summary}.
+%endif
+%package libOSMesa
+%replace_pkg libOSMesa
+Summary:        Mesa offscreen rendering libraries
+Requires:       %{name}-libglapi%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       libOSMesa
+Provides:       libOSMesa%{?_isa}
+%description libOSMesa
+%{summary}.
+%package libOSMesa-devel
+%replace_pkg libOSMesa-devel
+Summary:        Mesa offscreen rendering development package
+Requires:       %{name}-libOSMesa%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+%description libOSMesa-devel
+%{summary}.
+%package libgbm
+%replace_pkg libgbm
+Summary:        Mesa gbm runtime library
+Provides:       libgbm
+Provides:       libgbm%{?_isa}
+Recommends:     %{name}-dri-drivers%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+# If mesa-dri-drivers are installed, they must match in version. This is here to prevent using
+# older mesa-dri-drivers together with a newer mesa-libgbm and its dependants.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=2193135 .
+Requires:       (%{name}-dri-drivers%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release} if %{name}-dri-drivers%{?_isa})
+%description libgbm
+%{summary}.
+%package libgbm-devel
+%replace_pkg libgbm-devel
+Summary:        Mesa libgbm development package
+Requires:       %{name}-libgbm%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       libgbm-devel
+Provides:       libgbm-devel%{?_isa}
+%description libgbm-devel
+%{summary}.
+%if 0%{?with_xa}
+%package libxatracker
+%replace_pkg libxatracker
+Summary:        Mesa XA state tracker
+Provides:       libxatracker
+Provides:       libxatracker%{?_isa}
+%description libxatracker
+%{summary}.
+%package libxatracker-devel
+%replace_pkg libxatracker-devel
+Summary:        Mesa XA state tracker development package
+Requires:       %{name}-libxatracker%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       libxatracker-devel
+Provides:       libxatracker-devel%{?_isa}
+%description libxatracker-devel
+%{summary}.
+%endif
+%package libglapi
+%replace_pkg libglapi
+Summary:        Mesa shared glapi
+Provides:       libglapi
+Provides:       libglapi%{?_isa}
+# If mesa-dri-drivers are installed, they must match in version. This is here to prevent using
+# older mesa-dri-drivers together with a newer mesa-libglapi or its dependants.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=2193135 .
+Requires:       (%{name}-dri-drivers%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release} if %{name}-dri-drivers%{?_isa})
+%description libglapi
+%{summary}.
+%if 0%{?with_opencl}
+%package libOpenCL
+%replace_pkg libOpenCL
+Summary:        Mesa OpenCL runtime library
+Requires:       ocl-icd%{?_isa}
+Requires:       libclc%{?_isa}
+Requires:       %{name}-libgbm%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       opencl-filesystem
+%description libOpenCL
+%{summary}.
+%package libOpenCL-devel
+%replace_pkg libOpenCL-devel
+Summary:        Mesa OpenCL development package
+Requires:       %{name}-libOpenCL%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+%description libOpenCL-devel
+%{summary}.
+%endif
+%if 0%{?with_teflon}
+%package libTeflon
+%replace_pkg libTeflon
+Summary:        Mesa TensorFlow Lite delegate
+%description libTeflon
+%{summary}.
+%endif
+%if 0%{?with_nine}
+%package libd3d
+%replace_pkg libd3d
+Summary:        Mesa Direct3D9 state tracker
+%description libd3d
+%{summary}.
+%package libd3d-devel
+%replace_pkg libd3d-devel
+Summary:        Mesa Direct3D9 state tracker development package
+Requires:       %{name}-libd3d%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+%description libd3d-devel
+%{summary}.
+%endif
+%package vulkan-drivers
+%replace_pkg vulkan-drivers
+Summary:        Mesa Vulkan drivers
+Requires:       vulkan%{_isa}
+Obsoletes:      mesa-vulkan-devel < %{?epoch:%{epoch}:}%{version}-%{release}
+%description vulkan-drivers
+The drivers with support for the Vulkan API.
+%prep
+%autosetup -n %{srcname}-%{ver} -p1
+cp %{SOURCE1} docs/
+%build
+# ensure standard Rust compiler flags are set
+export RUSTFLAGS="%build_rustflags"
+%if 0%{?with_nvk}
+export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
+# So... Meson can't actually find them without tweaks
+%define inst_crate_nameversion() %(basename %{cargo_registry}/%{1}-*)
+%define rewrite_wrap_file() sed -e "/source.*/d" -e "s/%{1}-.*/%{inst_crate_nameversion %{1}}/" -i subprojects/%{1}.wrap
+%rewrite_wrap_file proc-macro2
+%rewrite_wrap_file quote
+%rewrite_wrap_file syn
+%rewrite_wrap_file unicode-ident
+%rewrite_wrap_file paste
+%endif
+# We've gotten a report that enabling LTO for mesa breaks some games. See
+# https://bugzilla.redhat.com/show_bug.cgi?id=1862771 for details.
+# Disable LTO for now
+%define _lto_cflags %{nil}
+%meson \
+  -Dplatforms=x11,wayland \
+  -Ddri3=enabled \
+  -Dosmesa=true \
+%if 0%{?with_hardware}
+  -Dgallium-drivers=swrast,virgl,nouveau%{?with_r300:,r300}%{?with_crocus:,crocus}%{?with_i915:,i915}%{?with_iris:,iris}%{?with_vmware:,svga}%{?with_radeonsi:,radeonsi}%{?with_r600:,r600}%{?with_freedreno:,freedreno}%{?with_etnaviv:,etnaviv}%{?with_tegra:,tegra}%{?with_vc4:,vc4}%{?with_v3d:,v3d}%{?with_lima:,lima}%{?with_panfrost:,panfrost}%{?with_vulkan_hw:,zink} \
+%else
+  -Dgallium-drivers=swrast,virgl \
+%endif
+  -Dgallium-vdpau=%{?with_vdpau:enabled}%{!?with_vdpau:disabled} \
+  -Dgallium-omx=%{?with_omx:bellagio}%{!?with_omx:disabled} \
+  -Dgallium-va=%{?with_va:enabled}%{!?with_va:disabled} \
+  -Dgallium-xa=%{?with_xa:enabled}%{!?with_xa:disabled} \
+  -Dgallium-nine=%{?with_nine:true}%{!?with_nine:false} \
+  -Dteflon=%{?with_teflon:true}%{!?with_teflon:false} \
+  -Dgallium-opencl=%{?with_opencl:icd}%{!?with_opencl:disabled} \
+%if 0%{?with_opencl}
+  -Dgallium-rusticl=true \
+%endif
+  -Dvideo-codecs=h264dec,h264enc,h265dec,h265enc,vc1dec,av1dec,av1enc,vp9dec \
+  -Dvulkan-drivers=%{?vulkan_drivers} \
+  -Dvulkan-layers=device-select \
+  -Dshared-glapi=enabled \
+  -Dgles1=enabled \
+  -Dgles2=enabled \
+  -Dopengl=true \
+  -Dgbm=enabled \
+  -Dglx=dri \
+  -Degl=enabled \
+  -Dglvnd=enabled \
+%if 0%{?with_intel_clc}
+  -Dintel-clc=enabled \
+%endif
+  -Dintel-rt=%{?with_intel_vk_rt:enabled}%{!?with_intel_vk_rt:disabled} \
+  -Dmicrosoft-clc=disabled \
+  -Dllvm=enabled \
+  -Dshared-llvm=enabled \
+  -Dvalgrind=%{?with_valgrind:enabled}%{!?with_valgrind:disabled} \
+  -Dbuild-tests=false \
+  -Dselinux=true \
+%if !0%{?with_libunwind}
+  -Dlibunwind=disabled \
+%endif
+%if !0%{?with_lmsensors}
+  -Dlmsensors=disabled \
+%endif
+  -Dandroid-libbacktrace=disabled \
+%ifarch %{ix86}
+  -Dglx-read-only-text=true \
+%endif
+  %{nil}
+%meson_build
+%install
+%meson_install
+# libvdpau opens the versioned name, don't bother including the unversioned
+rm -vf %{buildroot}%{_libdir}/vdpau/*.so
+# likewise glvnd
+rm -vf %{buildroot}%{_libdir}/libGLX_mesa.so
+rm -vf %{buildroot}%{_libdir}/libEGL_mesa.so
+# XXX can we just not build this
+rm -vf %{buildroot}%{_libdir}/libGLES*
+# glvnd needs a default provider for indirect rendering where it cannot
+# determine the vendor
+ln -s %{_libdir}/libGLX_mesa.so.0 %{buildroot}%{_libdir}/libGLX_system.so.0
+# this keeps breaking, check it early.  note that the exit from eu-ftr is odd.
+pushd %{buildroot}%{_libdir}
+for i in libOSMesa*.so libGL.so ; do
+    eu-findtextrel $i && exit 1
+done
+popd
+%files filesystem
+%doc docs/Mesa-MLAA-License-Clarification-Email.txt
+%dir %{_libdir}/dri
+%if 0%{?with_hardware}
+%if 0%{?with_vdpau}
+%dir %{_libdir}/vdpau
+%endif
+%endif
+%files libGL
+%{_libdir}/libGLX_mesa.so.0*
+%{_libdir}/libGLX_system.so.0*
+%files libGL-devel
+%dir %{_includedir}/GL/internal
+%{_includedir}/GL/internal/dri_interface.h
+%{_libdir}/pkgconfig/dri.pc
+%{_libdir}/libglapi.so
+%files libEGL
+%{_datadir}/glvnd/egl_vendor.d/50_mesa.json
+%{_libdir}/libEGL_mesa.so.0*
+%files libEGL-devel
+%dir %{_includedir}/EGL
+%{_includedir}/EGL/eglext_angle.h
+%{_includedir}/EGL/eglmesaext.h
+%files libglapi
+%{_libdir}/libglapi.so.0
+%{_libdir}/libglapi.so.0.*
+%files libOSMesa
+%{_libdir}/libOSMesa.so.8*
+%files libOSMesa-devel
+%dir %{_includedir}/GL
+%{_includedir}/GL/osmesa.h
+%{_libdir}/libOSMesa.so
+%{_libdir}/pkgconfig/osmesa.pc
+%files libgbm
+%{_libdir}/libgbm.so.1
+%{_libdir}/libgbm.so.1.*
+%files libgbm-devel
+%{_libdir}/libgbm.so
+%{_includedir}/gbm.h
+%{_libdir}/pkgconfig/gbm.pc
+%if 0%{?with_xa}
+%files libxatracker
+%if 0%{?with_hardware}
+%{_libdir}/libxatracker.so.2
+%{_libdir}/libxatracker.so.2.*
+%endif
+%files libxatracker-devel
+%if 0%{?with_hardware}
+%{_libdir}/libxatracker.so
+%{_includedir}/xa_tracker.h
+%{_includedir}/xa_composite.h
+%{_includedir}/xa_context.h
+%{_libdir}/pkgconfig/xatracker.pc
+%endif
+%endif
+%if 0%{?with_teflon}
+%files libTeflon
+%{_libdir}/libteflon.so
+%endif
+%if 0%{?with_opencl}
+%files libOpenCL
+%{_libdir}/libMesaOpenCL.so.*
+%{_libdir}/libRusticlOpenCL.so.*
+%{_sysconfdir}/OpenCL/vendors/mesa.icd
+%{_sysconfdir}/OpenCL/vendors/rusticl.icd
+%files libOpenCL-devel
+%{_libdir}/libMesaOpenCL.so
+%{_libdir}/libRusticlOpenCL.so
+%endif
+%if 0%{?with_nine}
+%files libd3d
+%dir %{_libdir}/d3d/
+%{_libdir}/d3d/*.so.*
+%files libd3d-devel
+%{_libdir}/pkgconfig/d3d.pc
+%{_includedir}/d3dadapter/
+%{_libdir}/d3d/*.so
+%endif
+%files dri-drivers
+%dir %{_datadir}/drirc.d
+%{_datadir}/drirc.d/00-mesa-defaults.conf
+%{_libdir}/dri/kms_swrast_dri.so
+%{_libdir}/dri/swrast_dri.so
+%{_libdir}/dri/virtio_gpu_dri.so
+%if 0%{?with_hardware}
+%if 0%{?with_r300}
+%{_libdir}/dri/r300_dri.so
+%endif
+%if 0%{?with_radeonsi}
+%if 0%{?with_r600}
+%{_libdir}/dri/r600_dri.so
+%endif
+%{_libdir}/dri/radeonsi_dri.so
+%endif
+%ifarch %{ix86} x86_64
+%{_libdir}/dri/crocus_dri.so
+%{_libdir}/dri/i915_dri.so
+%{_libdir}/dri/iris_dri.so
+%endif
+%ifarch aarch64 x86_64 %{ix86}
+%{_libdir}/dri/ingenic-drm_dri.so
+%{_libdir}/dri/imx-drm_dri.so
+%{_libdir}/dri/imx-lcdif_dri.so
+%{_libdir}/dri/kirin_dri.so
+%{_libdir}/dri/komeda_dri.so
+%{_libdir}/dri/mali-dp_dri.so
+%{_libdir}/dri/mcde_dri.so
+%{_libdir}/dri/mxsfb-drm_dri.so
+%{_libdir}/dri/rcar-du_dri.so
+%{_libdir}/dri/stm_dri.so
+%endif
+%if 0%{?with_vc4}
+%{_libdir}/dri/vc4_dri.so
+%endif
+%if 0%{?with_v3d}
+%{_libdir}/dri/v3d_dri.so
+%endif
+%if 0%{?with_freedreno}
+%{_libdir}/dri/kgsl_dri.so
+%{_libdir}/dri/msm_dri.so
+%endif
+%if 0%{?with_etnaviv}
+%{_libdir}/dri/etnaviv_dri.so
+%endif
+%if 0%{?with_tegra}
+%{_libdir}/dri/tegra_dri.so
+%endif
+%if 0%{?with_lima}
+%{_libdir}/dri/lima_dri.so
+%endif
+%if 0%{?with_panfrost}
+%{_libdir}/dri/panfrost_dri.so
+%{_libdir}/dri/panthor_dri.so
+%endif
+%{_libdir}/dri/nouveau_dri.so
+%if 0%{?with_vmware}
+%{_libdir}/dri/vmwgfx_dri.so
+%endif
+%endif
+%if 0%{?with_opencl}
+%dir %{_libdir}/gallium-pipe
+%{_libdir}/gallium-pipe/*.so
+%endif
+
+
+#kmsro?
+%{_libdir}/dri/armada-drm_dri.so
+%{_libdir}/dri/exynos_dri.so
+%{_libdir}/dri/gm12u320_dri.so
+%{_libdir}/dri/hdlcd_dri.so
+%{_libdir}/dri/hx8357d_dri.so
+%{_libdir}/dri/ili9163_dri.so
+%{_libdir}/dri/ili9225_dri.so
+%{_libdir}/dri/ili9341_dri.so
+%{_libdir}/dri/ili9486_dri.so
+%{_libdir}/dri/imx-dcss_dri.so
+%{_libdir}/dri/mediatek_dri.so
+%{_libdir}/dri/meson_dri.so
+%{_libdir}/dri/mi0283qt_dri.so
+%{_libdir}/dri/panel-mipi-dbi_dri.so
+%{_libdir}/dri/pl111_dri.so
+%{_libdir}/dri/repaper_dri.so
+%{_libdir}/dri/rockchip_dri.so
+%{_libdir}/dri/rzg2l-du_dri.so
+%{_libdir}/dri/ssd130x_dri.so
+%{_libdir}/dri/st7586_dri.so
+%{_libdir}/dri/st7735r_dri.so
+%{_libdir}/dri/sti_dri.so
+%{_libdir}/dri/sun4i-drm_dri.so
+%{_libdir}/dri/udl_dri.so
+%{_libdir}/dri/zynqmp-dpsub_dri.so
+
+%if 0%{?with_vulkan_hw}
+%{_libdir}/dri/libdril_dri.so
+%{_libdir}/dri/libgallium*
+%{_libdir}/dri/vkms_dri.so
+
+
+%endif
+%if 0%{?with_omx}
+%files omx-drivers
+%{_libdir}/bellagio/libomx_mesa.so
+%endif
+%if 0%{?with_va}
+%files va-drivers
+%{_libdir}/dri/nouveau_drv_video.so
+%if 0%{?with_r600}
+%{_libdir}/dri/r600_drv_video.so
+%endif
+%if 0%{?with_radeonsi}
+%{_libdir}/dri/radeonsi_drv_video.so
+%endif
+%{_libdir}/dri/virtio_gpu_drv_video.so
+%endif
+
+%if 0%{?with_vdpau}
+%files vdpau-drivers
+%{_libdir}/vdpau/libvdpau_nouveau.so.1*
+%if 0%{?with_r600}
+%{_libdir}/vdpau/libvdpau_r600.so.1*
+%endif
+%if 0%{?with_radeonsi}
+%{_libdir}/vdpau/libvdpau_radeonsi.so.1*
+%endif
+%{_libdir}/vdpau/libvdpau_virtio_gpu.so.1*
+%{_libdir}/vdpau/libvdpau_gallium.so.1*
+%endif
+%files vulkan-drivers
+%{_libdir}/libvulkan_lvp.so
+%{_datadir}/vulkan/icd.d/lvp_icd.*.json
+%{_libdir}/libVkLayer_MESA_device_select.so
+%{_datadir}/vulkan/implicit_layer.d/VkLayer_MESA_device_select.json
+%if 0%{?with_vulkan_hw}
+%{_libdir}/libvulkan_radeon.so
+%{_datadir}/drirc.d/00-radv-defaults.conf
+%{_datadir}/vulkan/icd.d/radeon_icd.*.json
+%if 0%{?with_nvk}
+%{_libdir}/libvulkan_nouveau.so
+%{_datadir}/vulkan/icd.d/nouveau_icd.*.json
+%endif
+
+%ifarch %{ix86} x86_64
+%{_libdir}/libvulkan_intel.so
+%{_datadir}/vulkan/icd.d/intel_icd.*.json
+%{_libdir}/libvulkan_intel_hasvk.so
+%{_datadir}/vulkan/icd.d/intel_hasvk_icd.*.json
+%endif
+%ifarch aarch64 x86_64 %{ix86}
+%{_libdir}/libvulkan_broadcom.so
+%{_datadir}/vulkan/icd.d/broadcom_icd.*.json
+%{_libdir}/libvulkan_freedreno.so
+%{_datadir}/vulkan/icd.d/freedreno_icd.*.json
+%{_libdir}/libvulkan_panfrost.so
+%{_datadir}/vulkan/icd.d/panfrost_icd.*.json
+%{_libdir}/libpowervr_rogue.so
+%{_libdir}/libvulkan_powervr_mesa.so
+%{_datadir}/vulkan/icd.d/powervr_mesa_icd.*.json
+%endif
+%endif
+%changelog
+%autochangelog

--- a/anda/system/terra-mesa/update.rhai
+++ b/anda/system/terra-mesa/update.rhai
@@ -1,0 +1,7 @@
+let v = gitlab_tag("gitlab.freedesktop.org", "176");
+if v.contains("-rc") {
+  print(`mesa: skipping (rc) ${v}`);
+  terminate();
+}
+v.crop(5);
+rpm.global("ver", v);


### PR DESCRIPTION
Let's add back Mesa, but we need to somehow make the dependency solver not prefer our version over Fedora's (unless we have a dedicated breaking repo for this)

## Building
```
anda build -c terra-40-x86_64 system/terra-mesa
anda build -c terra-40-i386 system/terra-mesa
```
## Testing
```bash
sudo dnf update --repofrompath=tmp,anda-build/rpm/rpms/
```
If you have upstream Mesa installed and it prompts you to upgrade to terra-mesa instead, we have failed

Bonus: Build a chroot and try to install mesa inside it, see if it tries to pull it terra-mesa

```
sudo dnf --repofrompath=tmp,anda-build/rpm/rpms/ --use-host-config --installroot=$PWD/chroot steam
```
