### PR TITLE
[el10] fix: voicevox (#2343)

### DIFF
--- a/anda/apps/voicevox/voicevox.spec
+++ b/anda/apps/voicevox/voicevox.spec
@@ -6,7 +6,7 @@
 
 # do not perform compression in cpio
 %define _source_payload w0.ufdio
-%define _binary_payload w0.gzdio
+%define _binary_payload w19.zstdio
 
 # Exclude private libraries
 %global __requires_exclude libffmpeg.so


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: voicevox (#2343)](https://github.com/terrapkg/packages/pull/2343)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)