### PR TITLE
Fix (conflict/other issues): Switch Steam to the correct arch

### DIFF
--- a/anda/games/steam/anda.hcl
+++ b/anda/games/steam/anda.hcl
@@ -1,10 +1,9 @@
 project pkg {
-    arches = ["i386"]
+         arches = ["i386"]
 	rpm {
-		spec = "steam.spec"
+         spec = "steam.spec"
 	}
-    // todo: force-arches macro?
-    // labels {
-    //     multilib = 1
-    // }
+        labels {
+         mock = 1
+     }
 }

--- a/anda/games/steam/anda.hcl
+++ b/anda/games/steam/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
-    arches = ["x86_64"]
+    arches = ["i386"]
 	rpm {
 		spec = "steam.spec"
 	}

--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -33,7 +33,7 @@ Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT
 URL:            http://www.steampowered.com/
-ExclusiveArch:  x86_64
+ExclusiveArch:  i686
 Packager:       Cappy Ishihara <cappy@fyralabs.com>
 
 Source0:        https://repo.steampowered.com/%{name}/archive/beta/%{name}_%{version}.tar.gz


### PR DESCRIPTION
To my understanding Steam was made "x86_64" on purpose, but what ends up happening if RPM Fusion or any other source of Steam is installed is this package tries to install on top of the other one. Since we fixed other conflicts/weird behavior with Fusion for now, I think it may be a good idea to change this as well.