### PR TITLE
Change (Anki): Move to Extras, minor dep changes

### DIFF
--- a/anda/apps/anki-bin/anda.hcl
+++ b/anda/apps/anki-bin/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
 	rpm {
 		spec = "anki-bin.spec"
 	}
+        labels {
+        subrepo = "extras"
+       }
 }

--- a/anda/apps/anki-bin/anki-bin.spec
+++ b/anda/apps/anki-bin/anki-bin.spec
@@ -4,7 +4,7 @@
 
 Name:			anki-bin
 Version:		24.11
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Flashcard program for using space repetition learning (Installed with wheel)
 License:		AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
 URL:			https://apps.ankiweb.net/

--- a/anda/apps/anki-bin/anki-bin.spec
+++ b/anda/apps/anki-bin/anki-bin.spec
@@ -2,31 +2,31 @@
 %global aurl https://files.pythonhosted.org/packages/58/6e/9f2d4853a83e57cea48ccae3bc2d887bf7c0550042185e156bab23f524bf/anki-24.11-cp39-abi3-manylinux_2_31_aarch64.whl
 %global qurl https://files.pythonhosted.org/packages/40/3c/b70ef91f1dad8248332971c0cbb2922277512789cadc33cb16233e360a56/aqt-24.11-py3-none-any.whl
 
-Name:			      anki-bin
-Version:		    24.11
-Release:		    1%?dist
-Summary:		    Flashcard program for using space repetition learning (Installed with wheel)
-License:		    AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
-URL:			      https://apps.ankiweb.net/
+Name:			anki-bin
+Version:		24.11
+Release:		1%?dist
+Summary:		Flashcard program for using space repetition learning (Installed with wheel)
+License:		AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
+URL:			https://apps.ankiweb.net/
 BuildRequires:	python3-pip rpm_macro(fdupes) cargo
-Requires:		    python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
-Requires:		    python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
-Requires:		    python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
-Requires:       libxcrypt-compat hicolor-icon-theme sox 
+Requires:		python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
+Requires:		python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
+Requires:		python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
+Requires:       libxcrypt-compat hicolor-icon-theme sox
 Requires:       (mpv or mpv-nightly)
 ExclusiveArch:	x86_64
-Conflicts:		  anki
+Conflicts:		anki
 %ifarch x86_64
-Source0:		    %xurl
+Source0:		%xurl
 %elifarch aarch64
 Source0:        %aurl
 %endif
