### PR TITLE
ghostty package fixes

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -8,7 +8,7 @@ Name:           ghostty-nightly
 Version:        %{commit_date}.%{shortcommit}
 Release:        1%?dist
 Summary:        A fast, native terminal emulator written in Zig; this is the Tip (nightly) build.
-License:        MIT
+License:        MIT AND MPL-2.0 AND OFL-1.1
 URL:            https://ghostty.org/
 Source0:        https://github.com/ghostty-org/ghostty/archive/%{commit}/ghostty-%{commit}.tar.gz
 Patch0:         no-strip.diff

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -147,9 +147,10 @@ zig build \
 %_datadir/terminfo/x/xterm-ghostty
 
 %changelog
-* Thu Dec 26 2024 ShinyGil <rockgrub@protonmail.com>
-- Initial package
 * Tue Dec 31 2024 ShinyGil <rockgrub@protonmail.com>
 - Update to 20241231.3f7c3af
     * High CVE-2003-0063: Allows execution of arbitrary commands
     * Medium CVE-2003-0070: Allows execution of arbitrary commands
+
+* Thu Dec 26 2024 ShinyGil <rockgrub@protonmail.com>
+- Initial package

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -79,10 +79,13 @@ Supplements:    %{name}
 %build
 
 %install
+DESTDIR="%{buildroot}" \
 zig build \
     --summary all \
-    -Doptimize=ReleaseFast --release=fast \
-    --prefix %{buildroot}%{_prefix} --verbose \
+    --release=fast \
+    --prefix "%{_prefix}" --prefix-lib-dir "%{_libdir}" \
+    --prefix-exe-dir "%{_bindir}" --prefix-include-dir "%{_includedir}" \
+    --verbose \
     -Dcpu=baseline \
     -Dpie=true \
     -Demit-docs

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -6,7 +6,7 @@
 
 Name:           ghostty-nightly
 Version:        %{commit_date}.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A fast, native terminal emulator written in Zig; this is the Tip (nightly) build.
 License:        MIT AND MPL-2.0 AND OFL-1.1
 URL:            https://ghostty.org/

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -2,6 +2,8 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20250101
 
+%global cache_dir %{builddir}/zig-cache
+
 Name:           ghostty-nightly
 Version:        %{commit_date}.%{shortcommit}
 Release:        1%?dist
@@ -76,6 +78,9 @@ Supplements:    %{name}
 %prep
 %autosetup -n ghostty-%{commit} -p1
 
+# Download everything ahead of time so we can enable system integration mode
+ZIG_GLOBAL_CACHE_DIR="%{cache_dir}" ./nix/build-support/fetch-zig-cache.sh
+
 %build
 
 %install
@@ -83,6 +88,7 @@ DESTDIR="%{buildroot}" \
 zig build \
     --summary all \
     --release=fast \
+    --system "%{cache_dir}/p" \
     --prefix "%{_prefix}" --prefix-lib-dir "%{_libdir}" \
     --prefix-exe-dir "%{_bindir}" --prefix-include-dir "%{_includedir}" \
     --verbose \

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -20,16 +20,17 @@ BuildRequires:  pandoc-cli
 BuildRequires:  zig
 Requires:       %{name}-terminfo = %{version}-%{release}
 Requires:       %{name}-shell-integration = %{version}-%{release}
-Requires:       fontconfig
-Requires:       freetype
-Requires:       glib2
-Requires:       gtk4
-Requires:       harfbuzz
-Requires:       libpng
-Requires:       oniguruma
-Requires:       pixman
-Requires:       zlib-ng
-Suggests:       libadwaita
+BuildRequires:  pkgconfig(bzip2)
+BuildRequires:  pkgconfig(freetype2)
+BuildRequires:  pkgconfig(fontconfig)
+BuildRequires:  pkgconfig(harfbuzz)
+BuildRequires:  pkgconfig(libpng)
+BuildRequires:  pkgconfig(zlib)
+BuildRequires:  pkgconfig(oniguruma)
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(gtk4)
+BuildRequires:  pkgconfig(libadwaita-1)
+BuildRequires:  libX11-devel
 Conflicts:      ghostty
 Provides:       ghostty-tip = %{version}-%{release}
 Packager:       ShinyGil <rockgrub@protonmail.com>

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -80,10 +80,13 @@ Supplements:    %{name}
 %build
 
 %install
+DESTDIR="%{buildroot}" \
 zig build \
     --summary all \
-    -Doptimize=ReleaseFast --release=fast \
-    --prefix %{buildroot}%{_prefix} --verbose \
+    --release=fast \
+    --prefix "%{_prefix}" --prefix-lib-dir "%{_libdir}" \
+    --prefix-exe-dir "%{_bindir}" --prefix-include-dir "%{_includedir}" \
+    --verbose \
     -Dcpu=baseline \
     -Dpie=true \
     -Demit-docs

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -148,9 +148,10 @@ zig build \
 %_datadir/terminfo/x/xterm-ghostty
 
 %changelog
-* Thu Dec 26 2024 ShinyGil <rockgrub@protonmail.com>
-- Initial package
 * Tue Dec 31 2024 ShinyGil <rockgrub@protonmail.com>
 - Update to 1.0.1
     * High CVE-2003-0063: Allows execution of arbitrary commands
     * Medium CVE-2003-0070: Allows execution of arbitrary commands
