### PR TITLE
[f41] fix: SIPA fonts licensing, Deprecate &#x60;TH Sarabun&#x60; (#2482) (#3090)

### DIFF
--- a/anda/fonts/sipa/15-supercede-sarabun.conf
+++ b/anda/fonts/sipa/15-supercede-sarabun.conf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <description>Set Thai font preferences</description>
+
+  <match target="pattern">
+    <test qual="any" name="family" compare="eq">
+        <string>Sarabun</string>
+    </test>
+    <edit name="family" mode="prepend" binding="same">
+      <string>TH Sarabun New</string>
+    </edit>
+  </match>
+  <match target="pattern">
+    <test qual="any" name="family" compare="eq">
+        <string>TH Sarabun</string>
+    </test>
+    <edit name="family" mode="prepend" binding="same">
+      <string>TH Sarabun New</string>
+    </edit>
+  </match>
+</fontconfig>

--- a/anda/fonts/sipa/sipa-fonts.spec
+++ b/anda/fonts/sipa/sipa-fonts.spec
@@ -2,20 +2,29 @@
 
 Name:			sipa-fonts
 Version:		20200217
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Thai National Fonts collection
-URL:			https://www.f0nt.com/release/13-free-fonts-from-sipa/
-License:		OFL-1.1
+URL:			https://www.nstda.or.th/home/news_post/thai-font/
+License:		LicenseRef-DIP-SIPA AND OFL-1.1-RFN
 Source0:		https://waa.inter.nstda.or.th/stks/pub/%(x=%version;echo ${x:0:4})/%version-13Fonts.zip
+Source1:        15-supercede-sarabun.conf
 BuildRequires:	unzip
+Supplements:    (default-fonts-th)
 BuildArch:		noarch
+# Sarabun has very tiny latin alphanumeric glyphs, so it's not suitable for general use.
+# And this causes legibility issues in many applications that defer to it.
+# So let's have Laksaman synthesize it instead.
+# TH Sarabun has also been superceded by Google Fonts' Sarabun/TH Sarabun New by the same foundry. (#2482)
+
 Recommends:		%{lua:
 local x = ""
 local ver = rpm.expand("%version-%release")
 for variant in (rpm.expand("%variants")):gmatch("[^ ]+") do
 	local v = string.gsub(variant, "_", " ")
 	local name = "th-"..string.gsub(v:lower(), " ", "-").."-fonts"
-	x = x .. name .. " = "..ver.." "
+	if name ~= "th-sarabun-fonts" then
+		x = x .. name .. " = "..ver.." "
+	end
 end
 print(x)
 }
@@ -42,11 +51,70 @@ end
 
 # copied from https://www.f0nt.com/about/license/
 cat <<EOF > LICENSE
