### PR TITLE
[f41] feat(kf6-kio): per branch update scripts (#3202)

### DIFF
--- a/anda/desktops/kde/kf6-kio/anda.hcl
+++ b/anda/desktops/kde/kf6-kio/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		subrepo = "extras"
+		updbranch = 1
 	}
 }

--- a/anda/desktops/kde/kf6-kio/update.rhai
+++ b/anda/desktops/kde/kf6-kio/update.rhai
@@ -1,0 +1,16 @@
+import "andax/bump_extras.rhai" as bump;
+
+let pkg = "kf6-kio";
+let branch = bump::as_bodhi_ver(labels.branch);
+
+let url = `https://bodhi.fedoraproject.org/updates/?search=${pkg}&status=stable&releases=${branch}&rows_per_page=1&page=1`;
+
+for entry in get(url).json().updates[0].title.split(' ') {
+  let matches = find_all(`${pkg}-([\d.]+)-(\d+)\.[\w\d]+$`, entry);
+  if matches.len() == 0 { continue; }
+  if matches[0][1].ends_with(".0") {
+    rpm.global("majmin_ver_kf6", matches[0][1][0..matches[0][1].len()-2]);
+    rpm.f = sub(`Release: (.+?)\n`, "Release: " + matches[0][2] + "%{?dist}.switcheroo\n", rpm.f);
+  }
+  break;
+}

--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -18,5 +18,12 @@ fn as_bodhi_ver(branch) {
 
 fn bodhi(pkg, branch) {
     let url = `https://bodhi.fedoraproject.org/updates/?search=${pkg}&status=stable&releases=${branch}&rows_per_page=1&page=1`;
-    return find(`^${pkg}-([\d.]+)-\d+\.[\w\d]+$`, get(url).json().updates[0].title, 1);
+    for entry in get(url).json().updates[0].title.split(' ') {
+        let matches = find_all(`${pkg}-([\d.]+)-(\d+)\.[\w\d]+$`, entry);
+        //                             ──────── ───── .fc??
+        //                             version  release
+        if matches.len() != 0 {
+            return matches[0][1];
+        }
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(kf6-kio): per branch update scripts (#3202)](https://github.com/terrapkg/packages/pull/3202)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)