### PR TITLE
[f39] fix: stardust-black-hole (#2329)

### DIFF
--- a/anda/stardust/black-hole/stardust-black-hole.spec
+++ b/anda/stardust/black-hole/stardust-black-hole.spec
@@ -30,8 +30,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 export STARDUST_RES_PREFIXES=%_datadir
 %cargo_install
 
-mkdir -p %buildroot%_datadir
-cp -r res/* %buildroot%_datadir/
+mkdir -p %buildroot%_datadir/black_hole
+cp -r res/* %buildroot%_datadir/black_hole/
 
 %files
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: stardust-black-hole (#2329)](https://github.com/terrapkg/packages/pull/2329)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)