### PR TITLE
[f41] fix(libcusparselt): update.rhai (#3007)

### DIFF
--- a/anda/lib/nvidia/libcusparselt/update.rhai
+++ b/anda/lib/nvidia/libcusparselt/update.rhai
@@ -1,4 +1,4 @@
-let series = "0.6.3"
+let series = "0.6.3";
 let url = `https://developer.download.nvidia.com/compute/cusparselt/redist/redistrib_${series}.json`;
 let json = get(url).json();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(libcusparselt): update.rhai (#3007)](https://github.com/terrapkg/packages/pull/3007)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)