### PR TITLE
fix: keyd-2.5.0

### DIFF
--- a/anda/tools/keyd/keyd.spec
+++ b/anda/tools/keyd/keyd.spec
@@ -1,6 +1,6 @@
 Name:			keyd
-Version:		2.4.3
-Release:		1%?dist
+Version:		2.5.0
+Release:		2%?dist
 Summary:		Key remapping daemon for linux
 URL:			https://github.com/rvaiya/keyd
 License:		MIT


### PR DESCRIPTION
a55f3b12551d27e0c17cbacfea23da845812b37a wasn't built for 41