### PR TITLE
[f41] add: stardust-flatland (#2049)

### DIFF
--- a/anda/stardust/flatland/anda.hcl
+++ b/anda/stardust/flatland/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "stardust-flatland.spec"
+	}
+	labels {
+	   nightly = 1
+	}
+}

--- a/anda/stardust/flatland/stardust-flatland.spec
+++ b/anda/stardust/flatland/stardust-flatland.spec
@@ -1,0 +1,41 @@
+%global commit b83f2eced868fe71248ba7681df978698eb978f0
+%global commit_date 20240824
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+
+Name:           stardust-flatland
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Flatland for Stardust XR.
+URL:            https://github.com/StardustXR/flatland
+Source0:        %url/archive/%commit/flatland-%commit.tar.gz
+License:        MIT
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
+
+Provides:       flatland
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary
+
+%prep
+%autosetup -n flatland-%commit
+%cargo_prep_online
+
+%build
+STARDUST_RES_PREFIXES=/usr/share
+
+%install
+%define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
+STARDUST_RES_PREFIXES=%_datadir
+%cargo_install
+
+%files
+%_bindir/flatland
+%license LICENSE
+%doc README.md
+
+%changelog
+* Sat Sep 7 2024 Owen-sz <owen@fyralabs.com>
+- Package StardustXR Flatland

--- a/anda/stardust/flatland/update.rhai
+++ b/anda/stardust/flatland/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("StardustXR/flatland"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: stardust-flatland (#2049)](https://github.com/terrapkg/packages/pull/2049)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)