### PR TITLE
[el10] fix(update): zrythm (#2740)

### DIFF
--- a/anda/multimedia/zrythm/update.rhai
+++ b/anda/multimedia/zrythm/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gitlab_tag("gitlab.zrythm.org", "26"));
+rpm.global("v", gitlab_tag("gitlab.zrythm.org", "26"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(update): zrythm (#2740)](https://github.com/terrapkg/packages/pull/2740)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)