### PR TITLE
[f39] fix: gtk4-layer-shell (#2468)

### DIFF
--- a/anda/lib/gtk4-layer-shell/gtk4-layer-shell.spec
+++ b/anda/lib/gtk4-layer-shell/gtk4-layer-shell.spec
@@ -7,6 +7,7 @@ URL:			https://github.com/wmww/gtk4-layer-shell
 Source0:		%url/archive/refs/tags/v%version.tar.gz
 BuildRequires:	meson ninja-build python3.11 vala
 BuildRequires:	libwayland-client gtk4-devel gobject-introspection gtk-doc
+BuildRequires:  pkgconfig(wayland-protocols)
 Recommends:		gtk4-layer-shell-devel
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: gtk4-layer-shell (#2468)](https://github.com/terrapkg/packages/pull/2468)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)