### PR TITLE
[el10] bump: muon (#2140)

### DIFF
--- a/anda/tools/buildsys/muon/muon.spec
+++ b/anda/tools/buildsys/muon/muon.spec
@@ -1,5 +1,5 @@
 Name:           muon
-Version:        0.2.0
+Version:        0.3.0
 Release:        1%{?dist}
 Summary:        A meson-compatible build system
 

--- a/anda/tools/buildsys/muon/update.rhai
+++ b/anda/tools/buildsys/muon/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(get("https://muon.build/releases/").json_arr().pop().name);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [bump: muon (#2140)](https://github.com/terrapkg/packages/pull/2140)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)