### PR TITLE
[f40] fix: legcord* (#2395)

### DIFF
--- a/anda/apps/legcord-bin/legcord-bin.spec
+++ b/anda/apps/legcord-bin/legcord-bin.spec
@@ -15,7 +15,7 @@
 
 Name:			legcord-bin
 Version:		1.0.2
-Release:		2%?dist
+Release:		3%?dist
 License:		OSL-3.0
 Summary:		Custom lightweight Discord client designed to enhance your experience
 URL:			https://github.com/LegCord/LegCord
@@ -28,6 +28,7 @@ BuildRequires:  unzip
 ExclusiveArch:	x86_64 aarch64 armv7l
 Conflicts:		legcord
 BuildRequires:	add-determinism
+Obsoletes:      armcord < 3.3.2-1
 
 %description
 LegCord is a custom client designed to enhance your Discord experience
@@ -58,15 +59,24 @@ cd legcord
 mkdir -p %buildroot%_bindir %buildroot%_datadir/applications %buildroot%_datadir/pixmaps %buildroot%_datadir/legcord %buildroot%_docdir/%name
 cp -a * %buildroot%_datadir/legcord/
 ln -s %_datadir/legcord/legcord %buildroot%_bindir/legcord
+ln -s %_datadir/legcord %buildroot%_datadir/armcord
 chmod +x -R %buildroot%_datadir/legcord/*
 chmod 755 %buildroot%_datadir/legcord/legcord
 install -Dm644 .legcord.desktop %buildroot%_datadir/applications/LegCord.desktop
 install -Dm644 %SOURCE1 %buildroot%_datadir/pixmaps/legcord.png
 install -Dm644 %SOURCE2 %buildroot%_docdir/%name/
 
+# HACK: rpm bug for unability to replace existing files on system.
+%pre
+if [ -d %_datadir/armcord ] && [ ! -L %_datadir/armcord ]; then
+  echo "Found old %_datadir/armcord directory, removing…"
+  rm -rf %_datadir/armcord
+fi
+
 %files
 %doc README.md
 %_datadir/legcord
+%_datadir/armcord
 %_bindir/legcord
 %_datadir/applications/LegCord.desktop
 %_datadir/pixmaps/legcord.png

--- a/anda/apps/legcord/legcord.spec
+++ b/anda/apps/legcord/legcord.spec
@@ -2,7 +2,7 @@
 
 Name:		legcord
 Version:	1.0.2
-Release:	2%?dist
+Release:	3%?dist
 License:	OSL-3.0
 Summary:	Custom lightweight Discord client designed to enhance your experience
 URL:		https://github.com/LegCord/LegCord
@@ -10,20 +10,18 @@ Group:		Applications/Internet
 Source1:	launch.sh
 Packager:	madonuko <mado@fyralabs.com>
 Requires:	electron xdg-utils
-BuildRequires:	git-core add-determinism pnpm
 Provides:   armcord
-Obsoletes:  armcord
+Obsoletes:  armcord < 3.3.2-1
 Conflicts:	legcord-bin
 BuildArch:	noarch
+BuildRequires:  anda-srpm-macros pnpm
 
 %description
 legcord is a custom client designed to enhance your Discord experience
 while keeping everything lightweight.
 
 %prep
-rm -rf *
-git clone %url .
-git checkout v%version
+%git_clone %url v%version
 
 cat <<EOF > legcord.desktop
 [Desktop Entry]
@@ -51,6 +49,15 @@ install -Dm755 %SOURCE1 %buildroot/usr/bin/legcord
 install -Dm644 legcord.desktop %buildroot/usr/share/applications/LegCord.desktop
 install -Dm644 build/icon.png %buildroot/usr/share/pixmaps/legcord.png
 
+ln -s %_datadir/legcord %buildroot%_datadir/armcord
+
+# HACK: rpm bug for unability to replace existing files on system.
+%pre
+if [ -d %_datadir/armcord ] && [ ! -L %_datadir/armcord ]; then
+  echo "Found old %_datadir/armcord directory, removing…"
+  rm -rf %_datadir/armcord
+fi
+
 %files
 %doc README.md
 %license license.txt
@@ -58,6 +65,7 @@ install -Dm644 build/icon.png %buildroot/usr/share/pixmaps/legcord.png
 /usr/share/applications/LegCord.desktop
 /usr/share/pixmaps/legcord.png
 /usr/share/legcord/app.asar
+/usr/share/armcord
 
 %changelog
 * Mon Oct 21 2024 madonuko <mado@fyralabs.com> - 1.0.2-2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: legcord* (#2395)](https://github.com/terrapkg/packages/pull/2395)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)