### PR TITLE
[f40] fix: nushell (#2141)

### DIFF
--- a/anda/langs/rust/nushell/nushell.spec
+++ b/anda/langs/rust/nushell/nushell.spec
@@ -5,7 +5,7 @@ Summary:		A new type of shell
 License:		MIT
 URL:			https://www.nushell.sh/
 BuildRequires:	anda-srpm-macros rust-packaging git-core
-BuildRequires:  openssl-devel-engine
+BuildRequires:  openssl-devel-engine mold
 Requires:		glibc openssl zlib
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: nushell (#2141)](https://github.com/terrapkg/packages/pull/2141)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)