### PR TITLE
[el10] follow package guidelines (#2802)

### DIFF
--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -85,6 +85,7 @@ zig build \
     --summary all \
     -Doptimize=ReleaseFast --release=fast \
     --prefix %{buildroot}%{_prefix} --verbose \
+    -Dcpu=baseline \
     -Dpie=true \
     -Demit-docs
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [follow package guidelines (#2802)](https://github.com/terrapkg/packages/pull/2802)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)