### PR TITLE
[f41] Add: libnvidia-container (#2954)

### DIFF
--- a/anda/lib/nvidia/libnvidia-container/anda.hcl
+++ b/anda/lib/nvidia/libnvidia-container/anda.hcl
@@ -1,0 +1,9 @@
+project "pkg" {
+    rpm {
+        spec = "libnvidia-container.spec"
+    }
+    labels = {
+        subrepo = "nvidia"
+        mock = 1
+    }
+}

--- a/anda/lib/nvidia/libnvidia-container/fix-debug-packages.patch
+++ b/anda/lib/nvidia/libnvidia-container/fix-debug-packages.patch
@@ -1,0 +1,32 @@
+--- a/Makefile
++++ b/Makefile
+@@ -219,22 +219,14 @@
+ -include $(DEPENDENCIES)
+ 
+ $(LIB_SHARED): $(LIB_OBJS)
+-	$(MKDIR) -p $(DEBUG_DIR)
+ 	$(CC) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(LIB_LDFLAGS) $(OUTPUT_OPTION) $^ $(LIB_SCRIPT) $(LIB_LDLIBS)
+-	$(OBJCPY) --only-keep-debug $@ $(LIB_SONAME)
+-	$(OBJCPY) --add-gnu-debuglink=$(LIB_SONAME) $@
+-	$(MV) $(LIB_SONAME) $(DEBUG_DIR)
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ $(LIB_STATIC_OBJ): $(LIB_OBJS)
+ 	# FIXME Handle user-defined LDFLAGS and LDLIBS
+ 	$(LD) -d -r --exclude-libs ALL -L$(DEPS_DIR)$(libdir) $(OUTPUT_OPTION) $^ $(LIB_LDLIBS_STATIC)
+-	$(OBJCPY) --localize-hidden $@
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ $(BIN_NAME): $(BIN_OBJS)
+ 	$(CC) $(BIN_CFLAGS) $(BIN_CPPFLAGS) $(BIN_LDFLAGS) $(OUTPUT_OPTION) $^ $(BIN_SCRIPT) $(BIN_LDLIBS)
+-	$(STRIP) --strip-unneeded -R .comment $@
+ 
+ ##### Public rules #####
+ 
+@@ -281,6 +281,4 @@ endif
+ 	$(LDCONFIG) -n $(DESTDIR)$(libdir)
+-	# Install debugging symbols
+-	$(INSTALL) -m 644 $(DEBUG_DIR)/$(LIB_SONAME) $(DESTDIR)$(libdbgdir)
+ 	# Install configuration files
+ 	$(MAKE_DIR)/$(LIB_PKGCFG).in "$(strip $(VERSION))" "$(strip $(LIB_LDLIBS_SHARED))" > $(DESTDIR)$(pkgconfdir)/$(LIB_PKGCFG)
+ 	# Install binary files

--- a/anda/lib/nvidia/libnvidia-container/fix-makefile.patch
+++ b/anda/lib/nvidia/libnvidia-container/fix-makefile.patch
@@ -1,0 +1,12 @@
+--- a/Makefile
++++ b/Makefile
+@@ -165,6 +165,9 @@ ifeq ($(WITH_TIRPC), yes)
+ LIB_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
+ LIB_LDLIBS_STATIC  += -l:libtirpc.a
+ LIB_LDLIBS_SHARED  += -lpthread
++else
++CPPFLAGS           += -I/usr/include/tirpc
++LIB_LDLIBS_SHARED  += -lpthread -ltirpc
+ endif
+ ifeq ($(WITH_SECCOMP), yes)
+ LIB_CPPFLAGS       += -DWITH_SECCOMP $(shell pkg-config --cflags libseccomp)

--- a/anda/lib/nvidia/libnvidia-container/fix-revision.patch
+++ b/anda/lib/nvidia/libnvidia-container/fix-revision.patch
@@ -1,0 +1,17 @@
+--- a/mk/common.mk
++++ b/mk/common.mk
+@@ -19,6 +19,7 @@
+ BMAKE    ?= MAKEFLAGS= bmake
+ DOCKER   ?= docker
+ PATCH    ?= patch
++REVISION ?= $(shell git rev-parse HEAD)
+ 
+ UID      := $(shell id -u)
+ GID      := $(shell id -g)
+@@ -27,7 +28,6 @@
+ else
+     DATE := $(shell date -u --iso-8601=minutes)
+ endif
+-REVISION ?= $(shell git rev-parse HEAD)
+ COMPILER := $(realpath $(shell which $(CC)))
+ PLATFORM ?= $(shell uname -m)

--- a/anda/lib/nvidia/libnvidia-container/libnvidia-container.spec
+++ b/anda/lib/nvidia/libnvidia-container/libnvidia-container.spec
@@ -1,0 +1,111 @@
+%global _major 1
+
+Name:           libnvidia-container
+Version:        1.17.3
+Release:        1%{?dist}
+Summary:        NVIDIA container runtime library
+License:        BSD-3-Clause AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND GPL-2.0-only
+Vendor:         NVIDIA Corporation
+URL:            https://github.com/NVIDIA/%{name}
+Source0:        https://github.com/NVIDIA/%{name}/archive/v%{version}.tar.gz
+Patch0:         fix-revision.patch
+Patch1:         fix-makefile.patch
+Patch2:         fix-debug-packages.patch
+BuildRequires:  bmake
+BuildRequires:  elfutils-libelf-devel
+BuildRequires:  gcc
+BuildRequires:  git
+BuildRequires:  golang
+BuildRequires:  libcap-devel
+BuildRequires:  libtirpc-devel
+BuildRequires:  libseccomp-devel
+BuildRequires:  rpcgen
+
+%description
+The nvidia-container library provides an interface to configure containers using NVIDIA hardware.
+
+%prep
+rm -rf ./*
+### Must be built this way because the Makefile expects be to in a Git directory.
+git clone https://github.com/NVIDIA/%{name}.git
+cd %{name}
+git checkout v%{version}
+%autopatch -p1
+
+%build
+cd %{name}
+make distclean
+%make_build REVISION=%{version} WITH_LIBELF=yes
+
+%install
+cd %{name}
+make install DESTDIR=%{buildroot} REVISION=%{version} WITH_LIBELF=yes \
+             LDCONFIG=/bin/true \
+             prefix=%{_prefix} \
+             exec_prefix=%{_exec_prefix} \
+             bindir=%{_bindir} \
+             libdir=%{_libdir} \
+             includedir=%{_includedir} \
+             docdir=%{_licensedir}
+
+%package -n %{name}%{_major}
+Summary:        NVIDIA container runtime library
+Requires:       nvidia-driver >= 340.29
+%description -n %{name}%{_major}
+The nvidia-container library provides an interface to configure containers using NVIDIA hardware.
+
+%post -n %{name}%{_major} -p /sbin/ldconfig
+%postun -n %{name}%{_major} -p /sbin/ldconfig
+
+%package devel
+Requires:       %{name}%{_major}%{?_isa} = %{version}-%{release}
+Summary:        NVIDIA container runtime library development files
+Requires:       nvidia-driver >= 340.29
+%description devel
+This package contains the files required to compile programs with the library.
+
+%package static
+Requires:      %{name}-devel%{?_isa} = %{version}-%{release}
+Summary:        NVIDIA container runtime library static library
+Requires:       nvidia-driver >= 340.29
+%description static
+The nvidia-container library provides an interface to configure containers using NVIDIA hardware.
+
+%package tools
+Requires:       %{name}%{_major}%{?_isa} >= %{version}-%{release}
+Summary:        NVIDIA container runtime library command-line tools
+Requires:       nvidia-driver >= 340.29
+%description tools
+This package contains command-line tools that facilitate using the nvidia-container library.
+
+%package   libseccomp2
+Requires:  libseccomp2
+Provides:  libseccomp.so
+Conflicts: libseccomp.so
+Summary:   A virtual package to provide libseccomp through libseccomp2
+%description libseccomp2
+This is a virtual package to satisfy the libseccomp.so dependency through a transitive dependency on libseccomp2.so.
+
+%files -n %{name}%{_major}
+%license %{_licensedir}/*
+%{_libdir}/lib*.so.*
+
+%files devel
+%license %{_licensedir}/*
+%{_includedir}/*.h
+%{_libdir}/lib*.so
+%{_libdir}/pkgconfig/*.pc
+
+%files static
+%license %{_licensedir}/*
+%{_libdir}/lib*.a
+
+%files tools
+%license %{_licensedir}/*
+%{_bindir}/*
+
+%files libseccomp2
+%license %{_licensedir}/*
+
+%changelog
+%autochangelog

--- a/anda/lib/nvidia/libnvidia-container/update.rhai
+++ b/anda/lib/nvidia/libnvidia-container/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("NVIDIA/libnvidia-container"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Add: libnvidia-container (#2954)](https://github.com/terrapkg/packages/pull/2954)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)