### PR TITLE
[f40] add: nph (#2016)

### DIFF
--- a/anda/langs/nim/nph/anda.hcl
+++ b/anda/langs/nim/nph/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "nph.spec"
+    }
+}

--- a/anda/langs/nim/nph/nph.spec
+++ b/anda/langs/nim/nph/nph.spec
@@ -1,0 +1,31 @@
+%define debug_package %nil
+
+Name:           nph
+Version:        0.6.0
+Release:        1%?dist
+Summary:        An opinionated code formatter for Nim
+License:        MIT
+URL:            https://github.com/arnetheduck/nph
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+SourceLicense:  MIT
+Packager:       madonuko <mado@fyralabs.com>
+BuildRequires:  anda-srpm-macros
+BuildRequires:  nim
+
+%description
+nph is an opinionated source code formatter for the Nim language, aiming to take the drudgery of manual formatting out of your coding day.
+
+%prep
+%autosetup
+%nim_prep -t:"%nim_tflags" -l:"%nim_lflags"
+
+%build
+nimble c -d:release -t:"%nim_tflags" -l:"%nim_lflags" src/nph
+
+%install
+install -Dpm755 src/nph %buildroot%_bindir/nph
+
+%files
+%_bindir/nph
+%license copying.txt
+%doc README.md

--- a/anda/langs/nim/nph/update.rhai
+++ b/anda/langs/nim/nph/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arnetheduck/nph"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: nph (#2016)](https://github.com/terrapkg/packages/pull/2016)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)