### PR TITLE
Change (Steam): Obsoletes/Provides

### DIFF
--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -137,7 +137,7 @@ Requires:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 
 # Fix upgrading from old versions
 Provides:       %{name} = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
-Obsoletes:      %{name} <= %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
 
 %description
 Steam is a software distribution service with an online store, automated
@@ -153,7 +153,7 @@ Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}
 # Fix upgrading from old versions
 Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
-Obsoletes:      steam-devices <= %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
 
 %description    devices
 Steam is a software distribution service with an online store, automated

--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -5,7 +5,7 @@
 
 Name:           steam
 Version:        1.0.0.82
-Release:        3%?dist
+Release:        4%?dist
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT
@@ -135,6 +135,10 @@ Recommends:     gobject-introspection
 
 Requires:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 
+# Fix upgrading from old versions
+Provides:       %{name} = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+Obsoletes:      %{name} <= %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+
 %description
 Steam is a software distribution service with an online store, automated
 installation, automatic updates, achievements, SteamCloud synchronized savegame
@@ -147,6 +151,9 @@ Summary:        Permissions required by Steam for gaming devices
 BuildArch:      noarch
 Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}
+# Fix upgrading from old versions
+Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+Obsoletes:      steam-devices <= %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
 
 %description    devices
 Steam is a software distribution service with an online store, automated


### PR DESCRIPTION
I've tested a ton of builds and this seems to have the best success of upgrading from the previous `x86_64` labelled package. None have been perfect on every command, but this at least got an upgrade via installing the RPMs.