### PR TITLE
[f41] add: xwayland-satellite (#2318)

### DIFF
--- a/anda/langs/rust/xwayland-satellite/anda.hcl
+++ b/anda/langs/rust/xwayland-satellite/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "xwayland-satellite.spec"
+    }
+}

--- a/anda/langs/rust/xwayland-satellite/update.rhai
+++ b/anda/langs/rust/xwayland-satellite/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("supreeeme/xwayland-satellite"));

--- a/anda/langs/rust/xwayland-satellite/xwayland-satellite.spec
+++ b/anda/langs/rust/xwayland-satellite/xwayland-satellite.spec
@@ -1,0 +1,32 @@
+Name:           xwayland-satellite
+Version:        0.4
+Release:        1%?dist
+Summary:        Xwayland outside your Wayland.
+License:        MPL-2.0
+URL:            https://github.com/supreeeme/xwayland-satellite
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+BuildRequires:  anda-srpm-macros cargo-rpm-macros mold
+BuildRequires:  pkgconfig(xcb)
+BuildRequires:  xcb-util-cursor-devel
+BuildRequires:  clang-devel
+
+%description
+xwayland-satellite grants rootless Xwayland integration to any Wayland
+compositor implementing xdg_wm_base. This is particularly useful for
+compositors that (understandably) do not want to go through implementing
+support for rootless Xwayland themselves.
+
+%prep
+%autosetup
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+%cargo_install
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/xwayland-satellite


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: xwayland-satellite (#2318)](https://github.com/terrapkg/packages/pull/2318)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)