### PR TITLE
[f41] add: fluent-kde-theme (#3207)

### DIFF
--- a/anda/themes/fluent-kde-theme/anda.hcl
+++ b/anda/themes/fluent-kde-theme/anda.hcl
@@ -1,0 +1,6 @@
+project "pkg" {
+    arches = ["x86_64"]
+    rpm {
+        spec = "fluent-kde-theme.spec"
+    }
+}

--- a/anda/themes/fluent-kde-theme/fluent-kde-theme.spec
+++ b/anda/themes/fluent-kde-theme/fluent-kde-theme.spec
@@ -1,0 +1,57 @@
+%global commit 9d6b7d4733707c38f72e8a614528f1df591419f3
+%global commit_date 20240827
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           fluent-kde-theme
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Fluent design theme for KDE
+
+License:        GPL-3.0-only
+URL:            https://github.com/vinceliuice/Fluent-kde
+Source0:        %url/archive/%commit/Fluent-kde-%commit.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  fdupes
+
+%description
+%summary
+
+%prep
+%autosetup -n Fluent-kde-%{commit}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_datadir}/aurorae
+mkdir -p %{buildroot}%{_datadir}/color-schemes
+mkdir -p %{buildroot}%{_datadir}/plasma/desktoptheme
+mkdir -p %{buildroot}%{_datadir}/plasma/look-and-feel
+mkdir -p %{buildroot}%{_datadir}/Kvantum
+mkdir -p %{buildroot}%{_datadir}/wallpapers
+
+# Patch install.sh to use the buildroot destination directories
+sed -i "s|^[[:space:]]*AURORAE_DIR=.*|AURORAE_DIR=%{buildroot}%{_datadir}/aurorae|" install.sh
+sed -i "s|^[[:space:]]*SCHEMES_DIR=.*|SCHEMES_DIR=%{buildroot}%{_datadir}/color-schemes|" install.sh
+sed -i "s|^[[:space:]]*PLASMA_DIR=.*|PLASMA_DIR=%{buildroot}%{_datadir}/plasma/desktoptheme|" install.sh
+sed -i "s|^[[:space:]]*LOOKFEEL_DIR=.*|LOOKFEEL_DIR=%{buildroot}%{_datadir}/plasma/look-and-feel|" install.sh
+sed -i "s|^[[:space:]]*KVANTUM_DIR=.*|KVANTUM_DIR=%{buildroot}%{_datadir}/Kvantum|" install.sh
+sed -i "s|^[[:space:]]*WALLPAPER_DIR=.*|WALLPAPER_DIR=%{buildroot}%{_datadir}/wallpapers|" install.sh
+
+# Invoke the installer now that variables are patched
+./install.sh
+
+%fdupes %buildroot%_datadir
+
+%files
+%license LICENSE
+%doc README.md
+%{_datadir}/aurorae/Fluent*/
+%{_datadir}/color-schemes/Fluent*.colors
+%{_datadir}/plasma/desktoptheme/Fluent*/
+%{_datadir}/plasma/look-and-feel/com.github.vinceliuice.Fluent*/
+%{_datadir}/Kvantum/Fluent*/
+%{_datadir}/wallpapers/Fluent*/
+
+%changelog
+%autochangelog

--- a/anda/themes/fluent-kde-theme/update.rhai
+++ b/anda/themes/fluent-kde-theme/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("vinceliuice/Fluent-kde"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: fluent-kde-theme (#3207)](https://github.com/terrapkg/packages/pull/3207)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)