### PR TITLE
[f41] test build removing black hole directories (#2364)

### DIFF
--- a/anda/stardust/black-hole/stardust-black-hole.spec
+++ b/anda/stardust/black-hole/stardust-black-hole.spec
@@ -30,8 +30,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 export STARDUST_RES_PREFIXES=%_datadir
 %cargo_install
 
-mkdir -p %buildroot%_datadir/black_hole
-cp -r res/* %buildroot%_datadir/black_hole/
+mkdir -p %buildroot%_datadir
+cp -r res/* %buildroot%_datadir/
 
 %files
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [test build removing black hole directories (#2364)](https://github.com/terrapkg/packages/pull/2364)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)