### PR TITLE
[f41] fix(nim): do not symlink the dist directory (#2955)

### DIFF
--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,13 +1,13 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit d83ff81695096fac8fa230b91a254c4287041173
+%global commit 7dfadb8b4e95d09981fbeb01d85b12f23946c3e7
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global ver 2.3.1
-%global commit_date 20250114
+%global ver 2.2.1
+%global commit_date 20241004
 %global debug_package %nil
 
 Name:			nim-nightly
 Version:		%ver^%commit_date.%shortcommit
-Release:		1%?dist
+Release:		3%?dist
 Summary:		Imperative, multi-paradigm, compiled programming language
 License:		MIT and BSD
 URL:			https://nim-lang.org
@@ -125,7 +125,8 @@ rm -rf %buildroot/nim || true
 rm %buildroot%_bindir/*.bat || true
 
 cp -r dist %buildroot%_prefix/lib/nim/
-ln -s %_prefix/lib/nim/dist %buildroot%_datadir/nim/dist
+# cannot use `ln` here, possibly a nim bug
+cp -r %buildroot%_prefix/lib/nim/dist %buildroot%_datadir/nim/
 
 
 %files

--- a/anda/langs/nim/nim/nim.spec
+++ b/anda/langs/nim/nim/nim.spec
@@ -120,7 +120,8 @@ rm %buildroot%_bindir/*.bat || true
 rm -rf %buildroot%_bindir/empty.txt
 
 cp -r dist %buildroot%_prefix/lib/nim/
-ln -s %_prefix/lib/nim/dist %buildroot%_datadir/nim/dist
+# cannot use `ln` here, possibly a nim bug
+cp -r %buildroot%_prefix/lib/nim/dist %buildroot%_datadir/nim/
 
 
 %files


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(nim): do not symlink the dist directory (#2955)](https://github.com/terrapkg/packages/pull/2955)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)