### PR TITLE
[f40] fix: stardust-{armillary,black-hole,protostar} (#2309)

### DIFF
--- a/anda/stardust/armillary/anda.hcl
+++ b/anda/stardust/armillary/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "stardust-armillary.spec"
 	}
+	labels {
+		nightly = 1
+	}
 }

--- a/anda/stardust/black-hole/stardust-black-hole.spec
+++ b/anda/stardust/black-hole/stardust-black-hole.spec
@@ -27,13 +27,17 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %install
 %define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
-STARDUST_RES_PREFIXES=%_datadir
+export STARDUST_RES_PREFIXES=%_datadir
 %cargo_install
 
+mkdir -p %buildroot%_datadir
+cp -r res/* %buildroot%_datadir/
+
 %files
-%_bindir/black-hole
-%license LICENSE
 %doc README.md
+%license LICENSE
+%_bindir/black-hole
+%_datadir/black_hole/
 
 %changelog
 * Sat Sep 8 2024 Owen-sz <owen@fyralabs.com>

--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -27,7 +27,7 @@ Prototype application launcher for StardustXR, providing an easy to use crate to
 
 %install
 %define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
-STARDUST_RES_PREFIXES=%_datadir
+export STARDUST_RES_PREFIXES=%_datadir
 (cd app_grid && %cargo_install) &
 (cd hexagon_launcher && %cargo_install) &
 (cd single && %cargo_install) &
@@ -35,13 +35,16 @@ STARDUST_RES_PREFIXES=%_datadir
 
 wait
 
+cp -r res/* %buildroot%_datadir/
+
 %files
+%doc README.md
+%license LICENSE
 %_bindir/app_grid
 %_bindir/hexagon_launcher
 %_bindir/single
 %_bindir/sirius
-%license LICENSE
-%doc README.md
+%_datadir/protostar/
 
 %changelog
 * Tue Sep 10 2024 Owen-sz <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: stardust-{armillary,black-hole,protostar} (#2309)](https://github.com/terrapkg/packages/pull/2309)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)