### PR TITLE
[f41] pop-shell: require GNOME 47 and bump release (#2464)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-pop-shell/terra-gnome-shell-extension-pop-shell.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-pop-shell/terra-gnome-shell-extension-pop-shell.spec
@@ -8,7 +8,7 @@
 
 Name:           terra-gnome-shell-extension-%{extension}
 Version:        %{ver}^%commit_date.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        GNOME Shell extension for advanced tiling window management
 License:        GPL-3.0-only
 URL:            https://github.com/pop-os/shell
@@ -26,7 +26,7 @@ Patch0:         0001-Remove-schema-handling-from-transpile.sh.patch
 BuildRequires:  typescript >= 3.8
 BuildRequires:  make
 
-Requires:       (gnome-shell >= 45~ with gnome-shell < 46~)
+Requires:       gnome-shell = 47~
 Recommends:     gnome-extensions-app
 Recommends:     %{name}-shortcut-overrides = %{version}-%{release}
 Provides:       %{extension} = %{version}-%{release}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [pop-shell: require GNOME 47 and bump release (#2464)](https://github.com/terrapkg/packages/pull/2464)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)