### PR TITLE
[f40] Fix: Update patch (#2892)

### DIFF
--- a/anda/apps/ruffle/desktop_file_patch.diff
+++ b/anda/apps/ruffle/desktop_file_patch.diff
@@ -1,6 +1,6 @@
 --- a/desktop/packages/linux/rs.ruffle.Ruffle.desktop
 +++ b/desktop/packages/linux/rs.ruffle.Ruffle.desktop
-@@ -47,7 +47,7 @@ Comment[zh_CN]=播放 Flash 游戏和动画
+@@ -54,7 +54,7 @@ Comment[zh_CN]=播放 Flash 游戏和动画
  Comment[zh_TW]=播放 Flash 遊戲和動畫
  Comment=Play Flash games & movies
  Icon=rs.ruffle.Ruffle
@@ -8,4 +8,4 @@
 +Exec=ruffle_desktop %u
  MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie
  Categories=AudioVideo;Player;Graphics;Viewer;VectorGraphics;Game
- Keywords[ar]=الفلاش;swf;مشغل;محاكي;رَسْت
+ Keywords[ar]=الفلاش;swf;مشغل;محاكي

--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -9,7 +9,7 @@ language. Ruffle targets both the desktop and the web using WebAssembly.}
 
 Name:           ruffle-nightly
 Version:        %goodver
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A Flash Player emulator written in Rust
 License:        Apache-2.0 OR MIT
 URL:            https://ruffle.rs/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Fix: Update patch (#2892)](https://github.com/terrapkg/packages/pull/2892)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)