### PR TITLE
[f41] fix(katsu): buildrequires mold (#2483)

### DIFF
--- a/anda/tools/buildsys/katsu/katsu.spec
+++ b/anda/tools/buildsys/katsu/katsu.spec
@@ -31,7 +31,7 @@ Source0:		%url/archive/refs/tags/v%version.tar.gz
 BuildRequires:  anda-srpm-macros cargo-rpm-macros >= 26
 Requires:		xorriso dracut limine grub2 systemd-devel squashfs-tools parted gdisk
 Requires:		dracut-live dracut-config-generic dracut-config-rescue grub2-tools-extra dracut-squash
-BuildRequires:	cargo rust-packaging pkgconfig(libudev) clang-devel
+BuildRequires:	cargo rust-packaging pkgconfig(libudev) clang-devel mold
 
 %description
 Katsu is a tool for building bootable images from RPM based systems.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(katsu): buildrequires mold (#2483)](https://github.com/terrapkg/packages/pull/2483)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)