### PR TITLE
[f41] fix: libusermetrics (#2420)

### DIFF
--- a/anda/lib/libusermetrics/libusermetrics.spec
+++ b/anda/lib/libusermetrics/libusermetrics.spec
@@ -55,7 +55,7 @@ The %{name}-doc contains documentation for %{name}.
 %files -f %{name}.lang
 %doc ChangeLog
 %license LGPL_EXCEPTION.txt LICENSE.GPL LICENSE.LGPL LICENSE.LGPL-3
-/usr/etc/dbus-1/system.d/com.lomiri.UserMetrics.conf
+%{_sysconfdir}/dbus-1/system.d/com.lomiri.UserMetrics.conf
 %{_bindir}/usermetricsinput
 %{_bindir}/usermetricsinput-increment
 %{_libdir}/libusermetricsinput.so.*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: libusermetrics (#2420)](https://github.com/terrapkg/packages/pull/2420)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)