### PR TITLE
[el10] fix(walker): workaround for F40 Go not producing debug packages (#3221)

### DIFF
--- a/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
+++ b/anda/desktops/waylands/walker/golang-github-abenz1267-walker.spec
@@ -8,6 +8,10 @@
 %global __requires_exclude %{?__requires_exclude:%{__requires_exclude}|}^golang\\(.*\\)$
 %endif
 
+%if 0%{?fedora} <= 40
+%global debug_package %{nil}
+%endif
+
 # https://github.com/abenz1267/walker
 %global goipath         github.com/abenz1267/walker
 Version:                0.11.4


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(walker): workaround for F40 Go not producing debug packages (#3221)](https://github.com/terrapkg/packages/pull/3221)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)