### PR TITLE
[f41] add: stardust-magnetar (#2062)

### DIFF
--- a/anda/stardust/magnetar/anda.hcl
+++ b/anda/stardust/magnetar/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "stardust-magnetar.spec"
+    }
+    labels {
+       nightly = 1
+    }
+}

--- a/anda/stardust/magnetar/stardust-magnetar.spec
+++ b/anda/stardust/magnetar/stardust-magnetar.spec
@@ -1,0 +1,41 @@
+%global commit 48064b84b71d27ceea00b5d2f19dcbf21d75f554
+%global commit_date 20240831
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+
+Name:           stardust-magnetar
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Workspaces client for Stardust XR.
+URL:            https://github.com/StardustXR/magnetar
+Source0:        %url/archive/%commit/magnetar-%commit.tar.gz
+License:        MIT
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
+
+Provides:       magnetar
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary
+
+%prep
+%autosetup -n magnetar-%commit
+%cargo_prep_online
+
+%build
+
+%install
+%define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
+%cargo_install
+
+
+%files
+%_bindir/magnetar
+%license LICENSE
+%doc README.md
+
+%changelog
+* Wed Sep 11 2024 Owen-sz <owen@fyralabs.com>
+- Package StardustXR magnetar
+

--- a/anda/stardust/magnetar/update.rhai
+++ b/anda/stardust/magnetar/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("StardustXR/magnetar"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: stardust-magnetar (#2062)](https://github.com/terrapkg/packages/pull/2062)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)