### PR TITLE
[f41] fix(ghostty): additional licenses, new upstream files (#2890)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -6,9 +6,9 @@
 
 Name:           ghostty-nightly
 Version:        %{commit_date}.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        A fast, native terminal emulator written in Zig; this is the Tip (nightly) build.
-License:        MIT AND MPL-2.0 AND OFL-1.1
+License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
 URL:            https://ghostty.org/
 Source0:        https://github.com/ghostty-org/ghostty/archive/%{commit}/ghostty-%{commit}.tar.gz
 BuildRequires:  gtk4-devel
@@ -105,9 +105,12 @@ zig build \
 %_datadir/bat/syntaxes/ghostty.sublime-syntax
 %_datadir/ghostty/
 %_datadir/kio/servicemenus/com.mitchellh.ghostty.desktop
+%_datadir/nautilus-python/extensions/com.mitchellh.ghostty.py
+%_datadir/nvim/site/compiler/ghostty.vim
 %_datadir/nvim/site/ftdetect/ghostty.vim
 %_datadir/nvim/site/ftplugin/ghostty.vim
 %_datadir/nvim/site/syntax/ghostty.vim
+%_datadir/vim/vimfiles/compiler/ghostty.vim
 %_datadir/vim/vimfiles/ftdetect/ghostty.vim
 %_datadir/vim/vimfiles/ftplugin/ghostty.vim
 %_datadir/vim/vimfiles/syntax/ghostty.vim

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -5,9 +5,9 @@
 
 Name:           ghostty
 Version:        1.0.1
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        A fast, native terminal emulator written in Zig.
-License:        MIT AND MPL-2.0 AND OFL-1.1
+License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
 URL:            https://ghostty.org/
 Source0:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz
 Source1:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz.minisig
@@ -152,8 +152,8 @@ zig build \
 %changelog
 * Tue Dec 31 2024 ShinyGil <rockgrub@protonmail.com>
 - Update to 1.0.1
-    * High CVE-2003-0063: Allows execution of arbitrary commands
-    * Medium CVE-2003-0070: Allows execution of arbitrary commands
+ * High CVE-2003-0063: Allows execution of arbitrary commands
+ * Medium CVE-2003-0070: Allows execution of arbitrary commands
 
 * Thu Dec 26 2024 ShinyGil <rockgrub@protonmail.com>
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(ghostty): additional licenses, new upstream files (#2890)](https://github.com/terrapkg/packages/pull/2890)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)