### PR TITLE
[f40] fix: dive (#2986)

### DIFF
--- a/anda/langs/nim/dive/umdive.spec
+++ b/anda/langs/nim/dive/umdive.spec
@@ -7,7 +7,7 @@ URL:            https://github.com/Ultramarine-Linux/dive
 Source0:		%url/archive/refs/tags/v%version.tar.gz
 Requires:       (%_bindir/chroot or %_sbindir/chroot)
 Requires:       %_bindir/mount
-BuildRequires:  anda-srpm-macros nim
+BuildRequires:  anda-srpm-macros nim mock
 Provides:       dive = %version-%release
 
 %description
@@ -15,10 +15,10 @@ Provides:       dive = %version-%release
 
 %prep
 %autosetup -n dive-%version
+%nim_prep
 
 %build
-nimble setup -y
-nim c %nim_c src/dive
+%nim_c src/dive
 
 %install
 install -Dpm755 src/dive %buildroot%_bindir/dive


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: dive (#2986)](https://github.com/terrapkg/packages/pull/2986)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)