### PR TITLE
[f40] Change stardust package names (#2390)

### DIFF
--- a/anda/stardust/armillary/stardust-armillary.spec
+++ b/anda/stardust/armillary/stardust-armillary.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-armillary
+Name:           stardust-xr-armillary
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        Model viewer for Stardust XR.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/armillary-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
-Provides:       armillary
+Provides:       armillary stardust-armillary
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/atmosphere/stardust-atmosphere.spec
+++ b/anda/stardust/atmosphere/stardust-atmosphere.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-atmosphere
+Name:           stardust-xr-atmosphere
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        Environment, homespace, and setup client for Stardust XR.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/atmosphere-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
-Provides:       atmosphere
+Provides:       atmosphere stardust-atmosphere
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/black-hole/stardust-black-hole.spec
+++ b/anda/stardust/black-hole/stardust-black-hole.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$ 
 
-Name:           stardust-black-hole
+Name:           stardust-xr-black-hole
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        Spatial storage for Stardust XR.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/black-hole-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
-Provides:       black-hole
+Provides:       black-hole stardust-black-hole
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/comet/stardust-comet.spec
+++ b/anda/stardust/comet/stardust-comet.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-comet
+Name:           stardust-xr-comet
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        Annotate things in Stardust XR.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/comet-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
-Provides:       comet
+Provides:       comet stardust-comet
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/flatland/stardust-flatland.spec
+++ b/anda/stardust/flatland/stardust-flatland.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-flatland
+Name:           stardust-xr-flatland
 Version:        %commit_date.%shortcommit
 Release:        2%?dist
 Summary:        Flatland for Stardust XR.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/flatland-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
-Provides:       flatland
+Provides:       flatland stardust-flatland
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/gravity/stardust-gravity.spec
+++ b/anda/stardust/gravity/stardust-gravity.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-gravity
+Name:           stardust-xr-gravity
 Version:        %commit_date.%shortcommit
 Release:        2%?dist
 Summary:        Utility to launch apps and Stardust XR clients spatially.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/gravity-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold  
 
-Provides:       gravity
+Provides:       stardust-gravity
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/magnetar/stardust-magnetar.spec
+++ b/anda/stardust/magnetar/stardust-magnetar.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-magnetar
+Name:           stardust-xr-magnetar
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        Workspaces client for Stardust XR.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/magnetar-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
-Provides:       magnetar
+Provides:       magnetar stardust-magnetar
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/non-spatial-input/stardust-non-spatial-input.spec
+++ b/anda/stardust/non-spatial-input/stardust-non-spatial-input.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-non-spatial-input
+Name:           stardust-xr-non-spatial-input
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        Tools you can easily snap together to get non-spatial input into Stardust XR.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/non-spatial-input-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
-Provides:       non-spatial-input
+Provides:       non-spatial-input stardust-non-spatial-input
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -4,7 +4,7 @@
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-protostar
+Name:           stardust-xr-protostar
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        Prototype application launcher for Stardust XR.
@@ -13,7 +13,7 @@ Source0:        %url/archive/%commit/protostar-%commit.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
-Provides:       protostar
+Provides:       protostar stardust-protostar
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/server/stardust-server.spec
+++ b/anda/stardust/server/stardust-server.spec
@@ -1,6 +1,6 @@
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
-Name:           stardust-server
+Name:           stardust-xr-server
 Version:        0.45.1
 Release:        1%?dist
 Summary:        Usable Linux display server that reinvents human-computer interaction for all kinds of XR.
@@ -13,7 +13,7 @@ BuildRequires:  glx-utils fontconfig-devel glibc libxcb-devel wayland-devel
 BuildRequires:  openxr-devel libglvnd-devel libglvnd-gles mesa-libgbm-devel
 BuildRequires:  libwayland-egl libX11-devel libXfixes-devel
 BuildRequires:  mesa-libEGL-devel libxkbcommon-devel
-Provides:       stardust-xr-server
+Provides:       stardust-server
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description

--- a/anda/stardust/telescope/stardust-telescope.spec
+++ b/anda/stardust/telescope/stardust-telescope.spec
@@ -4,7 +4,7 @@
 %global commit_date 20241023
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-Name:           stardust-telescope
+Name:           stardust-xr-telescope
 Version:        %commit_date.git~%shortcommit
 Release:        1%?dist
 Summary:        See the stars! Easy stardust setups to run on your computer. 
@@ -18,6 +18,7 @@ Requires:       stardust-black-hole
 Requires:       stardust-protostar
 Requires:       xwayland-satellite
 BuildArch:      noarch
+Provides:       telescope stardust-telescope
 
 %description
 See the stars! Easy stardust setups to run on your computer.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Change stardust package names (#2390)](https://github.com/terrapkg/packages/pull/2390)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)