### PR TITLE
[f40] Add: Raspberry Pi Picotool (#2500)

### DIFF
--- a/anda/tools/picotool/anda.hcl
+++ b/anda/tools/picotool/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "picotool.spec"
+	}
+}

--- a/anda/tools/picotool/picotool.spec
+++ b/anda/tools/picotool/picotool.spec
@@ -1,0 +1,34 @@
+%define sdk_version 2.0.0
+Name:           picotool
+Version:        2.0.0
+Release:        1%?dist
+Summary:        Tool to inspect RP2040 binaries
+License:        BSD-3-Clause
+URL:            https://github.com/raspberrypi/picotool
+Source0:        https://github.com/raspberrypi/picotool/archive/%version.tar.gz#/picotool-%version.tar.gz
+Source1:        https://github.com/raspberrypi/pico-sdk/archive/%sdk_version.tar.gz#/pico-sdk-%sdk_version.tar.gz
+BuildRequires:  cmake g++ libusb1-devel
+
+%description
+Picotool is a tool for inspecting RP2040 binaries, and interacting with RP2040 devices when they are in BOOTSEL mode.
+
+%prep
+%autosetup -a 1
+
+%build
+%cmake -DPICO_SDK_PATH="../pico-sdk-%sdk_version"
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%doc README.md
+%license LICENSE.TXT
+%_bindir/picotool
+%_libdir/cmake/picotool
+%_datadir/picotool
+
+%changelog
+* Mon Nov 18 2024 Owen-sz <owen@fyralabs.com>
+- Package Raspberry Pi Picotools

--- a/anda/tools/picotool/update.rhai
+++ b/anda/tools/picotool/update.rhai
@@ -1,0 +1,2 @@
+rpm.version(gh("raspberrypi/picotool"));
+rpm.define("sdk_version", gh("raspberrypi/pico-sdk"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Add: Raspberry Pi Picotool (#2500)](https://github.com/terrapkg/packages/pull/2500)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)