### PR TITLE
[f41] fix(nushell): conflict with fedora package (#3113)

### DIFF
--- a/anda/langs/rust/nushell/nushell.spec
+++ b/anda/langs/rust/nushell/nushell.spec
@@ -1,12 +1,13 @@
 Name:			nushell
 Version:		0.101.0
-Release:		1%?dist
+Release:		2%?dist
 Summary:		A new type of shell
 License:		MIT
 URL:			https://www.nushell.sh/
 BuildRequires:	anda-srpm-macros rust-packaging git-core
 BuildRequires:  openssl-devel-engine mold
 Requires:		glibc openssl zlib
+Conflicts:      nu
 
 %description
 %summary.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(nushell): conflict with fedora package (#3113)](https://github.com/terrapkg/packages/pull/3113)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)