### PR TITLE
[el10] fix: gitoxide (#2340)

### DIFF
--- a/anda/langs/rust/gitoxide/rust-gitoxide.spec
+++ b/anda/langs/rust/gitoxide/rust-gitoxide.spec
@@ -13,7 +13,7 @@ License:        MIT OR Apache-2.0
 URL:            https://crates.io/crates/gitoxide
 Source:         %{crates_source}
 
-BuildRequires:  openssl-devel-engine cmake anda-srpm-macros rust-packaging >= 21
+BuildRequires:  openssl-devel-engine cmake anda-srpm-macros rust-packaging >= 21 mold
 
 %global _description %{expand:
 A command-line application for interacting with git repositories.}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: gitoxide (#2340)](https://github.com/terrapkg/packages/pull/2340)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)