### PR TITLE
[f41] fix: mise (#2936)

### DIFF
--- a/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
+++ b/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
@@ -1,11 +1,11 @@
---- mise-2024.12.14/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ mise-2024.12.14/Cargo.toml	2024-12-19T16:42:09.096450+00:00
-@@ -461,17 +461,6 @@
+--- mise-2025.1.6/Cargo.toml	1970-01-01T00:00:01+00:00
++++ mise-2025.1.6/Cargo.toml	2025-01-12T13:52:48.260853+00:00
+@@ -465,17 +465,6 @@
  ]
  default-features = false
  
 -[target."cfg(windows)".dependencies.self_update]
--version = "0.41"
+-version = "0.42"
 -features = [
 -    "archive-zip",
 -    "signatures",
@@ -18,7 +18,7 @@
  [lints.clippy]
  borrowed_box = "allow"
  
-@@ -479,3 +468,4 @@
+@@ -483,3 +472,4 @@
  level = "warn"
  priority = 0
  check-cfg = ["cfg(coverage,coverage_nightly)"]

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -7,7 +7,7 @@ Name:           rust-mise
 Version:        2025.1.6
 Release:        1%?dist
 Summary:        Front-end to your dev env
-Provides:       mise
+
 License:        MIT
 URL:            https://crates.io/crates/mise
 Source:         %{crates_source}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: mise (#2936)](https://github.com/terrapkg/packages/pull/2936)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)