### PR TITLE
[f41] fix: gnome-shell-extension-appmenu-is-back (#2011)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
@@ -11,6 +11,7 @@ URL:            https://github.com/fthx/appmenu-is-back
 BuildArch:      noarch
 
 Source0:        https://github.com/fthx/appmenu-is-back/archive/refs/tags/v%{version}.tar.gz
+Patch0:         https://github.com/fthx/appmenu-is-back/compare/v2..703a31acf900eb7bcab3462baeefa815ec7f13ab.patch
 
 Requires:       (gnome-shell >= 45~ with gnome-shell < 46~)
 Recommends:     gnome-extensions-app
@@ -19,7 +20,7 @@ Recommends:     gnome-extensions-app
 This extension brings back the app menu in the top panel, for GNOME 45 and later.
 
 %prep
-%autosetup -n appmenu-is-back-%{version}
+%autosetup -n appmenu-is-back-%{version} -p1
 
 %install
 install -Dm644 metadata.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/metadata.json


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: gnome-shell-extension-appmenu-is-back (#2011)](https://github.com/terrapkg/packages/pull/2011)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)