### PR TITLE
[f41] add: stardust-comet (#2051)

### DIFF
--- a/anda/stardust/comet/anda.hcl
+++ b/anda/stardust/comet/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "stardust-comet.spec"
+	}
+	labels {
+	   nightly = 1
+	}
+}

--- a/anda/stardust/comet/stardust-comet.spec
+++ b/anda/stardust/comet/stardust-comet.spec
@@ -1,0 +1,39 @@
+%global commit afbf6109398794791ffb30317712d742143fd08a
+%global commit_date 20240831
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+
+Name:           stardust-comet
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Annotate things in Stardust XR.
+URL:            https://github.com/StardustXR/comet
+Source0:        %url/archive/%commit/comet-%commit.tar.gz
+License:        MIT
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
+
+Provides:       comet
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary
+
+%prep
+%autosetup -n comet-%commit
+%cargo_prep_online
+
+%build
+
+%install
+%define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
+%cargo_install
+
+%files
+%_bindir/comet
+%license LICENSE
+%doc README.md
+
+%changelog
+* Sat Sep 7 2024 Owen-sz <owen@fyralabs.com>
+- Package StardustXR comet

--- a/anda/stardust/comet/update.rhai
+++ b/anda/stardust/comet/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("StardustXR/comet"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: stardust-comet (#2051)](https://github.com/terrapkg/packages/pull/2051)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)