### PR TITLE
[f41] Update stardust-protostar.spec (#2363)

### DIFF
--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -35,8 +35,8 @@ export STARDUST_RES_PREFIXES=%_datadir
 
 wait
 
-mkdir -p %buildroot%_datadir/protostar
-cp -r res/* %buildroot%_datadir/protostar/
+mkdir -p %buildroot%_datadir
+cp -r res/* %buildroot%_datadir/
 
 %files
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Update stardust-protostar.spec (#2363)](https://github.com/terrapkg/packages/pull/2363)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)