### PR TITLE
Fix (walker): Remove gtk4-layer-shell dependency

### DIFF
--- a/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
+++ b/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
@@ -30,7 +30,7 @@ Source:         %{gosource}
 Provides:       golang-github-abenz1267-walker = %version-%release
 Obsoletes:      golang-github-abenz1267-walker < 0.11.4-2
 Packager:       madonuko <mado@fyralabs.com>
-Requires:       gtk4-layer-shell
+Conflicts:      gtk4-layer-shell
 BuildRequires:  anda-srpm-macros
 BuildRequires:  gtk4-devel
 BuildRequires:  gtk4-layer-shell-devel


### PR DESCRIPTION
When `gtk4-layer-shell` and Walker are installed at the same time, the following error occurs:
```gtk-layer-shell not supported```
```panic: gtk-layer-shell not supported```

Note: I did not miss the `gtk4-layer-shell-devel` build dep. For some incomprehensible reason the package still needs this to build, despite the conflict post build. Don't ask me.