### PR TITLE
bump: terra-mock-configs

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,5 +1,5 @@
 Name:           terra-mock-configs
-Version:        1.2.2
+Version:        1.2.6
 Release:        1%?dist
 Epoch:          1
 Summary:        Mock configs for Terra repos


### PR DESCRIPTION
While upgrading to 41, noticed that terra-mock-configs was going to be downgraded for some reason, realised that version didn't get bumped