### PR TITLE
Fix: Move CUDA to NVIDIA subrepo

### DIFF
--- a/anda/lib/nvidia/compat-nvidia-repo/anda.hcl
+++ b/anda/lib/nvidia/compat-nvidia-repo/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
         rpm {
 		spec = "compat-nvidia-repo.spec"
 	}
+	labels {
+	   subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-cccl/anda.hcl
+++ b/anda/lib/nvidia/cuda-cccl/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-cccl.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-cudart/anda.hcl
+++ b/anda/lib/nvidia/cuda-cudart/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-cudart.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-cudnn/anda.hcl
+++ b/anda/lib/nvidia/cuda-cudnn/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-cudnn.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-cuobjdump/anda.hcl
+++ b/anda/lib/nvidia/cuda-cuobjdump/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-cuobjdump.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-cupti/anda.hcl
+++ b/anda/lib/nvidia/cuda-cupti/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-cupti.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-cuxxfilt/anda.hcl
+++ b/anda/lib/nvidia/cuda-cuxxfilt/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-cuxxfilt.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-gcc/anda.hcl
+++ b/anda/lib/nvidia/cuda-gcc/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
 	}
     labels {
         updbranch = 1
+        subrepo = "nvidia"
     }
 }

--- a/anda/lib/nvidia/cuda-gdb/anda.hcl
+++ b/anda/lib/nvidia/cuda-gdb/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-gdb.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-nvdisasm/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvdisasm/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-nvdisasm.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-nvml/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvml/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-nvml.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-nvprof/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvprof/anda.hcl
@@ -1,7 +1,9 @@
 project pkg {
+        arches = ["x86_64"]
     rpm {
         spec = "cuda-nvprof.spec"
     }
-
-    arches = ["x86_64"]
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-nvprune/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvprune/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-nvprune.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-nvrtc/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvrtc/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-nvrtc.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-nvtx/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvtx/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "cuda-nvtx.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/cuda-profiler/anda.hcl
+++ b/anda/lib/nvidia/cuda-profiler/anda.hcl
@@ -2,6 +2,9 @@ project pkg {
    arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "cuda-profiler.spec"
+    }
+    labels {
         mock = 1
+	    subrepo = "nvidia"
     }
 }

--- a/anda/lib/nvidia/cuda-sanitizer/anda.hcl
+++ b/anda/lib/nvidia/cuda-sanitizer/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels {
         mock = 1
+        subrepo = "nvidia"
     }
 }

--- a/anda/lib/nvidia/cuda/anda.hcl
+++ b/anda/lib/nvidia/cuda/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
 	spec = "cuda.spec"
 	}
+	labels {
+	   subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libcublas/anda.hcl
+++ b/anda/lib/nvidia/libcublas/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "libcublas.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libcudla/anda.hcl
+++ b/anda/lib/nvidia/libcudla/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
     rpm {
         spec = "libcudla.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libcufft/anda.hcl
+++ b/anda/lib/nvidia/libcufft/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "libcufft.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libcurand/anda.hcl
+++ b/anda/lib/nvidia/libcurand/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "libcurand.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libcusparse/anda.hcl
+++ b/anda/lib/nvidia/libcusparse/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "libcusparse.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libcusparselt/anda.hcl
+++ b/anda/lib/nvidia/libcusparselt/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "libcusparselt.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libnpp/anda.hcl
+++ b/anda/lib/nvidia/libnpp/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "libnpp.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libnvfatbin/anda.hcl
+++ b/anda/lib/nvidia/libnvfatbin/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "libnvfatbin.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }

--- a/anda/lib/nvidia/libnvjpeg/anda.hcl
+++ b/anda/lib/nvidia/libnvjpeg/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
     rpm {
         spec = "libnvjpeg.spec"
     }
+    labels {
+	    subrepo = "nvidia"
+    }
 }


### PR DESCRIPTION
Also fixed an HCL that had the Mock label in the RPM section.

CUDA relies on Terra's NVIDIA packages, so it should be in the NVIDIA subrepo.