### PR TITLE
[f39] fix: prismlauncher (#2285)

### DIFF
--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -46,6 +46,7 @@ BuildRequires:    cmake(Qt%{qt_version}Network) >= %{min_qt_version}
 BuildRequires:    cmake(Qt%{qt_version}Test) >= %{min_qt_version}
 BuildRequires:    cmake(Qt%{qt_version}Widgets) >= %{min_qt_version}
 BuildRequires:    cmake(Qt%{qt_version}Xml) >= %{min_qt_version}
+BuildRequires:    cmake(Qt%{qt_version}NetworkAuth) >= %{min_qt_version}
 BuildRequires:    tomlplusplus-devel
 
 %if %{with qt6}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: prismlauncher (#2285)](https://github.com/terrapkg/packages/pull/2285)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)