### PR TITLE
[el10] Add: geteltorito (#3174)

### DIFF
--- a/anda/tools/geteltorito/anda.hcl
+++ b/anda/tools/geteltorito/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+    arches = ["x86_64"]
+	rpm {
+		spec = "geteltorito.spec"
+	}
+	labels {
+	   nightly = 1
+	}
+}

--- a/anda/tools/geteltorito/geteltorito.spec
+++ b/anda/tools/geteltorito/geteltorito.spec
@@ -1,0 +1,32 @@
+%global commit 46474a4a86692b7c38ecdb4f135bee7badbfa8b0
+%global commit_date 20250116
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:          geteltorito
+Version:       %{commit_date}.%{shortcommit}
+Release:       1%?dist
+Summary:       An El Torito boot image extractor
+License:       GPLv3
+Packager:      Owen Zimmerman <owen@fyralabs.com>
+Url:           https://github.com/rainer042/geteltorito
+Source0:       %{url}/archive/%{commit}.tar.gz
+BuildArch:     noarch
+Requires:      perl
+
+%description
+%summary
+
+%prep
+%autosetup -n geteltorito-%commit
+
+%install
+install -Dm 755 geteltorito.pl %buildroot%{_bindir}/geteltorito
+
+%files
+%license LICENSE
+%doc README
+%{_bindir}/geteltorito
+
+%changelog
+* Sat Feb 01 2025 Owen Zimmerman <owen@fyralabs.com>
+- Package geteltorito

--- a/anda/tools/geteltorito/update.rhai
+++ b/anda/tools/geteltorito/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("rainer042/geteltorito"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Add: geteltorito (#3174)](https://github.com/terrapkg/packages/pull/3174)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)