### PR TITLE
[el10] fix: zellij (#2469)

### DIFF
--- a/anda/langs/rust/zellij/rust-zellij.spec
+++ b/anda/langs/rust/zellij/rust-zellij.spec
@@ -20,6 +20,7 @@ BuildRequires:  rust-packaging
 BuildRequires:  openssl-devel
 BuildRequires:  gcc
 BuildRequires:  perl
+BuildRequires:  mold
 
 #BuildRequires:  external:crate:sccache
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: zellij (#2469)](https://github.com/terrapkg/packages/pull/2469)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)