### PR TITLE
[f39] feat(comps): stardust XR group (#2391)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -85,4 +85,24 @@
       <packagereq type="default">hydrogen-icon-theme</packagereq>
     </packagelist>
   </group>
+  <group>
+    <id>stardust-xr</id>
+    <name>Starudst XR</name>
+    <description>All Stardust XR packages needed to run the Stardust server</description>
+    <default>false</default>
+    <uservisable>true</uservisable>
+    <packagelist>
+      <packagereq type="default">stardust-xr-armillary</packagereq>
+      <packagereq type="default">stardust-xr-atmosphere</packagereq>
+      <packagereq type="default">stardust-xr-black-hole</packagereq>
+      <packagereq type="default">stardust-xr-comet</packagereq>
+      <packagereq type="default">stardust-xr-flatland</packagereq>
+      <packagereq type="default">stardust-xr-gravity</packagereq>
+      <packagereq type="default">stardust-xr-magnetar</packagereq>
+      <packagereq type="default">stardust-xr-non-spatial-input</packagereq>
+      <packagereq type="default">stardust-xr-protostar</packagereq>
+      <packagereq type="default">stardust-xr-server</packagereq>
+      <packagereq type="default">stardust-xr-telescope</packagereq>
+    </packagelist>
+  </group>
 </comps>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [feat(comps): stardust XR group (#2391)](https://github.com/terrapkg/packages/pull/2391)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)