### PR TITLE
chore(devcontainer): simplify image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,0 @@
-ARG VARIANT="rawhide"
-FROM fedora:${VARIANT}
-
-RUN useradd -m vscode
-RUN groupadd mock
-RUN usermod -aG mock vscode
-RUN echo vscode ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/vscode
-RUN curl -Lo /etc/yum.repos.d/terra.repo https://raw.githubusercontent.com/terrapkg/subatomic-repos/main/terra.repo
-RUN dnf -y install git mock createrepo_c anda terra-mock-configs

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,19 @@
 {
-  "name": "Fedora",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": { "VARIANT": "rawhide" }
-  },
-  "remoteUser": "vscode",
+  "name": "Terra Devcontainer",
+  "image": "ghcr.io/terrapkg/builder:frawhide",
   "runArgs": [
     "--privileged"
   ],
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
   "customizations": {
     "vscode": {
       "extensions": [
         "rhaiscript.vscode-rhai"
       ]
     }
-  }
+  },
+  "remoteUser": "vscode",
+  "onCreateCommand": "sudo usermod -a -G mock vscode"
 }


### PR DESCRIPTION
I was having issues running `anda build` with both mock and rpmbuild through the devcontainer. This simplifies the devcontainer using the builder image as the base and adding the common-utils feature (which takes care of creating the vscode user and more).