### PR TITLE
[f41] fix(update): stardust-telescope (#2333)

### DIFF
--- a/anda/stardust/telescope/anda.hcl
+++ b/anda/stardust/telescope/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
     rpm {
         spec = "stardust-telescope.spec"
     }
+    labels {
+        nightly = 1
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(update): stardust-telescope (#2333)](https://github.com/terrapkg/packages/pull/2333)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)