### PR TITLE
[f40] Fix: obsoletes and bump release to surface-dtx-daemon (#3215)

### DIFF
--- a/anda/system/surface-dtx-daemon/surface-dtx-daemon.spec
+++ b/anda/system/surface-dtx-daemon/surface-dtx-daemon.spec
@@ -4,13 +4,14 @@
 
 Name:           terra-surface-dtx-daemon
 Version:        %(echo %ver | sed 's/-/~/g')
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Surface Detachment System (DTX) Daemon
 License:        MIT
 URL:            https://github.com/linux-surface/surface-dtx-daemon
 Source:         %url/archive/refs/tags/%ver.tar.gz
 BuildRequires:  rust cargo dbus-devel anda-srpm-macros cargo-rpm-macros mold
 Packager:       Owen Zimmerman <owen@fyralabs.com>
+Obsoletes:      surface-dtx-daemon < 0.3.8~1-3
 
 %description
 Linux User-Space Detachment System (DTX) Daemon for the Surface ACPI Driver


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Fix: obsoletes and bump release to surface-dtx-daemon (#3215)](https://github.com/terrapkg/packages/pull/3215)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)