### PR TITLE
[f39] fix(update): stardust-protostar (#2378)

### DIFF
--- a/anda/stardust/protostar/update.rhai
+++ b/anda/stardust/protostar/update.rhai
@@ -1,4 +1,4 @@
-rpm.global("commit", gh_commit("StardustXR/protostart"));
+rpm.global("commit", gh_commit("StardustXR/protostar"));
 if rpm.changed() {
   rpm.release();
   rpm.global("commit_date", date());


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix(update): stardust-protostar (#2378)](https://github.com/terrapkg/packages/pull/2378)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)