-1. คุณสามารถดาวน์โหลดฟอนต์ไปใช้งานได้ฟรี ไม่ต้องเสียค่าใช้จ่ายแต่อย่างใด
-2. แต่ถ้ามีการระบุข้อตกลงอื่นใดจากเจ้าของฟอนต์ ดังที่แสดงไว้ในหน้าดาวน์โหลดฟอนต์ หรือเป็นไฟล์เอกสารแสดงข้อตกลงที่แนบไปกับฟอนต์นั้นๆ ให้ยึดข้อตกลงดังกล่าวเป็นสำคัญ
-3. คุณสามารถคัดลอกรายละเอียดอธิบายข้อมูล, ภาพตัวอย่างฟอนต์ ไปเผยแพร่ แจกจ่ายในเว็บไซต์หรือสื่ออื่นๆ ได้ โดยต้องระบุที่มา และทำลิงก์กลับมายังหน้าแสดงรายละเอียดฟอนต์
-4. ไม่อนุญาตให้นำ “ไฟล์ฟอนต์” ไปขาย เว้นแต่จะเป็นการแนบไฟล์ติดไปกับสื่อ โปรแกรม เพื่อความสะดวกในการใช้งาน แต่ไม่ใช่เพื่อการขายฟอนต์เป็นหลัก
-5. หากคุณต้องการดัดแปลงฟอนต์เพื่อใช้งานเป็นการส่วนตัว สามารถทำได้ แต่ถ้าทำเพื่อขายหรือรับจ้างผลิต คุณจะต้องได้รับอนุญาตจากเจ้าของฟอนต์ก่อนเท่านั้น
+สัญญาอนุญาตให้ใช้โปรแกรมคอมพิวเตอร์ฟอนต์
+
+ชื่อที่สงวนไว้สำหรับโปรแกรมคอมพิวเตอร์ฟอนต์นี้
+TH Krub, TH Krub Italic, TH Krub Bold, TH Krub Bold Italic,
+TH Niramit AS, TH Niramit AS Italic, TH Niramit AS Bold, TH Niramit AS Bold Italic,
+TH Kodchasal, TH Kodchasal Italic, TH Kodchasal Bold, TH Kodchasal Bold Italic,
+TH Sarabun PSK, TH Sarabun PSK Italic, TH Sarabun PSK Bold, TH Sarabun PSK Bold Italic,
+TH K2D July8, TH K2D July8 Italic, TH K2D July8 Bold, TH K2D July8 Bold Italic,
+TH Mali Grade 6, TH Mali Grade 6 Italic, TH Mali Grade 6 Bold, TH Mali Grade 6 Bold Italic,
+TH Chakra Petch, TH Chakra Petch Italic, TH Chakra Petch Bold, TH Chakra Petch Bold Italic,
+TH Baijam, TH Baijam Italic, TH Baijam Bold, TH Baijam Bold Italic,
+TH KoHo, TH KoHo Italic, TH KoHo Bold, TH KoHo Bold Italic,
+TH Fah Kwang, TH Fah Kwang Italic, TH Fah Kwang Bold, TH Fah Kwang Bold Italic.
+
+โปรแกรมคอมพิวเตอร์ฟอนต์นี้ เป็นลิขสิทธิ์ร่วมกันของกรมทรัพย์สินทางปัญญา กระทรวงพาณิชย์ และสำนักงานส่งเสริมอุตสาหกรรมซอฟต์แวร์แห่งชาติ (องค์การมหาชน)
+
+สัญญาอนุญาตให้ใช้โปรแกรมคอมพิวเตอร์ฟอนต์นี้ มีวัตถุประสงค์เพื่อก่อให้เกิดความร่วมมือในการสร้างสรรค์ฟอนต์ในวงกว้าง รวมทั้งเพื่อประโยชน์ทางด้านการศึกษาและการแบ่งปันความรู้และพัฒนาโปรแกรมคอมพิวเตอร์ฟอนต์นี้
+
+ข้อกำหนดและเงื่อนไขของสัญญาอนุญาตให้ใช้โปรแกรมคอมพิวเตอร์ฟอนต์นี้
+
+(1)  อนุญาตให้ใช้ได้โดยไม่คิดค่าใช้จ่ายและอนุญาตให้ทำซ้ำโปรแกรมคอมพิวเตอร์ฟอนต์นี้ได้ รวมทั้งอนุญาตให้ได้ศึกษา ดัดแปลง และแจกจ่ายให้แก่ผู้อื่นได้ ทั้งนี้จะต้องไม่นำโปรแกรมคอมพิวเตอร์ฟอนต์นี้และโปรแกรมคอมพิวเตอร์ฟอนต์ที่ดัดแปลงออกจำหน่าย เว้นแต่เป็นการจำหน่ายรวมติดไปกับโปรแกรมคอมพิวเตอร์อื่น
+
+(2)  ก่อนดำเนินการดัดแปลงโปรแกรมคอมพิวเตอร์ฟอนต์ จะต้องแจ้งให้เจ้าของลิขสิทธิ์ทราบเป็นลายลักษณ์อักษร
+
+(3)  เมื่อดัดแปลงโปรแกรมคอมพิวเตอร์ฟอนต์นี้แล้ว ห้ามผู้ดัดแปลงใช้ชื่อฟอนต์เดิม รวมทั้งห้ามใช้ชื่อเจ้าของลิขสิทธิ์และผู้สร้างสรรค์โปรแกรมคอมพิวเตอร์ฟอนต์นี้ ในการโฆษณาโปรแกรมคอมพิวเตอร์ฟอนต์ที่ได้ดัดแปลง เว้นแต่ได้รับอนุญาตเป็นลายลักษณ์อักษรจากเจ้าของลิขสิทธิ์
+
+(4)  ผู้ดัดแปลงโปรแกรมคอมพิวเตอร์นี้จะต้องยินยอมให้โปรแกรมคอมพิวเตอร์ฟอนต์ ที่ดัดแปลงขึ้นใหม่มีข้อกำหนดและเงื่อนไขสัญญาอนุญาตให้ใช้โปรแกรมเช่นเดียวกันกับข้อกำหนด และเงื่อนไขของสัญญาอนุญาตนี้เช่นกัน
+
+ข้อถือสิทธิ
+เจ้าของลิขสิทธิ์ไม่รับประกันการใช้งานโปรแกรมคอมพิวเตอร์ฟอนต์และไฟล์ที่เกี่ยวข้องนี้แต่อย่างใด  ไม่มีการรับรองว่าโปรแกรมคอมพิวเตอร์ฟอนต์นี้จะทำงานได้อย่างที่ควรจะเป็น และไม่มีการรับรองว่าจะมีการพัฒนาต่อยอดในอนาคต ไม่มีและไม่รับรองว่าจะมีการให้คำแนะนำทางเทคนิคสำหรับโปรแกรมคอมพิวเตอร์ฟอนต์นี้
+
+
+Font Computer Program License Agreement
+
+Reserved Font Names for this Font Computer Program:
+TH Krub, TH Krub Italic, TH Krub Bold, TH Krub Bold Italic,
+TH Niramit AS, TH Niramit AS Italic, TH Niramit AS Bold, TH Niramit AS Bold Italic,
+TH Kodchasal, TH Kodchasal Italic, TH Kodchasal Bold, TH Kodchasal Bold Italic,
+TH Sarabun PSK, TH Sarabun PSK Italic, TH Sarabun PSK Bold, TH Sarabun PSK Bold Italic,
+TH K2D July8, TH K2D July8 Italic, TH K2D July8 Bold, TH K2D July8 Bold Italic,
+TH Mali Grade 6, TH Mali Grade 6 Italic, TH Mali Grade 6 Bold, TH Mali Grade 6 Bold Italic,
+TH Chakra Petch, TH Chakra Petch Italic, TH Chakra Petch Bold, TH Chakra Petch Bold Italic,
+TH Baijam, TH Baijam Italic, TH Baijam Bold, TH Baijam Bold Italic,
+TH KoHo, TH KoHo Italic, TH KoHo Bold, TH KoHo Bold Italic,
+TH Fah Kwang, TH Fah Kwang Italic, TH Fah Kwang Bold, TH Fah Kwang Bold Italic.
+
+This Font Computer Program is the copyright of the Department of Intellectual Property (DIP), Ministry of Commerce and the Software Industry Promotion Agency (Public Organization) (SIPA)
+
+The purposes of this Font Computer Program License are to stimulate worldwide development of cooperative font creation, to benefit for academic, to share and to develop in partnership with others.
+
+Terms and Conditions of the Font Computer Program
+
+(1) Allow to use without any charges and allow to reproduce, study, adapt and distribute this Font Computer Program. Neither the original version nor adapted version of Font Computer Program may be sold by itself, except bundled and/or sold with any computer program.
+
+(2) If you wish to adapt this Font Computer Program, you must notify copyright owners (DIP & SIPA) in writing.
+
+(3) No adapted version of Font Computer Program may use the Reserved Font Name(s), the name(s) of the copyright owners and the author(s) of the Font Computer Program must not be used to promote or advertise any adapted version, except obtaining written permission from copyright owners and the author(s).
+
+(4) The adapted version of Font Computer Program must be released under the term and condition of this license.
+
+DISCLAIMER
+THE FONT COMPUTER PROGRAM AND RELATED FILES ARE PROVIDED “AS IS” AND WITHOUT WARRANTY OF ANY KIND.  NO GUARANTEES ARE MADE THAT THIS FONT COMPUTER PROGRAM WILL WORK AS EXPECTED OR WILL BE DEVELOPED FURTHUR IN ANY SPECIFIC WAY.  THERE IS NO OFFER OR GUARANTEE OF TECHNICAL SUPPORT.
+
+
 EOF
 
 %build
