### PR TITLE
[f40] add: stardust gravity (#2063)

### DIFF
--- a/anda/stardust/gravity/anda.hcl
+++ b/anda/stardust/gravity/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "stardust-gravity.spec"
+    }
+    labels {
+       nightly = 1
+    }
+}

--- a/anda/stardust/gravity/stardust-gravity.spec
+++ b/anda/stardust/gravity/stardust-gravity.spec
@@ -1,0 +1,40 @@
+%global commit 96787ed3139717ea6061f6e259e9fed3e483274a
+%global commit_date 20240821
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+
+Name:           stardust-gravity
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Utility to launch apps and Stardust XR clients spatially.
+URL:            https://github.com/StardustXR/gravity
+Source0:        %url/archive/%commit/gravity-%commit.tar.gz
+License:        MIT
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold  
+
+Provides:       gravity
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary
+
+%prep
+%autosetup -n gravity-%commit
+%cargo_prep_online
+
+%build
+
+%install
+%define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
+%cargo_install
+
+
+%files
+%_bindir/gravity
+%license LICENSE
+%doc README.md
+
+%changelog
+* Wed Sep 11 2024 Owen-sz <owen@fyralabs.com>
+- Package StardustXR gravity

--- a/anda/stardust/gravity/update.rhai
+++ b/anda/stardust/gravity/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("StardustXR/gravity"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: stardust gravity (#2063)](https://github.com/terrapkg/packages/pull/2063)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)