### PR TITLE
[f40] add: crossystem (#2418)

### DIFF
--- a/anda/tools/crossystem/anda.hcl
+++ b/anda/tools/crossystem/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "crossystem.spec"
+	}
+}

--- a/anda/tools/crossystem/crossystem.spec
+++ b/anda/tools/crossystem/crossystem.spec
@@ -1,0 +1,42 @@
+%global commit_date 20221215
+%global commit 	c4102fe4eef8c0539c03d60c7256fd4bc599bf4a
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           crossystem
+Summary:        Manage ChromeOS firmware
+License:        BSD-3-Clause
+URL:            https://chromium.googlesource.com/chromiumos/platform/vboot_reference
+
+Version:        %shortcommit
+Release:        1%?dist
+Source0:        %url/+archive/refs/heads/release-R110-15278.B.tar.gz
+Patch0:         use-flashrom-cros.patch
+Patch1:         disable-werror.patch
+
+Requires:       flashrom-cros
+BuildRequires:  make gcc openssl-devel flashrom-devel libuuid-devel
+
+Packager:       WeirdTreeThing <bradyn127@protonmail.com>
+
+%description
+A tool to manage ChromeOS bootloader flags and get various
+info from a ChromeOS system
+
+%prep
+%setup -C
+%patch -P0 -p1
+%patch -P1 -p1
+
+%build
+%make_build
+
+%install
+install -Dm755 build/utility/crossystem %{buildroot}%{_bindir}/crossystem
+
+%files
+%license LICENSE
+%{_bindir}/crossystem
+
+%changelog
+* Fri Oct 25 2024 WeirdTreeThing <bradyn127@protonmail.com>
+- initial release

--- a/anda/tools/crossystem/disable-werror.patch
+++ b/anda/tools/crossystem/disable-werror.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 295b680..2e12cfa 100644
+--- a/Makefile
++++ b/Makefile
+@@ -125,7 +125,7 @@ endif
+ # Provide default CC and CFLAGS for firmware builds; if you have any -D flags,
+ # please add them after this point (e.g., -DVBOOT_DEBUG).
+ DEBUG_FLAGS := $(if $(filter-out 0,${DEBUG}),-g -Og,-g -Os)
+-WERROR := -Werror
++WERROR := -Wno-error
+ FIRMWARE_FLAGS := -nostdinc -ffreestanding -fno-builtin -fno-stack-protector
+ COMMON_FLAGS := -pipe ${WERROR} -Wall -Wstrict-prototypes -Wtype-limits \
+ 	-Wundef -Wmissing-prototypes -Wno-trigraphs -Wredundant-decls -Wshadow \

--- a/anda/tools/crossystem/use-flashrom-cros.patch
+++ b/anda/tools/crossystem/use-flashrom-cros.patch
@@ -1,0 +1,26 @@
+diff --git a/host/lib/flashrom.c b/host/lib/flashrom.c
+index 6a80201..c67a99d 100644
+--- a/host/lib/flashrom.c
++++ b/host/lib/flashrom.c
+@@ -23,7 +23,7 @@
+ #include "flashrom.h"
+ #include "subprocess.h"
+
+-#define FLASHROM_EXEC_NAME "flashrom"
++#define FLASHROM_EXEC_NAME "flashrom-cros"
+
+ /**
+  * Helper to create a temporary file, and optionally write some data
+diff --git a/host/lib/include/flashrom.h b/host/lib/include/flashrom.h
+index 81d6ba9..6b760d6 100644
+--- a/host/lib/include/flashrom.h
++++ b/host/lib/include/flashrom.h
+@@ -10,7 +10,7 @@
+ #include "2return_codes.h"
+ #include "fmap.h"
+
+-#define FLASHROM_PROGRAMMER_INTERNAL_AP "host"
++#define FLASHROM_PROGRAMMER_INTERNAL_AP "internal"
+ #define FLASHROM_PROGRAMMER_INTERNAL_EC "ec"
+
+ /* Utilities for firmware images and (FMAP) sections */


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: crossystem (#2418)](https://github.com/terrapkg/packages/pull/2418)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)