### PR TITLE
[f41] fix: nvidia-driver (#2940)

### DIFF
--- a/anda/system/nvidia/nvidia-driver/anda.hcl
+++ b/anda/system/nvidia/nvidia-driver/anda.hcl
@@ -8,5 +8,6 @@ project "pkg" {
     arches = ["x86_64", "aarch64", "i386"]
     labels = {
         subrepo = "nvidia"
+        mock = 1
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: nvidia-driver (#2940)](https://github.com/terrapkg/packages/pull/2940)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)