### PR TITLE
[f40] Fix: legcord-nightly date (#2516)

### DIFF
--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,5 +1,5 @@
 %global commit 54a482bcf4384ffdeaf57568f52c7f2b5178695d
-%global commit_date 20241022
+%global commit_date 20241122
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %define debug_package %nil
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Fix: legcord-nightly date (#2516)](https://github.com/terrapkg/packages/pull/2516)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)