### PR TITLE
fix: blackbox-terminal

### DIFF
--- a/anda/apps/blackbox-terminal/0001-Rename-executable-to-blackbox-terminal.patch
+++ b/anda/apps/blackbox-terminal/0001-Rename-executable-to-blackbox-terminal.patch
@@ -1,0 +1,41 @@
+From d5e5bc6fbdab8e575299b995ed3aa26faaaf01bc Mon Sep 17 00:00:00 2001
+From: Carl George <carl@george.computer>
+Date: Thu, 20 Jul 2023 00:01:26 -0500
+Subject: [PATCH 1/2] Rename executable to blackbox-terminal
+
+This is to avoid file conflicts with the blackbox window manager, which
+is already packaged in several Linux distros.
+---
+ com.raggesilver.BlackBox.json            | 2 +-
+ data/com.raggesilver.BlackBox.desktop.in | 2 +-
+ src/meson.build                          | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/data/com.raggesilver.BlackBox.desktop.in b/data/com.raggesilver.BlackBox.desktop.in
+index 28f3b55..1d45a17 100644
+--- a/data/com.raggesilver.BlackBox.desktop.in
++++ b/data/com.raggesilver.BlackBox.desktop.in
+@@ -1,6 +1,6 @@
+ [Desktop Entry]
+ Name=Black Box
+-Exec=blackbox
++Exec=blackbox-terminal
+ Terminal=false
+ Type=Application
+ Categories=GNOME;GTK;System;TerminalEmulator;
+diff --git a/src/meson.build b/src/meson.build
+index 8891f58..47d03f1 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -75,7 +75,7 @@ if get_option('blackbox_is_flatpak')
+   add_project_arguments('-D', 'BLACKBOX_IS_FLATPAK', language: 'vala')
+ endif
+ 
+-executable('blackbox', blackbox_sources, config_header,
++executable('blackbox-terminal', blackbox_sources, config_header,
+   vala_args: '--target-glib=2.50',  dependencies: blackbox_deps,
+   install: true,
+ )
+-- 
+2.45.2
+

--- a/anda/apps/blackbox-terminal/blackbox-terminal.spec
+++ b/anda/apps/blackbox-terminal/blackbox-terminal.spec
@@ -48,7 +48,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/com.raggesilver.Black
 %files
 %doc README.md CHANGELOG.md
 %license COPYING
-%{_bindir}/blackbox
+%{_bindir}/blackbox-terminal
 %{_datadir}/applications/com.raggesilver.BlackBox.desktop
 %{_datadir}/metainfo/com.raggesilver.BlackBox.metainfo.xml
 %{_datadir}/blackbox/

--- a/anda/apps/blackbox-terminal/blackbox-terminal.spec
+++ b/anda/apps/blackbox-terminal/blackbox-terminal.spec
@@ -1,61 +1,64 @@
-%global commit d5fff0dd5bfb8bda19b050f66610d19370c5fd39
-%global commit_date 20241019
+%global commit 53be9986dea776eb4c2804d4e342cbd3a3cf06fc
+%global commit_date 20240716
 %global shortcommit %{sub %{commit} 1 7}
 
 Name:           blackbox-terminal
-Version:        0.14.0^%{commit_date}.%{shortcommit}
+Version:        0.15.0~^%{commit_date}.%{shortcommit}
 Release:        1%{?dist}
 Summary:        A beautiful GTK 4 terminal
 
 License:        GPL-3.0
 URL:            https://gitlab.gnome.org/raggesilver/blackbox
 Source0:        %{url}/-/archive/%{commit}/blackbox-%{commit}.tar.gz
+# Patch modified from upstream Fedora for terra use to rename executable to blackbox-terminal to avoid conflict with blackbox wm
+Patch0:         0001-Rename-executable-to-blackbox-terminal.patch
 
 BuildRequires:  vala meson gettext
-BuildRequires:  pkgconfig(gtk4) >= 4.6.2
-BuildRequires:  pkgconfig(gio-2.0) >= 2.50
-BuildRequires:  libadwaita-devel >= 1.1
-BuildRequires:  pkgconfig(pqmarble) >= 2
-BuildRequires:  pkgconfig(vte-2.91-gtk4) >= 0.69.0
-BuildRequires:  pkgconfig(json-glib-1.0) >= 1.4.4
-BuildRequires:  pkgconfig(libxml-2.0) >= 2.9.12
-BuildRequires:  pkgconfig(librsvg-2.0) >= 2.54.0
+BuildRequires:  pkgconfig(gtk4)
+BuildRequires:  pkgconfig(gio-2.0)
+BuildRequires:  pkgconfig(libadwaita-1)
+BuildRequires:  pkgconfig(pqmarble)
+BuildRequires:  pkgconfig(vte-2.91-gtk4)
+BuildRequires:  pkgconfig(json-glib-1.0)
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(librsvg-2.0)
 BuildRequires:  pkgconfig(libpcre2-8)
 BuildRequires:  pkgconfig(graphene-gobject-1.0)
 BuildRequires:  pkgconfig(gee-0.8)
-BuildRequires:  desktop-file-utils libappstream-glib cmake
+BuildRequires:  desktop-file-utils
 
 %description
 An elegant and customizable terminal for GNOME.
 
 %prep
-%autosetup -n blackbox-%{commit}
+%autosetup -n blackbox-%{commit} -p1
 
 %build
-%meson
+%meson -Dblackbox_is_flatpak=false
 %meson_build
 
 %install
 %meson_install
 
 %check
-appstream-util validate-relax --nonet %buildroot%_datadir/metainfo/com.raggesilver.BlackBox.metainfo.xml
+desktop-file-validate %{buildroot}%{_datadir}/applications/com.raggesilver.BlackBox.desktop
+# don't validate appstream data because terra doesn't use it currently anyway
+# appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/com.raggesilver.BlackBox.metainfo.xml
 
 %files
-%doc README.md
+%doc README.md CHANGELOG.md
 %license COPYING
-%_bindir/blackbox
-%_bindir/terminal-toolbox
-%_datadir/applications/com.raggesilver.BlackBox.desktop
-%_datadir/metainfo/com.raggesilver.BlackBox.metainfo.xml
-%_datadir/blackbox/
-%_datadir/glib-2.0/schemas/com.raggesilver.BlackBox.gschema.xml
-%_datadir/icons/hicolor/scalable/actions/com.raggesilver.BlackBox-fullscreen-symbolic.svg
-%_datadir/icons/hicolor/scalable/actions/com.raggesilver.BlackBox-show-headerbar-symbolic.svg
-%_datadir/icons/hicolor/scalable/actions/external-link-symbolic.svg
-%_datadir/icons/hicolor/scalable/actions/settings-symbolic.svg
-%_datadir/icons/hicolor/scalable/apps/com.raggesilver.BlackBox.svg
-%_datadir/locale/*/LC_MESSAGES/blackbox.mo
+%{_bindir}/blackbox
+%{_datadir}/applications/com.raggesilver.BlackBox.desktop
+%{_datadir}/metainfo/com.raggesilver.BlackBox.metainfo.xml
+%{_datadir}/blackbox/
+%{_datadir}/glib-2.0/schemas/com.raggesilver.BlackBox.gschema.xml
+%{_datadir}/icons/hicolor/scalable/actions/com.raggesilver.BlackBox-fullscreen-symbolic.svg
+%{_datadir}/icons/hicolor/scalable/actions/com.raggesilver.BlackBox-show-headerbar-symbolic.svg
+%{_datadir}/icons/hicolor/scalable/actions/external-link-symbolic.svg
+%{_datadir}/icons/hicolor/scalable/actions/settings-symbolic.svg
+%{_datadir}/icons/hicolor/scalable/apps/com.raggesilver.BlackBox.svg
+%{_datadir}/locale/*/LC_MESSAGES/blackbox.mo
 
 
 %changelog


### PR DESCRIPTION
- changes version to match upstream fedora's major version
- fixes the previous terra version 0.14.0^20241019.d5fff0d which is broken
- will not maintain going forward, package is maintained in 41 and beyond in fedora

package was moved to terra{41, rawhide}-extras in #3106 