### PR TITLE
[el10] fix: manrope-fonts (#2617)

### DIFF
--- a/anda/fonts/manrope/manrope-fonts.spec
+++ b/anda/fonts/manrope/manrope-fonts.spec
@@ -1,45 +1,29 @@
-%global commit ffa0fdf363527c9993b8836cce48cd12bd2b81ba
-
 Summary:        A modernist sans serif font
 Name:           manrope-fonts
 Version:        4.505
 Release:        1%{?dist}
 License:        OFL-1.1
-URL:            https://github.com/sharanda/manrope
+#URL:            https://github.com/sharanda/manrope
+URL:            https://github.com/terrapkg/pkg-manrope-fonts
 
-Source0:        %url/archive/%commit.tar.gz
+Source0:        %url/archive/%version.tar.gz
 BuildArch:      noarch
 
 %description
 Manrope – modern geometric sans-serif
 
 %prep
-%autosetup -n manrope-%commit
+%autosetup -n pkg-manrope-fonts-%version
 
 %build
 
 %install
 install -d %{buildroot}%{_datadir}/fonts/manrope
-install -pm 644 fonts/otf/*.otf %{buildroot}%{_datadir}/fonts/manrope
-install -pm 644 fonts/ttf/*.ttf %{buildroot}%{_datadir}/fonts/manrope
-install -pm 644 fonts/variable/Manrope* %{buildroot}%{_datadir}/fonts/manrope
+install -pm 644 manrope-* %{buildroot}%{_datadir}/fonts/manrope
+install -pm 644 Manrope* %{buildroot}%{_datadir}/fonts/manrope
 
 %files
 %doc README.md
 %doc documentation.html
 %license OFL.txt
 %{_datadir}/fonts/manrope/*
-
- 
-%changelog
-* Thu Jun 22 2023 windowsboy111 <windowsboy111@fyralabs.com> - 4.505-1
-- Bump version and fix sources
-
-* Tue Jan 10 2023 Cappy Ishihara <cappy@cappuchino.xyz> - 1-3
-- Ported from tauOS
-
-* Sat May 14 2022 Jamie Murphy <jamie@fyralabs.com> - 1-1
-- Fix specfile
-
-* Sat May 14 2022 Lains <lainsce@airmail.cc> - 1-1
-- Initial release


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: manrope-fonts (#2617)](https://github.com/terrapkg/packages/pull/2617)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)