### PR TITLE
[el10] fix: rgbds (#2757)

### DIFF
--- a/anda/devs/rgbds/terra-rgbds.spec
+++ b/anda/devs/rgbds/terra-rgbds.spec
@@ -49,10 +49,11 @@ It consists of:
 %{_mandir}/man5/rgbds.5.*
 %{_mandir}/man5/rgbasm.5.*
 %{_mandir}/man5/rgblink.5.*
+%{_mandir}/man5/rgbasm-old.5.gz
 %{_mandir}/man7/rgbds.7.*
 %{_mandir}/man7/gbz80.7.*
 %license LICENSE
-%doc README.rst
+%doc README.md
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: rgbds (#2757)](https://github.com/terrapkg/packages/pull/2757)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)