### PR TITLE
fix: nvidia-driver

### DIFF
--- a/anda/system/nvidia/nvidia-driver/anda.hcl
+++ b/anda/system/nvidia/nvidia-driver/anda.hcl
@@ -8,5 +8,6 @@ project "pkg" {
     arches = ["x86_64", "aarch64", "i386"]
     labels = {
         subrepo = "nvidia"
+        mock = 1
     }
 }


### PR DESCRIPTION
Forces the NVIDIA driver to build using Mock because we're doing multilib