### PR TITLE
[f41] fix: youtube-music: ignore vendored libraries (#3162)

### DIFF
--- a/anda/apps/youtube-music/youtube-music.spec
+++ b/anda/apps/youtube-music/youtube-music.spec
@@ -1,5 +1,8 @@
 %define debug_package %nil
 
+# Exclude private libraries since this is bundled with electron
+%global __requires_exclude libffmpeg.so
+%global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
 
 # macro shorthand for calling pnpm
 %global pnpm npx pnpm@%{pnpm_version}
@@ -10,7 +13,7 @@
 
 Name:           youtube-music
 Version:        3.7.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
 Source1:        youtube-music.desktop
 License:        MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: youtube-music: ignore vendored libraries (#3162)](https://github.com/terrapkg/packages/pull/3162)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)