### PR TITLE
[f41] add: tela-icon-theme (#3206)

### DIFF
--- a/anda/themes/tela-icon-theme/anda.hcl
+++ b/anda/themes/tela-icon-theme/anda.hcl
@@ -1,0 +1,6 @@
+project "pkg" {
+    arches = ["x86_64"]
+    rpm {
+        spec = "tela-icon-theme.spec"
+    }
+}

--- a/anda/themes/tela-icon-theme/tela-icon-theme.spec
+++ b/anda/themes/tela-icon-theme/tela-icon-theme.spec
@@ -1,0 +1,38 @@
+%global commit ba6354539f1b7802a15da662b35a3be287befb4d
+%global commit_date 20250110
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           tela-icon-theme
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        Tela icon theme for linux desktops
+
+License:        GPL-3.0-only
+URL:            https://github.com/vinceliuice/Tela-icon-theme/
+Source0:        %url/archive/%commit/Tela-icon-theme-%commit.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  gtk-update-icon-cache fdupes
+
+%description
+Tela icon theme for linux desktops.
+
+%prep
+%autosetup -n Tela-icon-theme-%{commit}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_datadir}/themes
+./install.sh -c -d %{buildroot}%{_datadir}/icons
+
+%fdupes %buildroot%_datadir/icons/
+
+%files
+%license COPYING
+%doc README.md
+
+%{_datadir}/icons/Tela*/
+
+%changelog
+%autochangelog

--- a/anda/themes/tela-icon-theme/update.rhai
+++ b/anda/themes/tela-icon-theme/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("vinceliuice/Tela-icon-theme"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: tela-icon-theme (#3206)](https://github.com/terrapkg/packages/pull/3206)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)