### PR TITLE
Fix: Switch openh264 to Terra Extras

### DIFF
--- a/anda/lib/openh264/anda.hcl
+++ b/anda/lib/openh264/anda.hcl
@@ -1,5 +1,8 @@
 project pkg {
-  rpm {
-    spec = "openh264.spec"
-  }
+    rpm {
+        spec = "openh264.spec"
+    }
+    labels {
+        extra = 1
+    }
 }

--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -5,7 +5,7 @@
 Name:           openh264
 Version:        2.5.0
 # Also bump the Release tag for gstreamer1-plugin-openh264 down below
-Release:        1%?dist
+Release:        2%?dist
 Summary:        H.264 codec library
 
 License:        BSD


### PR DESCRIPTION
This conflicts with a base Fedora package, shouldn't it go in Extras?