### PR TITLE
[f41] fix: open-in-mpv (#2717)

### DIFF
--- a/anda/tools/open-in-mpv/open-in-mpv.spec
+++ b/anda/tools/open-in-mpv/open-in-mpv.spec
@@ -12,6 +12,7 @@ Source0:        https://github.com/Baldomo/open-in-mpv/archive/refs/tags/v%{vers
 ExclusiveArch:  %{golang_arches}
 
 BuildRequires:  go-rpm-macros
+BuildRequires:  anda-srpm-macros
 BuildRequires:  git
 BuildRequires:  elfutils
 
@@ -21,13 +22,13 @@ This is a simple web extension (for Chrome and Firefox) which helps open any vid
 The extension itself shares a lot of code with the one from the awesome iina, while the (bare) native binary is written in Go (this is a rewrite from C++).
 
 %prep
-%autosetup -p1
+%git_clone %{url} v%{version}
 
 %build
-make build/linux/open-in-mpv
+make build/%{version}/linux/open-in-mpv
 
 %install
-install -Dm755 build/linux/open-in-mpv %{buildroot}%{_bindir}/open-in-mpv
+install -Dm755 build/%{version}/linux/open-in-mpv %{buildroot}%{_bindir}/open-in-mpv
 install -Dm644 scripts/open-in-mpv.desktop %{buildroot}%{_datarootdir}/applications/open-in-mpv.desktop
 
 %post


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: open-in-mpv (#2717)](https://github.com/terrapkg/packages/pull/2717)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)