### PR TITLE
[f40] Add: Ghostty and Ghostty Tip (#2760)

### DIFF
--- a/anda/devs/ghostty/nightly/anda.hcl
+++ b/anda/devs/ghostty/nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "ghostty-nightly.spec"
+    }
+    labels {
+        nightly = 1
+    }
+}

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,0 +1,155 @@
+%global commit 5293fc9c2f19b7e01472de8c2ef08bef603b754a
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20241228
+
+Name:           ghostty-nightly
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        A fast, native terminal emulator written in Zig; this is the Tip (nightly) build
+License:        MIT
+URL:            https://ghostty.org/
+Source0:        https://github.com/ghostty-org/ghostty/archive/%{commit}/ghostty-%{commit}.tar.gz
+#Patch0:         pkgconfig-libadwaita-1.diff
+#Patch1:         use-pkg-config.diff
+Patch2:         no-strip.diff
+BuildRequires:  zig
+BuildRequires:  gtk4-devel libadwaita-devel
+BuildRequires:  pandoc-cli
+#BuildRequires:  pkg-config
+#BuildRequires:  pkgconfig(harfbuzz)
+#BuildRequires:  pkgconfig(fontconfig)
+#BuildRequires:  pkgconfig(libpng)
+#BuildRequires:  pkgconfig(zlib)
+#BuildRequires:  pkgconfig(oniguruma)
+#BuildRequires:  pkgconfig(glslang)
+# Not in Fedora
+#BuildRequires:  pkgconfig(spirv-cross)
+#BuildRequires:  pkgconfig(simdutf)
+#BuildRequires:  pkgconfig(libxml-2.0)
+Requires:       %{name}-terminfo = %{version}-%{release}
+Requires:       %{name}-shell-integration = %{version}-%{release}
+Requires:       fontconfig
+Requires:       freetype
+Requires:       glib2
+Requires:       gtk4
+Requires:       harfbuzz
+Requires:       libpng
+Requires:       oniguruma
+Requires:       pixman
+Requires:       zlib-ng
+Suggests:       libadwaita
+Conflicts:      ghostty
+Provides:       ghostty-tip = %{version}-%{release}
+Packager:       ShinyGil <rockgrub@protonmail.com>
+
+%description
+👻 Ghostty is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration.
+
+%package        bash-completion
+Summary:        Ghostty Bash completion
+Requires:       %{name}
+Requires:       bash-completion
+Supplements:    (%{name} and bash-completion)
+
+%description    bash-completion
+%summary.
+
+%package        fish-completion
+Summary:        Ghostty Fish completion
+Requires:       %{name}
+Requires:       fish
+Supplements:    (%{name} and fish)
+
+%description    fish-completion
+%summary.
+
+%package        zsh-completion
+Summary:        Ghostty Zsh completion
+Requires:       %{name}
+Requires:       zsh
+Supplements:    (%{name} and zsh)
+
+%description    zsh-completion
+%summary.
+
+%package        shell-integration
+Summary:        Ghostty shell integration
+Requires:       %{name}
+Supplements:    %{name}
+
+%description    shell-integration
+%summary.
+
+%package        terminfo
+Summary:        Ghostty terminfo
+Requires:       %{name}
+Supplements:    %{name}
+
+%description    terminfo
+%summary.
+
+%prep
+%autosetup -n ghostty-%{commit} -p1
+
+%build
+
+%install
+zig build \
+    --summary all \
+    -Doptimize=ReleaseFast --release=fast \
+    --prefix %{buildroot}%{_prefix} --verbose \
+    -Dpie=true \
+    -Demit-docs
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/ghostty
+%_datadir/applications/com.mitchellh.ghostty.desktop
+%_datadir/bat/syntaxes/ghostty.sublime-syntax
+%_datadir/ghostty/
+%_datadir/kio/servicemenus/com.mitchellh.ghostty.desktop
+%_datadir/nvim/site/ftdetect/ghostty.vim
+%_datadir/nvim/site/ftplugin/ghostty.vim
+%_datadir/nvim/site/syntax/ghostty.vim
+%_datadir/vim/vimfiles/ftdetect/ghostty.vim
+%_datadir/vim/vimfiles/ftplugin/ghostty.vim
+%_datadir/vim/vimfiles/syntax/ghostty.vim
+%_iconsdir/hicolor/16x16/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/16x16@2/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/32x32/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/32x32@2/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/128x128/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/128x128@2/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/256x256/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/256x256@2/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/512x512/apps/com.mitchellh.ghostty.png
+%_mandir/man1/ghostty.1.gz
+%_mandir/man5/ghostty.5.gz
+
+%files bash-completion
+%bash_completions_dir/ghostty.bash
+
+%files fish-completion
+%fish_completions_dir/ghostty.fish
+
+%files zsh-completion
+%zsh_completions_dir/_ghostty
+
+%files shell-integration
+%_datadir/ghostty/shell-integration/bash/bash-preexec.sh
+%_datadir/ghostty/shell-integration/bash/ghostty.bash
+%_datadir/ghostty/shell-integration/elvish/lib/ghostty-integration.elv
+%_datadir/ghostty/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+%_datadir/ghostty/shell-integration/zsh/.zshenv
+%_datadir/ghostty/shell-integration/zsh/ghostty-integration
+
+%files terminfo
+%_datadir/terminfo/ghostty.termcap
+%_datadir/terminfo/ghostty.terminfo
+%_datadir/terminfo/g/ghostty
+%_datadir/terminfo/x/xterm-ghostty
+
+%changelog
+* Thu Dec 26 2024 ShinyGil <rockgrub@protonmail.com>
+- Initial package

