### PR TITLE
Fix (walker): Revert #3051, follow upstream build guidelines, enable debug packages

### DIFF
--- a/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
+++ b/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
@@ -21,7 +21,7 @@ Multi-Purpose Launcher with a lot of features. Highly Customizable and fast.}
 %global godocs          README.md cmd/version.txt
 
 Name:           walker
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Multi-Purpose Launcher with a lot of features. Highly Customizable and fast
 
 License:        MIT

--- a/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
+++ b/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
@@ -2,8 +2,6 @@
 %bcond check 0
 %bcond bootstrap 0
 
-%global debug_package %{nil}
-
 %if %{with bootstrap}
 %global __requires_exclude %{?__requires_exclude:%{__requires_exclude}|}^golang\\(.*\\)$
 %endif
@@ -43,18 +41,19 @@ BuildRequires:  pkgconfig(vips)
 
 %prep
 %goprep -A
-%autopatch -p1
 %go_prep_online
+mv {LICENSE,README.md} cmd
+%setup -T -D -n %{name}-%{version}/cmd
 
 
 %build
-%go_build_online cmd/walker.go
+go build -x -o walker
 
 %install
 #gopkginstall
 %if %{without bootstrap}
-install -m 0755 -vd                         %{buildroot}%{_bindir}
-install -m 0755 -vp build/bin/cmd/walker.go %{buildroot}%{_bindir}/walker
+install -m 0755 -vd        %{buildroot}%{_bindir}
+install -m 0755 -vp walker %{buildroot}%{_bindir}/walker
 %endif
 
 %if %{without bootstrap}

--- a/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
+++ b/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
@@ -30,7 +30,7 @@ Source:         %{gosource}
 Provides:       golang-github-abenz1267-walker = %version-%release
 Obsoletes:      golang-github-abenz1267-walker < 0.11.4-2
 Packager:       madonuko <mado@fyralabs.com>
-Conflicts:      gtk4-layer-shell
+Requires:       gtk4-layer-shell
 BuildRequires:  anda-srpm-macros
 BuildRequires:  gtk4-devel
 BuildRequires:  gtk4-layer-shell-devel


### PR DESCRIPTION
Walker was crashing when `gtk4-layer-shell` was installed, but this wasn't the root cause of the issue and broke new Walker installs due to unstated library dependencies. I have changed how Walker builds to match upstream build guidelines and added the dependency back, this should _hopefully_ make Walker actually work.