### PR TITLE
[f41] docs(readme): add repology 41, remove 39 (#2414)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Terra Sources
 
-[![Repository status](https://repology.org/badge/repository-big/terra_39.svg?header=Terra+39)](https://repology.org/repository/terra_39)
 [![Repository status](https://repology.org/badge/repository-big/terra_40.svg?header=Terra+40)](https://repology.org/repository/terra_40)
+[![Repository status](https://repology.org/badge/repository-big/terra_41.svg?header=Terra+41)](https://repology.org/repository/terra_41)
 [![Repository status](https://repology.org/badge/repository-big/terra_rawhide.svg?header=Terra+Rawhide)](https://repology.org/repository/terra_rawhide)
 
 Terra is a rolling-release Fedora repository for all the software you need.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [docs(readme): add repology 41, remove 39 (#2414)](https://github.com/terrapkg/packages/pull/2414)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)