### PR TITLE
[f41] Fix: systemd services (#2752)

### DIFF
--- a/anda/system/chromebook-usbc-fix/chromebook-usbc-fix.spec
+++ b/anda/system/chromebook-usbc-fix/chromebook-usbc-fix.spec
@@ -8,7 +8,7 @@
 
 Name:           chromebook-usbc-fix
 Version:        %commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 
 License:        CCO
 Summary:        Fixes usbc on TigerLake and AlderLake Chromebooks
@@ -28,14 +28,15 @@ BuildRequires:  systemd-rpm-macros
 %install
 install -Dm755 chromebook-usbc.service %buildroot%{_unitdir}/chromebook-usbc.service
 
+# These systemd services should be included in the preset file for Ultramarine Linux Chromebook images
 %post
-%systemd_post 88-ultramarine-chromebook-default.preset
+%systemd_post chromebook-usbc.service
 
 %preun
-%systemd_preun 88-ultramarine-chromebook-default.preset
+%systemd_preun chromebook-usbc.service
 
 %postun
-%systemd_postun_with_restart 88-ultramarine-chromebook-default.preset
+%systemd_postun_with_restart chromebook-usbc.service
 
 %files
 %doc README.md

--- a/anda/system/cros-keyboard-map/cros-keyboard-map.spec
+++ b/anda/system/cros-keyboard-map/cros-keyboard-map.spec
@@ -11,7 +11,7 @@
 
 Name:           cros-keyboard-map
 Version:        %commit_date.%tree_shortcommit.%um_shortcommit
-Release:        1%?dist
+Release:        2%?dist
 
 License:        BSD-3-Clause and GPLv3
 Summary:        Utility to generate keyd configurations for use on Chromebooks
@@ -41,14 +41,15 @@ mkdir -p %buildroot%{_unitdir}
 install -Dm644 cros-keyboard-map.service %{buildroot}%{_unitdir}/cros-keyboard-map.service
 chmod +x %buildroot%{_bindir}/um-generate-cros-keymap
 
+# These systemd services should be included in the preset file for Ultramarine Linux Chromebook images
 %post
-%systemd_post 88-ultramarine-chromebook-default.preset
+%systemd_post cros-keyboard-map.service
 
 %preun
-%systemd_preun 88-ultramarine-chromebook-default.preset
+%systemd_preun cros-keyboard-map.service
 
 %postun
-%systemd_postun_with_restart 88-ultramarine-chromebook-default.preset
+%systemd_postun_with_restart cros-keyboard-map.service
 
 %files
 %doc README.md

--- a/anda/system/msm-cros-efs-loader/msm-cros-efs-loader.spec
+++ b/anda/system/msm-cros-efs-loader/msm-cros-efs-loader.spec
@@ -1,6 +1,6 @@
 Name:                   terra-msm-cros-efs-loader
 Version:                1.0.2
-Release:                1%?dist
+Release:                2%?dist
 Summary:                EFS loader for Qualcomm-based Chrome OS devices
 License:                GPL-3.0-or-later
 URL:                    https://gitlab.postmarketos.org/postmarketOS/msm-cros-efs-loader
@@ -24,15 +24,16 @@ EFS loader for Qualcomm-based Chrome OS devices
 %install
 install -Dm755 msm-cros-efs-loader.sh %{buildroot}/usr/bin/msm-cros-efs-loader
 install -Dm644 %SOURCE1 %{buildroot}/%{_unitdir}/msm-cros-efs-loader.service
- 
+
+# These systemd services should be included in the preset file for Ultramarine Linux sc7180 (ARM) Chromebook images
 %post
-%systemd_post 88-ultramarine-chromebook-default.preset
+%systemd_post msm-cros-efs-loader.service
 
 %preun
-%systemd_preun 88-ultramarine-chromebook-default.preset
+%systemd_preun msm-cros-efs-loader.service
 
 %postun
-%systemd_postun_with_restart 88-ultramarine-chromebook-default.preset
+%systemd_postun_with_restart msm-cros-efs-loader.service
  
 %files
 %_bindir/msm-cros-efs-loader

--- a/anda/system/surface-dtx-daemon/surface-dtx-daemon.spec
+++ b/anda/system/surface-dtx-daemon/surface-dtx-daemon.spec
@@ -1,13 +1,14 @@
 %global debug_package %{nil}
 %global ver v0.3.8-1
+%global ver2 %(echo %{ver} | sed 's/^v//')
 
 Name:           surface-dtx-daemon
 Version:        %(echo %ver | sed 's/-/~/g')
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Surface Detachment System (DTX) Daemon
 License:        MIT
 URL:            https://github.com/linux-surface/surface-dtx-daemon
-Source:         %url/archive/refs/tags/v%ver.tar.gz
+Source:         %url/archive/refs/tags/%ver.tar.gz
 BuildRequires:  rust cargo dbus-devel anda-srpm-macros cargo-rpm-macros mold
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
@@ -17,7 +18,7 @@ Linux User-Space Detachment System (DTX) Daemon for the Surface ACPI Driver
 lack of driver-support on the Surface Book 1. This may change in the future.
 
 %prep
-%autosetup -n %{name}-%{ver}
+%autosetup -n %{name}-%{ver2}
 %cargo_prep_online
 
 %build
@@ -47,6 +48,19 @@ install -D -m644 "target/_surface-dtx-daemon" "%{buildroot}/usr/share/zsh/site-f
 install -D -m644 "target/_surface-dtx-userd" "%{buildroot}/usr/share/zsh/site-functions/_surface-dtx-userd"
 install -D -m644 "target/surface-dtx-daemon.fish" "%{buildroot}/usr/share/fish/vendor_completions.d/surface-dtx-daemon.fish"
 install -D -m644 "target/surface-dtx-userd.fish" "%{buildroot}/usr/share/fish/vendor_completions.d/surface-dtx-userd.fish"
+
+# These systemd services should be included in the preset file for Ultramarine Linux Surface images
+%post
+%systemd_post surface-dtx-daemon.service
+%systemd_user_post surface-dtx-userd.service
+
+%preun
+%systemd_preun surface-dtx-daemon.service
+%systemd_user_preun surface-dtx-userd.service
+
+%postun
+%systemd_postun_with_restart surface-dtx-daemon.service
+%systemd_user_postun_with_restart surface-dtx-userd.service
 
 %files
 %config /etc/dbus-1/system.d/org.surface.dtx.conf


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix: systemd services (#2752)](https://github.com/terrapkg/packages/pull/2752)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)