### PR TITLE
[f40] Add: abuild (#3175)

### DIFF
--- a/anda/tools/abuild/abuild.spec
+++ b/anda/tools/abuild/abuild.spec
@@ -1,0 +1,25 @@
+Name:           abuild
+Version:        24.12
+Release:        1%?dist
+Summary:        coreboot autobuild script builds coreboot images for all available targets.
+URL:            https://doc.coreboot.org/util/abuild/index.html
+License:        GPLv2
+BuildRequires:  git
+BuildArch:      noarch
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary 
+
+%prep
+git clone https://review.coreboot.org/coreboot.git -b %version
+
+%install
+install -Dm 777 coreboot/util/abuild/abuild %buildroot%_bindir/abuild
+
+%files
+/usr/bin/abuild
+
+%changelog
+* Sat Feb 01 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial Package

--- a/anda/tools/abuild/anda.hcl
+++ b/anda/tools/abuild/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+        rpm {
+                spec = "abuild.spec"
+        }
+}

--- a/anda/tools/abuild/update.rhai
+++ b/anda/tools/abuild/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("coreboot/coreboot"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Add: abuild (#3175)](https://github.com/terrapkg/packages/pull/3175)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)