### PR TITLE
[el10] fix: mesa-freeworld (#2452)

### DIFF
--- a/anda/system/mesa-freeworld/anda.hcl
+++ b/anda/system/mesa-freeworld/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
         updbranch = 1
+        multilib = 1
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: mesa-freeworld (#2452)](https://github.com/terrapkg/packages/pull/2452)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)