### PR TITLE
[f40] fontviewer: temporary disable building against latest commit (#2730)

### DIFF
--- a/anda/apps/fontviewer/update.rhai
+++ b/anda/apps/fontviewer/update.rhai
@@ -1,5 +1,5 @@
-rpm.global("commit", gh_commit("chocolateimage/fontviewer"));
-if rpm.changed() {
-    rpm.release();
-    rpm.global("commit_date", date());
-}
+# rpm.global("commit", gh_commit("chocolateimage/fontviewer"));
+# if rpm.changed() {
+#    rpm.release();
+#    rpm.global("commit_date", date());
+# }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fontviewer: temporary disable building against latest commit (#2730)](https://github.com/terrapkg/packages/pull/2730)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)