### PR TITLE
[f40] fix: prismlauncher-nightly (#2467)

### DIFF
--- a/anda/games/prismlauncher-nightly/anda.hcl
+++ b/anda/games/prismlauncher-nightly/anda.hcl
@@ -1,6 +1,7 @@
 project pkg {
 	rpm {
 		spec = "prismlauncher-nightly.spec"
+        extra_repos = ["https://packages.adoptium.net/artifactory/rpm/fedora/\\$releasever/\\$basearch"]
 	}
 	labels {
 		nightly = "1"

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,7 +3,7 @@
 
 %global commit 616aa002e1c007c381c7d352fcd03ede9be173b5
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global libnbtplusplus_commit a5e8fd52b8bf4ab5d5bcc042b2a247867589985f
+%global libnbtplusplus_commit 23b955121b8217c1c348a9ed2483167a6f3ff4ad
 
 %global commit_date 20241129
 %global snapshot_info %{commit_date}.%{shortcommit}
@@ -43,7 +43,16 @@ Patch0:           0001-find-cmark-with-pkgconfig.patch
 BuildRequires:    cmake >= 3.15
 BuildRequires:    extra-cmake-modules
 BuildRequires:    gcc-c++
+# JDKs less than the most recent release & LTS are no longer in the default
+# Fedora repositories
+# Make sure you have Adoptium's repositories enabled
+# https://fedoraproject.org/wiki/Changes/ThirdPartyLegacyJdks
+# https://adoptium.net/installation/linux/#_centosrhelfedora_instructions
+%if 0%{?fedora} > 41
+BuildRequires:    temurin-17-jdk
+%else
 BuildRequires:    java-17-openjdk-devel
+%endif
 BuildRequires:    desktop-file-utils
 BuildRequires:    libappstream-glib
 BuildRequires:    tomlplusplus-devel
@@ -77,9 +86,11 @@ Requires(postun): desktop-file-utils
 Requires:         qt%{qt_version}-qtimageformats
 Requires:         qt%{qt_version}-qtsvg
 Requires:         javapackages-filesystem
-Recommends:       java-21-openjdk
+# See note above
+%if 0%{?fedora} && 0%{?fedora} < 42
 Recommends:       java-17-openjdk
 Suggests:         java-1.8.0-openjdk
+%endif
 
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
 Recommends:       xrandr
@@ -116,6 +127,9 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 %cmake \
   -DLauncher_QT_VERSION_MAJOR="%{qt_version}" \
   -DLauncher_BUILD_PLATFORM="%{build_platform}" \
+  %if 0%{?fedora} > 41
+  -DLauncher_ENABLE_JAVA_DOWNLOADER=ON \
+  %endif
   %if "%{msa_id}" != "default"
   -DLauncher_MSA_CLIENT_ID="%{msa_id}" \
   %endif

--- a/anda/games/prismlauncher/anda.hcl
+++ b/anda/games/prismlauncher/anda.hcl
@@ -1,5 +1,6 @@
 project pkg {
 	rpm {
 		spec = "prismlauncher.spec"
+        extra_repos = ["https://packages.adoptium.net/artifactory/rpm/fedora/\\$releasever/\\$basearch"]
 	}
 }

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -35,7 +35,16 @@ Source0:          https://github.com/PrismLauncher/PrismLauncher/releases/downlo
 BuildRequires:    cmake >= 3.15
 BuildRequires:    extra-cmake-modules
 BuildRequires:    gcc-c++
+# JDKs less than the most recent release & LTS are no longer in the default
+# Fedora repositories
+# Make sure you have Adoptium's repositories enabled
+# https://fedoraproject.org/wiki/Changes/ThirdPartyLegacyJdks
+# https://adoptium.net/installation/linux/#_centosrhelfedora_instructions
+%if 0%{?fedora} > 41
+BuildRequires:    temurin-17-jdk
+%else
 BuildRequires:    java-17-openjdk-devel
+%endif
 BuildRequires:    desktop-file-utils
 BuildRequires:    libappstream-glib
 BuildRequires:    cmake(ghc_filesystem)
@@ -68,8 +77,11 @@ Requires:         qt%{qt_version}-qtimageformats
 Requires:         qt%{qt_version}-qtsvg
 Requires:         javapackages-filesystem
 Recommends:       java-21-openjdk
+# See note above
+%if 0%{?fedora} && 0%{?fedora} < 42
 Recommends:       java-17-openjdk
 Suggests:         java-1.8.0-openjdk
+%endif
 
 # xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
 Recommends:       xrandr
@@ -101,6 +113,9 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 %cmake \
   -DLauncher_QT_VERSION_MAJOR="%{qt_version}" \
   -DLauncher_BUILD_PLATFORM="%{build_platform}" \
+  %if 0%{?fedora} > 41
+  -DLauncher_ENABLE_JAVA_DOWNLOADER=ON \
+  %endif
   %if "%{msa_id}" != "default"
   -DLauncher_MSA_CLIENT_ID="%{msa_id}" \
   %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: prismlauncher-nightly (#2467)](https://github.com/terrapkg/packages/pull/2467)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)