### PR TITLE
[f40] fix(steam): Obsoletes/Provides (#3136)

### DIFF
--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -5,7 +5,7 @@
 
 Name:           steam
 Version:        1.0.0.82
-Release:        3%?dist
+Release:        4%?dist
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT
@@ -135,6 +135,10 @@ Recommends:     gobject-introspection
 
 Requires:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 
+# Fix upgrading from old versions
+Provides:       %{name} = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+
 %description
 Steam is a software distribution service with an online store, automated
 installation, automatic updates, achievements, SteamCloud synchronized savegame
@@ -147,6 +151,9 @@ Summary:        Permissions required by Steam for gaming devices
 BuildArch:      noarch
 Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}
+# Fix upgrading from old versions
+Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
 
 %description    devices
 Steam is a software distribution service with an online store, automated


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(steam): Obsoletes/Provides (#3136)](https://github.com/terrapkg/packages/pull/3136)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)