### PR TITLE
[f41] fix(update): opentabletdriver (#2377)

### DIFF
--- a/anda/system/opentabletdriver-nightly/update.rhai
+++ b/anda/system/opentabletdriver-nightly/update.rhai
@@ -1,6 +1,8 @@
 rpm.global("commit", gh_commit("OpenTabletDriver/OpenTabletDriver"));
 if rpm.changed() {
     rpm.global("commit_date", date());
-    rpm.global("ver", gh("OpenTabletDriver/OpenTabletDriver"));
+    let v = gh("OpenTabletDriver/OpenTabletDriver");
+    v.crop(1); // "v" prefix
+    rpm.global("ver", v);
     rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(update): opentabletdriver (#2377)](https://github.com/terrapkg/packages/pull/2377)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)