--- a/anda/devs/ghostty/nightly/no-strip.diff
+++ b/anda/devs/ghostty/nightly/no-strip.diff
@@ -1,0 +1,17 @@
+diff --git a/build.zig b/build.zig
+index c3f7302..a0ecf25 100644
+--- a/build.zig
++++ b/build.zig
+@@ -295,11 +295,7 @@ pub fn build(b: *std.Build) !void {
+         .root_source_file = b.path("src/main.zig"),
+         .target = target,
+         .optimize = optimize,
+-        .strip = switch (optimize) {
+-            .Debug => false,
+-            .ReleaseSafe => false,
+-            .ReleaseFast, .ReleaseSmall => true,
+-        },
++        .strip = false,
+     }) else null;
+
+     // Exe

--- a/anda/devs/ghostty/nightly/pkgconfig-libadwaita-1.diff
+++ b/anda/devs/ghostty/nightly/pkgconfig-libadwaita-1.diff
@@ -1,0 +1,13 @@
+diff --git a/build.zig b/build.zig
+index 0969c64..68e16cd 100644
+--- a/build.zig
++++ b/build.zig
+@@ -1374,7 +1374,7 @@ fn addDeps(
+ 
+             .gtk => {
+                 step.linkSystemLibrary2("gtk4", dynamic_link_opts);
+-                if (config.adwaita) step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
++                if (config.adwaita) step.linkSystemLibrary2("libadwaita-1", dynamic_link_opts);
+ 
+                 {
+                     const gresource = @import("src/apprt/gtk/gresource.zig");

--- a/anda/devs/ghostty/nightly/update.rhai
+++ b/anda/devs/ghostty/nightly/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("ghostty-org/ghostty"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}

--- a/anda/devs/ghostty/nightly/use-pkg-config.diff
+++ b/anda/devs/ghostty/nightly/use-pkg-config.diff
@@ -1,0 +1,12 @@
+diff --git a/build.zig b/build.zig
+index a0ecf25..0969c64 100644
+--- a/build.zig
++++ b/build.zig
+@@ -1047,6 +1047,7 @@ fn addDeps(
+     const dynamic_link_opts: std.Build.Module.LinkSystemLibraryOptions = .{
+         .preferred_link_mode = .dynamic,
+         .search_strategy = .mode_first,
++        .use_pkg_config = .force,
+     };
+ 
+     // Freetype

--- a/anda/devs/ghostty/stable/anda.hcl
+++ b/anda/devs/ghostty/stable/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "ghostty.spec"
+  }
+}

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -1,0 +1,150 @@
+Name:           ghostty
+Version:        1.0.0
+Release:        1%?dist
+Summary:        A fast, native terminal emulator written in Zig
+License:        MIT
+URL:            https://ghostty.org/
+Source0:        https://release.files.ghostty.org/%{version}/ghostty-source.tar.gz
+#Patch0:         pkgconfig-libadwaita-1.diff
+#Patch1:         use-pkg-config.diff
+Patch2:         no-strip.diff
+BuildRequires:  zig
+BuildRequires:  gtk4-devel libadwaita-devel
+BuildRequires:  pandoc-cli
+#BuildRequires:  pkg-config
+#BuildRequires:  pkgconfig(harfbuzz)
+#BuildRequires:  pkgconfig(fontconfig)
+#BuildRequires:  pkgconfig(libpng)
+#BuildRequires:  pkgconfig(zlib)
+#BuildRequires:  pkgconfig(oniguruma)
+#BuildRequires:  pkgconfig(glslang)
+# Not in Fedora
+#BuildRequires:  pkgconfig(spirv-cross)
+#BuildRequires:  pkgconfig(simdutf)
+#BuildRequires:  pkgconfig(libxml-2.0)
+Requires:       %{name}-terminfo = %{version}-%{release}
+Requires:       %{name}-shell-integration = %{version}-%{release}
+Requires:       fontconfig
+Requires:       freetype
+Requires:       glib2
+Requires:       gtk4
+Requires:       harfbuzz
+Requires:       libpng
+Requires:       oniguruma
+Requires:       pixman
+Requires:       zlib-ng
+Suggests:       libadwaita
+Conflicts:      ghostty-nightly
+Packager:       ShinyGil <rockgrub@protonmail.com>
+
+%description
+👻 Ghostty is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration.
+
+%package        bash-completion
+Summary:        Ghostty Bash completion
+Requires:       %{name}
+Requires:       bash-completion
+Supplements:    (%{name} and bash-completion)
+
+%description    bash-completion
+%summary.
+
+%package        fish-completion
+Summary:        Ghostty Fish completion
+Requires:       %{name}
+Requires:       fish
+Supplements:    (%{name} and fish)
+
+%description    fish-completion
+%summary.
+
+%package        zsh-completion
+Summary:        Ghostty Zsh completion
+Requires:       %{name}
+Requires:       zsh
+Supplements:    (%{name} and zsh)
+
+%description    zsh-completion
+%summary.
+
+%package        shell-integration
+Summary:        Ghostty shell integration
+Requires:       %{name}
+Supplements:    %{name}
+
+%description    shell-integration
+%summary.
+
+%package        terminfo
+Summary:        Ghostty terminfo
+Requires:       %{name}
+Supplements:    %{name}
+
+%description    terminfo
+%summary.
+
+%prep
+%autosetup -n ghostty-source -p1
+
+%build
+
+%install
+zig build \
+    --summary all \
+    -Doptimize=ReleaseFast --release=fast \
+    --prefix %{buildroot}%{_prefix} --verbose \
+    -Dpie=true \
+    -Demit-docs
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/ghostty
+%_datadir/applications/com.mitchellh.ghostty.desktop
+%_datadir/bat/syntaxes/ghostty.sublime-syntax
+%_datadir/ghostty/
+%_datadir/kio/servicemenus/com.mitchellh.ghostty.desktop
+%_datadir/nvim/site/ftdetect/ghostty.vim
+%_datadir/nvim/site/ftplugin/ghostty.vim
+%_datadir/nvim/site/syntax/ghostty.vim
+%_datadir/vim/vimfiles/ftdetect/ghostty.vim
+%_datadir/vim/vimfiles/ftplugin/ghostty.vim
+%_datadir/vim/vimfiles/syntax/ghostty.vim
+%_iconsdir/hicolor/16x16/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/16x16@2/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/32x32/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/32x32@2/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/128x128/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/128x128@2/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/256x256/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/256x256@2/apps/com.mitchellh.ghostty.png
+%_iconsdir/hicolor/512x512/apps/com.mitchellh.ghostty.png
+%_mandir/man1/ghostty.1.gz
+%_mandir/man5/ghostty.5.gz
+
+%files bash-completion
+%bash_completions_dir/ghostty.bash
+
+%files fish-completion
+%fish_completions_dir/ghostty.fish
+
+%files zsh-completion
+%zsh_completions_dir/_ghostty
+
+%files shell-integration
+%_datadir/ghostty/shell-integration/bash/bash-preexec.sh
+%_datadir/ghostty/shell-integration/bash/ghostty.bash
+%_datadir/ghostty/shell-integration/elvish/lib/ghostty-integration.elv
+%_datadir/ghostty/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+%_datadir/ghostty/shell-integration/zsh/.zshenv
+%_datadir/ghostty/shell-integration/zsh/ghostty-integration
+
+%files terminfo
+%_datadir/terminfo/ghostty.termcap
+%_datadir/terminfo/ghostty.terminfo
+%_datadir/terminfo/g/ghostty
+%_datadir/terminfo/x/xterm-ghostty
+
+%changelog
+* Thu Dec 26 2024 ShinyGil <rockgrub@protonmail.com>
+- Initial package

--- a/anda/devs/ghostty/stable/no-strip.diff
+++ b/anda/devs/ghostty/stable/no-strip.diff
@@ -1,0 +1,17 @@
+diff --git a/build.zig b/build.zig
+index c3f7302..a0ecf25 100644
+--- a/build.zig
++++ b/build.zig
+@@ -295,11 +295,7 @@ pub fn build(b: *std.Build) !void {
+         .root_source_file = b.path("src/main.zig"),
+         .target = target,
+         .optimize = optimize,
+-        .strip = switch (optimize) {
+-            .Debug => false,
+-            .ReleaseSafe => false,
+-            .ReleaseFast, .ReleaseSmall => true,
+-        },
++        .strip = false,
+     }) else null;
+ 
+     // Exe

--- a/anda/devs/ghostty/stable/pkgconfig-libadwaita-1.diff
+++ b/anda/devs/ghostty/stable/pkgconfig-libadwaita-1.diff
@@ -1,0 +1,13 @@
+diff --git a/build.zig b/build.zig
+index 0969c64..68e16cd 100644
+--- a/build.zig
++++ b/build.zig
+@@ -1374,7 +1374,7 @@ fn addDeps(
+ 
+             .gtk => {
+                 step.linkSystemLibrary2("gtk4", dynamic_link_opts);
+-                if (config.adwaita) step.linkSystemLibrary2("adwaita-1", dynamic_link_opts);
++                if (config.adwaita) step.linkSystemLibrary2("libadwaita-1", dynamic_link_opts);
+ 
+                 {
+                     const gresource = @import("src/apprt/gtk/gresource.zig");

--- a/anda/devs/ghostty/stable/update.rhai
+++ b/anda/devs/ghostty/stable/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("ghostty-org/ghostty"));

--- a/anda/devs/ghostty/stable/use-pkg-config.diff
+++ b/anda/devs/ghostty/stable/use-pkg-config.diff
@@ -1,0 +1,12 @@
+diff --git a/build.zig b/build.zig
+index a0ecf25..0969c64 100644
+--- a/build.zig
++++ b/build.zig
+@@ -1047,6 +1047,7 @@ fn addDeps(
+     const dynamic_link_opts: std.Build.Module.LinkSystemLibraryOptions = .{
+         .preferred_link_mode = .dynamic,
+         .search_strategy = .mode_first,
++        .use_pkg_config = .force,
+     };
+ 
+     // Freetype


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Add: Ghostty and Ghostty Tip (#2760)](https://github.com/terrapkg/packages/pull/2760)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)