### PR TITLE
[f41] fix: update legcord provides excludes (#2458)

### DIFF
--- a/anda/apps/legcord-bin/legcord-bin.spec
+++ b/anda/apps/legcord-bin/legcord-bin.spec
@@ -11,11 +11,11 @@
 
 # Exclude private libraries
 %global __requires_exclude libffmpeg.so
-%global __provides_exclude_from %{_datadir}/armcord/.*\\.so
+%global __provides_exclude_from %{_datadir}/(armcord|legcord)/.*\\.so
 
 Name:			legcord-bin
 Version:		1.0.2
-Release:		3%?dist
+Release:		4%?dist
 License:		OSL-3.0
 Summary:		Custom lightweight Discord client designed to enhance your experience
 URL:			https://github.com/LegCord/LegCord
@@ -23,7 +23,7 @@ Group:			Applications/Internet
 Source0:		%url/releases/download/v%version/%src.zip
 Source1:		legcord.png
 Source2:		https://raw.githubusercontent.com/LegCord/LegCord/v%version/README.md
-Requires:		electron xdg-utils
+Requires:		xdg-utils
 BuildRequires:  unzip
 ExclusiveArch:	x86_64 aarch64 armv7l
 Conflicts:		legcord


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: update legcord provides excludes (#2458)](https://github.com/terrapkg/packages/pull/2458)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)