### PR TITLE
[f40] fix(stardust-telescope): stardust XR deps (#2401)

### DIFF
--- a/anda/stardust/telescope/stardust-telescope.spec
+++ b/anda/stardust/telescope/stardust-telescope.spec
@@ -6,16 +6,16 @@
 
 Name:           stardust-xr-telescope
 Version:        %commit_date.git~%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        See the stars! Easy stardust setups to run on your computer. 
 License:        MIT
 URL:            https://github.com/StardustXR/telescope
 Source0:        %url/archive/%commit.tar.gz
 Requires:       bash
-Requires:       stardust-server
-Requires:       stardust-gravity
-Requires:       stardust-black-hole
-Requires:       stardust-protostar
+Requires:       stardust-xr-server
+Requires:       stardust-xr-gravity
+Requires:       stardust-xr-black-hole
+Requires:       stardust-xr-protostar
 Requires:       xwayland-satellite
 BuildArch:      noarch
 Provides:       telescope stardust-telescope


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(stardust-telescope): stardust XR deps (#2401)](https://github.com/terrapkg/packages/pull/2401)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)