### PR TITLE
[f41] Fix (conflict/other issues): Switch Steam to the correct arch (#3043)

### DIFF
--- a/anda/games/steam/anda.hcl
+++ b/anda/games/steam/anda.hcl
@@ -1,10 +1,9 @@
 project pkg {
-    arches = ["x86_64"]
+         arches = ["i386"]
 	rpm {
-		spec = "steam.spec"
+         spec = "steam.spec"
 	}
-    // todo: force-arches macro?
-    // labels {
-    //     multilib = 1
-    // }
+        labels {
+         mock = 1
+     }
 }

--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -33,7 +33,7 @@ Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT
 URL:            http://www.steampowered.com/
-ExclusiveArch:  x86_64
+ExclusiveArch:  i686
 Packager:       Cappy Ishihara <cappy@fyralabs.com>
 
 Source0:        https://repo.steampowered.com/%{name}/archive/beta/%{name}_%{version}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix (conflict/other issues): Switch Steam to the correct arch (#3043)](https://github.com/terrapkg/packages/pull/3043)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)