### PR TITLE
[f41] fix(yt-dlp): follow upstream versioning + rename package to -git (#3042)

### DIFF
--- a/anda/tools/yt-dlp/anda.hcl
+++ b/anda/tools/yt-dlp/anda.hcl
@@ -1,9 +1,8 @@
 project pkg {
 	rpm {
-		spec = "yt-dlp-nightly.spec"
+		spec = "yt-dlp-git.spec"
 	}
 	labels {
-		nightly = "1"
 		mock = 1
 	}
 }

--- a/anda/tools/yt-dlp/update.rhai
+++ b/anda/tools/yt-dlp/update.rhai
@@ -1,8 +1,4 @@
-if filters.contains("nightly") {
-	rpm.global("commit", gh_commit("yt-dlp/yt-dlp"));
-	if rpm.changed() {
-		rpm.global("ver", gh("yt-dlp/yt-dlp"));
-		rpm.global("commit_date", date());
-		rpm.release();
-	}
+rpm.version(gh("yt-dlp/yt-dlp-master-builds"));
+if rpm.changed() {
+    rpm.release();
 }

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -1,18 +1,12 @@
 #bcond_without tests
-%global commit 164368610456e2d96b279f8b120dea08f7b1d74f
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250117
-%global ver 2025.01.15
 
-Name:           yt-dlp-nightly
-Version:        %commit_date.git~%shortcommit
-Provides:       yt-dlp-nightly = %ver^%version
+Name:           yt-dlp-git
+Version:        2025.01.16.024033
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 
 License:        Unlicense
 URL:            https://github.com/yt-dlp/yt-dlp
-Source:         %url/archive/%commit.tar.gz
 # License of the specfile
 Source:         https://src.fedoraproject.org/rpms/yt-dlp/raw/rawhide/f/yt-dlp.spec.license
 
@@ -31,6 +25,8 @@ BuildRequires:  %{py3_dist pytest}
 BuildRequires:  pandoc
 BuildRequires:  make
 
+BuildRequires:  anda-srpm-macros
+
 # ffmpeg-free is now available in Fedora.
 Recommends:     /usr/bin/ffmpeg
 Recommends:     /usr/bin/ffprobe
@@ -39,12 +35,16 @@ Conflicts:      yt-dlp
 
 Suggests:       python3dist(keyring)
 
+Provides:       yt-dlp-nightly = 1:0-1%?dist
+
+Obsoletes:      yt-dlp-nightly < 0:20250117.git~1643686-2%?dist
+
 %global _description %{expand:
 yt-dlp is a command-line program to download videos from many different online
 video platforms, such as youtube.com. The project is a fork of youtube-dl with
 additional features and fixes.}
 
-%description %{_description}
+%description %{_description}. This package is built from the yt-dlp master branch.
 
 %package bash-completion
 Summary:        Bash completion for yt-dlp
@@ -83,12 +83,15 @@ Conflicts:      yt-dlp-fish-completion
 Fish command line completion support for %{name}.
 
 %prep
-%autosetup -n yt-dlp-%commit
+%git_clone %{url} master
 
 # Remove unnecessary shebangs
 find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{}' +
 # Relax version constraints
 sed -i 's@"\(requests\|urllib3\|websockets\)>=.*"@"\1"@' pyproject.toml
+
+# Update version number
+%{python3} devscripts/update-version.py %{version} -c master -r yt-dlp/yt-dlp-master-builds
 
 %generate_buildrequires
 %pyproject_buildrequires -r


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(yt-dlp): follow upstream versioning + rename package to -git (#3042)](https://github.com/terrapkg/packages/pull/3042)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)