-Source1:		    %qurl
-Source2:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/runanki.py
-Source3:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.desktop
-Source4:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.png
-Source5:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/LICENSE
-Source6:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/README.md
+Source1:		%qurl
+Source2:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/runanki.py
+Source3:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.desktop
+Source4:	    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.png
+Source5:		https://raw.githubusercontent.com/ankitects/anki/%{version}/LICENSE
+Source6:		https://raw.githubusercontent.com/ankitects/anki/%{version}/README.md
 
 %description
 Anki is a program designed to help you remember facts (such as words and

--- a/anda/apps/anki-bin/anki-bin.spec
+++ b/anda/apps/anki-bin/anki-bin.spec
@@ -2,30 +2,31 @@
 %global aurl https://files.pythonhosted.org/packages/58/6e/9f2d4853a83e57cea48ccae3bc2d887bf7c0550042185e156bab23f524bf/anki-24.11-cp39-abi3-manylinux_2_31_aarch64.whl
 %global qurl https://files.pythonhosted.org/packages/40/3c/b70ef91f1dad8248332971c0cbb2922277512789cadc33cb16233e360a56/aqt-24.11-py3-none-any.whl
 
-Name:			anki-bin
-Version:		24.11
-Release:		1%?dist
-Summary:		Flashcard program for using space repetition learning (Installed with wheel)
-License:		AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
-URL:			https://apps.ankiweb.net/
+Name:			      anki-bin
+Version:		    24.11
+Release:		    1%?dist
+Summary:		    Flashcard program for using space repetition learning (Installed with wheel)
+License:		    AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
+URL:			      https://apps.ankiweb.net/
 BuildRequires:	python3-pip rpm_macro(fdupes) cargo
-Requires:		python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
-Requires:		python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
-Requires:		python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
-Requires:       libxcrypt-compat hicolor-icon-theme sox mpv 
+Requires:		    python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
+Requires:		    python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
+Requires:		    python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
+Requires:       libxcrypt-compat hicolor-icon-theme sox 
+Requires:       (mpv or mpv-nightly)
 ExclusiveArch:	x86_64
-Conflicts:		anki
+Conflicts:		  anki
 %ifarch x86_64
-Source0:		%xurl
+Source0:		    %xurl
 %elifarch aarch64
 Source0:        %aurl
 %endif
-Source1:		%qurl
-Source2:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/runanki.py
-Source3:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.desktop
-Source4:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.png
-Source5:		https://raw.githubusercontent.com/ankitects/anki/%{version}/LICENSE
-Source6:		https://raw.githubusercontent.com/ankitects/anki/%{version}/README.md
+Source1:		    %qurl
+Source2:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/runanki.py
+Source3:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.desktop
+Source4:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.png
+Source5:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/LICENSE
+Source6:		    https://raw.githubusercontent.com/ankitects/anki/%{version}/README.md
 
 %description
 Anki is a program designed to help you remember facts (such as words and

--- a/anda/apps/anki-bin/anki-bin.spec
+++ b/anda/apps/anki-bin/anki-bin.spec
@@ -8,23 +8,25 @@ Release:		2%?dist
 Summary:		Flashcard program for using space repetition learning (Installed with wheel)
 License:		AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
 URL:			https://apps.ankiweb.net/
-BuildRequires:	python3-pip rpm_macro(fdupes) cargo
-Requires:		python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
-Requires:		python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
-Requires:		python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
-Requires:       libxcrypt-compat hicolor-icon-theme sox
-Requires:       (mpv or mpv-nightly)
-ExclusiveArch:	x86_64
+BuildRequires:          python3-pip rpm_macro(fdupes) cargo
+Requires:               python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
+Requires:               python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
+Requires:               python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
+Requires:               python3-protobuf >= 4.21
+Requires:               libxcrypt-compat hicolor-icon-theme sox
+Requires:               (mpv or mpv-nightly)
+
+ExclusiveArch:	        x86_64
 Conflicts:		anki
 %ifarch x86_64
 Source0:		%xurl
 %elifarch aarch64
-Source0:        %aurl
+Source0:                %aurl
 %endif
 Source1:		%qurl
 Source2:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/runanki.py
 Source3:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.desktop
-Source4:	    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.png
+Source4:                https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.png
 Source5:		https://raw.githubusercontent.com/ankitects/anki/%{version}/LICENSE
 Source6:		https://raw.githubusercontent.com/ankitects/anki/%{version}/README.md
 

--- a/anda/apps/anki/anda.hcl
+++ b/anda/apps/anki/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
 	rpm {
 		spec = "anki.spec"
 	}
+        labels {
+                subrepo = "extras"
+        }
 }

--- a/anda/apps/anki/anki.spec
+++ b/anda/apps/anki/anki.spec
@@ -9,7 +9,7 @@ BuildRequires:  python3-distro python3-flask-cors python3-jsonschema python3-sen
 BuildRequires:  python3-installer make mold cargo git rsync ninja-build libxcrypt-compat nodejs python3.9 python-unversioned-command gcc python3-pyqt6-webengine
 Requires:       hicolor-icon-theme python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-send2trash
 Requires:       python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema sox libxcrypt-compat python3-pyqt6-webengine
-Recommends:     mpv
+Recommends:     (mpv or mpv-nightly)
 Obsoletes:      anki <= 2.1.15
 Conflicts:      anki-qt5
 Patch0:         0001-No-update.patch


### PR DESCRIPTION
Since Anki depends on a package that conflicts with upstream (and is in Extras), it makes sense to move it to Extras as well.

I also made minor changes to allow `mpv` _or_ `mpv-nightly` to satisfy deps/recommendations.