### PR TITLE
[el10] fix(update): apparmor (#2434)

### DIFF
--- a/anda/lib/apparmor/update.rhai
+++ b/anda/lib/apparmor/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gitlab_tag("4484878"));
+let v = gitlab_tag("4484878");
+v.replace("-", "~");
+rpm.version(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(update): apparmor (#2434)](https://github.com/terrapkg/packages/pull/2434)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)