### PR TITLE
[f41] moby-addons: do not hard-depend on Docker (#2185)

### DIFF
--- a/anda/docker/moby-buildx/moby-buildx.spec
+++ b/anda/docker/moby-buildx/moby-buildx.spec
@@ -12,8 +12,11 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires:  go-rpm-macros
 BuildRequires:  git-core
 BuildRequires:  gcc
-Requires:       docker
+BuildRequires:  anda-srpm-macros
+
 Provides:       docker-buildx = %{version}-%{release}
+Provides:       docker-buildx-cli = %{version}-%{release}
+
 
 %description
 buildx is a Docker CLI plugin for extended build capabilities with BuildKit.
@@ -21,18 +24,15 @@ buildx is a Docker CLI plugin for extended build capabilities with BuildKit.
 
 %prep
 %autosetup -n buildx-%{version}
-go mod download
 
 
 %build
 export CGO_ENABLED=1
-go build -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -s -w -extldflags '--static-pie'" \
-  -buildmode=pie -tags 'osusergo,netgo,static_build' -v -x \
-  -o docker-buildx ./cmd/buildx
+%go_build_online ./cmd/buildx
 
 
 %install
-install -D -m 0755 docker-buildx %{buildroot}%{_libexecdir}/docker/cli-plugins/docker-buildx
+install -D -m 0755 build/bin/cmd/buildx %{buildroot}%{_libexecdir}/docker/cli-plugins/docker-buildx
 
 
 %files

--- a/anda/docker/moby-compose/moby-compose.spec
+++ b/anda/docker/moby-compose/moby-compose.spec
@@ -1,8 +1,8 @@
 %define debug_package %{nil}
 
 Name:           moby-compose
-Version:        2.29.7
-Release:        1%?dist
+Version:        2.29.2
+Release:        2%?dist
 Summary:        Define and run multi-container applications with Docker
 
 License:        Apache-2.0
@@ -13,7 +13,6 @@ Source0:        %{url}archive/refs/tags/v%{version}.tar.gz
 BuildRequires:  go-rpm-macros
 BuildRequires:  git-core
 BuildRequires:  docker
-Requires:       docker
 Provides:       docker-compose = %{version}-%{release}
 Provides:       docker-compose-cli = %{version}-%{release}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [moby-addons: do not hard-depend on Docker (#2185)](https://github.com/terrapkg/packages/pull/2185)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)