### PR TITLE
[f41] fix(mesa-freeworld): better update script that tracks bodhi (#2535)

### DIFF
--- a/anda/system/mesa-freeworld/update.rhai
+++ b/anda/system/mesa-freeworld/update.rhai
@@ -2,10 +2,6 @@ if !labels.branch.starts_with("f") {
     print(`mesa-freeworld: unsupported branch: ${labels.branch}`);
     terminate();
 }
-let b = labels.branch;
-if b == "frawhide" {
-    b = "rawhide";
-}
-let spec = get(`https://src.fedoraproject.org/rpms/mesa/raw/${b}/f/mesa.spec`);
-let v = find(`(?m)^%global\s+ver\s+([\w\d.-]+)$`, spec, 1);
-rpm.global("ver", v);
+let release = labels.branch.to_upper();
+let ver = get(`https://bodhi.fedoraproject.org/updates/?search=mesa&status=stable&releases=${release}&rows_per_page=1&page=1`).json().updates[0].title;
+rpm.global("ver", find(`^mesa-([\d.]+)`, ver, 1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(mesa-freeworld): better update script that tracks bodhi (#2535)](https://github.com/terrapkg/packages/pull/2535)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)