### PR TITLE
[f41] fix: oxipng (#2548)

### DIFF
--- a/anda/langs/rust/oxipng/oxipng-fix-metadata-auto.diff
+++ b/anda/langs/rust/oxipng/oxipng-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- oxipng-9.1.2/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ oxipng-9.1.2/Cargo.toml	2024-07-13T07:08:09.478330+00:00
-@@ -150,7 +150,6 @@
+--- oxipng-9.1.3/Cargo.toml	1970-01-01T00:00:01+00:00
++++ oxipng-9.1.3/Cargo.toml	2024-11-30T06:39:39.902804+00:00
+@@ -149,7 +149,6 @@
  [features]
  binary = [
      "dep:clap",
@@ -8,7 +8,7 @@
      "dep:env_logger",
  ]
  default = [
-@@ -169,13 +168,10 @@
+@@ -168,13 +167,10 @@
  sanity-checks = ["dep:image"]
  zopfli = ["dep:zopfli"]
  

--- a/anda/langs/rust/oxipng/rust-oxipng.spec
+++ b/anda/langs/rust/oxipng/rust-oxipng.spec
@@ -7,7 +7,7 @@
 
 Name:           rust-oxipng
 Version:        9.1.3
-Release:        1%?dist
+Release:        %autorelease
 Summary:        Lossless PNG compression optimizer
 
 License:        MIT
@@ -16,7 +16,7 @@ Source:         %{crates_source}
 # Automatically generated patch to strip dependencies and normalize metadata
 Patch:          oxipng-fix-metadata-auto.diff
 
-BuildRequires:  anda-srpm-macros cargo-rpm-macros >= 24
+BuildRequires:  mold anda-srpm-macros cargo-rpm-macros >= 24
 
 %global _description %{expand:
 A lossless PNG compression optimizer.}
@@ -33,7 +33,7 @@ License:        # FIXME
 
 %files       -n %{crate}
 %license LICENSE
-#license LICENSE.dependencies
+%license LICENSE.dependencies
 %doc CHANGELOG.md
 %doc MANUAL.txt
 %doc README.md
@@ -145,8 +145,8 @@ use the "zopfli" feature of the "%{crate}" crate.
 
 %build
 %cargo_build
-#{cargo_license_summary}
-#{cargo_license} > LICENSE.dependencies
+%{cargo_license_summary_online}
+%{cargo_license_online} > LICENSE.dependencies
 
 %install
 %cargo_install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: oxipng (#2548)](https://github.com/terrapkg/packages/pull/2548)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)