### PR TITLE
[f40] fix version formatting for cros-keyboard-map (#1989)

### DIFF
--- a/anda/system/cros-keyboard-map/cros-keyboard-map.spec
+++ b/anda/system/cros-keyboard-map/cros-keyboard-map.spec
@@ -1,16 +1,16 @@
+%global commit_date 20240824
+
 %global tree_commit b2e69368f96bdf7562dc1a95a0d863c794756842
-%global tree_commit_date 20240814
 %global tree_shortcommit %(c=%{tree_commit}; echo ${c:0:7})
 
 %global um_commit 46892acafb2fff3f3ace425d4694382c92645feb
-%global um_commit_date 20240824
 %global um_shortcommit %(c=%{um_commit}; echo ${c:0:7})
 
 %global debug_package %{nil}
 %define __os_install_post %{nil}
 
 Name:           cros-keyboard-map
-Version:        %tree_commit_date.%tree_shortcommit.%um_commit_date.%um_shortcommit
+Version:        %commit_date.%tree_shortcommit.%um_shortcommit
 Release:        1%?dist
 
 License:        BSD-3-Clause and GPLv3

--- a/anda/system/cros-keyboard-map/update.rhai
+++ b/anda/system/cros-keyboard-map/update.rhai
@@ -3,7 +3,6 @@ if filters.contains("nightly") {
   rpm.global("commit", gh_commit("WeirdTreeThing/cros-keyboard-map"));
   if rpm.changed() {
     rpm.release();
-    rpm.global("tree_commit_date", date());
-    rpm.global("um_commit_date", date());
+    rpm.global("commit_date", date());
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix version formatting for cros-keyboard-map (#1989)](https://github.com/terrapkg/packages/pull/1989)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)