### PR TITLE
[f41] fix: multimedia arches (#2993)

### DIFF
--- a/anda/lib/libfreeaptx/anda.hcl
+++ b/anda/lib/libfreeaptx/anda.hcl
@@ -1,8 +1,10 @@
 project pkg {
+  arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "libfreeaptx.spec"
   }
   labels {
         weekly = 1
+        mock = 1
     }
 }

--- a/anda/lib/rtmpdump/anda.hcl
+++ b/anda/lib/rtmpdump/anda.hcl
@@ -1,5 +1,9 @@
 project pkg {
+    arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "rtmpdump.spec"
+  }
+  labels {
+    mock =1
   }
 }

--- a/anda/lib/vo-aacenc/anda.hcl
+++ b/anda/lib/vo-aacenc/anda.hcl
@@ -1,8 +1,10 @@
 project pkg {
+  arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "vo-aacenc.spec"
   }
   labels {
         weekly = 1
+        mock = 1
     }
 }

--- a/anda/multimedia/faad2/anda.hcl
+++ b/anda/multimedia/faad2/anda.hcl
@@ -1,5 +1,9 @@
 project pkg {
+    arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "faad2.spec"
     }
+    labels {
+        mock = 1
+   }
 }

--- a/anda/multimedia/ffmpeg/anda.hcl
+++ b/anda/multimedia/ffmpeg/anda.hcl
@@ -1,8 +1,10 @@
 project pkg {
+    arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "ffmpeg.spec"
     }
     labels {
         updbranch = 1
+        mock = 1
     }
 }

--- a/anda/multimedia/x264-bootstrap/anda.hcl
+++ b/anda/multimedia/x264-bootstrap/anda.hcl
@@ -1,5 +1,9 @@
 project pkg {
+    arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "x264-bootstrap.spec"
+    }
+    labels {
+        mock = 1
     }
 }

--- a/anda/multimedia/x264/anda.hcl
+++ b/anda/multimedia/x264/anda.hcl
@@ -1,5 +1,9 @@
 project pkg {
+    arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "x264.spec"
+    }
+    labels { 
+        mock = 1
     }
 }

--- a/anda/multimedia/x265/anda.hcl
+++ b/anda/multimedia/x265/anda.hcl
@@ -1,5 +1,9 @@
 project pkg {
+    arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "x265.spec"
     }
+    labels {
+        mock =1
+   }
 }

--- a/anda/multimedia/x265/x265-high-bit-depth-soname.patch
+++ b/anda/multimedia/x265/x265-high-bit-depth-soname.patch
@@ -1,0 +1,31 @@
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -611,7 +611,15 @@
+     if(MSVC)
+         set_target_properties(x265-shared PROPERTIES OUTPUT_NAME libx265)
+     else()
+-        set_target_properties(x265-shared PROPERTIES OUTPUT_NAME x265)
++        if(HIGH_BIT_DEPTH)
++            if(MAIN12)
++                set_target_properties(x265-shared PROPERTIES OUTPUT_NAME x265_main12)
++            else()
++                set_target_properties(x265-shared PROPERTIES OUTPUT_NAME x265_main10)
++            endif()
++        else()
++            set_target_properties(x265-shared PROPERTIES OUTPUT_NAME x265)
++        endif(HIGH_BIT_DEPTH)
+     endif()
+     if(UNIX)
+         set_target_properties(x265-shared PROPERTIES VERSION ${X265_BUILD})
+--- a/source/encoder/api.cpp
++++ b/source/encoder/api.cpp
+@@ -704,7 +704,7 @@
+ #define ext ".dylib"
+ #else
+ #include <dlfcn.h>
+-#define ext ".so"
++#define ext ".so." xstr(X265_BUILD)
+ #endif
+ #if defined(__GNUC__) && __GNUC__ >= 8
+ #pragma GCC diagnostic ignored "-Wcast-function-type"
+

--- a/anda/multimedia/x265/x265-pic.patch
+++ b/anda/multimedia/x265/x265-pic.patch
@@ -1,0 +1,11 @@
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -212,7 +212,7 @@
+         add_definitions(-std=gnu++98)
+     endif()
+     if(ENABLE_PIC)
+-         add_definitions(-fPIC)
++         add_definitions(-fPIC -DPIC)
+     endif(ENABLE_PIC)
+     if(NATIVE_BUILD)
+         if(INTEL_CXX)

--- a/anda/multimedia/x265/x265-pkgconfig_path_fix.patch
+++ b/anda/multimedia/x265/x265-pkgconfig_path_fix.patch
@@ -1,0 +1,11 @@
+--- a/source/x265.pc.in
++++ b/source/x265.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${exec_prefix}/@LIB_INSTALL_DIR@
++libdir=@LIB_INSTALL_DIR@
+ includedir=${prefix}/include
+ 
+ Name: @CMAKE_PROJECT_NAME@
+

--- a/anda/multimedia/x265/x265-sei-length-crash-fix.patch
+++ b/anda/multimedia/x265/x265-sei-length-crash-fix.patch
@@ -1,0 +1,29 @@
+From 8454caf458c5f5d20cce711ff8ea8de55ec1ae50 Mon Sep 17 00:00:00 2001
+From: harlanc <hailiang8@staff.weibo.com>
+Date: Thu, 1 Dec 2022 07:46:13 +0000
+Subject: [PATCH] fix crash when SEI length is variable
+
+---
+ source/encoder/encoder.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/source/encoder/encoder.cpp b/source/encoder/encoder.cpp
+index 0fea6553c..5a3fcafc7 100644
+--- a/source/encoder/encoder.cpp
++++ b/source/encoder/encoder.cpp
+@@ -1103,6 +1103,12 @@ void Encoder::copyUserSEIMessages(Frame *frame, const x265_picture* pic_in)
+                 input = seiMsg;
+             else
+                 input = pic_in->userSEI.payloads[i];
++            
++            if (frame->m_userSEI.payloads[i].payload && (frame->m_userSEI.payloads[i].payloadSize < input.payloadSize))
++            {
++                delete[] frame->m_userSEI.payloads[i].payload;
++                frame->m_userSEI.payloads[i].payload = NULL;
++            }
+ 
+             if (!frame->m_userSEI.payloads[i].payload)
+                 frame->m_userSEI.payloads[i].payload = new uint8_t[input.payloadSize];
+-- 
+2.45.0
+

--- a/anda/multimedia/x265/x265.spec
+++ b/anda/multimedia/x265/x265.spec
@@ -1,3 +1,5 @@
+%global build_cxxflags %{__build_flags_lang_cxx} %{?_distro_extra_cxxflags} -include %_includedir/c++/*/cstdint
+
 # Use old cmake macro
 %global __cmake_in_source_build 1
 
@@ -24,6 +26,7 @@ Patch2:     https://raw.githubusercontent.com/terrapkg/pkg-x265/%terrasrc_commit
 Patch3:     https://bitbucket.org/harlancc/x265_git/commits/8454caf458c5f5d20cce711ff8ea8de55ec1ae50/raw#/x265-sei-length-crash-fix.patch
 
 BuildRequires:  gcc-c++
+BuildRequires:  libstdc++-devel
 BuildRequires:  git
 BuildRequires:  cmake
 %{?el7:BuildRequires: epel-rpm-macros}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: multimedia arches (#2993)](https://github.com/terrapkg/packages/pull/2993)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)