### PR TITLE
[f39] fix: zed-preview (#2142)

### DIFF
--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -26,6 +26,7 @@ BuildRequires:  anda-srpm-macros
 BuildRequires:  gcc
 BuildRequires:  g++
 BuildRequires:  clang
+BuildRequires:  cmake
 BuildRequires:  mold
 BuildRequires:  alsa-lib-devel
 BuildRequires:  fontconfig-devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: zed-preview (#2142)](https://github.com/terrapkg/packages/pull/2142)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)