### PR TITLE
[f39] add: stardust-non-spatial-input (#2053)

### DIFF
--- a/anda/stardust/non-spatial-input/anda.hcl
+++ b/anda/stardust/non-spatial-input/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "stardust-non-spatial-input.spec"
+    }
+    labels {
+       nightly = 1
+    }
+}

--- a/anda/stardust/non-spatial-input/stardust-non-spatial-input.spec
+++ b/anda/stardust/non-spatial-input/stardust-non-spatial-input.spec
@@ -1,0 +1,47 @@
+%global commit 5ac7f04f6876097aa8c3cf9af033d609a8a49944
+%global commit_date 20240824
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+
+Name:           stardust-non-spatial-input
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Tools you can easily snap together to get non-spatial input into Stardust XR.
+URL:            https://github.com/StardustXR/non-spatial-input
+Source0:        %url/archive/%commit/non-spatial-input-%commit.tar.gz
+License:        MIT
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
+
+Provides:       non-spatial-input
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary
+
+%prep
+%autosetup -n non-spatial-input-%commit
+%cargo_prep_online
+
+%build
+
+%install
+%define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
+(cd azimuth && %cargo_install) &
+(cd eclipse && %cargo_install) &
+(cd manifold && %cargo_install) &
+(cd simular && %cargo_install) &
+
+wait
+
+%files
+%_bindir/azimuth
+%_bindir/eclipse
+%_bindir/manifold
+%_bindir/simular
+%license LICENSE
+%doc README.md
+
+%changelog
+* Mon Sep 9 2024 Owen-sz <owen@fyralabs.com>
+- Package StardustXR non-spatial-input

--- a/anda/stardust/non-spatial-input/update.rhai
+++ b/anda/stardust/non-spatial-input/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("StardustXR/non-spatial-input"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add: stardust-non-spatial-input (#2053)](https://github.com/terrapkg/packages/pull/2053)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)