### PR TITLE
[f40] fix: typeracer (#2342)

### DIFF
--- a/anda/games/typeracer/rust-typeracer.spec
+++ b/anda/games/typeracer/rust-typeracer.spec
@@ -14,7 +14,7 @@ License:        GPL-3.0
 URL:            https://crates.io/crates/typeracer
 Source:         %{crates_source}
 
-BuildRequires:  perl openssl-devel anda-srpm-macros rust-packaging >= 21
+BuildRequires:  perl openssl-devel anda-srpm-macros rust-packaging >= 21 mold
 
 %global _description %{expand:
 Terminal typing game. Race to see the fastest time you can get!.}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: typeracer (#2342)](https://github.com/terrapkg/packages/pull/2342)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)