### PR TITLE
[f40] add: WoeUSB-ng (#2561)

### DIFF
--- a/anda/apps/woeusb-ng/WoeUSB-ng.spec
+++ b/anda/apps/woeusb-ng/WoeUSB-ng.spec
@@ -1,0 +1,50 @@
+Name:           WoeUSB-ng
+Version:        0.2.12
+Release:        1%?dist
+Summary:        Simple tool that enable you to create your own usb stick with Windows installer
+License:        GPL-3.0-only
+Requires:       parted dosfstools ntfsprogs p7zip p7zip-plugins xdg-utils grub2-tools
+URL:            https://github.com/WoeUSB/WoeUSB-ng
+Source:         https://github.com/WoeUSB/WoeUSB-ng/archive/refs/tags/v%version.tar.gz
+Patch0:         https://patch-diff.githubusercontent.com/raw/WoeUSB/WoeUSB-ng/pull/79.patch
+BuildArch:      noarch
+BuildRequires:  python3-devel python3-installer
+
+%global _description %{expand:
+WoeUSB-ng is a simple tool that enable you to create your own usb stick windows installer from an iso image or a real DVD. This is a rewrite of original WoeUSB.}
+
+%description %_description
+
+%prep
+%autosetup -p1
+
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+
+%build
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+%pyproject_save_files WoeUSB
+install -Dpm644 miscellaneous/WoeUSB-ng.desktop %buildroot%_datadir/applications/WoeUSB-ng.desktop
+install -Dpm644 miscellaneous/com.github.woeusb.woeusb-ng.policy %buildroot%_datadir/polkit-1/actions/com.github.woeusb.woeusb-ng.policy
+
+
+%check
+#pyproject_check_import
+
+
+%files -f %{pyproject_files}
+%_bindir/woeusb
+%_bindir/woeusbgui
+%_datadir/applications/WoeUSB-ng.desktop
+%_iconsdir/hicolor/scalable/apps/woeusb-logo.png
+%_datadir/polkit-1/actions/com.github.woeusb.woeusb-ng.policy
+
+
+%changelog
+%autochangelog

--- a/anda/apps/woeusb-ng/anda.hcl
+++ b/anda/apps/woeusb-ng/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "WoeUSB-ng.spec"
+    }
+}

--- a/anda/apps/woeusb-ng/update.rhai
+++ b/anda/apps/woeusb-ng/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("WoeUSB/WoeUSB-ng"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: WoeUSB-ng (#2561)](https://github.com/terrapkg/packages/pull/2561)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)