### PR TITLE
[f41] Remove: gtk4-layer-shell package dep (#3051)

### DIFF
--- a/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
+++ b/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
@@ -30,7 +30,7 @@ Source:         %{gosource}
 Provides:       golang-github-abenz1267-walker = %version-%release
 Obsoletes:      golang-github-abenz1267-walker < 0.11.4-2
 Packager:       madonuko <mado@fyralabs.com>
-Requires:       gtk4-layer-shell
+Conflicts:      gtk4-layer-shell
 BuildRequires:  anda-srpm-macros
 BuildRequires:  gtk4-devel
 BuildRequires:  gtk4-layer-shell-devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Remove: gtk4-layer-shell package dep (#3051)](https://github.com/terrapkg/packages/pull/3051)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)