### PR TITLE
Add: AAC

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -3,7 +3,7 @@ project pkg {
     spec = "fdk-aac.spec"
   }
   labels {
-        subrepo = extras
+        subrepo = "extras"
         weekly = 1
     }
 }

--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -3,7 +3,7 @@ project pkg {
     spec = "fdk-aac.spec"
   }
   labels {
-        extra = 1
+        subrepo = extras
         weekly = 1
     }
 }

--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+  rpm {
+    spec = "fdk-aac.spec"
+  }
+  labels {
+        extra = 1
+        weekly = 1
+    }
+}

--- a/anda/lib/fdk-aac/fdk-aac.spec
+++ b/anda/lib/fdk-aac/fdk-aac.spec
@@ -1,0 +1,59 @@
+Name:           fdk-aac
+Version:        2.0.3
+Release:        1%{?dist}
+Summary:        Fraunhofer FDK Advanced Audio Coding Codec Library
+License:        Software License for The Fraunhofer FDK AAC Codec Library for Android
+URL:            http://sourceforge.net/projects/opencore-amr/
+Source0:        https://github.com/mstorsjo/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
+Provides:       fdk-aac = %{version}-%{release}
+Provides:       fdk-aac%{?_isa} = %{version}-%{release}
+Obsoletes:      fdk-aac < %{version}-%{release}
+Provides:       fdk-aac-free = %{version}-%{release}
+Provides:       fdk-aac-free%{?_isa} = %{version}-%{release}
+Obsoletes:      fdk-aac-free < %{version}-%{release}
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  gcc-c++
+BuildRequires:  libtool
+
+%description
+Fraunhofer FDK Advanced Audio Coding Codec Library for Android.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Provides:       fdk-aac-devel = %{version}-%{release}
+Provides:       fdk-aac-devel%{?_isa} = %{version}-%{release}
+Obsoletes:      fdk-aac-devel < %{version}-%{release}
+Provides:       fdk-aac-free-devel = %{version}-%{release}
+Provides:       fdk-aac-free-devel%{?_isa} = %{version}-%{release}
+Obsoletes:      fdk-aac-free-devel < %{version}-%{release}
+
+%description    devel
+This package contains libraries and header files for developing applications that use %{name}.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+autoreconf -vif
+%configure --disable-static
+%make_build
+
+%install
+%make_install
+find %{buildroot} -name "*.la" -delete
+
+%files
+%license NOTICE
+%doc ChangeLog
+%{_libdir}/lib%{name}*.so.*
+
+%files devel
+%doc documentation/*
+%{_includedir}/*
+%{_libdir}/lib%{name}.so
+%{_libdir}/pkgconfig/fdk-aac.pc
+
+%changelog
+%autochangelog

--- a/anda/lib/fdk-aac/update.rhai
+++ b/anda/lib/fdk-aac/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("mstorsjo/fdk-aac"));

--- a/anda/lib/vo-aacenc/anda.hcl
+++ b/anda/lib/vo-aacenc/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "vo-aacenc.spec"
+  }
+  labels {
+        weekly = 1
+    }
+}

--- a/anda/lib/vo-aacenc/update.rhai
+++ b/anda/lib/vo-aacenc/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("mstorsjo/vo-aacenc"));

--- a/anda/lib/vo-aacenc/vo-aacenc.spec
+++ b/anda/lib/vo-aacenc/vo-aacenc.spec
@@ -1,0 +1,52 @@
+Name:           vo-aacenc
+Version:        0.1.3
+Release:        1%{?dist}
+Summary:        VisualOn AAC encoder library
+License:        ASL 2.0
+URL:            http://sourceforge.net/projects/opencore-amr/
+Source0:        http://downloads.sourceforge.net/opencore-amr/%{name}/%{name}-%{version}.tar.gz
+BuildRequires:  gcc
+
+%description
+This library contains an encoder implementation of the Advanced Audio
+Coding (AAC) audio codec. The library is based on a codec implementation
+by VisualOn as part of the Stagefright framework from the Google
+Android project.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%configure --disable-static
+make %{?_smp_mflags}
+
+%install
+%make_install
+find %{buildroot} -name '*.la' -delete
+
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%license COPYING NOTICE
+%doc ChangeLog
+%{_libdir}/*.so.*
+
+%files devel
+%{_includedir}/*
+%{_libdir}/*.so
+%{_libdir}/pkgconfig/vo-aacenc.pc
+
+
+%changelog
+%autochangelog


### PR DESCRIPTION
The complete version of `fdk-aac` and `vo-aacenc` (latter omitted from Fedora). Needed for GStreamer.

Related:
- #2877