### PR TITLE
[f41] fix(yt-dlp): try using mock instead (#2935)

### DIFF
--- a/anda/tools/yt-dlp/anda.hcl
+++ b/anda/tools/yt-dlp/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		nightly = "1"
+		mock = 1
 	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(yt-dlp): try using mock instead (#2935)](https://github.com/terrapkg/packages/pull/2935)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)