### PR TITLE
[el10] fix(comps): Stardust spelling (#2402)

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -87,7 +87,7 @@
   </group>
   <group>
     <id>stardust-xr</id>
-    <name>Starudst XR</name>
+    <name>Stardust XR</name>
     <description>All Stardust XR packages needed to run the Stardust server</description>
     <default>false</default>
     <uservisable>true</uservisable>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(comps): Stardust spelling (#2402)](https://github.com/terrapkg/packages/pull/2402)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)