### PR TITLE
[f41] Fix (anki-bin): New files (#3277)

### DIFF
--- a/anda/apps/anki-bin/anki-bin.spec
+++ b/anda/apps/anki-bin/anki-bin.spec
@@ -60,6 +60,8 @@ rm -rf %buildroot%_bindir/{distro,flask,jsonschema,markdown_py,normalizer,send2t
 %license LICENSE
 %doc README.md
 %_bindir/anki
+%_bindir/pyuic6
+%_bindir/pylupdate6
 /usr/lib/python*/site-packages/_aqt/
 /usr/lib/python*/site-packages/anki-%{version}.dist-info/
 /usr/lib/python*/site-packages/anki/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix (anki-bin): New files (#3277)](https://github.com/terrapkg/packages/pull/3277)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)