### PR TITLE
[f41] Fix (Ghostty): New build flags for &#x60;.terminfo&#x60; and &#x60;.termcap&#x60; (#3122)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -6,7 +6,7 @@
 
 Name:           ghostty-nightly
 Version:        %{commit_date}.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A fast, native terminal emulator written in Zig; this is the Tip (nightly) build.
 License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
 URL:            https://ghostty.org/
@@ -98,7 +98,9 @@ zig build \
     -Dcpu=baseline \
     -Dstrip=false \
     -Dpie=true \
-    -Demit-docs
+    -Demit-docs \
+    -Demit-termcap \
+    -Demit-terminfo
 
 %files
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix (Ghostty): New build flags for &#x60;.terminfo&#x60; and &#x60;.termcap&#x60; (#3122)](https://github.com/terrapkg/packages/pull/3122)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)