### PR TITLE
add: icoextract-thumbnailer

### DIFF
--- a/anda/misc/icoextract-thumbnailer/anda.hcl
+++ b/anda/misc/icoextract-thumbnailer/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "icoextract-thumbnailer.spec"
+	}
+}

--- a/anda/misc/icoextract-thumbnailer/icoextract-thumbnailer.spec
+++ b/anda/misc/icoextract-thumbnailer/icoextract-thumbnailer.spec
@@ -1,0 +1,37 @@
+Name:           icoextract-thumbnailer
+Version:        0.1.5
+Release:        1%{?dist}
+Summary:        XDG-compatible thumbnailer for Windows PE executables
+
+URL:            https://github.com/jlu5/icoextract/
+License:        MIT
+Source0:        %{url}/raw/refs/tags/%{version}/exe-thumbnailer.thumbnailer
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+BuildArch:      noarch
+BuildRequires:  /usr/bin/install
+Requires:       python3dist(icoextract)
+
+
+%description
+%{summary}.
+This package supplements icoextract by providing the thumbnailer configuration file for file managers
+that support XDG thumbnailers, such as Nautilus, Dolphin and Thunar.
+
+%prep
+
+%build
+
+
+
+%install
+install -Dm644 %{SOURCE0} %{buildroot}%{_datadir}/thumbnailers/exe-thumbnailer.thumbnailer
+
+
+%files
+%{_datadir}/thumbnailers/exe-thumbnailer.thumbnailer
+
+
+
+%changelog
+* Sat Dec 14 2024 Cappy Ishihara <cappy@cappuchino.xyz>
+- Initial package

--- a/anda/misc/icoextract-thumbnailer/update.rhai
+++ b/anda/misc/icoextract-thumbnailer/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("jlu5/icoextract"));


### PR DESCRIPTION
Supplemental package for python3-icoextract so it could be used as an XDG thumbnailer for Windows PE Executables
