### PR TITLE
[f40] Fix (protobuf): Move to Extras (#3013)

### DIFF
--- a/anda/langs/python/protobuf/anda.hcl
+++ b/anda/langs/python/protobuf/anda.hcl
@@ -1,5 +1,8 @@
 project pkg {
 	rpm {
-		spec = "python3-protobuf.spec"
+	  spec = "python3-protobuf.spec"
 	}
+        labels {
+          subrepo = "extras"
+     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Fix (protobuf): Move to Extras (#3013)](https://github.com/terrapkg/packages/pull/3013)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)