### PR TITLE
[f41] add: arduino-create-agent (#3129)

### DIFF
--- a/anda/tools/arduino-create-agent/anda.hcl
+++ b/anda/tools/arduino-create-agent/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "arduino-create-agent.spec"
+	}
+}

--- a/anda/tools/arduino-create-agent/arduino-create-agent.spec
+++ b/anda/tools/arduino-create-agent/arduino-create-agent.spec
@@ -1,0 +1,35 @@
+%define debug_package %nil
+
+Name:          arduino-create-agent
+Version:       1.6.1
+Release:       1%?dist
+Summary:       Arduino Cloud Agent.
+License:       AGPLv3
+Packager:      Owen Zimmerman <owen@fyralabs.com>
+Url:           https://github.com/arduino/arduino-create-agent
+Source0:       %url/archive/refs/tags/%version.tar.gz
+Patch0:        update.patch
+BuildRequires: golang git go-rpm-macros anda-srpm-macros 
+
+%description
+The Arduino Cloud Agent is a single binary that will sit on the traybar and work in the background.
+It allows you to use the Arduino Cloud to seamlessly upload code to any USB connected Arduino board (or Yún in LAN) directly from the browser.
+
+%prep
+%autosetup -n arduino-create-agent-%version -p1
+
+%build
+%go_build_online
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+install -Dm 755 build/bin/arduino-create-agent %buildroot%{_bindir}/arduino-create-agent
+
+%files
+%license LICENSE.txt
+%doc README.md 
+%{_bindir}/arduino-create-agent
+
+%changelog
+* Sat Jan 25 2025 Owen Zimmerman <owen@fyralabs.com>
+- Package arduino-create-agent

--- a/anda/tools/arduino-create-agent/update.patch
+++ b/anda/tools/arduino-create-agent/update.patch
@@ -1,0 +1,25 @@
+diff --git a/main.go b/main.go
+index 1ca857b..c945487 100755
+--- a/main.go
++++ b/main.go
+@@ -461,7 +461,6 @@ func loop() {
+ 	r.Handle("WSS", "/socket.io/", socketHandler)
+ 	r.GET("/info", infoHandler)
+ 	r.POST("/pause", pauseHandler)
+-	r.POST("/update", updateHandler)
+ 
+ 	// Mount goa handlers
+ 	goa := v2.Server(config.GetDataDir().String(), Index)
+diff --git a/updater/updater.go b/updater/updater.go
+index db4e545..693431a 100644
+--- a/updater/updater.go
++++ b/updater/updater.go
+@@ -34,7 +34,7 @@ import (
+ // binary to be executed to perform the update. If no update has been downloaded
+ // it returns an empty string.
+ func Start(src string) string {
+-	return start(src)
++	return ""
+ }
+ 
+ // CheckForUpdates checks if there is a new version of the binary available and

--- a/anda/tools/arduino-create-agent/update.rhai
+++ b/anda/tools/arduino-create-agent/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/arduino-create-agent"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: arduino-create-agent (#3129)](https://github.com/terrapkg/packages/pull/3129)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)