### PR TITLE
[el10] [IPU6 Part 1] Add: IPU6 Camera Stack (Without ipu6-camera-hal) (#2919)

### DIFF
--- a/anda/lib/ipu6-camera-bins/anda.hcl
+++ b/anda/lib/ipu6-camera-bins/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "ipu6-camera-bins.spec"
+  }
+  labels {
+        weekly = 1
+    }
+}

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -1,0 +1,85 @@
+%global debug_package %{nil}
+%global commit 987b09ad7e6124ab8623a986f92ecb47061b8fa0
+%global commitdate 20240507
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           ipu6-camera-bins
+Summary:        Binary libraries for Intel IPU6
+Version:        %{commitdate}.%{shortcommit}
+Release:        1%{?dist}
+License:        Proprietary
+URL:            https://github.com/intel/ipu6-camera-bins
+Source0:        https://github.com/intel/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  chrpath
+BuildRequires:  patchelf
+ExclusiveArch:  x86_64
+#Requires:       gstreamer1-plugin-icamerasrc
+Requires:       v4l2-relayd
+Requires:       intel-ipu6-kmod
+Requires:       intel-vsc-firmware >= 20240513
+Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
+### For Akmods package
+Provides:       intel-ipu6-kmod-common = %{version}
+
+%description
+Provides binaries for Intel IPU6, including libraries and firmware.
+
+
+%package devel
+Summary:        IPU6 development files
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+This provides the header files for IPU6 development.
+
+%prep
+%setup -q -n %{name}-%{commit}
+for i in ipu_tgl ipu_adl ipu_mtl; do
+  chrpath --delete lib/$i/*.so
+done
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_includedir}
+for i in ipu_tgl ipu_adl ipu_mtl; do
+  mkdir -p %{buildroot}%{_libdir}/$i
+  cp -pr include/$i %{buildroot}%{_includedir}
+  cp -pr lib/$i/lib* lib/$i/pkgconfig %{buildroot}%{_libdir}/$i
+  patchelf --set-rpath %{_libdir}/$i %{buildroot}%{_libdir}/$i/*.so
+  sed -i \
+    -e "s|libdir=\${prefix}/lib/$i|libdir=%{_libdir}/$i|g" \
+    %{buildroot}%{_libdir}/$i/pkgconfig/*.pc
+done
+
+
+%files
+%license LICENSE
+%dir %{_libdir}/ipu_tgl
+%dir %{_libdir}/ipu_adl
+%dir %{_libdir}/ipu_mtl
+%{_libdir}/ipu_tgl/*.so*
+%{_libdir}/ipu_adl/*.so*
+%{_libdir}/ipu_mtl/*.so*
+
+%files devel
+%dir %{_includedir}/ipu_tgl
+%dir %{_includedir}/ipu_adl
+%dir %{_includedir}/ipu_mtl
+%dir %{_libdir}/ipu_tgl/pkgconfig
+%dir %{_libdir}/ipu_adl/pkgconfig
+%dir %{_libdir}/ipu_mtl/pkgconfig
+%{_includedir}/ipu_tgl/*
+%{_includedir}/ipu_adl/*
+%{_includedir}/ipu_mtl/*
+%{_libdir}/ipu_tgl/pkgconfig/*
+%{_libdir}/ipu_adl/pkgconfig/*
+%{_libdir}/ipu_mtl/pkgconfig/*
+%{_libdir}/ipu_tgl/*.a
+%{_libdir}/ipu_adl/*.a
+%{_libdir}/ipu_mtl/*.a
+
+
+%changelog
+%autochangelog

--- a/anda/lib/ipu6-camera-bins/update.rhai
+++ b/anda/lib/ipu6-camera-bins/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("intel/ipu6-camera-bins"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}

--- a/anda/system/intel-ipu6-kmod/0000-probe-improvements.patch
+++ b/anda/system/intel-ipu6-kmod/0000-probe-improvements.patch
@@ -1,0 +1,183 @@
+--- a/drivers/media/pci/intel/ipu-isys-csi2.c
++++ b/drivers/media/pci/intel/ipu-isys-csi2.c
+@@ -532,8 +532,10 @@ int ipu_isys_csi2_init(struct ipu_isys_csi2 *csi2,
+ 				    NR_OF_CSI2_SINK_PADS, 0,
+ 				    CSI2_PAD_SOURCE,
+ 				    CSI2_PAD_SINK);
+-	if (rval)
++	if (rval) {
++		dev_err(&isys->adev->dev, "ipu_isys_subdev_init() err %d\n", rval);
+ 		goto fail;
++	}
+ 
+ 	csi2->asd.pad[CSI2_PAD_SINK].flags |= MEDIA_PAD_FL_MUST_CONNECT;
+ 
+--- a/drivers/media/pci/intel/ipu-isys-subdev.c
++++ b/drivers/media/pci/intel/ipu-isys-subdev.c
+@@ -849,17 +849,22 @@ int ipu_isys_subdev_init(struct ipu_isys_subdev *asd,
+ 		return -ENOMEM;
+ 
+ 	rval = media_entity_pads_init(&asd->sd.entity, num_pads, asd->pad);
+-	if (rval)
++	if (rval) {
++		dev_err(&asd->isys->adev->dev, "%s: media_entity_pads_init(%d) err %d\n", __func__, num_pads, rval);
+ 		goto out_mutex_destroy;
++	}
+ 
+ 	if (asd->ctrl_init) {
+ 		rval = v4l2_ctrl_handler_init(&asd->ctrl_handler, nr_ctrls);
+-		if (rval)
++		if (rval) {
++			dev_err(&asd->isys->adev->dev, "%s: v4l2_ctrl_handler_init() err %d\n", __func__, rval);
+ 			goto out_media_entity_cleanup;
++		}
+ 
+ 		asd->ctrl_init(&asd->sd);
+ 		if (asd->ctrl_handler.error) {
+ 			rval = asd->ctrl_handler.error;
++			dev_err(&asd->isys->adev->dev, "%s: ctrl_handler.error %d\n", __func__, rval);
+ 			goto out_v4l2_ctrl_handler_free;
+ 		}
+ 
+--- a/drivers/media/pci/intel/ipu-isys.c
++++ b/drivers/media/pci/intel/ipu-isys.c
+@@ -396,8 +396,10 @@ static int isys_register_subdevices(struct ipu_isys *isys)
+ 		rval = ipu_isys_csi2_init(&isys->csi2[i], isys,
+ 					  isys->pdata->base +
+ 					  csi2->offsets[i], i);
+-		if (rval)
++		if (rval) {
++			dev_err(&isys->adev->dev, "ipu_isys_csi2_init() err %d\n", rval);
+ 			goto fail;
++		}
+ 
+ 		isys->isr_csi2_bits |= IPU_ISYS_UNISPART_IRQ_CSI2(i);
+ 	}
+@@ -1009,12 +1011,16 @@ static int isys_register_devices(struct ipu_isys *isys)
+ 		goto out_v4l2_device_unregister;
+ 
+ 	rval = isys_notifier_init(isys);
+-	if (rval)
++	if (rval) {
++		dev_err(&isys->adev->dev, "isys_notifier_init() err %d\n", rval);
+ 		goto out_isys_unregister_subdevices;
++	}
+ 
+ 	rval = v4l2_device_register_subdev_nodes(&isys->v4l2_dev);
+-	if (rval)
++	if (rval) {
++		dev_err(&isys->adev->dev, "error registering subdev nodes %d\n", rval);
+ 		goto out_isys_notifier_cleanup;
++	}
+ 
+ 	return 0;
+ 
+@@ -1561,8 +1567,10 @@ static int isys_probe(struct ipu_bus_device *adev)
+ 	if (rval)
+ 		goto out_remove_pkg_dir_shared_buffer;
+ 	rval = isys_iwake_watermark_init(isys);
+-	if (rval)
++	if (rval) {
++		dev_err(&adev->dev, "isys_iwake_watermark_init() err %d\n", rval);
+ 		goto out_unregister_devices;
++	}
+ 
+ 	ipu_mmu_hw_cleanup(adev->mmu);
+ 
+--- a/drivers/media/pci/intel/ipu-isys.c
++++ b/drivers/media/pci/intel/ipu-isys.c
+@@ -382,15 +382,12 @@ static int isys_register_subdevices(struct ipu_isys *isys)
+ 	const struct ipu_isys_internal_csi2_pdata *csi2 =
+ 	    &isys->pdata->ipdata->csi2;
+ 	struct ipu_isys_csi2_be_soc *csi2_be_soc;
+-	unsigned int i, k;
+-	int rval;
++	int i = 0, k = 0, rval;
+ 
+ 	isys->csi2 = devm_kcalloc(&isys->adev->dev, csi2->nports,
+ 				  sizeof(*isys->csi2), GFP_KERNEL);
+-	if (!isys->csi2) {
+-		rval = -ENOMEM;
+-		goto fail;
+-	}
++	if (!isys->csi2)
++		return -ENOMEM;
+ 
+ 	for (i = 0; i < csi2->nports; i++) {
+ 		rval = ipu_isys_csi2_init(&isys->csi2[i], isys,
+@@ -425,7 +422,8 @@ static int isys_register_subdevices(struct ipu_isys *isys)
+ 			if (rval) {
+ 				dev_info(&isys->adev->dev,
+ 					 "can't create link csi2->be_soc\n");
+-				goto fail;
++				isys_unregister_subdevices(isys);
++				return rval;
+ 			}
+ 		}
+ 	}
+@@ -433,7 +431,16 @@ static int isys_register_subdevices(struct ipu_isys *isys)
+ 	return 0;
+ 
+ fail:
+-	isys_unregister_subdevices(isys);
++	while (--k >= 0) {
++		dev_info(&isys->adev->dev, "foo %d\n", k);
++		ipu_isys_csi2_be_soc_cleanup(&isys->csi2_be_soc[k]);
++	}
++
++	while (--i >= 0) {
++		dev_info(&isys->adev->dev, "bar %d\n", k);
++		ipu_isys_csi2_cleanup(&isys->csi2[i]);
++	}
++
+ 	return rval;
+ }
+ 
+--- a/drivers/media/pci/intel/ipu-isys.c
++++ b/drivers/media/pci/intel/ipu-isys.c
+@@ -1170,8 +1170,7 @@ static void isys_remove(struct ipu_bus_device *adev)
+ 
+ 	dev_info(&adev->dev, "removed\n");
+ #ifdef CONFIG_DEBUG_FS
+-	if (isp->ipu_dir)
+-		debugfs_remove_recursive(isys->debugfsdir);
++	debugfs_remove_recursive(isys->debugfsdir);
+ #endif
+ 
+ 	list_for_each_entry_safe(fwmsg, safe, &isys->framebuflist, head) {
+@@ -1217,6 +1216,7 @@ static void isys_remove(struct ipu_bus_device *adev)
+ 
+ 	mutex_destroy(&isys->stream_mutex);
+ 	mutex_destroy(&isys->mutex);
++	mutex_destroy(&isys->lib_mutex);
+ 
+ 	if (isys->short_packet_source == IPU_ISYS_SHORT_PACKET_FROM_TUNIT) {
+ 		u32 trace_size = IPU_ISYS_SHORT_PACKET_TRACE_BUFFER_SIZE;
+@@ -1587,7 +1587,15 @@ static int isys_probe(struct ipu_bus_device *adev)
+ 	isys_iwake_watermark_cleanup(isys);
+ 	isys_unregister_devices(isys);
+ out_remove_pkg_dir_shared_buffer:
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+ 	cpu_latency_qos_remove_request(&isys->pm_qos);
++#else
++	pm_qos_remove_request(&isys->pm_qos);
++#endif
++	ipu_trace_uninit(&adev->dev);
++#ifdef CONFIG_DEBUG_FS
++	debugfs_remove_recursive(isys->debugfsdir);
++#endif
+ 	if (!isp->secure_mode)
+ 		ipu_cpd_free_pkg_dir(adev, isys->pkg_dir,
+ 				     isys->pkg_dir_dma_addr,
+@@ -1598,10 +1606,10 @@ static int isys_probe(struct ipu_bus_device *adev)
+ release_firmware:
+ 	if (!isp->secure_mode)
+ 		release_firmware(isys->fw);
+-	ipu_trace_uninit(&adev->dev);
+ 
+ 	mutex_destroy(&isys->mutex);
+ 	mutex_destroy(&isys->stream_mutex);
++	mutex_destroy(&isys->lib_mutex);
+ 
+ 	if (isys->short_packet_source == IPU_ISYS_SHORT_PACKET_FROM_TUNIT)
+ 		mutex_destroy(&isys->short_packet_tracing_mutex);

--- a/anda/system/intel-ipu6-kmod/0001-fix-compilation-6.8.patch
+++ b/anda/system/intel-ipu6-kmod/0001-fix-compilation-6.8.patch
@@ -1,0 +1,73 @@
+--- a/Makefile
++++ b/Makefile
+@@ -83,10 +83,10 @@ export CONFIG_VIDEO_OV02E10 = m
+ export CONFIG_VIDEO_HM2170 = m
+ export CONFIG_VIDEO_HM2172 = m
+ export CONFIG_VIDEO_HI556 = m
++export CONFIG_VIDEO_GC5035 = m
+ 
+ ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV2740)),true)
+ export CONFIG_VIDEO_OV2740 = m
+-export CONFIG_VIDEO_GC5035 = m
+ endif
+ obj-y += drivers/media/i2c/
+ 
+--- a/drivers/media/i2c/gc5035.c
++++ b/drivers/media/i2c/gc5035.c
+@@ -1497,7 +1497,11 @@ static int gc5035_set_fmt(struct v4l2_subdev *sd,
+ 
+ 	mutex_lock(&gc5035->mutex);
+ 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+ 		*v4l2_subdev_get_try_format(sd, sd_state, fmt->pad) = fmt->format;
++#else
++		*v4l2_subdev_state_get_format(sd_state, fmt->pad) = fmt->format;
++#endif
+ 	} else {
+ 		gc5035->cur_mode = mode;
+ 		h_blank = mode->hts_def - mode->width;
+@@ -1522,7 +1526,11 @@ static int gc5035_get_fmt(struct v4l2_subdev *sd,
+ 
+ 	mutex_lock(&gc5035->mutex);
+ 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+ 		fmt->format = *v4l2_subdev_get_try_format(sd, sd_state, fmt->pad);
++#else
++		fmt->format = *v4l2_subdev_state_get_format(sd_state, fmt->pad);
++#endif
+ 	} else {
+ 		fmt->format.width = mode->width;
+ 		fmt->format.height = mode->height;
+@@ -1714,7 +1722,9 @@ static const struct v4l2_subdev_video_ops gc5035_video_ops = {
+ };
+ 
+ static const struct v4l2_subdev_pad_ops gc5035_pad_ops = {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+ 	.init_cfg = gc5035_entity_init_cfg,
++#endif
+ 	.enum_mbus_code = gc5035_enum_mbus_code,
+ 	.enum_frame_size = gc5035_enum_frame_sizes,
+ 	.get_fmt = gc5035_get_fmt,
+@@ -1730,6 +1740,12 @@ static const struct media_entity_operations gc5035_subdev_entity_ops = {
+ 	.link_validate = v4l2_subdev_link_validate,
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
++static const struct v4l2_subdev_internal_ops gc5035_internal_ops = {
++	.init_state = gc5035_entity_init_cfg,
++};
++#endif
++
+ static int gc5035_set_exposure(struct gc5035 *gc5035, u32 val)
+ {
+ 	u32 caltime = 0;
+@@ -2091,6 +2107,9 @@ static int gc5035_probe(struct i2c_client *client)
+ 	mutex_init(&gc5035->mutex);
+ 	sd = &gc5035->subdev;
+ 	v4l2_i2c_subdev_init(sd, client, &gc5035_subdev_ops);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
++	sd->internal_ops = &gc5035_internal_ops;
++#endif
+ 	ret = gc5035_initialize_controls(gc5035);
+ 	if (ret) {
+ 		dev_err_probe(dev, ret, "Failed to initialize controls\n");

--- a/anda/system/intel-ipu6-kmod/0002-fix-compilation-6.10.patch
+++ b/anda/system/intel-ipu6-kmod/0002-fix-compilation-6.10.patch
@@ -1,0 +1,85 @@
+From 5917297efb44d52548a052c04e9f759926ca2ddd Mon Sep 17 00:00:00 2001
+From: Hans de Goede <hdegoede@redhat.com>
+Date: Tue, 11 Jun 2024 11:39:34 +0200
+Subject: [PATCH 2/6] media: ipu6: Fix compilation with kernels >= 6.10
+
+Fix compilation with kernels >= 6.10.
+
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+[vicamo: update for v6.12-rc1]
+Signed-off-by: You-Sheng Yang <vicamo.yang@canonical.com>
+---
+ drivers/media/pci/intel/ipu-mmu.c  |  1 +
+ drivers/media/pci/intel/ipu-psys.c | 31 ++++++++++++++++++++++++++++++
+ drivers/media/pci/intel/ipu.c      |  1 +
+ 3 files changed, 33 insertions(+)
+
+diff --git a/drivers/media/pci/intel/ipu-mmu.c b/drivers/media/pci/intel/ipu-mmu.c
+index a36a6ded8..b06c9f8c1 100644
+--- a/drivers/media/pci/intel/ipu-mmu.c
++++ b/drivers/media/pci/intel/ipu-mmu.c
+@@ -7,6 +7,7 @@
+ #include <linux/iova.h>
+ #include <linux/module.h>
+ #include <linux/sizes.h>
++#include <linux/vmalloc.h>
+ 
+ #include "ipu.h"
+ #include "ipu-platform.h"
+diff --git a/drivers/media/pci/intel/ipu-psys.c b/drivers/media/pci/intel/ipu-psys.c
+index b12ecf3fc..87fab7cf8 100644
+--- a/drivers/media/pci/intel/ipu-psys.c
++++ b/drivers/media/pci/intel/ipu-psys.c
+@@ -128,6 +128,37 @@ ipu_psys_lookup_kbuffer_by_kaddr(struct ipu_psys_fh *fh, void *kaddr)
+ 	return NULL;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
++/* Dropped from 6.10, use our own copy for now */
++static int follow_pfn(struct vm_area_struct *vma, unsigned long address, unsigned long *pfn)
++{
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++	spinlock_t *ptl;
++	pte_t *ptep;
++
++	if (follow_pte(vma, address, &ptep, &ptl))
++		return -EINVAL;
++
++	*pfn = pte_pfn(ptep_get(ptep));
++	pte_unmap_unlock(ptep, ptl);
++#else
++	struct follow_pfnmap_args args = {
++		.vma = vma,
++		.address = address,
++	};
++	int ret;
++
++	ret = follow_pfnmap_start(&args);
++	if (ret)
++		return ret;
++
++	*pfn = args.pfn;
++	follow_pfnmap_end(&args);
++#endif
++	return 0;
++}
++#endif
++
+ static int ipu_psys_get_userpages(struct ipu_dma_buf_attach *attach)
+ {
+ 	struct vm_area_struct *vma;
+diff --git a/drivers/media/pci/intel/ipu.c b/drivers/media/pci/intel/ipu.c
+index 33592a662..fc091a11a 100644
+--- a/drivers/media/pci/intel/ipu.c
++++ b/drivers/media/pci/intel/ipu.c
+@@ -15,6 +15,7 @@
+ #include <linux/timer.h>
+ #include <linux/sched.h>
+ #include <linux/version.h>
++#include <linux/vmalloc.h>
+ 
+ #include "ipu.h"
+ #include "ipu-buttress.h"
+-- 
+2.47.0
+

--- a/anda/system/intel-ipu6-kmod/0003-prefix-modules.patch
+++ b/anda/system/intel-ipu6-kmod/0003-prefix-modules.patch
@@ -1,0 +1,84 @@
+From 3ddee5543a8caa4bb716fd0ff815d52b0d09bbb1 Mon Sep 17 00:00:00 2001
+From: Hans de Goede <hdegoede@redhat.com>
+Date: Mon, 10 Jun 2024 19:30:48 +0200
+Subject: [PATCH 3/6] Makefile: prefix ipu6 modules with icamera- instead of
+ intel-
+
+Now that IPU6 isys support has landed upstream, using an auxbus approach
+rather then the custom ipu6-bus, there is a conflict between the mainline
+intel-ipu6* kernel modules and the out of tree ipu6-drivers intel-ipu6*
+kernel modules.
+
+Rename the out of tree ipu6 modules to icamera-ipu6* so that both can be
+installed together and the user can easily switch by blacklisting one of
+the 2 sets of modules.
+
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+---
+ drivers/media/pci/intel/ipu6/Makefile | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/media/pci/intel/ipu6/Makefile b/drivers/media/pci/intel/ipu6/Makefile
+index 23f8cdba4..92cd9fe1b 100644
+--- a/drivers/media/pci/intel/ipu6/Makefile
++++ b/drivers/media/pci/intel/ipu6/Makefile
+@@ -8,7 +8,7 @@ endif
+ ccflags-y += -DIPU_TPG_FRAME_SYNC -DIPU_PSYS_GPC \
+ 		-DIPU_ISYS_GPC
+ 
+-intel-ipu6-objs				+= ../ipu.o \
++icamera-ipu6-objs			+= ../ipu.o \
+ 					   ../ipu-bus.o \
+ 					   ../ipu-dma.o \
+ 					   ../ipu-mmu.o \
+@@ -18,12 +18,12 @@ intel-ipu6-objs				+= ../ipu.o \
+ 					   ipu6.o \
+ 					   ../ipu-fw-com.o
+ ifdef CONFIG_IPU_ISYS_BRIDGE
+-intel-ipu6-objs				+= ../cio2-bridge.o
++icamera-ipu6-objs			+= ../cio2-bridge.o
+ endif
+ 
+-obj-$(CONFIG_VIDEO_INTEL_IPU6)		+= intel-ipu6.o
++obj-$(CONFIG_VIDEO_INTEL_IPU6)		+= icamera-ipu6.o
+ 
+-intel-ipu6-isys-objs			+= ../ipu-isys.o \
++icamera-ipu6-isys-objs			+= ../ipu-isys.o \
+ 					   ../ipu-isys-csi2.o \
+ 					   ipu6-isys.o \
+ 					   ipu6-isys-phy.o \
+@@ -36,26 +36,26 @@ intel-ipu6-isys-objs			+= ../ipu-isys.o \
+ 					   ../ipu-isys-queue.o \
+ 					   ../ipu-isys-subdev.o
+ 
+-obj-$(CONFIG_VIDEO_INTEL_IPU6)		+= intel-ipu6-isys.o
++obj-$(CONFIG_VIDEO_INTEL_IPU6)		+= icamera-ipu6-isys.o
+ 
+-intel-ipu6-psys-objs			+= ../ipu-psys.o \
++icamera-ipu6-psys-objs			+= ../ipu-psys.o \
+ 					   ipu6-psys.o \
+ 					   ipu-resources.o \
+ 					   ipu6-psys-gpc.o \
+ 					   ipu6-l-scheduler.o \
+ 					   ipu6-ppg.o
+ 
+-intel-ipu6-psys-objs			+= ipu-fw-resources.o \
++icamera-ipu6-psys-objs			+= ipu-fw-resources.o \
+ 					   ipu6-fw-resources.o \
+ 					   ipu6se-fw-resources.o \
+ 					   ipu6ep-fw-resources.o \
+ 					   ../ipu-fw-psys.o
+ 
+ ifeq ($(CONFIG_COMPAT),y)
+-intel-ipu6-psys-objs			+= ../ipu-psys-compat32.o
++icamera-ipu6-psys-objs			+= ../ipu-psys-compat32.o
+ endif
+ 
+-obj-$(CONFIG_VIDEO_INTEL_IPU6)		+= intel-ipu6-psys.o
++obj-$(CONFIG_VIDEO_INTEL_IPU6)		+= icamera-ipu6-psys.o
+ 
+ ccflags-y += -I$(srcpath)/$(src)/../../../../../include/
+ ccflags-y += -I$(srcpath)/$(src)/../
+-- 
+2.47.0
+

--- a/anda/system/intel-ipu6-kmod/0004-fix-compilation-6.11.patch
+++ b/anda/system/intel-ipu6-kmod/0004-fix-compilation-6.11.patch
@@ -1,0 +1,32 @@
+From 5c1e910f6c473f7f53377219e1f00b36e6ae7da1 Mon Sep 17 00:00:00 2001
+From: You-Sheng Yang <vicamo.yang@canonical.com>
+Date: Thu, 8 Aug 2024 14:30:51 +0800
+Subject: [PATCH 4/6] media: ipu6: Fix compilation with kernels >= 6.11
+
+Signed-off-by: You-Sheng Yang <vicamo.yang@canonical.com>
+---
+ drivers/media/pci/intel/ipu-bus.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/pci/intel/ipu-bus.c b/drivers/media/pci/intel/ipu-bus.c
+index 0569ccb61..234fde8f1 100644
+--- a/drivers/media/pci/intel/ipu-bus.c
++++ b/drivers/media/pci/intel/ipu-bus.c
+@@ -75,9 +75,13 @@ static const struct dev_pm_ops ipu_bus_pm_ops = {
+ #define IPU_BUS_PM_OPS	NULL
+ #endif
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
+ static int ipu_bus_match(struct device *dev, struct device_driver *drv)
++#else
++static int ipu_bus_match(struct device *dev, const struct device_driver *drv)
++#endif
+ {
+-	struct ipu_bus_driver *adrv = to_ipu_bus_driver(drv);
++	const struct ipu_bus_driver *adrv = to_ipu_bus_driver(drv);
+ 
+ 	dev_dbg(dev, "bus match: \"%s\" --- \"%s\"\n", dev_name(dev),
+ 		adrv->wanted);
+-- 
+2.47.0
+

--- a/anda/system/intel-ipu6-kmod/0005-fix-compilation-6.12.patch
+++ b/anda/system/intel-ipu6-kmod/0005-fix-compilation-6.12.patch
@@ -1,0 +1,269 @@
+From 3bbe043c6c92ef8fb2482077911ca6ea5fb2ef52 Mon Sep 17 00:00:00 2001
+From: You-Sheng Yang <vicamo.yang@canonical.com>
+Date: Fri, 11 Oct 2024 01:44:50 +0800
+Subject: [PATCH 5/6] media: ipu6: Fix compilation with kernels >= 6.12: move
+ asm/unaligned.h to linux/unaligned.h
+
+Accommodate to v6.12-rc2 commit 5f60d5f6bbc12 ("move asm/unaligned.h to
+linux/unaligned.h").
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2083996
+Signed-off-by: You-Sheng Yang <vicamo.yang@canonical.com>
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+---
+ drivers/media/i2c/hi556.c   | 6 +++++-
+ drivers/media/i2c/hm11b1.c  | 6 +++++-
+ drivers/media/i2c/hm2170.c  | 6 +++++-
+ drivers/media/i2c/hm2172.c  | 6 +++++-
+ drivers/media/i2c/ov01a10.c | 6 +++++-
+ drivers/media/i2c/ov01a1s.c | 6 +++++-
+ drivers/media/i2c/ov02c10.c | 6 +++++-
+ drivers/media/i2c/ov02e10.c | 6 +++++-
+ drivers/media/i2c/ov2740.c  | 6 +++++-
+ drivers/media/i2c/ov8856.c  | 6 +++++-
+ 10 files changed, 50 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/media/i2c/hi556.c b/drivers/media/i2c/hi556.c
+index 4fc020b65..90080438b 100644
+--- a/drivers/media/i2c/hi556.c
++++ b/drivers/media/i2c/hi556.c
+@@ -1,14 +1,18 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2019 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/clk.h>
+ #include <linux/delay.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/hm11b1.c b/drivers/media/i2c/hm11b1.c
+index f3900d29f..173bb32eb 100644
+--- a/drivers/media/i2c/hm11b1.c
++++ b/drivers/media/i2c/hm11b1.c
+@@ -1,13 +1,17 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2020-2022 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/delay.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/hm2170.c b/drivers/media/i2c/hm2170.c
+index 102eec25a..060bb04d1 100644
+--- a/drivers/media/i2c/hm2170.c
++++ b/drivers/media/i2c/hm2170.c
+@@ -1,7 +1,12 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2022 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/delay.h>
+ #include <linux/i2c.h>
+@@ -9,7 +14,6 @@
+ #include <linux/pm_runtime.h>
+ #include <linux/nvmem-provider.h>
+ #include <linux/regmap.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/hm2172.c b/drivers/media/i2c/hm2172.c
+index 3362d3151..422166f04 100644
+--- a/drivers/media/i2c/hm2172.c
++++ b/drivers/media/i2c/hm2172.c
+@@ -1,7 +1,12 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2022 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/delay.h>
+ #include <linux/i2c.h>
+@@ -9,7 +14,6 @@
+ #include <linux/pm_runtime.h>
+ #include <linux/nvmem-provider.h>
+ #include <linux/regmap.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/ov01a10.c b/drivers/media/i2c/ov01a10.c
+index 78ae01811..aa47a50e5 100644
+--- a/drivers/media/i2c/ov01a10.c
++++ b/drivers/media/i2c/ov01a10.c
+@@ -1,13 +1,17 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2020-2022 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/delay.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/ov01a1s.c b/drivers/media/i2c/ov01a1s.c
+index f7cf2218c..639b0921f 100644
+--- a/drivers/media/i2c/ov01a1s.c
++++ b/drivers/media/i2c/ov01a1s.c
+@@ -1,13 +1,17 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2020-2022 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/delay.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/ov02c10.c b/drivers/media/i2c/ov02c10.c
+index 40865f8e3..0a1fed161 100644
+--- a/drivers/media/i2c/ov02c10.c
++++ b/drivers/media/i2c/ov02c10.c
+@@ -1,7 +1,12 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2022 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/clk.h>
+ #include <linux/delay.h>
+@@ -9,7 +14,6 @@
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/ov02e10.c b/drivers/media/i2c/ov02e10.c
+index 916def90f..ea82040f2 100644
+--- a/drivers/media/i2c/ov02e10.c
++++ b/drivers/media/i2c/ov02e10.c
+@@ -1,7 +1,12 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2023 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/clk.h>
+ #include <linux/delay.h>
+@@ -9,7 +14,6 @@
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/ov2740.c b/drivers/media/i2c/ov2740.c
+index bd9b68e34..4ed0094f7 100644
+--- a/drivers/media/i2c/ov2740.c
++++ b/drivers/media/i2c/ov2740.c
+@@ -1,7 +1,12 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2022 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/delay.h>
+ #include <linux/i2c.h>
+@@ -9,7 +14,6 @@
+ #include <linux/pm_runtime.h>
+ #include <linux/nvmem-provider.h>
+ #include <linux/regmap.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+diff --git a/drivers/media/i2c/ov8856.c b/drivers/media/i2c/ov8856.c
+index 1c4469ea0..a2c7c8c22 100644
+--- a/drivers/media/i2c/ov8856.c
++++ b/drivers/media/i2c/ov8856.c
+@@ -1,13 +1,17 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (c) 2021-2022 Intel Corporation.
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ #include <asm/unaligned.h>
++#else
++#include <linux/unaligned.h>
++#endif
+ #include <linux/acpi.h>
+ #include <linux/delay.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/pm_runtime.h>
+-#include <linux/version.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+-- 
+2.47.0
+

--- a/anda/system/intel-ipu6-kmod/0006-fix-compilation-6.12-no-no_llseek.patch
+++ b/anda/system/intel-ipu6-kmod/0006-fix-compilation-6.12-no-no_llseek.patch
@@ -1,0 +1,53 @@
+From f89a4e3da45753d012b3c40bfe9c8b56671e5306 Mon Sep 17 00:00:00 2001
+From: You-Sheng Yang <vicamo.yang@canonical.com>
+Date: Fri, 11 Oct 2024 01:28:38 +0800
+Subject: [PATCH 6/6] media: ipu6: Fix compilation with kernels >= 6.12:
+ Finally take no_llseek out
+
+Accommodate to v6.12-rc1 commit cb787f4ac0c2 ("[tree-wide] finally take
+no_llseek out").
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2083996
+Signed-off-by: You-Sheng Yang <vicamo.yang@canonical.com>
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+---
+ drivers/media/pci/intel/ipu-trace.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/media/pci/intel/ipu-trace.c b/drivers/media/pci/intel/ipu-trace.c
+index 282ac659a..2dc458a1d 100644
+--- a/drivers/media/pci/intel/ipu-trace.c
++++ b/drivers/media/pci/intel/ipu-trace.c
+@@ -517,7 +517,9 @@ static const struct file_operations ipu_traceconf_fops = {
+ 	.release = traceconf_release,
+ 	.read = traceconf_read,
+ 	.write = traceconf_write,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ 	.llseek = no_llseek,
++#endif
+ };
+ 
+ static void wptraceconf_dump(struct ipu_device *isp)
+@@ -673,7 +675,9 @@ static const struct file_operations ipu_wptraceconf_fops = {
+ 	.release = wptraceconf_release,
+ 	.read = wptraceconf_read,
+ 	.write = wptraceconf_write,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ 	.llseek = no_llseek,
++#endif
+ };
+ 
+ static int gettrace_open(struct inode *inode, struct file *file)
+@@ -740,7 +744,9 @@ static const struct file_operations ipu_gettrace_fops = {
+ 	.release = gettrace_release,
+ 	.read = gettrace_read,
+ 	.write = gettrace_write,
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ 	.llseek = no_llseek,
++#endif
+ };
+ 
+ int ipu_trace_init(struct ipu_device *isp, void __iomem *base,
+-- 
+2.47.0
+

--- a/anda/system/intel-ipu6-kmod/0007-modules-per-kernel.patch
+++ b/anda/system/intel-ipu6-kmod/0007-modules-per-kernel.patch
@@ -1,0 +1,773 @@
+From 2c4ad1398dddfb307e8a40a714a6d5f70d6d14cb Mon Sep 17 00:00:00 2001
+From: Hans de Goede <hdegoede@redhat.com>
+Date: Mon, 10 Jun 2024 13:05:53 +0200
+Subject: [PATCH 4/4] Makefile: Adjust which modules to build for which
+ kernel-versions for Fedora
+
+Fedora's kernels have not enabled various IPU6 related drivers as soon
+as they were mainlined. Instead they were enabled at later times.
+
+Fix the automatic disabling of certain modules to match when they were
+enabled in the Fedora kernels:
+
+Do not build ljca        for kernels >= 6.7
+Do not build ivsc        for kernels >= 6.10
+Do not build ov2740      for kernels >= 6.10 (1)
+Do not build ov01a10     for kernels >= 6.10
+Do not build hi556       for kernels >= 6.10 (2)
+Do not build cio2-bridge for kernels >= 6.10 (3)
+
+1) Also switch the Kconfig symbols for mainlined sensor drivers from
+CONFIG_VIDEO_FOO to CONFIG_ICAMERA_FOO to avoid these still being
+set when they should not because of the CONFIG_VIDEO_FOO symbols
+inherited from the base kernel.
+
+2) hi556 was enabled in earlier Fedora patches but the mainline version
+missed reset GPIO / clk / regulator support
+
+3) The mainline ipu6-bridge is only used for kernels >= 6.10 because it
+lacked ACPI HIDs for many of the still out of tree sensor drivers, see:
+https://lore.kernel.org/linux-media/20240610173418.16119-1-hdegoede@redhat.com/
+
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+---
+ Makefile                    | 20 ++++++++++++--------
+ drivers/media/i2c/Makefile  |  7 ++++---
+ drivers/media/i2c/hi556.c   | 20 ++++++++++----------
+ drivers/media/i2c/hm2170.c  | 20 ++++++++++----------
+ drivers/media/i2c/hm2172.c  | 20 ++++++++++----------
+ drivers/media/i2c/ov01a10.c | 18 +++++++++---------
+ drivers/media/i2c/ov01a1s.c | 20 ++++++++++----------
+ drivers/media/i2c/ov02c10.c | 20 ++++++++++----------
+ drivers/media/i2c/ov02e10.c | 20 ++++++++++----------
+ 9 files changed, 85 insertions(+), 80 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 4734c4497..5d716eb61 100644
+--- a/Makefile
++++ b/Makefile
+@@ -20,15 +20,16 @@ version_lt = $(shell \
+         echo "false"; \
+     fi)
+ 
+-KV_IVSC := 6.6.0
+-KV_IPU_BRIDGE := 6.6.0
+-KV_OV2740 := 6.8.0
++KV_LJCA := 6.7.0
++KV_IVSC := 6.10.0
++KV_IPU_BRIDGE := 6.10.0
++KV_OV2740 := 6.10.0
+ 
+ KERNEL_SRC ?= /lib/modules/$(KERNELRELEASE)/build
+ MODSRC := $(shell pwd)
+ 
+-ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_IVSC)),true)
+-$(warning build ljca ivsc)
++ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_LJCA)),true)
++$(warning build ljca)
+ obj-m += ljca.o
+ ljca-y := drivers/mfd/ljca.o
+ 
+@@ -40,7 +41,10 @@ gpio-ljca-y := drivers/gpio/gpio-ljca.o
+ 
+ obj-m += i2c-ljca.o
+ i2c-ljca-y := drivers/i2c/busses/i2c-ljca.o
++endif
+ 
++ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_IVSC)),true)
++$(warning build ivsc)
+ obj-m += mei-vsc.o
+ mei-vsc-y := drivers/misc/mei/spi-vsc.o
+ mei-vsc-y += drivers/misc/mei/hw-vsc.o
+@@ -77,16 +81,16 @@ obj-y += drivers/media/pci/intel/
+ 
+ export CONFIG_VIDEO_HM11B1 = m
+ export CONFIG_VIDEO_OV01A1S = m
+-export CONFIG_VIDEO_OV01A10 = m
+ export CONFIG_VIDEO_OV02C10 = m
+ export CONFIG_VIDEO_OV02E10 = m
+ export CONFIG_VIDEO_HM2170 = m
+ export CONFIG_VIDEO_HM2172 = m
+-export CONFIG_VIDEO_HI556 = m
+ export CONFIG_VIDEO_GC5035 = m
+ 
+ ifeq ($(call version_lt,$(KERNEL_VERSION),$(KV_OV2740)),true)
+-export CONFIG_VIDEO_OV2740 = m
++export CONFIG_ICAMERA_OV2740 = m
++export CONFIG_ICAMERA_OV01A10 = m
++export CONFIG_ICAMERA_HI556 = m
+ endif
+ obj-y += drivers/media/i2c/
+ 
+diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile
+index 1f395448b..f49609620 100644
+--- a/drivers/media/i2c/Makefile
++++ b/drivers/media/i2c/Makefile
+@@ -4,11 +4,12 @@
+ obj-$(CONFIG_VIDEO_HM11B1) += hm11b1.o
+ obj-$(CONFIG_VIDEO_GC5035) += gc5035.o
+ obj-$(CONFIG_VIDEO_OV01A1S) += ov01a1s.o
+-obj-$(CONFIG_VIDEO_OV01A10) += ov01a10.o
+ obj-$(CONFIG_VIDEO_OV02C10) += ov02c10.o
+ obj-$(CONFIG_VIDEO_OV02E10) += ov02e10.o
+-obj-$(CONFIG_VIDEO_OV2740) += ov2740.o
+ obj-$(CONFIG_VIDEO_HM2170) += hm2170.o
+ obj-$(CONFIG_VIDEO_HM2170) += hm2172.o
+-obj-$(CONFIG_VIDEO_HI556) += hi556.o
+ obj-$(CONFIG_POWER_CTRL_LOGIC) += power_ctrl_logic.o
++
++obj-$(CONFIG_ICAMERA_OV2740) += ov2740.o
++obj-$(CONFIG_ICAMERA_OV01A10) += ov01a10.o
++obj-$(CONFIG_ICAMERA_HI556) += hi556.o
+diff --git a/drivers/media/i2c/hi556.c b/drivers/media/i2c/hi556.c
+index 4fc020b65..2adb5a1fe 100644
+--- a/drivers/media/i2c/hi556.c
++++ b/drivers/media/i2c/hi556.c
+@@ -12,7 +12,7 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ #include <linux/vsc.h>
+ 
+@@ -510,7 +510,7 @@ struct hi556 {
+ 	/* Clock provider */
+ 	struct clk *img_clk;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	struct vsc_mipi_config conf;
+ 	struct vsc_camera_status status;
+@@ -527,7 +527,7 @@ struct hi556 {
+ 
+ 	/* True if the device has been identified */
+ 	bool identified;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	bool use_intel_vsc;
+ #endif
+@@ -704,7 +704,7 @@ static int hi556_set_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = hi556_test_pattern(hi556, ctrl->val);
+ 		break;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	case V4L2_CID_PRIVACY:
+ 		dev_dbg(&client->dev, "set privacy to %d", ctrl->val);
+@@ -732,7 +732,7 @@ static int hi556_init_controls(struct hi556 *hi556)
+ 	int ret;
+ 
+ 	ctrl_hdlr = &hi556->ctrl_handler;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
+ #else
+@@ -771,7 +771,7 @@ static int hi556_init_controls(struct hi556 *hi556)
+ 					  h_blank);
+ 	if (hi556->hblank)
+ 		hi556->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	hi556->privacy_status = v4l2_ctrl_new_std(ctrl_hdlr, &hi556_ctrl_ops,
+ 						  V4L2_CID_PRIVACY, 0, 1, 1,
+@@ -836,7 +836,7 @@ static int hi556_identify_module(struct hi556 *hi556)
+ 	return 0;
+ }
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ static void hi556_vsc_privacy_callback(void *handle,
+ 				       enum vsc_privacy_status status)
+@@ -936,7 +936,7 @@ static int hi556_power_off(struct device *dev)
+ 	struct hi556 *hi556 = to_hi556(sd);
+ 	int ret = 0;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (hi556->use_intel_vsc) {
+ 		ret = vsc_release_camera_sensor(&hi556->status);
+@@ -961,7 +961,7 @@ static int hi556_power_on(struct device *dev)
+ 	struct hi556 *hi556 = to_hi556(sd);
+ 	int ret;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (hi556->use_intel_vsc) {
+ 		hi556->conf.lane_num = HI556_DATA_LANES;
+@@ -1217,7 +1217,7 @@ static int hi556_get_pm_resources(struct device *dev)
+ 	struct hi556 *hi556 = to_hi556(sd);
+ 	int ret;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	acpi_handle handle = ACPI_HANDLE(dev);
+ 	struct acpi_handle_list dep_devices;
+diff --git a/drivers/media/i2c/hm2170.c b/drivers/media/i2c/hm2170.c
+index 102eec25a..2987e0cbe 100644
+--- a/drivers/media/i2c/hm2170.c
++++ b/drivers/media/i2c/hm2170.c
+@@ -13,7 +13,7 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ #include <linux/vsc.h>
+ #endif
+@@ -615,7 +615,7 @@ struct hm2170 {
+ 	struct v4l2_ctrl *vblank;
+ 	struct v4l2_ctrl *hblank;
+ 	struct v4l2_ctrl *exposure;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	struct vsc_mipi_config conf;
+ 	struct vsc_camera_status status;
+@@ -792,7 +792,7 @@ static int hm2170_set_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = hm2170_test_pattern(hm2170, ctrl->val);
+ 		break;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	case V4L2_CID_PRIVACY:
+ 		dev_dbg(&client->dev, "set privacy to %d", ctrl->val);
+@@ -825,7 +825,7 @@ static int hm2170_init_controls(struct hm2170 *hm2170)
+ 	int ret = 0;
+ 
+ 	ctrl_hdlr = &hm2170->ctrl_handler;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
+ #else
+@@ -864,7 +864,7 @@ static int hm2170_init_controls(struct hm2170 *hm2170)
+ 					   h_blank);
+ 	if (hm2170->hblank)
+ 		hm2170->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	hm2170->privacy_status = v4l2_ctrl_new_std(ctrl_hdlr, &hm2170_ctrl_ops,
+ 						   V4L2_CID_PRIVACY, 0, 1, 1,
+@@ -904,7 +904,7 @@ static void hm2170_update_pad_format(const struct hm2170_mode *mode,
+ 	fmt->field = V4L2_FIELD_NONE;
+ }
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ static void hm2170_vsc_privacy_callback(void *handle,
+ 					enum vsc_privacy_status status)
+@@ -984,7 +984,7 @@ static int hm2170_set_stream(struct v4l2_subdev *sd, int enable)
+ 	return ret;
+ }
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ static int hm2170_power_off(struct device *dev)
+ {
+@@ -1323,7 +1323,7 @@ static int hm2170_probe(struct i2c_client *client)
+ 	}
+ 
+ 	v4l2_i2c_subdev_init(&hm2170->sd, client, &hm2170_subdev_ops);
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	hm2170->conf.lane_num = HM2170_DATA_LANES;
+ 	/* frequency unit 100k */
+@@ -1389,7 +1389,7 @@ probe_error_v4l2_ctrl_handler_free:
+ 	mutex_destroy(&hm2170->mutex);
+ 
+ probe_error_ret:
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	hm2170_power_off(&client->dev);
+ #endif
+@@ -1399,7 +1399,7 @@ probe_error_ret:
+ 
+ static const struct dev_pm_ops hm2170_pm_ops = {
+ 	SET_SYSTEM_SLEEP_PM_OPS(hm2170_suspend, hm2170_resume)
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	SET_RUNTIME_PM_OPS(hm2170_power_off, hm2170_power_on, NULL)
+ #endif
+diff --git a/drivers/media/i2c/hm2172.c b/drivers/media/i2c/hm2172.c
+index 3362d3151..8e1d1f883 100644
+--- a/drivers/media/i2c/hm2172.c
++++ b/drivers/media/i2c/hm2172.c
+@@ -15,7 +15,7 @@
+ #include <media/v4l2-fwnode.h>
+ #include <linux/clk.h>
+ #include <linux/gpio/consumer.h>
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ #include <linux/vsc.h>
+ 
+@@ -927,7 +927,7 @@ struct hm2172 {
+ 	struct gpio_desc *reset;
+ 	struct gpio_desc *handshake;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	struct vsc_mipi_config conf;
+ 	struct vsc_camera_status status;
+@@ -942,7 +942,7 @@ struct hm2172 {
+ 
+ 	/* Streaming on/off */
+ 	bool streaming;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	bool use_intel_vsc;
+ #endif
+@@ -1109,7 +1109,7 @@ static int hm2172_set_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = hm2172_test_pattern(hm2172, ctrl->val);
+ 		break;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	case V4L2_CID_PRIVACY:
+ 		dev_dbg(&client->dev, "set privacy to %d", ctrl->val);
+@@ -1142,7 +1142,7 @@ static int hm2172_init_controls(struct hm2172 *hm2172)
+ 	int ret = 0;
+ 
+ 	ctrl_hdlr = &hm2172->ctrl_handler;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
+ #else
+@@ -1183,7 +1183,7 @@ static int hm2172_init_controls(struct hm2172 *hm2172)
+ 	if (hm2172->hblank)
+ 		hm2172->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	hm2172->privacy_status = v4l2_ctrl_new_std(ctrl_hdlr, &hm2172_ctrl_ops,
+ 						   V4L2_CID_PRIVACY, 0, 1, 1,
+@@ -1223,7 +1223,7 @@ static void hm2172_update_pad_format(const struct hm2172_mode *mode,
+ 	fmt->field = V4L2_FIELD_NONE;
+ }
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ static void hm2172_vsc_privacy_callback(void *handle,
+ 				       enum vsc_privacy_status status)
+@@ -1309,7 +1309,7 @@ static int hm2172_power_off(struct device *dev)
+ 	struct hm2172 *hm2172 = to_hm2172(sd);
+ 	int ret = 0;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (hm2172->use_intel_vsc) {
+ 		ret = vsc_release_camera_sensor(&hm2172->status);
+@@ -1336,7 +1336,7 @@ static int hm2172_power_on(struct device *dev)
+ 	struct hm2172 *hm2172 = to_hm2172(sd);
+ 	int ret;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (hm2172->use_intel_vsc) {
+ 		hm2172->conf.lane_num = HM2172_DATA_LANES;
+@@ -1392,7 +1392,7 @@ static int hm2172_get_pm_resources(struct device *dev)
+ 	struct hm2172 *hm2172 = to_hm2172(sd);
+ 	int ret = 0;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	acpi_handle handle = ACPI_HANDLE(dev);
+ 	struct acpi_handle_list dep_devices;
+diff --git a/drivers/media/i2c/ov01a10.c b/drivers/media/i2c/ov01a10.c
+index 78ae01811..31f1e7a3d 100644
+--- a/drivers/media/i2c/ov01a10.c
++++ b/drivers/media/i2c/ov01a10.c
+@@ -11,7 +11,7 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ #include <linux/vsc.h>
+ #endif
+@@ -296,7 +296,7 @@ struct ov01a10 {
+ 	/* To serialize asynchronus callbacks */
+ 	struct mutex mutex;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	struct vsc_mipi_config conf;
+ 	struct vsc_camera_status status;
+@@ -469,7 +469,7 @@ static int ov01a10_set_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = ov01a10_test_pattern(ov01a10, ctrl->val);
+ 		break;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	case V4L2_CID_PRIVACY:
+ 		dev_dbg(&client->dev, "set privacy to %d", ctrl->val);
+@@ -500,7 +500,7 @@ static int ov01a10_init_controls(struct ov01a10 *ov01a10)
+ 	int ret = 0;
+ 
+ 	ctrl_hdlr = &ov01a10->ctrl_handler;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
+ #else
+@@ -539,7 +539,7 @@ static int ov01a10_init_controls(struct ov01a10 *ov01a10)
+ 	if (ov01a10->hblank)
+ 		ov01a10->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ov01a10->privacy_status = v4l2_ctrl_new_std(ctrl_hdlr,
+ 						    &ov01a10_ctrl_ops,
+@@ -661,7 +661,7 @@ static int ov01a10_set_stream(struct v4l2_subdev *sd, int enable)
+ 	return ret;
+ }
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ static void ov01a10_vsc_privacy_callback(void *handle,
+ 				       enum vsc_privacy_status status)
+@@ -1016,7 +1016,7 @@ static int ov01a10_probe(struct i2c_client *client)
+ 		return -ENOMEM;
+ 
+ 	v4l2_i2c_subdev_init(&ov01a10->sd, client, &ov01a10_subdev_ops);
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ov01a10->conf.lane_num = OV01A10_DATA_LANES;
+ 	/* frequency unit 100k */
+@@ -1082,7 +1082,7 @@ probe_error_v4l2_ctrl_handler_free:
+ 	mutex_destroy(&ov01a10->mutex);
+ 
+ probe_error_ret:
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ov01a10_power_off(&client->dev);
+ #endif
+@@ -1092,7 +1092,7 @@ probe_error_ret:
+ 
+ static const struct dev_pm_ops ov01a10_pm_ops = {
+ 	SET_SYSTEM_SLEEP_PM_OPS(ov01a10_suspend, ov01a10_resume)
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	SET_RUNTIME_PM_OPS(ov01a10_power_off, ov01a10_power_on, NULL)
+ #endif
+diff --git a/drivers/media/i2c/ov01a1s.c b/drivers/media/i2c/ov01a1s.c
+index f7cf2218c..85f9c684c 100644
+--- a/drivers/media/i2c/ov01a1s.c
++++ b/drivers/media/i2c/ov01a1s.c
+@@ -17,7 +17,7 @@
+ #elif IS_ENABLED(CONFIG_POWER_CTRL_LOGIC)
+ #include "power_ctrl_logic.h"
+ #endif
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ #include <linux/vsc.h>
+ #endif
+@@ -303,7 +303,7 @@ struct ov01a1s {
+ 	struct v4l2_ctrl *vblank;
+ 	struct v4l2_ctrl *hblank;
+ 	struct v4l2_ctrl *exposure;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	struct v4l2_ctrl *privacy_status;
+ 
+@@ -337,7 +337,7 @@ struct ov01a1s {
+ #if IS_ENABLED(CONFIG_INTEL_SKL_INT3472) || IS_ENABLED(CONFIG_POWER_CTRL_LOGIC)
+ 		OV01A1S_USE_INT3472 = 1,
+ #endif
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 		OV01A1S_USE_INTEL_VSC = 2,
+ #endif
+@@ -508,7 +508,7 @@ static int ov01a1s_set_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = ov01a1s_test_pattern(ov01a1s, ctrl->val);
+ 		break;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	case V4L2_CID_PRIVACY:
+ 		dev_dbg(&client->dev, "set privacy to %d", ctrl->val);
+@@ -539,7 +539,7 @@ static int ov01a1s_init_controls(struct ov01a1s *ov01a1s)
+ 	int ret = 0;
+ 
+ 	ctrl_hdlr = &ov01a1s->ctrl_handler;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
+ #else
+@@ -577,7 +577,7 @@ static int ov01a1s_init_controls(struct ov01a1s *ov01a1s)
+ 					    1, h_blank);
+ 	if (ov01a1s->hblank)
+ 		ov01a1s->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ov01a1s->privacy_status = v4l2_ctrl_new_std(ctrl_hdlr,
+ 						    &ov01a1s_ctrl_ops,
+@@ -619,7 +619,7 @@ static void ov01a1s_update_pad_format(const struct ov01a1s_mode *mode,
+ 	fmt->field = V4L2_FIELD_NONE;
+ }
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ static void ov01a1s_vsc_privacy_callback(void *handle,
+ 				       enum vsc_privacy_status status)
+@@ -729,7 +729,7 @@ static int ov01a1s_power_off(struct device *dev)
+ 	if (ov01a1s->power_type == OV01A1S_USE_INT3472)
+ 		ret = power_ctrl_logic_set_power(0);
+ #endif
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (ov01a1s->power_type == OV01A1S_USE_INTEL_VSC) {
+ 		ret = vsc_release_camera_sensor(&ov01a1s->status);
+@@ -764,7 +764,7 @@ static int ov01a1s_power_on(struct device *dev)
+ 	if (ov01a1s->power_type == OV01A1S_USE_INT3472)
+ 		ret = power_ctrl_logic_set_power(1);
+ #endif
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (ov01a1s->power_type == OV01A1S_USE_INTEL_VSC) {
+ 		ret = vsc_acquire_camera_sensor(&ov01a1s->conf,
+@@ -1125,7 +1125,7 @@ static int ov01a1s_parse_power(struct ov01a1s *ov01a1s)
+ {
+ 	int ret = 0;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ov01a1s->conf.lane_num = OV01A1S_DATA_LANES;
+ 	/* frequency unit 100k */
+diff --git a/drivers/media/i2c/ov02c10.c b/drivers/media/i2c/ov02c10.c
+index 40865f8e3..4f58d5ac9 100644
+--- a/drivers/media/i2c/ov02c10.c
++++ b/drivers/media/i2c/ov02c10.c
+@@ -13,7 +13,7 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ #include <linux/vsc.h>
+ 
+@@ -697,7 +697,7 @@ struct ov02c10 {
+ 	struct gpio_desc *reset;
+ 	struct gpio_desc *handshake;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ 	struct vsc_mipi_config conf;
+ 	struct vsc_camera_status status;
+@@ -717,7 +717,7 @@ IS_ENABLED(CONFIG_INTEL_VSC)
+ 
+ 	/* Module name index */
+ 	u8 module_name_index;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ 
+ 	bool use_intel_vsc;
+@@ -857,7 +857,7 @@ static int ov02c10_set_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = ov02c10_test_pattern(ov02c10, ctrl->val);
+ 		break;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ 	case V4L2_CID_PRIVACY:
+ 		dev_dbg(&client->dev, "set privacy to %d", ctrl->val);
+@@ -888,7 +888,7 @@ static int ov02c10_init_controls(struct ov02c10 *ov02c10)
+ 	int ret = 0;
+ 
+ 	ctrl_hdlr = &ov02c10->ctrl_handler;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
+ #else
+@@ -926,7 +926,7 @@ IS_ENABLED(CONFIG_INTEL_VSC)
+ 					    1, h_blank);
+ 	if (ov02c10->hblank)
+ 		ov02c10->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ov02c10->privacy_status = v4l2_ctrl_new_std(ctrl_hdlr,
+ 						    &ov02c10_ctrl_ops,
+@@ -1102,7 +1102,7 @@ static int ov02c10_get_pm_resources(struct device *dev)
+ 	struct ov02c10 *ov02c10 = to_ov02c10(sd);
+ 	int ret;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ 	acpi_handle handle = ACPI_HANDLE(dev);
+ 	struct acpi_handle_list deps;
+@@ -1162,7 +1162,7 @@ IS_ENABLED(CONFIG_INTEL_VSC)
+ 	return 0;
+ }
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ static void ov02c10_vsc_privacy_callback(void *handle,
+ 				       enum vsc_privacy_status status)
+@@ -1179,7 +1179,7 @@ static int ov02c10_power_off(struct device *dev)
+ 	struct ov02c10 *ov02c10 = to_ov02c10(sd);
+ 	int ret = 0;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (ov02c10->use_intel_vsc) {
+ 		ret = vsc_release_camera_sensor(&ov02c10->status);
+@@ -1206,7 +1206,7 @@ static int ov02c10_power_on(struct device *dev)
+ 	struct ov02c10 *ov02c10 = to_ov02c10(sd);
+ 	int ret;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+ IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (ov02c10->use_intel_vsc) {
+ 		ov02c10->conf.lane_num = ov02c10->mipi_lanes;
+diff --git a/drivers/media/i2c/ov02e10.c b/drivers/media/i2c/ov02e10.c
+index 916def90f..c5c373aa6 100644
+--- a/drivers/media/i2c/ov02e10.c
++++ b/drivers/media/i2c/ov02e10.c
+@@ -13,7 +13,7 @@
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-device.h>
+ #include <media/v4l2-fwnode.h>
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ #include <linux/vsc.h>
+ 
+@@ -289,7 +289,7 @@ struct ov02e10 {
+ 	struct gpio_desc *reset;
+ 	struct gpio_desc *handshake;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	struct vsc_mipi_config conf;
+ 	struct vsc_camera_status status;
+@@ -304,7 +304,7 @@ struct ov02e10 {
+ 
+ 	/* Streaming on/off */
+ 	bool streaming;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	bool use_intel_vsc;
+ #endif
+@@ -486,7 +486,7 @@ static int ov02e10_set_ctrl(struct v4l2_ctrl *ctrl)
+ 		ret = ov02e10_test_pattern(ov02e10, ctrl->val);
+ 		break;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	case V4L2_CID_PRIVACY:
+ 		dev_dbg(&client->dev, "set privacy to %d", ctrl->val);
+@@ -520,7 +520,7 @@ static int ov02e10_init_controls(struct ov02e10 *ov02e10)
+ 	int ret;
+ 
+ 	ctrl_hdlr = &ov02e10->ctrl_handler;
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ret = v4l2_ctrl_handler_init(ctrl_hdlr, 9);
+ #else
+@@ -561,7 +561,7 @@ static int ov02e10_init_controls(struct ov02e10 *ov02e10)
+ 	if (ov02e10->hblank)
+ 		ov02e10->hblank->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	ov02e10->privacy_status = v4l2_ctrl_new_std(ctrl_hdlr, &ov02e10_ctrl_ops,
+ 						    V4L2_CID_PRIVACY, 0, 1, 1,
+@@ -602,7 +602,7 @@ static void ov02e10_update_pad_format(const struct ov02e10_mode *mode,
+ 	fmt->field = V4L2_FIELD_NONE;
+ }
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ static void ov02e10_vsc_privacy_callback(void *handle,
+ 				       enum vsc_privacy_status status)
+@@ -696,7 +696,7 @@ static int ov02e10_get_pm_resources(struct device *dev)
+ 	struct ov02e10 *ov02e10 = to_ov02e10(sd);
+ 	int ret;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	acpi_handle handle = ACPI_HANDLE(dev);
+ 	struct acpi_handle_list dep_devices;
+@@ -763,7 +763,7 @@ static int ov02e10_power_off(struct device *dev)
+ 	struct ov02e10 *ov02e10 = to_ov02e10(sd);
+ 	int ret = 0;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (ov02e10->use_intel_vsc) {
+ 		ret = vsc_release_camera_sensor(&ov02e10->status);
+@@ -790,7 +790,7 @@ static int ov02e10_power_on(struct device *dev)
+ 	struct ov02e10 *ov02e10 = to_ov02e10(sd);
+ 	int ret;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && \
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0) && \
+     IS_ENABLED(CONFIG_INTEL_VSC)
+ 	if (ov02e10->use_intel_vsc) {
+ 		ov02e10->conf.lane_num = OV02E10_DATA_LANES;
+-- 
+2.45.1
+

--- a/anda/system/intel-ipu6-kmod/anda.hcl
+++ b/anda/system/intel-ipu6-kmod/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "intel-ipu6-kmod.spec"
+    }
+    labels {
+        mock = 1
+    }
+}

--- a/anda/system/intel-ipu6-kmod/intel-ipu6-kmod.spec
+++ b/anda/system/intel-ipu6-kmod/intel-ipu6-kmod.spec
@@ -1,0 +1,93 @@
+%global commit0 aecec2aaef069fea56aa921cf5d7e449bb7a0b82
+%global date 20240624
+%global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
+%global commit1 a6dccbbf5a955489d20d996234b6ebb481183ed7
+%global date 20240416
+%global shortcommit1 %(c=%{commit0}; echo ${c:0:7})
+%define buildforkernels akmod
+%global debug_package %{nil}
+%global realname intel-ipu6
+
+Name:           %{realname}-kmod
+Version:        %{date}.%{shortcommit0}
+Release:        1%{?dist}
+Summary:        Kernel drivers for the IPU 6 and sensors
+License:        GPL-3.0-only
+URL:            https://github.com/intel/ipu6-drivers
+Source0:        https://github.com/intel/ipu6-drivers/archive/%{commit0}.tar.gz#/ipu6-drivers-%{shortcommit0}.tar.gz
+Source1:        https://github.com/intel/ivsc-driver/archive/%{commit1}.tar.gz#/ivsc-driver-%{shortcommit1}.tar.gz
+### intel/ipu6-drivers | PR #214 | Ipu6-isys probe improvements
+## https://github.com/intel/ipu6-drivers/pull/214
+Patch0:         0000-probe-improvements.patch
+### intel/ipu6-drivers | PR #239 | gc5035: Fix compilation with kernels >= 6.8
+## https://github.com/intel/ipu6-drivers/pull/239
+Patch1:         0001-fix-compilation-6.8.patch
+### intel/ipu6-drivers | PR #242 | media: ipu6: Fix compilation with kernels >= 6.10
+## https://github.com/intel/ipu6-drivers/pull/242
+Patch2:         0002-fix-compilation-6.10.patch
+### intel-ipu6-drivers | PR #243 | Rename ipu6 .ko files to avoid conflict with upstream ipu6 isys support
+## https://github.com/intel/ipu6-drivers/pull/243
+Patch3:         0003-prefix-modules.patch
+### intel/ipu6-drivers | PR #261 | media: ipu6: Fix compilation with kernels >= 6.11
+## https://github.com/intel/ipu6-drivers/pull/261
+Patch4:         0004-fix-compilation-6.11.patch
+### intel/ipu6-drivers | PR #283 | media: ipu6: Fix compilation with kernels >= 6.12
+## https://github.com/intel/ipu6-drivers/pull/283
+Patch5:         0005-fix-compilation-6.12.patch
+Patch6:         0006-fix-compilation-6.12-no-no_llseek.patch
+### jwrdegoede/ipu6-drivers | Commit 2c4ad13 | Makefile: Adjust which modules to build for which kernel-versions for Fedora
+## https://github.com/jwrdegoede/ipu6-drivers/commit/2c4ad1398dddfb307e8a40a714a6d5f70d6d14cb
+Patch7:         0007-modules-per-kernel.patch
+BuildRequires:  gcc
+BuildRequires:  elfutils-libelf-devel
+BuildRequires:  kmodtool
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra --kmodname %{realname} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"}) }
+
+%description
+Kernel drivers for Intel iVSC, IPU 6, and sensors.
+
+%prep
+%{?kmodtool_check}
+kmodtool  --target %{_target_cpu} --repo terra --kmodname %{realname} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"}
+
+%autosetup -p1 -n ipu6-drivers-%{commit0} -a 1
+
+cp -av ivsc-driver-%{commit1}/{backport-include,drivers,include} .
+rm -fr intel-vsc-%{commit1}
+
+for kernel_version in %{?kernel_versions}; do
+    mkdir _kmod_build_${kernel_version%%___*}
+    cp -fr backport-include drivers include Makefile _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version in %{?kernel_versions}; do
+    pushd _kmod_build_${kernel_version%%___*}/
+        %make_build -C "${kernel_version##*___}" M=$(pwd) VERSION="v%{version}" modules
+    popd
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+    mkdir -p %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+    install -p -m 0755 \
+        _kmod_build_${kernel_version%%___*}/*.ko \
+        _kmod_build_${kernel_version%%___*}/drivers/media/i2c/*.ko \
+        _kmod_build_${kernel_version%%___*}/drivers/media/pci/intel/ipu6/*.ko \
+        %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+done
+%{?akmod_install}
+
+### Reloading the modules is needed for %{PATCH0} to take effect properly on some kernels, as well for the changes to be properly reverted on uninstall.
+## See: https://github.com/intel/ipu6-drivers/pull/214#issuecomment-1986110818
+%post
+/usr/sbin/rmmod -f intel_ipu6_psys intel_ipu6_isys intel_ipu6
+/usr/sbin/modprobe -a intel_ipu6 intel_ipu6_isys intel_ipu6_psys
+
+%postun
+/usr/sbin/rmmod -f intel_ipu6_psys intel_ipu6_isys intel_ipu6
+/usr/sbin/modprobe -a intel_ipu6 intel_ipu6_isys intel_ipu6_psys
+
+%changelog
+%autochangelog

--- a/anda/system/ivsc-firmware/anda.hcl
+++ b/anda/system/ivsc-firmware/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "ivsc-firmware.spec"
+  }
+  labels {
+        weekly = 1
+    }
+}

--- a/anda/system/ivsc-firmware/ivsc-firmware.spec
+++ b/anda/system/ivsc-firmware/ivsc-firmware.spec
@@ -1,0 +1,39 @@
+%global debug_package %{nil}
+%global commit 10c214fea5560060d387fbd2fb8a1af329cb6232
+%global commitdate 20230811
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           ivsc-firmware
+Summary:        Intel iVSC firmware
+URL:            https://github.com/intel/ivsc-firmware
+Version:        %{commitdate}.%{shortcommit}
+Release:        1%{?dist}
+License:        Proprietary
+Source0:        https://github.com/intel/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
+Requires:       ipu6-camera-bins
+ExclusiveArch:  x86_64
+
+%description
+This provides the firmware for Intel iVSC for kernels below 6.10. Provided for potential LTS users.
+
+%prep
+%autosetup -n %{name}-%{commit}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_prefix}/lib/firmware/vsc/soc_a1
+mkdir -p %{buildroot}%{_prefix}/lib/firmware/vsc/soc_a1_prod
+pushd firmware/
+for i in *.bin; do
+  cp -a "$i" %{buildroot}%{_prefix}/lib/firmware/vsc/soc_a1/`echo "$i" | sed 's|\.bin|_a1\.bin|'`;
+  cp -a "$i" %{buildroot}%{_prefix}/lib/firmware/vsc/soc_a1_prod/`echo "$i" | sed 's|\.bin|_a1_prod\.bin|'`;
+done
+popd
+
+%files
+%license LICENSE
+%{_prefix}/lib/firmware/vsc/
+
+%changelog
+%autochangelog

--- a/anda/system/ivsc-firmware/update.rhai
+++ b/anda/system/ivsc-firmware/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("intel/ivsc-firmware"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [[IPU6 Part 1] Add: IPU6 Camera Stack (Without ipu6-camera-hal) (#2919)](https://github.com/terrapkg/packages/pull/2919)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)