### PR TITLE
[f40] fix: stardust-protostar (#2338)

### DIFF
--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -35,7 +35,8 @@ export STARDUST_RES_PREFIXES=%_datadir
 
 wait
 
-cp -r res/* %buildroot%_datadir/
+mkdir -p %buildroot%_datadir/protostar
+cp -r res/* %buildroot%_datadir/protostar/
 
 %files
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: stardust-protostar (#2338)](https://github.com/terrapkg/packages/pull/2338)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)