### PR TITLE
[f39] add: fontviewer (#2205)

### DIFF
--- a/anda/apps/fontviewer/anda.hcl
+++ b/anda/apps/fontviewer/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "fontviewer.spec"
+  }
+}

--- a/anda/apps/fontviewer/fontviewer-meson.patch
+++ b/anda/apps/fontviewer/fontviewer-meson.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index 4784ac2..2348b13 100644
+--- a/meson.build
++++ b/meson.build
+@@ -13,4 +13,5 @@ executable(
+         dependency('cairomm-1.0'),
+         dependency('freetype2'),
+     ],
+-)
+\ No newline at end of file
++    install: true
++)

--- a/anda/apps/fontviewer/fontviewer.spec
+++ b/anda/apps/fontviewer/fontviewer.spec
@@ -1,0 +1,47 @@
+%global commit dc5cd1490235f8c19424b3345a89727199c86df3
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20241003
+
+Name:           fontviewer
+Version:        %{commit_date}.git~%{shortcommit}
+Release:        1%{?dist}
+Summary:        View and install fonts
+
+License:        GPL-2.0
+URL:            https://github.com/chocolateimage/%{name}
+Source0:        %{url}/archive/%{commit}.tar.gz 
+Patch0:         fontviewer-meson.patch
+
+BuildRequires:  gcc-c++
+BuildRequires:  meson
+BuildRequires:  pkgconfig(cairomm-1.0)
+BuildRequires:  pkgconfig(fontconfig)
+BuildRequires:  pkgconfig(freetype2)
+BuildRequires:  pkgconfig(gtk+-3.0)
+BuildRequires:  pkgconfig(gtkmm-3.0)
+
+Requires:       gtk3 fontconfig
+
+Packager:       sadlerm <sad_lerm@hotmail.com>
+
+%description
+A platform-agnostic GTK+ 3 alternative to GNOME's Font Viewer
+
+%prep
+%autosetup -n %{name}-%{commit} -p1
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+install -m 0755 -vd %{buildroot}%{_datadir}/applications
+install -m 0755 -vp data/%{name}.desktop %{buildroot}%{_datadir}/applications/
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/%{name}
+%{_datadir}/applications/%{name}.desktop

--- a/anda/apps/fontviewer/update.rhai
+++ b/anda/apps/fontviewer/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("chocolateimage/fontviewer"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add: fontviewer (#2205)](https://github.com/terrapkg/packages/pull/2205)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)