### PR TITLE
[f39] Add: rpi-update (#2634)

### DIFF
--- a/anda/tools/rpi-update/anda.hcl
+++ b/anda/tools/rpi-update/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+  	arches = ["aarch64"]
+	rpm {
+		spec = "rpi-update.spec"
+	}
+	labels {
+	   nightly = 1
+	}
+}

--- a/anda/tools/rpi-update/rpi-update.spec
+++ b/anda/tools/rpi-update/rpi-update.spec
@@ -1,0 +1,35 @@
+%define debug_package %nil
+
+%global commit 7ce981c2125b2dd780f4e88dc320e1570dc4c51e
+%global commit_date 20240910
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           rpi-update
+Version:        %commit_date.git~%shortcommit
+Release:        1%?dist
+Summary:        An easier way to update the firmware of your Raspberry Pi. 
+License:        MIT
+URL:            https://github.com/raspberrypi/rpi-update
+Source0:        %url/archive/%commit.tar.gz
+Requires:       bash
+ExclusiveArch:  aarch64
+
+%description
+%summary
+
+%prep
+%autosetup -n rpi-update-%commit
+
+%build
+
+%install
+install -Dm755 rpi-update          %buildroot%_bindir/rpi-update
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/rpi-update
+
+%changelog
+* Sat Dec 14 2024 Owen Zimmerman <owen@fyralabs.com>
+- Package rpi-update

--- a/anda/tools/rpi-update/update.rhai
+++ b/anda/tools/rpi-update/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("raspberrypi/rpi-update"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [Add: rpi-update (#2634)](https://github.com/terrapkg/packages/pull/2634)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)