### PR TITLE
[f40] add: stardust-black-hole (#2052)

### DIFF
--- a/anda/stardust/black-hole/anda.hcl
+++ b/anda/stardust/black-hole/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "stardust-black-hole.spec"
+	}
+	labels {
+	   nightly = 1
+	}
+}

--- a/anda/stardust/black-hole/stardust-black-hole.spec
+++ b/anda/stardust/black-hole/stardust-black-hole.spec
@@ -1,0 +1,40 @@
+%global commit 0b847b6ddc383bfcc1e133a2238a37ce8202fe95
+%global commit_date 20240824
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$ 
+
+Name:           stardust-black-hole
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Spatial storage for Stardust XR.
+URL:            https://github.com/StardustXR/black-hole
+Source0:        %url/archive/%commit/black-hole-%commit.tar.gz
+License:        MIT
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
+
+Provides:       black-hole
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary
+
+%prep
+%autosetup -n black-hole-%commit
+%cargo_prep_online
+
+%build
+
+%install
+%define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
+STARDUST_RES_PREFIXES=%_datadir
+%cargo_install
+
+%files
+%_bindir/black-hole
+%license LICENSE
+%doc README.md
+
+%changelog
+* Sat Sep 8 2024 Owen-sz <owen@fyralabs.com>
+- Package StardustXR black-hole

--- a/anda/stardust/black-hole/update.rhai
+++ b/anda/stardust/black-hole/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("StardustXR/black-hole"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: stardust-black-hole (#2052)](https://github.com/terrapkg/packages/pull/2052)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)