@@ -65,9 +133,13 @@ mv "THSarabunNew BoldItalic.ttf"	"TH SarabunNew BoldItalic.ttf"
 mv "THSarabunNew Italic.ttf"		"TH SarabunNew Italic.ttf"
 mv "THSarabunNew.ttf"				"TH SarabunNew.ttf"
 
+install -Dm644 %{SOURCE1} %buildroot/%{_sysconfdir}/fonts/conf.d/15-supercede-sarabun.conf
+
 
 %files
 %license LICENSE
+%dir %{_datadir}/fonts/sipa/
+
 
 %{lua:
 for variant in (rpm.expand("%variants")):gmatch("[^ ]+") do
@@ -76,8 +148,12 @@ for variant in (rpm.expand("%variants")):gmatch("[^ ]+") do
 	print("%files -n "..name.."\n")
 	print("%license LICENSE\n")
 	print("/usr/share/fonts/sipa/TH?"..v:gsub(" ", "?").."*\n")
+	if name == "th-sarabunnew-fonts" then
+        print("/etc/fonts/conf.d/15-supercede-sarabun.conf\n")
+    end
 end
 }
+
 
 %changelog
 * Sun Jun 11 2023 windowsboy111 <windowsboy111@fyralabs.com> - 20200217-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: SIPA fonts licensing, Deprecate &#x60;TH Sarabun&#x60; (#2482) (#3090)](https://github.com/terrapkg/packages/pull/3090)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)