### PR TITLE
[f40] fix(cros-keyboard-map): amend dependencies (#1904)

### DIFF
--- a/anda/system/cros-keyboard-map/cros-keyboard-map.spec
+++ b/anda/system/cros-keyboard-map/cros-keyboard-map.spec
@@ -15,7 +15,7 @@ Source0:        https://github.com/WeirdTreeThing/cros-keyboard-map/archive/%com
 
 %{?systemd_requires}
 BuildRequires:  systemd-rpm-macros
-Requires:       keyd python3
+Requires:       keyd python3 python3-libfdt
 
 %description
 Set of tools designed to help develop and debug software and firmware on Intel platforms with AudioDSP onboard.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(cros-keyboard-map): amend dependencies (#1904)](https://github.com/terrapkg/packages/pull/1904)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)