### PR TITLE
[f41] Fix: msm-cros-efs-loader (#2557)

### DIFF
--- a/anda/system/msm-cros-efs-loader/msm-cros-efs-loader.service
+++ b/anda/system/msm-cros-efs-loader/msm-cros-efs-loader.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=EFS loader for Qualcomm-based Chrome OS devices
-Requires=qrtr-ns.service
-After=qrtr-ns.service
 
 [Service]
 ExecStartPre=/usr/bin/msm-cros-efs-loader

--- a/anda/system/msm-cros-efs-loader/msm-cros-efs-loader.spec
+++ b/anda/system/msm-cros-efs-loader/msm-cros-efs-loader.spec
@@ -1,4 +1,4 @@
-Name:                   msm-cros-efs-loader
+Name:                   terra-msm-cros-efs-loader
 Version:                1.0.2
 Release:                1%?dist
 Summary:                EFS loader for Qualcomm-based Chrome OS devices
@@ -9,6 +9,8 @@ Source1:                msm-cros-efs-loader.service
 Requires:               rmtfs crossystem
 BuildArch:              noarch
 Packager:               WeirdTreeThing <bradyn127@protonmail.com>
+Conflicts:              msm-cros-efs-loader
+Provides:               msm-cros-efs-loader
  
 %{?systemd_requires}
 BuildRequires:  systemd-rpm-macros
@@ -20,7 +22,7 @@ EFS loader for Qualcomm-based Chrome OS devices
 %autosetup -n msm-cros-efs-loader-v%{version}
  
 %install
-install -Dm755 %{name}.sh %{buildroot}/usr/bin/%{name}
+install -Dm755 msm-cros-efs-loader.sh %{buildroot}/usr/bin/msm-cros-efs-loader
 install -Dm644 %SOURCE1 %{buildroot}/%{_unitdir}/msm-cros-efs-loader.service
  
 %post
@@ -33,7 +35,7 @@ install -Dm644 %SOURCE1 %{buildroot}/%{_unitdir}/msm-cros-efs-loader.service
 %systemd_postun_with_restart 88-ultramarine-chromebook-default.preset
  
 %files
-%_bindir/%name
+%_bindir/msm-cros-efs-loader
 %{_unitdir}/msm-cros-efs-loader.service
  
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix: msm-cros-efs-loader (#2557)](https://github.com/terrapkg/packages/pull/2557)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)