### PR TITLE
[f41] feat(ghostty): adhere closer to packaging guidelines (#3021)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,18 +1,20 @@
 %global commit ff9414d9ea7b16a375d41cde8f6f193de7e5db72
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20250116
-
+%global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global cache_dir %{builddir}/zig-cache
 
 Name:           ghostty-nightly
 Version:        %{commit_date}.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A fast, native terminal emulator written in Zig; this is the Tip (nightly) build.
 License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
 URL:            https://ghostty.org/
-Source0:        https://github.com/ghostty-org/ghostty/archive/%{commit}/ghostty-%{commit}.tar.gz
+Source0:        https://github.com/ghostty-org/ghostty/releases/download/tip/ghostty-source.tar.gz
+Source1:        https://github.com/ghostty-org/ghostty/releases/download/tip/ghostty-source.tar.gz.minisig
 BuildRequires:  gtk4-devel
 BuildRequires:  libadwaita-devel
+BuildRequires:  minisign
 BuildRequires:  ncurses
 BuildRequires:  ncurses-devel
 BuildRequires:  pandoc-cli
@@ -76,7 +78,8 @@ Supplements:    %{name}
 %summary.
 
 %prep
-%autosetup -n ghostty-%{commit} -p1
+/usr/bin/minisign -V -m %{SOURCE0} -x %{SOURCE1} -P %{public_key}
+%autosetup -n ghostty-source
 
 # Download everything ahead of time so we can enable system integration mode
 ZIG_GLOBAL_CACHE_DIR="%{cache_dir}" ./nix/build-support/fetch-zig-cache.sh


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(ghostty): adhere closer to packaging guidelines (#3021)](https://github.com/terrapkg/packages/pull/3021)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)