### PR TITLE
mesa: Obsolete freeworld drivers

### DIFF
--- a/anda/lib/mesa/anda.hcl
+++ b/anda/lib/mesa/anda.hcl
@@ -7,5 +7,4 @@ project pkg {
 
         extra = 1
     }
-    arches = ["x86_64", "i386", "aarch64"]
 }

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -257,6 +257,7 @@ Recommends:     %{name}-va-drivers%{?_isa}
 Summary:        Mesa-based VA-API video acceleration drivers
 Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 Obsoletes:      %{name}-vaapi-drivers < 22.2.0-5
+Obsoletes:      %{name}-va-drivers-freeworld
 
 %description va-drivers
 %{summary}.
@@ -266,6 +267,7 @@ Obsoletes:      %{name}-vaapi-drivers < 22.2.0-5
 %package        vdpau-drivers
 Summary:        Mesa-based VDPAU drivers
 Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Obsoletes:      %{name}-vdpau-drivers-freeworld
 
 %description vdpau-drivers
 %{summary}.


### PR DESCRIPTION
Allows people who were already using `mesa-freeworld` to upgrade to our Mesa builds
