### PR TITLE
[el10] fix: ruffle (#3256)

### DIFF
--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -38,6 +38,8 @@ Packager:       madonuko <mado@fyralabs.com>
 %prep
 %autosetup -n ruffle-nightly-%ver
 %cargo_prep_online
+sed -iE 's@^Exec=ruffle %%u$@Exec=ruffle_desktop %%u@' desktop/packages/linux/rs.ruffle.Ruffle.desktop
+cat desktop/packages/linux/rs.ruffle.Ruffle.desktop
 
 cat<<EOF > ruffle_desktop.desktop
 [Desktop Entry]


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: ruffle (#3256)](https://github.com/terrapkg/packages/pull/3256)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)