### PR TITLE
[f41] feat: rename golang packages to shorter names (#2791)

### DIFF
--- a/anda/desktops/waylands/cliphist/golang-github-sentriz-cliphist.spec
+++ b/anda/desktops/waylands/cliphist/golang-github-sentriz-cliphist.spec
@@ -22,10 +22,11 @@ Wayland clipboard manager with support for multimedia.}
 %global golicenses      LICENSE
 %global godocs          CHANGELOG.md readme.md version.txt
 
-Name:           golang-github-sentriz-cliphist
-Release:        %autorelease
+Name:           cliphist
+Release:        2%?dist
 Summary:        Wayland clipboard manager with support for multimedia
-Provides:       cliphist
+Provides:       golang-github-sentriz-cliphist = %version-%release
+Obsoletes:      golang-github-sentriz-cliphist < 0.6.1-2
 Packager:       madonuko <mado@fyralabs.com>
 License:        GPL-3.0-only
 URL:            %{gourl}

--- a/anda/desktops/waylands/clipse/golang-github-savedra1-clipse.spec
+++ b/anda/desktops/waylands/clipse/golang-github-savedra1-clipse.spec
@@ -23,10 +23,11 @@ Configurable TUI clipboard manager for Unix.}
 %global godocs          CHANGELOG.md README.md examples resources/library.md\\\
                         resources/test_data/top_secret_credentials.txt
 
-Name:           golang-github-savedra1-clipse
-Release:        %autorelease
+Name:           clipse
+Release:        2%?dist
 Summary:        Configurable TUI clipboard manager for Unix
-Provides:       clipse
+Provides:       golang-github-savedra1-clipse = %version-%release
+Obsoletes:      golang-github-savedra1-clipse < 1.1.0-2
 Packager:       madonuko <mado@fyralabs.com>
 License:        MIT
 URL:            %{gourl}

--- a/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
+++ b/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
@@ -20,14 +20,15 @@ Multi-Purpose Launcher with a lot of features. Highly Customizable and fast.}
 %global golicenses      LICENSE
 %global godocs          README.md cmd/version.txt
 
-Name:           golang-github-abenz1267-walker
-Release:        1%?dist
+Name:           walker
+Release:        2%?dist
 Summary:        Multi-Purpose Launcher with a lot of features. Highly Customizable and fast
 
 License:        MIT
 URL:            %{gourl}
 Source:         %{gosource}
-Provides:       walker
+Provides:       golang-github-abenz1267-walker = %version-%release
+Obsoletes:      golang-github-abenz1267-walker < 0.11.4-2
 Packager:       madonuko <mado@fyralabs.com>
 Requires:       gtk4-layer-shell
 BuildRequires:  anda-srpm-macros


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat: rename golang packages to shorter names (#2791)](https://github.com/terrapkg/packages/pull/2791)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)