### PR TITLE
[f39] fix(yt-dlp): use new nightly versioning scheme (#2375)

### DIFF
--- a/anda/tools/yt-dlp/yt-dlp-nightly.spec
+++ b/anda/tools/yt-dlp/yt-dlp-nightly.spec
@@ -5,7 +5,8 @@
 %global ver 2024.10.07
 
 Name:           yt-dlp-nightly
-Version:        %ver^%commit_date.%shortcommit
+Version:        %commit_date.git~%shortcommit
+Provides:       yt-dlp-nightly = %ver^%version
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix(yt-dlp): use new nightly versioning scheme (#2375)](https://github.com/terrapkg/packages/pull/2375)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)