### PR TITLE
[f39] fix: use gh tags to update espanso (#2732)

### DIFF
--- a/anda/tools/espanso-wayland/update.rhai
+++ b/anda/tools/espanso-wayland/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("espanso/espanso"));
+rpm.version(gh_tag("espanso/espanso"));

--- a/anda/tools/espanso-x11/update.rhai
+++ b/anda/tools/espanso-x11/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("espanso/espanso"));
+rpm.version(gh_tag("espanso/espanso"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [fix: use gh tags to update espanso (#2732)](https://github.com/terrapkg/packages/pull/2732)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)