### PR TITLE
Add: pbcli

### DIFF
--- a/anda/misc/pbcli/anda.hcl
+++ b/anda/misc/pbcli/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "pbcli.spec"
+    }
+}

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -1,5 +1,3 @@
-%global ver v2.6.0
-%global goodver %(echo %ver | sed 's/v//g')
 %global __brp_mangle_shebangs %{nil}
 %bcond_without mold
 

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -12,7 +12,7 @@ Release:        1%?dist
 Summary:        A PrivateBin commandline upload and download utility
 License:        MIT
 URL:            https://github.com/Mydayyy/pbcli
-Source0:        https://github.com/Mydayyy/pbcli/archive/refs/tags/%ver.tar.gz
+Source0:        %url/archive/refs/tags/v%version.tar.gz
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros mold
 BuildRequires:  perl-IPC-Cmd perl-ExtUtils-MM-Utils perl-FindBin perl-lib perl-File-Compare perl-File-Copy

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -15,7 +15,6 @@ URL:            https://github.com/Mydayyy/pbcli
 Source0:        https://github.com/Mydayyy/pbcli/archive/refs/tags/%ver.tar.gz
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros mold
-BuildRequires:  rust2rpm
 BuildRequires:  perl-IPC-Cmd perl-ExtUtils-MM-Utils perl-FindBin perl-lib perl-File-Compare perl-File-Copy
 BuildRequires:  openssl-libs openssl-devel
 Packager:       ShinyGil <rockgrub@protonmail.com>

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -29,7 +29,7 @@ Packager:       ShinyGil <rockgrub@protonmail.com>
 %_libdir/libpbcli.so
 
 %prep
-%autosetup -n pbcli-%goodver
+%autosetup -n pbcli-%version
 %cargo_prep_online
 
 %build

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -1,0 +1,47 @@
+%global ver v2.6.0
+%global goodver %(echo %ver | sed 's/v//g')
+%global __brp_mangle_shebangs %{nil}
+%bcond_without mold
+
+%global _description %{expand:
+pbcli is a command line client which allows to upload and download pastes from privatebin directly from the command line.}
+
+Name:           pbcli
+Version:        %goodver
+Release:        1%?dist
+Summary:        A PrivateBin commandline upload and download utility
+License:        MIT
+URL:            https://github.com/Mydayyy/pbcli
+Source0:        https://github.com/Mydayyy/pbcli/archive/refs/tags/%ver.tar.gz
+BuildRequires:  cargo-rpm-macros >= 24
+BuildRequires:  anda-srpm-macros mold
+BuildRequires:  rust2rpm
+BuildRequires:  perl-IPC-Cmd perl-ExtUtils-MM-Utils perl-FindBin perl-lib perl-File-Compare perl-File-Copy
+BuildRequires:  openssl-libs openssl-devel
+Packager:       ShinyGil <rockgrub@protonmail.com>
+
+%description %_description
+
+%files
+%doc README.md
+%license LICENSE-MIT
+%license LICENSE-UNLICENSE
+%license LICENSE.dependencies
+%_bindir/pbcli
+%_libdir/libpbcli.so
+
+%prep
+%autosetup -n pbcli-%goodver
+%cargo_prep_online
+
+%build
+%cargo_build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+install -Dm755 target/rpm/pbcli %{buildroot}%{_bindir}/pbcli
+install -Dm755 target/rpm/libpbcli.so %{buildroot}%{_libdir}/libpbcli.so
+
+%changelog
+* Sat Dec 21 2024 ShinyGil <rockgrub@protonmail.com>
+- Initial package

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -10,7 +10,8 @@ Name:           pbcli
 Version:        2.6.0
 Release:        1%?dist
 Summary:        A PrivateBin commandline upload and download utility
-License:        MIT
+SourceLicense:  Unlicense OR MIT
+License:        (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:            https://github.com/Mydayyy/pbcli
 Source0:        %url/archive/refs/tags/v%version.tar.gz
 BuildRequires:  cargo-rpm-macros >= 24

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -7,7 +7,7 @@
 pbcli is a command line client which allows to upload and download pastes from privatebin directly from the command line.}
 
 Name:           pbcli
-Version:        %goodver
+Version:        2.6.0
 Release:        1%?dist
 Summary:        A PrivateBin commandline upload and download utility
 License:        MIT

--- a/anda/misc/pbcli/update.rhai
+++ b/anda/misc/pbcli/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Mydayyy/pbcli"));

--- a/anda/misc/pbcli/update.rhai
+++ b/anda/misc/pbcli/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("Mydayyy/pbcli"));
+rpm.version(crates("pbcli"));


### PR DESCRIPTION
Please let me know if any of this is incorrect and I'll amend, I did my best comparing to existing Terra packages' files. Also very happy to have this building in Mock after finding the hard way `%cargo_install` just doesn't want to work for this one... As this doubles as a request I'll fill out the template!

**What software are you requesting to be packaged?**
https://github.com/Mydayyy/pbcli

**Describe the motivation**
`pbcli` is a CLI utility to upload and download pastes from any PrivateBin instance. While Fedora has `fpaste`, some more privacy savvy users prefer PrivateBin instances, this also tends to be preferred by users of custom distros due to `fpaste` being an official Fedora tool.
