### PR TITLE
[f39] package spotx-bash (#2629)

### DIFF
--- a/anda/tools/spotx-bash/anda.hcl
+++ b/anda/tools/spotx-bash/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "spotx-bash.spec"
+    }
+    labels {
+        nightly = 1
+    }
+}

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,0 +1,36 @@
+%global commit 0143cd113cdec0f0516beba3afe46e42e69b8b1c
+%global commit_date 20241119
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           spotx-bash
+Version:        %commit_date.git~%shortcommit
+Release:        1%?dist
+Summary:        Adblock for the Spotify desktop client on Linux.
+License:        MIT
+URL:            https://github.com/SpotX-Official/SpotX-Bash
+Source0:        %url/archive/%commit.tar.gz
+Requires:       bash
+BuildArch:      noarch
+Provides:       spotx spotx-linux spot-x spotx.sh
+
+%description
+%summary
+
+%prep
+%autosetup -n SpotX-Bash-%commit
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+install -Dm 755 spotx.sh %buildroot%{_bindir}/spotx
+
+%post
+%{__ln_s} -f %{_bindir}/spotx %{_bindir}/spotx.sh
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/spotx
+
+%changelog
+* Sat Dec 14 2024 Its-J
+- Package SpotX-Bash

--- a/anda/tools/spotx-bash/update.rhai
+++ b/anda/tools/spotx-bash/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("SpotX-Official/SpotX-Bash"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [package spotx-bash (#2629)](https://github.com/terrapkg/packages/pull/2629)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)