### PR TITLE
[f40] Fix (openh274): Soname bump (#3288)

### DIFF
--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -5,7 +5,7 @@
 Name:           openh264
 Version:        2.6.0
 # Also bump the Release tag for gstreamer1-plugin-openh264 down below
-Release:        1%?dist
+Release:        2%?dist
 Summary:        H.264 codec library
 
 License:        BSD
@@ -94,7 +94,7 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.a
 %files
 %license LICENSE
 %doc README.md
-%{_libdir}/libopenh264.so.7
+%{_libdir}/libopenh264.so.8
 %{_libdir}/libopenh264.so.%{version}
 
 %files devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Fix (openh274): Soname bump (#3288)](https://github.com/terrapkg/packages/pull/3288)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)