### PR TITLE
[f39] add: inputplumber (#2258)

### DIFF
--- a/anda/games/inputplumber/anda.hcl
+++ b/anda/games/inputplumber/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "inputplumber.spec"
+    }
+}

--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -1,0 +1,47 @@
+Name:           inputplumber
+Version:        0.36.5
+Release:        1%?dist
+Summary:        Open source input router and remapper daemon for Linux
+License:        GPL-3.0-or-later
+URL:            https://github.com/ShadowBlip/InputPlumber
+Source0:        %{url}/archive/refs/tags/v%version.tar.gz
+BuildRequires:  libevdev-devel libiio-devel git make cargo libudev-devel llvm-devel clang-devel
+BuildRequires:  rust-packaging cargo-rpm-macros mold rpm_macro(cargo_prep_online)
+Requires:       libevdev libiio
+Recommends:     steam gamescope-session linuxconsoletools
+Packager:       madonuko <mado@fyralabs.com>
+Provides:       inputplumber
+Conflicts:      hhd
+
+%description
+InputPlumber is an open source input routing and control daemon for Linux. It
+can be used to combine any number of input devices (like gamepads, mice, and
+keyboards) and translate their input to a variety of virtual device formats.
+
+%prep
+%autosetup -n InputPlumber-%version
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+%make_install BUILD_TYPE=rpm PREFIX=%buildroot%_prefix
+
+%post
+%systemd_post inputplumber.service
+
+%preun
+%systemd_preun inputplumber.service
+
+%postun
+%systemd_postun_with_restart inputplumber.service
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/inputplumber
+%_unitdir/inputplumber.service
+%_udevhwdbdir/59-inputplumber.hwdb
+%_datadir/dbus-1/system.d/org.shadowblip.InputPlumber.conf
+%_datadir/inputplumber/

--- a/anda/games/inputplumber/update.rhai
+++ b/anda/games/inputplumber/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("ShadowBlip/InputPlumber"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add: inputplumber (#2258)](https://github.com/terrapkg/packages/pull/2258)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)