### PR TITLE
[f41] fix: armcord (#1996)

### DIFF
--- a/anda/apps/armcord/armcord.spec
+++ b/anda/apps/armcord/armcord.spec
@@ -8,8 +8,9 @@ Summary:	Custom lightweight Discord client designed to enhance your experience
 URL:		https://github.com/ArmCord/ArmCord
 Group:		Applications/Internet
 Source1:	launch.sh
+Packager:	madonuko <mado@fyralabs.com>
 Requires:	electron xdg-utils
-BuildRequires:	nodejs-npm git add-determinism
+BuildRequires:	git-core add-determinism pnpm
 Conflicts:	armcord-bin
 BuildArch:	noarch
 
@@ -37,8 +38,8 @@ EOF
 
 
 %build
-npx pnpm@7 install --no-frozen-lockfile
-npm run packageQuick
+pnpm install --no-frozen-lockfile
+pnpm run packageQuick
 
 
 %install
@@ -50,13 +51,16 @@ install -Dm644 build/icon.png %buildroot/usr/share/pixmaps/armcord.png
 
 %files
 %doc README.md
-%license LICENSE
+%license license.txt
 /usr/bin/armcord
 /usr/share/applications/ArmCord.desktop
 /usr/share/pixmaps/armcord.png
 /usr/share/armcord/app.asar
 
 %changelog
+* Mon Aug 26 2024 madonuko <mado@fyralabs.com> - 3.3.0-1
+- Update to license.txt
+
 * Sat Jun 17 2023 windowsboy111 <windowsboy111@fyralabs.com> - 3.2.0-2
 - Remove libnotify dependency.
 - Fix desktop entry.
@@ -64,4 +68,3 @@ install -Dm644 build/icon.png %buildroot/usr/share/pixmaps/armcord.png
 
 * Sat May 6 2023 windowsboy111 <windowsboy111@fyralabs.com> - 3.1.7-1
 - Initial package
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: armcord (#1996)](https://github.com/terrapkg/packages/pull/1996)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)