### PR TITLE
[f41] Add: arduino-fwuploader (#2763)

### DIFF
--- a/anda/tools/arduino-fwuploader/anda.hcl
+++ b/anda/tools/arduino-fwuploader/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "arduino-fwuploader.spec"
+	}
+}

--- a/anda/tools/arduino-fwuploader/arduino-fwuploader.spec
+++ b/anda/tools/arduino-fwuploader/arduino-fwuploader.spec
@@ -1,0 +1,34 @@
+%define debug_package %nil
+
+Name:          arduino-fwuploader
+Version:       2.4.1
+Release:       1%?dist
+Summary:       A Command Line Tool made to update the firmware and/or add SSL certificates for any Arduino board equipped with WINC or NINA Wi-Fi module.
+License:       AGPLv3
+Packager:      Owen Zimmerman <owen@fyralabs.com>
+Url:           https://github.com/arduino/arduino-fwuploader
+Source0:       %url/archive/refs/tags/%version.tar.gz
+BuildRequires: golang git go-rpm-macros anda-srpm-macros python3 go-task
+
+%description
+%summary
+
+%prep
+%autosetup -n arduino-fwuploader-%version
+
+%build
+mkdir -p bin
+%go_build_online
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+install -Dm 755 build/bin/arduino-fwuploader %buildroot%{_bindir}/arduino-fwuploader
+
+%files
+%license LICENSE.txt
+%doc README.md 
+%{_bindir}/arduino-fwuploader
+
+%changelog
+* Sat Dec 28 2024 Owen Zimmerman <owen@fyralabs.com>
+- Package arduino-fwuploader

--- a/anda/tools/arduino-fwuploader/update.rhai
+++ b/anda/tools/arduino-fwuploader/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/arduino-fwuploader"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Add: arduino-fwuploader (#2763)](https://github.com/terrapkg/packages/pull/2763)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)