### PR TITLE
[f39] fix: uxplay (#2138)

### DIFF
--- a/anda/misc/uxplay/uxplay.spec
+++ b/anda/misc/uxplay/uxplay.spec
@@ -4,7 +4,7 @@ Release:		1%?dist
 Summary:		AirPlay Unix mirroring server
 License:		GPL-3.0
 URL:			https://github.com/FDH2/UxPlay
-Source0:		%url/archive/refs/tags/%version.tar.gz
+Source0:		%url/archive/refs/tags/v%version.tar.gz
 Requires:		openssl libplist avahi gstreamer1-plugin-libav gstreamer1-plugins-bad-free gstreamer1-plugins-good gstreamer1-plugins-base
 Recommends:		gstreamer1-vaapi
 BuildRequires:	cmake desktop-file-utils systemd-rpm-macros gcc gcc-c++ openssl-devel avahi-compat-libdns_sd-devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: uxplay (#2138)](https://github.com/terrapkg/packages/pull/2138)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)