### PR TITLE
[f41] Fix: yt-dlp Build Deps (#2913)

### DIFF
--- a/anda/tools/yt-dlp/yt-dlp-nightly.spec
+++ b/anda/tools/yt-dlp/yt-dlp-nightly.spec
@@ -19,6 +19,8 @@ Source:         https://src.fedoraproject.org/rpms/yt-dlp/raw/rawhide/f/yt-dlp.s
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
+BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(pip)
 
 %if %{with tests}
 # Needed for %%check
@@ -33,7 +35,6 @@ BuildRequires:  make
 Recommends:     /usr/bin/ffmpeg
 Recommends:     /usr/bin/ffprobe
 
-Provides:       yt-dlp
 Conflicts:      yt-dlp
 
 Suggests:       python3dist(keyring)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix: yt-dlp Build Deps (#2913)](https://github.com/terrapkg/packages/pull/2913)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)