### PR TITLE
[f39] fix non-existent binary (#2656)

### DIFF
--- a/anda/langs/kotlin/kotlin/kotlin.spec
+++ b/anda/langs/kotlin/kotlin/kotlin.spec
@@ -35,7 +35,7 @@ sed -i "s|\(KOTLIN_HOME *= *\).*|\1%{_datadir}/%{name}|" bin/*
 %install
 rm -rf %{buildroot} && mkdir -p %{buildroot}%{_bindir}/ && cd kotlinc
 install -m 0755 bin/kotlin %{buildroot}%{_bindir}/
-install -m 0755 bin/kotlin-dce-js %{buildroot}%{_bindir}/
+install -m 0755 bin/kapt %{buildroot}%{_bindir}/
 install -m 0755 bin/kotlinc %{buildroot}%{_bindir}/
 install -m 0755 bin/kotlinc-js %{buildroot}%{_bindir}/
 install -m 0755 bin/kotlinc-jvm %{buildroot}%{_bindir}/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix non-existent binary (#2656)](https://github.com/terrapkg/packages/pull/2656)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)