### PR TITLE
fix: update install instructions to work on rawhide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This monorepo contains the package manifests for all packages in Terra.
 ## Installation
 
 ```bash
-sudo dnf install --repofrompath "terra,https://repos.fyralabs.com/terra$(rpm -E %fedora)" --setopt="terra.gpgkey=https://repos.fyralabs.com/terra$(rpm -E %fedora)/key.asc" terra-release
+sudo dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
 ```
 
 If you are using immutable/atomic editions of Fedora, run the following commands instead:


### PR DESCRIPTION
The lack of GPG check here is fine, we don't use the metalink for grabbing the terra-release package and hit our trusted origin directly (same one the key is hosted on.) On the next `dnf up`, the user will be prompted to trust the key as usual.

On merge, I'll update the website and devdocs to match.

closes #2716 