### PR TITLE
[f40] fix(fontviewer): fix desktop file perms (#2263)

### DIFF
--- a/anda/apps/fontviewer/fontviewer.spec
+++ b/anda/apps/fontviewer/fontviewer.spec
@@ -38,7 +38,7 @@ A platform-agnostic GTK+ 3 alternative to GNOME's Font Viewer
 %meson_install
 
 install -m 0755 -vd %{buildroot}%{_datadir}/applications
-install -m 0755 -vp data/%{name}.desktop %{buildroot}%{_datadir}/applications/
+install -m 0644 -vp data/%{name}.desktop %{buildroot}%{_datadir}/applications/
 
 %files
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(fontviewer): fix desktop file perms (#2263)](https://github.com/terrapkg/packages/pull/2263)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)