### PR TITLE
[f40] add: pet (#2127)

### DIFF
--- a/anda/tools/pet/anda.hcl
+++ b/anda/tools/pet/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "pet.spec"
+	}
+}

--- a/anda/tools/pet/pet.spec
+++ b/anda/tools/pet/pet.spec
@@ -1,0 +1,33 @@
+%define debug_package %nil
+
+Name:           pet
+Version:        0.9.0
+Release:        1%?dist
+Summary:        Simple command-line snippet manager
+URL:            https://github.com/knqyf263/pet
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+License:        MIT
+BuildRequires:  golang anda-srpm-macros
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+ 
+%description
+%summary
+
+%prep
+%autosetup -n pet-%version
+%go_prep_online
+ 
+%build
+%go_build_online
+
+%install
+install -Dm755 build/bin/pet %{buildroot}%{_bindir}/pet
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/pet
+ 
+%changelog
+* Wed Oct 2 2024 Owen-sz <owen@fyralabs.com> - 0.9.0-1
+- package pet

--- a/anda/tools/pet/update.rhai
+++ b/anda/tools/pet/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("knqyf263/pet"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: pet (#2127)](https://github.com/terrapkg/packages/pull/2127)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)