### PR TITLE
[f41] fix(blackbox-terminal): move to terra-extras (#3106)

### DIFF
--- a/anda/apps/blackbox-terminal/anda.hcl
+++ b/anda/apps/blackbox-terminal/anda.hcl
@@ -1,5 +1,8 @@
 project pkg {
-	rpm {
-		spec = "blackbox-terminal.spec"
-	}
+  rpm {
+    spec = "blackbox-terminal.spec"
+  }
+  labels {
+    subrepo = "extras"
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(blackbox-terminal): move to terra-extras (#3106)](https://github.com/terrapkg/packages/pull/3106)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)