### PR TITLE
[f41] add: zsh-autocomplete (#2565)

### DIFF
--- a/anda/devs/zsh-autocomplete/anda.hcl
+++ b/anda/devs/zsh-autocomplete/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "zsh-autocomplete.spec"
+    }
+}

--- a/anda/devs/zsh-autocomplete/update.rhai
+++ b/anda/devs/zsh-autocomplete/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("marlonrichert/zsh-autocomplete"));

--- a/anda/devs/zsh-autocomplete/zsh-autocomplete.spec
+++ b/anda/devs/zsh-autocomplete/zsh-autocomplete.spec
@@ -1,0 +1,31 @@
+%define debug_package %nil
+
+Name:           zsh-autocomplete
+Version:        24.09.04
+Release:        1%?dist
+Summary:        Real-time type-ahead completion for Zsh
+License:        MIT
+URL:            https://github.com/marlonrichert/zsh-autocomplete
+Source0:        %url/archive/refs/tags/%version.tar.gz
+Packager:       madonuko <mado@fyralabs.com>
+
+%description
+This plugin for Zsh adds real-time type-ahead autocompletion to your command
+line, similar to what you find desktop apps. While you type on the command
+line, available completions are listed automatically; no need to press any
+keyboard shortcuts. Press Tab to insert the top completion or ↓ to select a
+different one.
+
+%prep
+%autosetup
+
+%build
+
+%install
+install -Dpm644 zsh-autocomplete.plugin.zsh -t %buildroot%_datadir/zsh-autocomplete/
+mv Completions Functions %buildroot%_datadir/zsh-autocomplete/
+
+%files
+%doc README.md
+%license LICENSE
+%_datadir/zsh-autocomplete/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: zsh-autocomplete (#2565)](https://github.com/terrapkg/packages/pull/2565)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)