### PR TITLE
[f40] bump: process-cpp (#2018)

### DIFF
--- a/anda/lib/process-cpp/process-cpp.spec
+++ b/anda/lib/process-cpp/process-cpp.spec
@@ -3,7 +3,7 @@
 %forgemeta
 
 Name:          process-cpp
-Version:       3.0.1
+Version:       3.0.2
 Release:       %autorelease
 Summary:       A simple convenience library for handling processes in C++
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [bump: process-cpp (#2018)](https://github.com/terrapkg/packages/pull/2018)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)