### PR TITLE
bump: yt-dlp

### DIFF
--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,8 +2,8 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2025.01.20.204520
-Release:        2%?dist
+Version:        2025.01.21.215956
+Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 
 License:        Unlicense


### PR DESCRIPTION
interesting that if a package has an open PR rabo doesn't bump version? not exactly sure