### PR TITLE
[f40] Add cbfstool (#1997)

### DIFF
--- a/anda/tools/cbfstool/anda.hcl
+++ b/anda/tools/cbfstool/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "cbfstool.spec"
+	}
+}

--- a/anda/tools/cbfstool/cbfstool.spec
+++ b/anda/tools/cbfstool/cbfstool.spec
@@ -1,0 +1,28 @@
+Name:           cbfstool
+Version:        24.08
+Release:        1%?dist
+Summary:        Management utility for CBFS formatted ROM images
+URL:            https://doc.coreboot.org/lib/fw_config.html#cbfs
+License:        GPLv2
+BuildRequires:  gcc g++ gcc-gnat make cmake ncurses-devel iasl git
+Requires:       glibc
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+Management utility for CBFS formatted ROM images.
+
+%prep
+git clone https://review.coreboot.org/coreboot.git -b %version
+
+%build
+make -C coreboot/util/cbfstool
+
+%install
+install -Dm 777 coreboot/util/cbfstool/cbfstool %buildroot%_bindir/cbfstool
+
+%files
+/usr/bin/cbfstool
+
+%changelog
+* Sun Aug 25 2024 Owen Zimmerman <owen@fyralabs.com>
+- Initial Package

--- a/anda/tools/cbfstool/update.rhai
+++ b/anda/tools/cbfstool/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("coreboot/coreboot"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Add cbfstool (#1997)](https://github.com/terrapkg/packages/pull/1997)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)