### PR TITLE
chore(f40): add conflicts to terra-* packages that exist in fedora (and stop building them)

### DIFF
--- a/anda/devs/blueprint-compiler/terra-blueprint-compiler.spec
+++ b/anda/devs/blueprint-compiler/terra-blueprint-compiler.spec
@@ -1,13 +1,15 @@
-Name:			terra-blueprint-compiler
-Version:		0.16.0
-Release:		1%?dist
-License:		LGPL-3.0-or-later
-Summary:		Markup language for GTK user interfaces
-URL:			https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/
-Source0:		https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v%version/blueprint-compiler-v%version.tar.gz
-BuildArch:		noarch
-BuildRequires:	meson gtk4-devel python3-devel python3-gobject-devel
-Requires:		python3-gobject-devel
+Name:           terra-blueprint-compiler
+Version:        0.16.0
+Release:        2%?dist
+License:        LGPL-3.0-or-later
+Summary:        Markup language for GTK user interfaces
+URL:            https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/
+Source0:        https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v%version/blueprint-compiler-v%version.tar.gz
+BuildArch:      noarch
+BuildRequires:  meson gtk4-devel python3-devel python3-gobject-devel
+Requires:       python3-gobject-devel
+# Conflicts with upstream blueprint-compiler
+Conflicts:      blueprint-compiler
 
 %description
 GtkBuilder XML format is quite verbose, and many app developers don't like

--- a/anda/devs/blueprint-compiler/update.rhai
+++ b/anda/devs/blueprint-compiler/update.rhai
@@ -1,2 +1,0 @@
-let txt = get("https://gitlab.gnome.org/api/v4/projects/17669/releases/");
-rpm.version(txt.json_arr()[0].tag_name);

--- a/anda/devs/rgbds/terra-rgbds.spec
+++ b/anda/devs/rgbds/terra-rgbds.spec
@@ -1,6 +1,6 @@
 Name:		terra-rgbds
 Version:	0.9.0
-Release:	1%?dist
+Release:	2%?dist
 Summary:	A development package for the Game Boy, including an assembler
 
 # See LICENSE for details
@@ -16,6 +16,8 @@ BuildRequires:	bison
 BuildRequires:	flex
 BuildRequires:	git-core
 BuildRequires:	pkgconfig(libpng)
+# Conflict with upstream rgbds
+Conflicts:      rgbds
 
 %description
 RGBDS (Rednex Game Boy Development System) is a free assembler/linker package

--- a/anda/devs/rgbds/update.rhai
+++ b/anda/devs/rgbds/update.rhai
@@ -1,1 +1,0 @@
-rpm.version(gh("gbdev/rgbds"));

--- a/anda/langs/rust/maturin/rust-terra-maturin.spec
+++ b/anda/langs/rust/maturin/rust-terra-maturin.spec
@@ -10,7 +10,7 @@
 
 Name:           rust-terra-maturin
 Version:        1.8.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Build and publish Rust crates as Python packages
 
 License:        MIT OR Apache-2.0
@@ -29,6 +29,9 @@ rust binaries as python packages.}
 Summary:        %{summary}
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-DFS-2016) AND 0BSD AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSD-2-Clause) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND BSL-1.0 AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR LGPL-3.0-or-later) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 # LICENSE.dependencies contains a full license breakdown
+
+# Conflicts with upstream maturin
+Conflicts:      maturin
 
 %description -n terra-%{crate} %{_description}
 

--- a/anda/langs/rust/maturin/update.rhai
+++ b/anda/langs/rust/maturin/update.rhai
@@ -1,1 +1,0 @@
-rpm.version(gh("PyO3/maturin"));

--- a/anda/langs/rust/nushell/update.rhai
+++ b/anda/langs/rust/nushell/update.rhai
@@ -1,1 +1,0 @@
-rpm.version(gh("nushell/nushell"));

--- a/anda/lib/libindicator/terra-libindicator.spec
+++ b/anda/lib/libindicator/terra-libindicator.spec
@@ -1,14 +1,14 @@
-Name:			terra-libindicator
-Version:		16.10.0
-Release:		%autorelease
-Summary:		Shared functions for Ayatana indicators
+Name:           terra-libindicator
+Version:        16.10.0
+Release:        2%?dist
+Summary:        Shared functions for Ayatana indicators
 
-License:		GPL-3.0
-URL:			https://launchpad.net/libindicator
-Source0:		http://archive.ubuntu.com/ubuntu/pool/universe/libi/libindicator/libindicator_16.10.0+18.04.20180321.1.orig.tar.gz
-Source1:		https://raw.githubusercontent.com/ubports/libindicator/097906132ffb479205be15a92cae97e5daf4e154/data/indicators.target
+License:        GPL-3.0
+URL:            https://launchpad.net/libindicator
+Source0:        http://archive.ubuntu.com/ubuntu/pool/universe/libi/libindicator/libindicator_16.10.0+18.04.20180321.1.orig.tar.gz
+Source1:        https://raw.githubusercontent.com/ubports/libindicator/097906132ffb479205be15a92cae97e5daf4e154/data/indicators.target
 # From GLib 2.62
-Patch1:			http://archive.ubuntu.com/ubuntu/pool/universe/libi/libindicator/libindicator_16.10.0+18.04.20180321.1-0ubuntu5.diff.gz
+Patch1:         http://archive.ubuntu.com/ubuntu/pool/universe/libi/libindicator/libindicator_16.10.0+18.04.20180321.1-0ubuntu5.diff.gz
 
 BuildRequires:	chrpath
 BuildRequires:	gtk-doc
@@ -21,6 +21,8 @@ BuildRequires:	gtk3-devel
 BuildRequires:	systemd-rpm-macros
 BuildRequires:	gnome-common
 BuildRequires:	make
+# Conflicts with upstream libindicator
+Conflicts:      libindicator
 
 %description
 A set of symbols and convenience functions that all Ayatana indicators are

--- a/anda/lib/placebo/update.rhai
+++ b/anda/lib/placebo/update.rhai
@@ -1,4 +1,0 @@
-// let txt = get("https://code.videolan.org/api/v4/projects/380/releases/");
-// rpm.version(txt.json_arr()[0].tag_name);
-// apparently their API doesn't work (for sake)
-rpm.version(gh("haasn/libplacebo"));


### PR DESCRIPTION
since we're not removing terra-* packages (and probably shouldn't) in f40, conflicts are needed with upstream fedora packages

i literally cannot be bothered to use github runners to rebuild fucking sddm just to add conflicts, i will make sure terra-sddm is yeeted off the face of the earth everywhere

depending on whether terra* package rpms are getting removed in f41 or not, i can backport this to f41