### PR TITLE
[f41] fix: apparmor (#2135)

### DIFF
--- a/anda/lib/apparmor/apparmor.spec
+++ b/anda/lib/apparmor/apparmor.spec
@@ -1,9 +1,11 @@
 %{?python_enable_dependency_generator}
 
+%global __arch_install_post /bin/true
+
 %bcond_with tests
 
 Name:           apparmor
-Version:        4.1.0.beta1
+Version:        4.1.0~beta1
 Release:        1%?dist
 Summary:        AppArmor userspace components
 
@@ -12,7 +14,7 @@ Summary:        AppArmor userspace components
 
 License:        GPL-2.0
 URL:            https://gitlab.com/apparmor/apparmor
-Source0:        %url/-/archive/v%version/apparmor-v%version.tar.gz
+Source0:        %url/-/archive/v%normver/apparmor-v%normver.tar.gz
 Source1:        apparmor.preset
 Patch01:        0001-fix-avahi-daemon-authselect-denial-in-fedora.patch
 
@@ -139,7 +141,7 @@ confinement policies when running virtual hosts in the webserver by using the
 changehat abilities exposed through libapparmor.
 
 %prep
-%autosetup -p1 -n %name-v%version
+%autosetup -p1 -n %name-v%normver
 sed -i 's/@VERSION@/%normver/g' libraries/libapparmor/swig/python/setup.py.in
 sed -i 's/${VERSION}/%normver/g' utils/Makefile
 
@@ -165,6 +167,7 @@ popd
 %make_build -C utils/vim
 
 %install
+mkdir -p %buildroot%_datadir/polkit-1/actions/
 %make_install -C libraries/libapparmor
 %make_install -C binutils
 %make_install -C parser \
@@ -184,6 +187,7 @@ find %{buildroot} \( -name "*.a" -o -name "*.la" \) -delete
 %find_lang aa-binutils
 %find_lang apparmor-parser
 %find_lang apparmor-utils
+
 
 %if %{with tests}
 %check
@@ -276,6 +280,8 @@ make -C utils check
 %{_presetdir}/70-apparmor.preset
 %{_prefix}/lib/apparmor
 %dir %{_sysconfdir}/apparmor
+# FIXME: the confusion…? how did this happen
+%config(noreplace) %{_sysconfdir}/apparmor/default_unconfined.template
 %config(noreplace) %{_sysconfdir}/apparmor.d/
 %config(noreplace) %{_sysconfdir}/apparmor/parser.conf
 %{_mandir}/man1/aa-enabled.1.gz
@@ -316,6 +322,7 @@ make -C utils check
 %dir %{_datadir}/apparmor
 %{_datadir}/apparmor/easyprof
 %{_datadir}/apparmor/apparmor.vim
+%{_datadir}/polkit-1/actions/com.ubuntu.pkexec.aa-notify.policy
 %{_mandir}/man5/logprof.conf.5.gz
 %{_mandir}/man8/aa-audit.8.gz
 %{_mandir}/man8/aa-autodep.8.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: apparmor (#2135)](https://github.com/terrapkg/packages/pull/2135)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)