### PR TITLE
Fix: Ghostty internal version

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -6,7 +6,7 @@
 
 Name:           ghostty-nightly
 Version:        %{commit_date}.%{shortcommit}
-Release:        1%?dist
+Release:        1%{?dist}
 Summary:        A fast, native terminal emulator written in Zig; this is the Tip (nightly) build.
 License:        MIT AND MPL-2.0 AND OFL-1.1
 URL:            https://ghostty.org/

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -94,6 +94,7 @@ zig build \
     --prefix "%{_prefix}" --prefix-lib-dir "%{_libdir}" \
     --prefix-exe-dir "%{_bindir}" --prefix-include-dir "%{_includedir}" \
     --verbose \
+    -Dversion-string=%{version} \
     -Dcpu=baseline \
     -Dpie=true \
     -Demit-docs

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -5,7 +5,7 @@
 
 Name:           ghostty
 Version:        1.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT AND MPL-2.0 AND OFL-1.1
 URL:            https://ghostty.org/


### PR DESCRIPTION
This fixes the version Ghostty displays on fetches such as Fastfetch. Otherwise stable builds of Ghostty incorrectly report themselves as dev builds. This is _not_ needed for nightly builds, as they correctly report.

(Also just a tad bit of cleanup so `Release`'s `%?dist` macro formats are the same. It just bothered me.)