+
+* Thu Dec 26 2024 ShinyGil <rockgrub@protonmail.com>
+- Initial package

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -1,6 +1,8 @@
 # Signing key from https://github.com/ghostty-org/ghostty/blob/main/PACKAGING.md
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 
+%global cache_dir %{builddir}/zig-cache
+
 Name:           ghostty
 Version:        1.0.1
 Release:        2%{?dist}
@@ -77,6 +79,9 @@ Supplements:    %{name}
 /usr/bin/minisign -V -m %{SOURCE0} -x %{SOURCE1} -P %{public_key}
 %autosetup -p1
 
+# Download everything ahead of time so we can enable system integration mode
+ZIG_GLOBAL_CACHE_DIR="%{cache_dir}" ./nix/build-support/fetch-zig-cache.sh
+
 %build
 
 %install
@@ -84,6 +89,7 @@ DESTDIR="%{buildroot}" \
 zig build \
     --summary all \
     --release=fast \
+    --system "%{cache_dir}/p" \
     --prefix "%{_prefix}" --prefix-lib-dir "%{_libdir}" \
     --prefix-exe-dir "%{_bindir}" --prefix-include-dir "%{_includedir}" \
     --verbose \

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -1,3 +1,6 @@
+# Signing key from https://github.com/ghostty-org/ghostty/blob/main/PACKAGING.md
+%global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
+
 Name:           ghostty
 Version:        1.0.1
 Release:        2%{?dist}
@@ -5,6 +8,7 @@ Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT
 URL:            https://ghostty.org/
 Source0:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz
+Source1:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz.minisig
 Patch0:         no-strip.diff
 BuildRequires:  gtk4-devel
 BuildRequires:  libadwaita-devel
@@ -12,6 +16,7 @@ BuildRequires:  ncurses
 BuildRequires:  ncurses-devel
 BuildRequires:  pandoc-cli
 BuildRequires:  zig
+BuildRequires:  minisign
 Requires:       %{name}-terminfo = %{version}-%{release}
 Requires:       %{name}-shell-integration = %{version}-%{release}
 Requires:       fontconfig
@@ -69,7 +74,8 @@ Supplements:    %{name}
 %summary.
 
 %prep
-%autosetup -n ghostty-source -p1
+/usr/bin/minisign -V -m %{SOURCE0} -x %{SOURCE1} -P %{public_key}
+%autosetup -p1
 
 %build
 

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -4,7 +4,7 @@ Release:        2%{?dist}
 Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT
 URL:            https://ghostty.org/
-Source0:        https://release.files.ghostty.org/%{version}/ghostty-source.tar.gz
+Source0:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz
 Patch0:         no-strip.diff
 BuildRequires:  gtk4-devel
 BuildRequires:  libadwaita-devel

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -21,16 +21,17 @@ BuildRequires:  zig
 BuildRequires:  minisign
 Requires:       %{name}-terminfo = %{version}-%{release}
 Requires:       %{name}-shell-integration = %{version}-%{release}
-Requires:       fontconfig
-Requires:       freetype
-Requires:       glib2
-Requires:       gtk4
-Requires:       harfbuzz
-Requires:       libpng
-Requires:       oniguruma
-Requires:       pixman
-Requires:       zlib-ng
-Suggests:       libadwaita
+BuildRequires:  pkgconfig(bzip2)
+BuildRequires:  pkgconfig(freetype2)
+BuildRequires:  pkgconfig(fontconfig)
+BuildRequires:  pkgconfig(harfbuzz)
+BuildRequires:  pkgconfig(libpng)
+BuildRequires:  pkgconfig(zlib)
+BuildRequires:  pkgconfig(oniguruma)
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(gtk4)
+BuildRequires:  pkgconfig(libadwaita-1)
+BuildRequires:  libX11-devel
 Conflicts:      ghostty-nightly
 Packager:       ShinyGil <rockgrub@protonmail.com>
 

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -7,7 +7,7 @@ Name:           ghostty
 Version:        1.0.1
 Release:        2%{?dist}
 Summary:        A fast, native terminal emulator written in Zig.
-License:        MIT
+License:        MIT AND MPL-2.0 AND OFL-1.1
 URL:            https://ghostty.org/
 Source0:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz
 Source1:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz.minisig

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -5,7 +5,7 @@
 
 Name:           ghostty
 Version:        1.0.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT AND MPL-2.0 AND OFL-1.1
 URL:            https://ghostty.org/


### PR DESCRIPTION
- uses correct source for ghostty 1.0.1 (1.0.0 used a generic `ghostty-source` filename)
- verify tarball using minisign
- set appropriate zig options when building ghostty:
    - DESTDIR is used to specifiy the build root because including it in the prefix may result in broken paths in the resulting output
    - `-Doptimize` has been superseded by `--release` in zig with both doing the same in the background
    - added extra flags to specifiy lib dir, exe dir and include dir to ensure zig picks the right stuff
- fetch zig packages ahead of time and enable system integration mode
    - I haven't verified if all the build requirements are correct but a local build shows that this results in proper dynamic linking