### PR TITLE
fix: use gh tags to update espanso

### DIFF
--- a/anda/tools/espanso-wayland/update.rhai
+++ b/anda/tools/espanso-wayland/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("espanso/espanso"));
+rpm.version(gh_tag("espanso/espanso"));

--- a/anda/tools/espanso-x11/update.rhai
+++ b/anda/tools/espanso-x11/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("espanso/espanso"));
+rpm.version(gh_tag("espanso/espanso"));


### PR DESCRIPTION
Espanso's automated [prod-release workflow](https://github.com/espanso/espanso/blob/78c1be643ba6169e01c0995b8fec3ce6f583037e/.github/workflows/prod-release.yml#L46C1-L46C27) marks new GH releases as pre-releases, which are ignored by Terra. Tracking the latest GH tag instead of the GH release will always provide the latest version.