### PR TITLE
[f40] fix: cros-keyboard-map (#1958)

### DIFF
--- a/anda/system/cros-keyboard-map/cros-keyboard-map.spec
+++ b/anda/system/cros-keyboard-map/cros-keyboard-map.spec
@@ -1,69 +1,45 @@
-%global commit b2e69368f96bdf7562dc1a95a0d863c794756842
-%global commit_date 20240814
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global tree_commit b2e69368f96bdf7562dc1a95a0d863c794756842
+%global tree_commit_date 20240814
+%global tree_shortcommit %(c=%{tree_commit}; echo ${c:0:7})
+
+%global um_commit 46892acafb2fff3f3ace425d4694382c92645feb
+%global um_commit_date 20240824
+%global um_shortcommit %(c=%{um_commit}; echo ${c:0:7})
+
 %global debug_package %{nil}
 %define __os_install_post %{nil}
 
 Name:           cros-keyboard-map
-Version:        %commit_date.%shortcommit
+Version:        %tree_commit_date.%tree_shortcommit.%um_commit_date.%um_shortcommit
 Release:        1%?dist
 
-License:        BSD-3-Clause
+License:        BSD-3-Clause and GPLv3
 Summary:        Utility to generate keyd configurations for use on Chromebooks
-URL:            https://github.com/WeirdTreeThing/cros-keyboard-map
-Source0:        https://github.com/WeirdTreeThing/cros-keyboard-map/archive/%commit/cros-keyboard-map-%commit.tar.gz
+URL:            https://github.com/Ultramarine-Linux/cros-keyboard-map
+Source0:        https://github.com/WeirdTreeThing/cros-keyboard-map/archive/%{tree_commit}/cros-keyboard-map-%{tree_commit}.tar.gz
+Source1:        https://github.com/Ultramarine-Linux/cros-keyboard-map/archive/%{um_commit}/cros-keyboard-map-%{um_commit}.tar.gz
 
 %{?systemd_requires}
 BuildRequires:  systemd-rpm-macros
 Requires:       keyd python3 python3-libfdt
 
 %description
-Set of tools designed to help develop and debug software and firmware on Intel platforms with AudioDSP onboard.
-
-Related to alsa-utils which is also set of utilities but targets AdvancedLinuxSoundArchitecture (ALSA) audience in more general fashion.
+Bash script and systemd service to apply WeirdTreeThing's Chromebook keyboard maps.
 
 %prep
-%autosetup -n cros-keyboard-map-%commit
+%autosetup -n cros-keyboard-map-%tree_commit
+tar --strip-components=1 -zxvf %{SOURCE1}
 
 %install
-mkdir -p %buildroot/etc/cros-keyboard-map/configs
-install -Dm755 cros-keyboard-map.py %buildroot/etc/cros-keyboard-map/cros-keyboard-map.py
-cp configs/* %buildroot/etc/cros-keyboard-map/configs
+mkdir -p %buildroot%{_sysconfdir}/cros-keyboard-map/configs
+install -Dm755 cros-keyboard-map.py %buildroot%{_sysconfdir}/cros-keyboard-map/cros-keyboard-map.py
+cp configs/* %buildroot%{_sysconfdir}/cros-keyboard-map/configs
 
-mkdir -p %buildroot/usr/bin
-tee %buildroot/usr/bin/um-generate-cros-keymap <<EOF
-if (grep -E "^(Nocturne|Atlas|Eve)$" /sys/class/dmi/id/product_name &> /dev/null)
-then
-	cp /etc/cros-keyboard-map/configs/cros-pixel.conf /etc/cros-keyboard-map/current.config
-elif (grep -E "^(Sarien|Arcada)$" /sys/class/dmi/id/product_name &> /dev/null)
-then
-	cp /etc/cros-keyboard-map/configs/cros-sarien.conf /etc/cros-keyboard-map/current.config
-else
-	python3 /etc/cros-keyboard-map/cros-keyboard-map.py --file /etc/cros-keyboard-map/current.config
-fi
-
-mkdir -p /etc/keyd
-if [[ -f /etc/keyd/default.conf ]]; then
-	rm /etc/keyd/default.conf
-fi
-ln -s /etc/cros-keyboard-map/current.config /etc/keyd/default.conf
-EOF
-
-mkdir -p %buildroot/etc/systemd/system
-tee %buildroot/etc/systemd/system/cros-keyboard-map.service <<EOF
-[Unit]
-Description=Generate chromebook keyboard layout
-Before=keyd.service
-After=tmp.mount
-
-[Service]
-Type=oneshot
-ExecStart=/bin/bash /usr/bin/um-generate-cros-keymap
-
-[Install]
-WantedBy=sysinit.target
-EOF
-chmod +x %buildroot/usr/bin/um-generate-cros-keymap
+mkdir -p %buildroot%{_bindir}
+install -Dm755 um-generate-cros-keymap %{buildroot}%{_bindir}/um-generate-cros-keymap
+mkdir -p %buildroot%{_unitdir}
+install -Dm644 cros-keyboard-map.service %{buildroot}%{_unitdir}/cros-keyboard-map.service
+chmod +x %buildroot%{_bindir}/um-generate-cros-keymap
 
 %post
 %systemd_post cros-keyboard-map.service
@@ -80,10 +56,12 @@ chmod +x %buildroot/usr/bin/um-generate-cros-keymap
 %files
 %doc README.md
 %license LICENSE
-/etc/cros-keyboard-map/*
-/etc/systemd/system/cros-keyboard-map.service
-/usr/bin/um-generate-cros-keymap
+%{_sysconfdir}/cros-keyboard-map/*
+%{_unitdir}/cros-keyboard-map.service
+%{_bindir}/um-generate-cros-keymap
 
 %changelog
+* Sat Aug 24 2024 junefish <june@fyralabs.com>
+- Split off into seperate git repo.
 * Sat May 4 2024 Owen-sz <owen@fyralabs.com>
 - Initial package.

--- a/anda/system/cros-keyboard-map/update.rhai
+++ b/anda/system/cros-keyboard-map/update.rhai
@@ -1,7 +1,9 @@
 if filters.contains("nightly") {
+  rpm.global("tree_commit", gh_commit("WeirdTreeThing/cros-keyboard-map"));
   rpm.global("commit", gh_commit("WeirdTreeThing/cros-keyboard-map"));
   if rpm.changed() {
     rpm.release();
-    rpm.global("commit_date", date());
+    rpm.global("tree_commit_date", date());
+    rpm.global("um_commit_date", date());
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: cros-keyboard-map (#1958)](https://github.com/terrapkg/packages/pull/1958)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)