### PR TITLE
[f41] fix: picotool (#2520)

### DIFF
--- a/anda/tools/picotool/picotool.spec
+++ b/anda/tools/picotool/picotool.spec
@@ -22,6 +22,8 @@ Picotool is a tool for inspecting RP2040 binaries, and interacting with RP2040 d
 %install
 %cmake_install
 
+mv %buildroot{%_prefix/lib,%_libdir}
+
 %files
 %doc README.md
 %license LICENSE.TXT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: picotool (#2520)](https://github.com/terrapkg/packages/pull/2520)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)