### PR TITLE
add: sticky

### DIFF
--- a/anda/apps/sticky/anda.hcl
+++ b/anda/apps/sticky/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "sticky.spec"
+  }
+}

--- a/anda/apps/sticky/point-executable-to-sitepackages-directory.patch
+++ b/anda/apps/sticky/point-executable-to-sitepackages-directory.patch
@@ -1,0 +1,9 @@
+diff --git a/usr/bin/sticky b/usr/bin/sticky
+index 7425e9c..a00e755 100755
+--- a/usr/bin/sticky
++++ b/usr/bin/sticky
+@@ -1,3 +1,3 @@
+ #!/bin/bash
+ 
+-/usr/lib/sticky/sticky.py $*
++/usr/lib/python3*/site-packages/sticky/sticky.py $*

--- a/anda/apps/sticky/remove-meson-postinstall-script.patch
+++ b/anda/apps/sticky/remove-meson-postinstall-script.patch
@@ -1,0 +1,9 @@
+diff --git a/meson.build b/meson.build
+index b25d642..435a6f0 100644
+--- a/meson.build
++++ b/meson.build
+@@ -17,4 +17,3 @@ subdir('po')
+ install_subdir('etc', install_dir: sysconfdir, strip_directory: true)
+ install_subdir('usr', install_dir: prefix, strip_directory: true)
+ 
+-meson.add_install_script('meson/meson-postinstall.sh')

--- a/anda/apps/sticky/sticky.spec
+++ b/anda/apps/sticky/sticky.spec
@@ -1,0 +1,62 @@
+%global debug_package %{nil}
+
+Name:           sticky
+Version:        1.24
+Release:        1%{?dist}
+Summary:        A sticky notes app for the Linux desktop
+
+License:        GPL-2.0
+URL:            https://github.com/linuxmint/sticky
+Source0:        %{url}/archive/%{version}.tar.gz
+Patch0:         remove-meson-postinstall-script.patch
+Patch1:         point-executable-to-sitepackages-directory.patch
+
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  meson
+BuildRequires:  gettext-devel
+
+Requires:       python3
+Requires:       glib2
+Requires:       gspell
+Requires:       gtk3
+Requires:       python3-gobject-base
+Requires:       python3-xapp
+Requires:       xapps
+
+Packager:       sadlerm <sad_lerm@hotmail.com>
+
+%description
+Sticky is a note-taking app for the Linux desktop that simulates traditional "sticky note" style stationery on your desktop. Some of its features include basic text formatting (bold, italics, monospaced, etc.), spell-checking, a tray icon for controlling note visibility, color notes, manual and automatic backups, and a manager to organize your notes into groups.
+
+%prep
+%autosetup -p1
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+mkdir -p %{buildroot}%{python3_sitelib}
+mv -v %{buildroot}%{_prefix}/lib/%{name} %{buildroot}%{python3_sitelib}/%{name}
+
+%files
+%license COPYING
+%doc README.md
+%{_bindir}/%{name}
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/glib-2.0/schemas/org.x.%{name}.gschema.xml
+%{_datadir}/icons/hicolor/scalable/apps/%{name}*.svg
+%{_datadir}/icons/hicolor/scalable/status/%{name}*.svg
+%{_datadir}/locale/*/LC_MESSAGES/%{name}.mo
+%{_datadir}/%{name}/*
+%{_sysconfdir}/xdg/autostart/%{name}.desktop
+%{_datadir}/dbus-1/services/org.x.%{name}.service
+%{python3_sitelib}/%{name}/*.py
+%{python3_sitelib}/%{name}/__pycache__/*.pyc
+
+%changelog
+* Thu Jan 16 2025 sadlerm4 <sad_lerm@hotmail.com>
+- Initial package


### PR DESCRIPTION
Closes #2754 

patches are needed because packaging bytecode cache for python source is a fedora requirement

apparently dnf will automatically run ``glib-compile-schemas`` and ``gtk-update-icon-cache``, so the meson postinstall script is not needed - would appreciate confirmation on this