### PR TITLE
[f39] bump: libhelium to update tau-helium stylesheet (#2779)

### DIFF
--- a/anda/lib/libhelium/libhelium.spec
+++ b/anda/lib/libhelium/libhelium.spec
@@ -3,7 +3,7 @@
 Summary:        The Application Framework for tauOS apps
 Name:           libhelium
 Version:        %{sanitized_ver}
-Release:        2%?dist
+Release:        3%?dist
 License:        GPL-3.0
 URL:            https://github.com/tau-OS/libhelium
 Source0:        https://github.com/tau-OS/libhelium/archive/refs/tags/%{ver}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f39`:
 - [bump: libhelium to update tau-helium stylesheet (#2779)](https://github.com/terrapkg/packages/pull/2779)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)