### PR TITLE
[f40] add: stardust-armillary (#2050)

### DIFF
--- a/anda/stardust/armillary/anda.hcl
+++ b/anda/stardust/armillary/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "stardust-armillary.spec"
+	}
+}

--- a/anda/stardust/armillary/stardust-armillary.spec
+++ b/anda/stardust/armillary/stardust-armillary.spec
@@ -1,0 +1,39 @@
+%global commit 8ad02b636690170adbd4279fe3fc8265088cbcc2
+%global commit_date 20240726
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+
+Name:           stardust-armillary
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Model viewer for Stardust XR.
+URL:            https://github.com/StardustXR/armillary
+Source0:        %url/archive/%commit/armillary-%commit.tar.gz
+License:        MIT
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
+
+Provides:       armillary
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+A model viewer for Stardust XR which works great for hand tracking, pointers, and controllers.
+
+%prep
+%autosetup -n armillary-%commit
+%cargo_prep_online
+
+%build
+
+%install
+%define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
+%cargo_install
+
+%files
+%_bindir/armillary
+%license LICENSE
+%doc README.md
+
+%changelog
+* Sat Sep 7 2024 Owen-sz <owen@fyralabs.com>
+- Package StardustXR armillary

--- a/anda/stardust/armillary/update.rhai
+++ b/anda/stardust/armillary/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("StardustXR/armillary"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: stardust-armillary (#2050)](https://github.com/terrapkg/packages/pull/2050)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)