### PR TITLE
[f41] fix(tdlib): remove &#x60;rm&#x60; step for RPMBuild (#3124)

### DIFF
--- a/anda/lib/tdlib/tdlib-nightly.spec
+++ b/anda/lib/tdlib/tdlib-nightly.spec
@@ -5,7 +5,7 @@
 
 Name: tdlib-nightly
 Version: %ver^%commit_date.%shortcommit
-Release: 1%?dist
+Release: 2%?dist
 License: BSL-1.0
 URL: https://github.com/tdlib/td
 Summary: Cross-platform library for building Telegram clients
@@ -49,7 +49,6 @@ Requires: %name-devel%?_isa = %{?epoch:%epoch:}%version-%release
 
 %prep
 %autosetup -n td-%commit -p1
-rm %SOURCE0
 sed -e 's/"DEFAULT"/"PROFILE=SYSTEM"/g' -i tdnet/td/net/SslStream.cpp
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(tdlib): remove &#x60;rm&#x60; step for RPMBuild (#3124)](https://github.com/terrapkg/packages/pull/3124)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)