### PR TITLE
[f41] fix: elementary-camera (#1933)

### DIFF
--- a/anda/desktops/elementary/elementary-camera/elementary-camera.spec
+++ b/anda/desktops/elementary/elementary-camera/elementary-camera.spec
@@ -20,7 +20,7 @@ BuildRequires:  fdupes
 BuildRequires:  pkgconfig(gee-0.8)
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(glib-2.0)
-BuildRequires:  pkgconfig(granite) >= 6.0.0
+BuildRequires:  pkgconfig(granite-7)
 BuildRequires:  pkgconfig(gstreamer-1.0)
 BuildRequires:  pkgconfig(gstreamer-pbutils-1.0)
 BuildRequires:  pkgconfig(gtk+-3.0)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: elementary-camera (#1933)](https://github.com/terrapkg/packages/pull/1933)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)