### PR TITLE
[f40] add: ctwm (attempt 2) (#1400)

### DIFF
--- a/anda/desktops/ctwm/anda.hcl
+++ b/anda/desktops/ctwm/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "ctwm.spec"
+	}
+}

--- a/anda/desktops/ctwm/ctwm.desktop
+++ b/anda/desktops/ctwm/ctwm.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=CTWM
+Comment=Claude's Tab Window Manager
+TryExec=ctwm
+Exec=ctwm
+Type=Xsession
+Encoding=UTF-8

--- a/anda/desktops/ctwm/ctwm.spec
+++ b/anda/desktops/ctwm/ctwm.spec
@@ -1,0 +1,55 @@
+Summary: Lightweight window manager with virtual workspaces
+Name: ctwm
+Version: 4.1.0
+Release: 1%?dist
+URL: https://ctwm.org
+BuildRequires: libjpeg-turbo-devel libX11-devel libXext-devel libXmu-devel libXpm-devel libXt-devel libXrandr-devel cmake gcc m4
+Source0: https://www.ctwm.org/dist/%{name}-%{version}.tar.xz
+Source1: %{name}.desktop
+License: MIT
+Requires: m4 
+# Derived from RPMSphere's packaging
+
+%description
+CTWM is a window manager based on TWM (with virtual workspaces added).
+
+%prep
+%setup -q
+
+%build
+%cmake
+%cmake_build
+
+%install
+%cmake_install
+%{__install} -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/xsessions/%{name}.desktop
+
+%files
+%doc README.md CHANGES.md
+%license COPYRIGHT
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}*
+%{_datadir}/xsessions/%{name}.desktop
+%{_datadir}/ctwm
+%{_datadir}/doc/ctwm/ctwm.1.html
+%{_datadir}/examples/ctwm/system.ctwmrc
+
+%changelog
+* Tue Dec 17 2024 Owen Zimmerman <owen@fyralabs.com>
+- Add .desktop and .rhai file, fix dependancies, and switch to .tar.xz source (smaller download)
+* Thu Jun 27 2024 Jaiden Riordan <jade@fyralabs.com> - 4.1.0
+- Rewrite for Terra, Thanks RPMSphere
+* Tue Dec 24 2019 Wei-Lun Chao <bluebat@member.fsf.org> - 4.0.3
+- Rebuilt for Fedora
+* Sat Apr  9 2011 Agnelo de la Crotche <agnelo@unixversal.com>
+- package for openSUSE 11.3/11.4
+* Thu Feb 16 2006 Richard Levitte <richard@levitte.org>
+- Release ctwm 3.8a.
+* Wed May  4 2005 Rudolph T Maceyko <rm55@pobox.com>
+- Tweaks.  Added all .ctwmrc files as well as sound and VMS docs.
+* Wed May  4 2005 Richard Levitte <richard@levitte.org>
+- Changed some directory specifications to RedHat-ish standards.
+* Tue May  3 2005 Richard Levitte <richard@levitte.org>
+- Received the original from Johan Vromans. Adjusted it to become
+  an official .spec file.
+  

--- a/anda/desktops/ctwm/update.rhai
+++ b/anda/desktops/ctwm/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(find("<p>Current release: ([\\d.]+)</p>", get("https://www.ctwm.org/download.html"), 1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: ctwm (attempt 2) (#1400)](https://github.com/terrapkg/packages/pull/1400)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)