### PR TITLE
[f39] add modulo feature to espanso-wayland (#2628)

### DIFF
--- a/anda/tools/espanso-wayland/espanso-wayland.spec
+++ b/anda/tools/espanso-wayland/espanso-wayland.spec
@@ -14,6 +14,7 @@ BuildRequires:	pkgconfig(xkbcommon)
 BuildRequires:	pkgconfig(dbus-1)
 BuildRequires:	wxGTK-devel
 BuildRequires:	openssl-devel
+BuildRequires:  mold
 
 %description
 A cross-platform Text Expander written in Rust. A text expander is a program
@@ -30,7 +31,7 @@ cd espanso
 
 %build
 cd espanso
-%cargo_build -n -f vendored-tls,"wayland" -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-migrate,espanso-modulo,espanso-package,espanso-path,espanso-render,espanso-ui}
+%cargo_build -n -f vendored-tls,"wayland",modulo -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-migrate,espanso-modulo,espanso-package,espanso-path,espanso-render,espanso-ui}
 
 %install
 mkdir -p %buildroot%_bindir

--- a/anda/tools/espanso-x11/espanso-x11.spec
+++ b/anda/tools/espanso-x11/espanso-x11.spec
@@ -14,6 +14,7 @@ BuildRequires:	pkgconfig(xkbcommon)
 BuildRequires:	pkgconfig(dbus-1)
 BuildRequires:	wxGTK-devel
 BuildRequires:	openssl-devel
+BuildRequires:  mold
 
 %description
 A cross-platform Text Expander written in Rust. A text expander is a program


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [add modulo feature to espanso-wayland (#2628)](https://github.com/terrapkg/packages/pull/2628)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)