### PR TITLE
[f41] Fix: Update script for Mesa, bump Mesa back down (#3301)

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -75,15 +75,14 @@ Summary:        Mesa graphics libraries
 # This should not break anything by default as the Mesa stream is ***EXPLICITLY***
 # disabled by default, and has to be enabled manually. See `terra/release/terra-mesa.repo` for details.
 Epoch:          1
-%global ver 25.0.0-rc3
-Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        3%?dist
+Version:        24.3.4
+Release:        4%?dist
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 
 
 
-Source0:        https://archive.mesa3d.org/%{srcname}-%{ver}.tar.xz
+Source0:        https://archive.mesa3d.org/%{srcname}-%{version}.tar.xz
 # src/gallium/auxiliary/postprocess/pp_mlaa* have an ... interestingly worded license.
 # Source1 contains email correspondence clarifying the license terms.
 # Fedora opts to ignore the optional part of clause 2 and treat that code as 2 clause BSD.
@@ -396,7 +395,7 @@ Obsoletes:      mesa-vulkan-devel < %{?epoch:%{epoch}:}%{version}-%{release}
 The drivers with support for the Vulkan API.
 
 %prep
-%autosetup -n %{srcname}-%{ver} -p1
+%autosetup -n %{srcname}-%{version} -p1
 cp %{SOURCE1} docs/
 
 %build

--- a/anda/lib/mesa/update.rhai
+++ b/anda/lib/mesa/update.rhai
@@ -1,3 +1,5 @@
 let v = gitlab_tag("gitlab.freedesktop.org", "176");
 v.crop(5);
-rpm.global("ver", v);
+if `[\d.]+-rc\d+`.find_all(v).len == 0 {
+  rpm.version(v);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix: Update script for Mesa, bump Mesa back down (#3301)](https://github.com/terrapkg/packages/pull/3301)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)