### PR TITLE
[el10] fix: tdlib (#2456)

### DIFF
--- a/anda/lib/tdlib/tdlib-nightly.spec
+++ b/anda/lib/tdlib/tdlib-nightly.spec
@@ -49,6 +49,7 @@ Requires: %name-devel%?_isa = %{?epoch:%epoch:}%version-%release
 
 %prep
 %autosetup -n td-%commit -p1
+rm %SOURCE0
 sed -e 's/"DEFAULT"/"PROFILE=SYSTEM"/g' -i tdnet/td/net/SslStream.cpp
 
 %build
@@ -61,6 +62,10 @@ sed -e 's/"DEFAULT"/"PROFILE=SYSTEM"/g' -i tdnet/td/net/SslStream.cpp
 
 %install
 %cmake_install
+
+mv LICENSE_1_0.txt *.md ..
+rm -rf *
+mv ../LICENSE_1_0.txt ../*.md .
 
 %files
 %license LICENSE_1_0.txt


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: tdlib (#2456)](https://github.com/terrapkg/packages/pull/2456)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)