### PR TITLE
[f41] fix(nim): actually copy dist folder to the goddamn %buildroot (#2194)

### DIFF
--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -124,7 +124,7 @@ ln -s %_prefix/lib/nim %buildroot%_prefix/lib/nim/lib || true
 rm -rf %buildroot/nim || true
 rm %buildroot%_bindir/*.bat || true
 
-cp -r dist %_datadir/nim/
+cp -r dist %buildroot%_datadir/nim/
 
 
 %files

--- a/anda/langs/nim/nim/nim.spec
+++ b/anda/langs/nim/nim/nim.spec
@@ -118,7 +118,7 @@ rm -rf %buildroot/nim || true
 rm %buildroot%_bindir/*.bat || true
 rm -rf %buildroot%_bindir/empty.txt
 
-cp -r dist %_datadir/nim/
+cp -r dist %buildroot%_datadir/nim/
 
 
 %files


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(nim): actually copy dist folder to the goddamn %buildroot (#2194)](https://github.com/terrapkg/packages/pull/2194)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)