### PR TITLE
[el10] feat: add some missing update scripts (#3197)

### DIFF
--- a/anda/apps/switcheroo-control/update.rhai
+++ b/anda/apps/switcheroo-control/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gitlab("gitlab.freedesktop.org", "4339"));

--- a/anda/system/nvidia/libva-nvidia-driver/update.rhai
+++ b/anda/system/nvidia/libva-nvidia-driver/update.rhai
@@ -1,0 +1,8 @@
+rpm.global("commit0", gh_commit("elFarto/nvidia-vaapi-driver"));
+if rpm.changed() {
+  let v = gh("elFarto/nvidia-vaapi-driver");
+  v.crop(1);
+  v += "%{!?tag:^%{date}git%{shortcommit0}}";
+  rpm.version(v);
+  rpm.global("date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat: add some missing update scripts (#3197)](https://github.com/terrapkg/packages/pull/3197)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)