### PR TITLE
[f40] Fix: Switch openh264 to Terra Extras (#2837)

### DIFF
--- a/anda/lib/openh264/anda.hcl
+++ b/anda/lib/openh264/anda.hcl
@@ -1,5 +1,8 @@
 project pkg {
-  rpm {
-    spec = "openh264.spec"
-  }
+    rpm {
+        spec = "openh264.spec"
+    }
+    labels {
+        extra = 1
+    }
 }

--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -5,7 +5,7 @@
 Name:           openh264
 Version:        2.5.0
 # Also bump the Release tag for gstreamer1-plugin-openh264 down below
-Release:        1%?dist
+Release:        2%?dist
 Summary:        H.264 codec library
 
 License:        BSD


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Fix: Switch openh264 to Terra Extras (#2837)](https://github.com/terrapkg/packages/pull/2837)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)