### PR TITLE
[el10] fix: onefetch (#2137)

### DIFF
--- a/anda/langs/rust/onefetch/rust-onefetch.spec
+++ b/anda/langs/rust/onefetch/rust-onefetch.spec
@@ -15,7 +15,7 @@ Source:         %{crates_source}
 Patch:          onefetch-fix-metadata-auto.diff
 
 BuildRequires:  anda-srpm-macros cargo-rpm-macros >= 24
-BuildRequires:  cmake
+BuildRequires:  cmake mold
 
 %global _description %{expand:
 Command-line Git information tool.}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: onefetch (#2137)](https://github.com/terrapkg/packages/pull/2137)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)