### PR TITLE
Force all multilib packages to build inside a mock chroot

### DIFF
--- a/anda/games/gamescope-legacy/anda.hcl
+++ b/anda/games/gamescope-legacy/anda.hcl
@@ -2,5 +2,6 @@ project pkg {
     arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "gamescope-legacy.spec"
+        mock = 1
     }
 }

--- a/anda/games/gamescope/anda.hcl
+++ b/anda/games/gamescope/anda.hcl
@@ -4,6 +4,7 @@ project pkg {
 		spec = "gamescope.spec"
 	}
 	labels {
+		mock = 1
 		subrepo = "extras"
 	}
 }

--- a/anda/lib/mesa/anda.hcl
+++ b/anda/lib/mesa/anda.hcl
@@ -4,7 +4,7 @@ project pkg {
 		spec = "mesa.spec"
 	}
     labels {
-
+        mock = 1
         subrepo = "mesa"
     }
 }

--- a/anda/lib/nvidia/cuda-profiler/anda.hcl
+++ b/anda/lib/nvidia/cuda-profiler/anda.hcl
@@ -2,5 +2,6 @@ project pkg {
    arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "cuda-profiler.spec"
+        mock = 1
     }
 }

--- a/anda/lib/nvidia/cuda-sanitizer/anda.hcl
+++ b/anda/lib/nvidia/cuda-sanitizer/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
     rpm {
         spec = "cuda-sanitizer.spec"
     }
+    labels {
+        mock = 1
+    }
 }

--- a/anda/misc/extest/anda.hcl
+++ b/anda/misc/extest/anda.hcl
@@ -3,4 +3,8 @@ project pkg {
 	rpm {
 		spec = "rust-extest.spec"
 	}
+
+	labels {
+		mock = 1
+	}
 }

--- a/anda/system/nvidia/libva-nvidia-driver/anda.hcl
+++ b/anda/system/nvidia/libva-nvidia-driver/anda.hcl
@@ -5,5 +5,6 @@ project "pkg" {
     arches = ["x86_64", "aarch64", "i386"]
     labels = {
         subrepo = "nvidia"
+        mock = 1
     }
 }


### PR DESCRIPTION
Anda does not implement a forcearch mechanism yet, so every multilib package needs to still be built inside a mock container for it to actually output i686 builds