### PR TITLE
[f40] fix: mkfstab&#x60; (#2949)

### DIFF
--- a/anda/langs/nim/mkfstab/mkfstab.spec
+++ b/anda/langs/nim/mkfstab/mkfstab.spec
@@ -15,7 +15,7 @@ An alternative to genfstab from Arch Linux. This is a dead simple but faster imp
 
 %build
 nimble setup -y
-nim c %nim_c src/%name
+%nim_c src/%name
 
 %install
 install -Dpm755 src/%name %buildroot%_bindir/%name


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: mkfstab&#x60; (#2949)](https://github.com/terrapkg/packages/pull/2949)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)