### PR TITLE
[f41] fix(cuda-cudnn): update.rhai (#3006)

### DIFF
--- a/anda/lib/nvidia/cuda-cudnn/update.rhai
+++ b/anda/lib/nvidia/cuda-cudnn/update.rhai
@@ -1,5 +1,5 @@
 import "andax/nvidia.rhai" as nvidia;
-let series = "9.6.0"
+let series = "9.6.0";
 let url = `https://developer.download.nvidia.com/compute/cudnn/redist/redistrib_${series}.json`;
 let json = get(url).json();
 rpm.version(json["cudnn"]["version"]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(cuda-cudnn): update.rhai (#3006)](https://github.com/terrapkg/packages/pull/3006)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)