### PR TITLE
Fix (scenefx): Add missing build dependencies

### DIFF
--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -68,7 +68,6 @@ MESON_OPTIONS=(
 %files
 %license LICENSE
 %doc README.md
-%{_libdir}/lib%{name}.so.*
 
 
 %files  devel

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -72,5 +72,4 @@ MESON_OPTIONS=(
 
 %files  devel
 %{_includedir}/scenefx
-%{_libdir}/lib%{name}.so
 %{_libdir}/pkgconfig/%{name}.pc

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -72,4 +72,5 @@ MESON_OPTIONS=(
 
 %files  devel
 %{_includedir}/scenefx
+%{_libdir}/lib%{name}-%{version}.so
 %{_libdir}/pkgconfig/%{name}.pc

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -1,6 +1,6 @@
 Name:           scenefx
 Version:        0.2
-Release:        1%?dist
+Release:        2%?dist
 
 Summary:        A drop-in replacement for the wlroots scene API that allows wayland compositors to render surfaces with eye-candy effects
 URL:            https://github.com/wlrfx/scenefx

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -25,6 +25,7 @@ BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols) >= 1.32
 BuildRequires:  pkgconfig(wayland-scanner)
 BuildRequires:  pkgconfig(wayland-server) >= 1.22
+BuildRequires:  pkgconfig(wlroots)
 
 
 Packager:       Atmois <atmois@atmois.com>

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -14,7 +14,6 @@ BuildRequires:  gcc
 BuildRequires:  glslang
 BuildRequires:  gnupg2
 BuildRequires:  meson >= 0.59.0
-BuildRequires:  wlroots-devel >= 0.18.0
 
 BuildRequires:  pkgconfig(egl)
 BuildRequires:  pkgconfig(gbm) >= 17.1.0
@@ -26,6 +25,7 @@ BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols) >= 1.32
 BuildRequires:  pkgconfig(wayland-scanner)
 BuildRequires:  pkgconfig(wayland-server) >= 1.22
+BuildRequires:  pkgconfig(wlroots-0.18)
 
 
 Packager:       Atmois <atmois@atmois.com>

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -14,8 +14,8 @@ BuildRequires:  gcc
 BuildRequires:  glslang
 BuildRequires:  gnupg2
 BuildRequires:  meson >= 0.59.0
+BuildRequires:  wlroots >= 0.18.0
 
-BuildRequires:  pkgconfig(wlroots) >= 0.18
 BuildRequires:  pkgconfig(egl)
 BuildRequires:  pkgconfig(gbm) >= 17.1.0
 BuildRequires:  pkgconfig(glesv2)

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -9,12 +9,13 @@ License:        MIT
 Source0:        %{url}/archive/refs/tags/%version.tar.gz
 
 
+BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  glslang
 BuildRequires:  gnupg2
 BuildRequires:  meson >= 0.59.0
 
-BuildRequires:  (pkgconfig(wlroots) >= 0.17.0 with pkgconfig(wlroots) < 0.18)
+BuildRequires:  pkgconfig(wlroots) >= 0.18.0
 BuildRequires:  pkgconfig(egl)
 BuildRequires:  pkgconfig(gbm) >= 17.1.0
 BuildRequires:  pkgconfig(glesv2)
@@ -25,7 +26,6 @@ BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols) >= 1.32
 BuildRequires:  pkgconfig(wayland-scanner)
 BuildRequires:  pkgconfig(wayland-server) >= 1.22
-BuildRequires:  pkgconfig(wlroots)
 
 
 Packager:       Atmois <atmois@atmois.com>

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -15,7 +15,7 @@ BuildRequires:  glslang
 BuildRequires:  gnupg2
 BuildRequires:  meson >= 0.59.0
 
-BuildRequires:  pkgconfig(wlroots) >= 0.18.0
+BuildRequires:  pkgconfig(wlroots) >= 0.18
 BuildRequires:  pkgconfig(egl)
 BuildRequires:  pkgconfig(gbm) >= 17.1.0
 BuildRequires:  pkgconfig(glesv2)

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -14,7 +14,7 @@ BuildRequires:  gcc
 BuildRequires:  glslang
 BuildRequires:  gnupg2
 BuildRequires:  meson >= 0.59.0
-BuildRequires:  wlroots >= 0.18.0
+BuildRequires:  wlroots-devel >= 0.18.0
 
 BuildRequires:  pkgconfig(egl)
 BuildRequires:  pkgconfig(gbm) >= 17.1.0

--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -68,9 +68,9 @@ MESON_OPTIONS=(
 %files
 %license LICENSE
 %doc README.md
+%{_libdir}/lib%{name}-%{version}.so
 
 
 %files  devel
 %{_includedir}/scenefx
-%{_libdir}/lib%{name}-%{version}.so
 %{_libdir}/pkgconfig/%{name}.pc


### PR DESCRIPTION
Do not merge until #3274 is merged.

`cmake` added to the build shuts up about errors, not actually used.