### PR TITLE
[el10] Add: arduino-lint (#2580)

### DIFF
--- a/anda/tools/arduino-lint/anda.hcl
+++ b/anda/tools/arduino-lint/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "arduino-lint.spec"
+	}
+}

--- a/anda/tools/arduino-lint/arduino-lint.spec
+++ b/anda/tools/arduino-lint/arduino-lint.spec
@@ -1,0 +1,33 @@
+%define debug_package %nil
+
+Name:          arduino-lint
+Version:       1.2.1
+Release:       1%?dist
+Summary:       Tool to check for problems with Arduino projects.
+License:       GPLv3
+Packager:      Owen Zimmerman <owen@fyralabs.com>
+Url:           https://github.com/arduino/arduino-lint
+Source0:       %url/archive/refs/tags/%version.tar.gz
+BuildRequires: golang git go-rpm-macros anda-srpm-macros
+
+%description
+%summary
+
+%prep
+%autosetup -n arduino-lint-%version
+
+%build
+go build
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+install -Dm 755 arduino-lint %buildroot%{_bindir}/arduino-lint
+
+%files
+%license LICENSE.txt
+%doc README.md 
+%{_bindir}/arduino-lint
+
+%changelog
+* Thu Dec 5 2024 Owen Zimmerman <owen@fyralabs.com>
+- Package arduino-lint

--- a/anda/tools/arduino-lint/update.rhai
+++ b/anda/tools/arduino-lint/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/arduino-lint"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Add: arduino-lint (#2580)](https://github.com/terrapkg/packages/pull/2580)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)