### PR TITLE
[f39] Add: git runtime dep in anda.spec (#2490)

### DIFF
--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -21,11 +21,13 @@ BuildRequires:  openssl-devel
 BuildRequires:  git-core
 BuildRequires:  libgit2-devel
 BuildRequires:  libssh2-devel
+BuildRequires:  mold
 
 Requires:       mock
 Requires:       rpm-build
 Requires:       createrepo_c
 Requires:       git-core
+Requires:       libgit2
 %global _description %{expand:
 Andaman Build toolchain.}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [Add: git runtime dep in anda.spec (#2490)](https://github.com/terrapkg/packages/pull/2490)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)