### PR TITLE
[f41] fix: allow it to require gnome-shell 47 (#2014)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
@@ -13,7 +13,7 @@ BuildArch:      noarch
 Source0:        https://github.com/fthx/appmenu-is-back/archive/refs/tags/v%{version}.tar.gz
 Patch0:         https://github.com/fthx/appmenu-is-back/compare/v2..703a31acf900eb7bcab3462baeefa815ec7f13ab.patch
 
-Requires:       (gnome-shell >= 45~ with gnome-shell < 46~)
+Requires:       (gnome-shell >= 46~ with gnome-shell < 48~)
 Recommends:     gnome-extensions-app
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: allow it to require gnome-shell 47 (#2014)](https://github.com/terrapkg/packages/pull/2014)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)