### PR TITLE
[el9] fix: envision (#2035)

### DIFF
--- a/anda/apps/envision/envision.spec
+++ b/anda/apps/envision/envision.spec
@@ -21,6 +21,7 @@ BuildRequires:  openxr-devel
 BuildRequires:  libappstream-glib
 BuildRequires:  desktop-file-utils
 BuildRequires:  glib2-devel
+BuildRequires:  git-core
 Recommends:     android-tools
 
 %description
@@ -40,8 +41,8 @@ Recommends:     android-tools
 %doc README.md
 %license LICENSE
 %_bindir/envision
-%_datadir/applications/org.gabmus.envision.desktop
+%_datadir/applications/org.gabmus.envision.Devel.desktop
 %_datadir/envision/
-%_iconsdir/hicolor/scalable/apps/org.gabmus.envision.svg
-%_iconsdir/hicolor/symbolic/apps/org.gabmus.envision-symbolic.svg
-%_metainfodir/org.gabmus.envision.appdata.xml
+%_iconsdir/hicolor/scalable/apps/org.gabmus.envision.Devel.svg
+%_iconsdir/hicolor/symbolic/apps/org.gabmus.envision.Devel-symbolic.svg
+%_metainfodir/org.gabmus.envision.Devel.appdata.xml


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el9`:
 - [fix: envision (#2035)](https://github.com/terrapkg/packages/pull/2035)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)