### PR TITLE
[f41] add: flashrom-cros (#2417)

### DIFF
--- a/anda/tools/flashrom-cros/anda.hcl
+++ b/anda/tools/flashrom-cros/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "flashrom-cros.spec"
+	}
+}

--- a/anda/tools/flashrom-cros/flashrom-cros.spec
+++ b/anda/tools/flashrom-cros/flashrom-cros.spec
@@ -1,0 +1,38 @@
+%global commit_date 20240911
+%global commit  c1ab7468d28d164a30d598eb3e42a5febaf73bbc
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           flashrom-cros
+Version:        %shortcommit
+Release:        1%{?dist}
+Summary:        Simple program for reading/writing flash chips content (ChromiumOS fork)
+License:        GPL-2.0-only
+URL:            https://chromium.googlesource.com/chromiumos/third_party/flashrom
+Source0:        %url/+archive/refs/heads/release-R130-16033.B.tar.gz
+BuildRequires:  gcc gnupg2 libusb1-devel meson pciutils-devel python3-sphinx systemd zlib-devel dmidecode
+Requires:       dmidecode udev
+Packager:       WeirdTreeThing <bradyn127@protonmail.com>
+
+
+%description
+flashrom is a utility for identifying, reading, writing, verifying and erasing
+flash chips. It is designed to flash BIOS/EFI/coreboot/firmware/optionROM
+images on mainboards, network/graphics/storage controller cards, and various
+other programmer devices.
+
+%prep
+%setup -c
+
+%build
+%meson -Dtests=disabled -Ddocumentation=disabled -Duse_internal_dmi=false
+%meson_build
+
+%install
+install -Dm755 %{_vpath_builddir}/flashrom %{buildroot}%{_bindir}/%{name}
+
+%files
+%{_bindir}/%{name}
+
+%changelog
+* Fri Oct 25 2024 WeirdTreeThing <bradyn127@protonmail.com>
+- initial release


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: flashrom-cros (#2417)](https://github.com/terrapkg/packages/pull/2417)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)