### PR TITLE
[f39] add: stardust-protostar (#2056)

### DIFF
--- a/anda/stardust/protostar/anda.hcl
+++ b/anda/stardust/protostar/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "stardust-protostar.spec"
+    }
+    labels {
+       nightly = 1
+    }
+}

--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -1,0 +1,48 @@
+%global commit 39499a061af74c3a2d5e1e46e4ad21aca5727219
+%global commit_date 20240719
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+
+Name:           stardust-protostar
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Prototype application launcher for Stardust XR.
+URL:            https://github.com/StardustXR/protostar
+Source0:        %url/archive/%commit/protostar-%commit.tar.gz
+License:        MIT
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
+
+Provides:       protostar
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+Prototype application launcher for StardustXR, providing an easy to use crate to write applications launchers.
+
+%prep
+%autosetup -n protostar-%commit
+%cargo_prep_online
+
+%build
+
+%install
+%define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
+STARDUST_RES_PREFIXES=%_datadir
+(cd app_grid && %cargo_install) &
+(cd hexagon_launcher && %cargo_install) &
+(cd single && %cargo_install) &
+(cd sirius && %cargo_install) &
+
+wait
+
+%files
+%_bindir/app_grid
+%_bindir/hexagon_launcher
+%_bindir/single
+%_bindir/sirius
+%license LICENSE
+%doc README.md
+
+%changelog
+* Tue Sep 10 2024 Owen-sz <owen@fyralabs.com>
+- Package StardustXR protostar

--- a/anda/stardust/protostar/update.rhai
+++ b/anda/stardust/protostar/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("StardustXR/protostart"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add: stardust-protostar (#2056)](https://github.com/terrapkg/packages/pull/2056)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)