### PR TITLE
[f39] fix: gcm-core (#2241)

### DIFF
--- a/anda/tools/gcm-core/gcm-core.spec
+++ b/anda/tools/gcm-core/gcm-core.spec
@@ -8,7 +8,7 @@
 Name:           gcm-core
 Version:        2.6.0
 %forgemeta
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Secure, cross-platform Git credential storage
 
 License:        MIT
@@ -22,7 +22,7 @@ BuildRequires:  dotnet-sdk-8.0
 # Require DPKG, so that we can use the `dpkg-architecture` command. which makes the build script happy.
 # TODO: Better solution: Patch out the debian-specific packaging code.
 BuildRequires:  dpkg-dev
-Requires:       dotnet-runtime-7.0
+Requires:       dotnet-runtime-8.0
 
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: gcm-core (#2241)](https://github.com/terrapkg/packages/pull/2241)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)