### PR TITLE
[el10] bump: choosenim (#2017)

### DIFF
--- a/anda/langs/nim/choosenim/choosenim.spec
+++ b/anda/langs/nim/choosenim/choosenim.spec
@@ -1,22 +1,32 @@
+
 Name:			choosenim
-Version:		0.8.4
+Version:		0.8.9
 Release:		1%?dist
 Summary:		Easily install and manage multiple versions of the Nim programming language
 License:		BSD-3-Clause
-URL:			https://github.com/dom96/choosenim
-Source0:		%url/archive/refs/tags/v%version.tar.gz
-BuildRequires:	nim git
+URL:			https://github.com/nim-lang/choosenim
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+# Fix for https://github.com/nim-lang/choosenim/issues/13
+Patch0:         https://patch-diff.githubusercontent.com/raw/nim-lang/choosenim/pull/38.patch
+Packager:		madonuko <mado@fyralabs.com>
+BuildRequires:  nim
+BuildRequires:	git-core anda-srpm-macros
 
 %description
 choosenim installs the Nim programming language from official downloads and
 sources, enabling you to easily switch between stable and development compilers.
 
 %prep
-%autosetup
+%autosetup -p1
+#? https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=choosenim
+# we compile proxyexe in a separate step
+sed -i -e '/static: compileProxyexe()/d' src/choosenimpkg/switcher.nim
+%nim_prep
 
 %build
-nimble setup -y
-nim c -t:-fPIE -l:-pie -d:release -t:"$CFLAGS" -l:"$LDFLAGS" src/choosenim
+%nim_c -p:/usr/lib/nim/dist/nimble/src/ -p:`pwd` src/choosenimpkg/proxyexe
+strip src/choosenimpkg/proxyexe
+%nim_c -p:/usr/lib/nim/dist/nimble/src/ -p:`pwd` src/choosenim
 
 %install
 install -Dm755 src/choosenim %buildroot%_bindir/choosenim

--- a/anda/langs/nim/choosenim/update.rhai
+++ b/anda/langs/nim/choosenim/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("dom96/choosenim"));
+rpm.version(gh("nim-lang/choosenim"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [bump: choosenim (#2017)](https://github.com/terrapkg/packages/pull/2017)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)