### PR TITLE
stop fontviewer from building every single commit

### DIFF
--- a/anda/apps/fontviewer/update.rhai
+++ b/anda/apps/fontviewer/update.rhai
@@ -1,5 +1,5 @@
-rpm.global("commit", gh_commit("chocolateimage/fontviewer"));
-if rpm.changed() {
-    rpm.release();
-    rpm.global("commit_date", date());
-}
+# rpm.global("commit", gh_commit("chocolateimage/fontviewer"));
+# if rpm.changed() {
+#    rpm.release();
+#    rpm.global("commit_date", date());
+# }


### PR DESCRIPTION
this is my bad, i really thought the developer had moved on and there wouldn't be any active development on the repo

it looks like the developer is in the middle of adding major features with breaking changes every commit, so it makes no sense to build the package right now

i'll fix the spec (there are new dependencies at the very least *groan*) in a separate PR when the developer is done with everything

the existing package built from https://github.com/chocolateimage/fontviewer/commit/7b978d659ef757e40432606806f0cb6694782301 i think works perfectly fine