### PR TITLE
[f41] add provides/conflicts for alsa-ucm-cros (#2552)

### DIFF
--- a/anda/misc/alsa-ucm-cros/alsa-ucm-cros.spec
+++ b/anda/misc/alsa-ucm-cros/alsa-ucm-cros.spec
@@ -8,6 +8,8 @@ License:		BSD-3-Clause
 URL:			https://github.com/WeirdTreeThing/alsa-ucm-conf-cros/tree/standalone
 Source0:		https://github.com/WeirdTreeThing/alsa-ucm-conf-cros/archive/refs/tags/%version.tar.gz
 BuildArch:		noarch
+Provides:     alsa-ucm
+Conflicts:    alsa-ucm
 
 %description
 %summary for chromebooks.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add provides/conflicts for alsa-ucm-cros (#2552)](https://github.com/terrapkg/packages/pull/2552)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)