### PR TITLE
[f41] fix: mate-dock-applet (#2287)

### DIFF
--- a/anda/desktops/mate/dock-applet/mate-dock-applet.spec
+++ b/anda/desktops/mate/dock-applet/mate-dock-applet.spec
@@ -9,7 +9,7 @@ URL:            https://github.com/ubuntu-mate/mate-dock-applet
 Source0:        %url/archive/refs/tags/%version.tar.gz
 BuildRequires:  automake make gcc
 BuildRequires:  python3 python3-xlib python3-pillow glib2-devel python3-cairo bamf-daemon bamf python3-distro gettext-devel
-Requires:       bamf libnotify mate-panel python3-cairo python3-dbus python3-gobject python3-pillow python3-xdg python3-xlib
+Requires:       bamf libnotify mate-panel python3-cairo python3-dbus python3-gobject python3-pillow python3-pyxdg python3-xlib
 Packager:       madonuko <mado@fyralabs.com>
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: mate-dock-applet (#2287)](https://github.com/terrapkg/packages/pull/2287)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)