### PR TITLE
Feat (Steam): Changes for F42+

### DIFF
--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -5,7 +5,7 @@
 
 Name:           steam
 Version:        1.0.0.82
-Release:        4%?dist
+Release:        1%?dist
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT
@@ -135,9 +135,8 @@ Recommends:     gobject-introspection
 
 Requires:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 
-# Fix upgrading from old versions
-Provides:       %{name} = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
-Obsoletes:      %{name} < %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+# Woarkaround for GNOME issues with libei
+Recommends:     (extest if gnome-shell)
 
 %description
 Steam is a software distribution service with an online store, automated
@@ -149,11 +148,6 @@ This package contains the installer for the Steam software distribution service.
 %package        devices
 Summary:        Permissions required by Steam for gaming devices
 BuildArch:      noarch
-Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
-Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}
-# Fix upgrading from old versions
-Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
-Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
 
 %description    devices
 Steam is a software distribution service with an online store, automated


### PR DESCRIPTION
Do *not* backport to F41, please.

Changes done for the following reasons:
- Removed Obsoletes/Provides due to cosmetic issues if hitting upgrade issues from our old Steam "x86_64" package (not the cause of the issues, but still an error users can see), and to avoid any possible unexpected behavior in the future
- Bumped down rel to reflect above change and to hopefully less conflict with other distros shipping Steam (i.e. Nobara)
- Added `extest` as a recommendation for GNOME to work around an issue with GNOME libei permissions (the user would still need to load `extest` via env var, but the recommendation made sense to me)