### PR TITLE
[f41] feat(gnome-shell): update scripts (#3204)

### DIFF
--- a/anda/desktops/gnome/gnome-shell/anda.hcl
+++ b/anda/desktops/gnome/gnome-shell/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		subrepo = "extras"
+		updbranch = 1
 	}
 }

--- a/anda/desktops/gnome/gnome-shell/gnome-shell.spec
+++ b/anda/desktops/gnome/gnome-shell/gnome-shell.spec
@@ -1,6 +1,6 @@
 %global tarball_version %%(echo %{version} | tr '~' '.')
 %global major_version 47
-%global minor_version 1
+%global minor_version 3
 
 %if 0%{?rhel}
 %global portal_helper 0
@@ -10,7 +10,7 @@
 
 Name:           gnome-shell
 Version:        %{major_version}.%{minor_version}
-Release:        %autorelease.switcheroo
+Release:        1%{?dist}.switcheroo
 Summary:        Window management and application launching for GNOME
 
 License:        GPL-2.0-or-later

--- a/anda/desktops/gnome/gnome-shell/update.rhai
+++ b/anda/desktops/gnome/gnome-shell/update.rhai
@@ -1,0 +1,25 @@
+import "andax/bump_extras.rhai" as bump;
+
+let pkg = "gnome-shell";
+let branch = bump::as_bodhi_ver(labels.branch);
+
+let url = `https://bodhi.fedoraproject.org/updates/?search=${pkg}&status=stable&releases=${branch}&rows_per_page=10&page=1`;
+
+let done = false;
+
+for entry in get(url).json().updates {
+  for entry in entry.title.split(' ') {
+    let matches = find_all(`${pkg}-([\d.]+)-(\d+)\.[\w\d]+$`, entry);
+    if matches.len() == 0 { continue; }
+    let majminv = matches[0][1].split('.');
+    if majminv.len() != 2 {
+      print(`gnome-shell: ${matches[0][1]} has invalid version?`);
+      terminate();
+    }
+    rpm.global("major_version", majminv[0]);
+    rpm.global("minor_version", majminv[1]);
+    rpm.f = sub(`Release:(\s+)(.+?)\n`, "Release:${1}" + matches[0][2] + "%{?dist}.switcheroo\n", rpm.f);
+    done = true;
+  }
+  if done { break; }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(gnome-shell): update scripts (#3204)](https://github.com/terrapkg/packages/pull/3204)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)