### PR TITLE
[f42] youtube-music: fix WMClass (#3324)

### DIFF
--- a/anda/apps/youtube-music/youtube-music.desktop
+++ b/anda/apps/youtube-music/youtube-music.desktop
@@ -5,6 +5,6 @@ TryExec=/usr/bin/youtube-music
 Icon=youtube-music
 Terminal=false
 Type=Application
-StartupWMClass=YouTube Music
+StartupWMClass=com.github.th_ch.youtube_music
 Comment=YouTube Music Desktop App - including custom plugins
 Categories=AudioVideo;

--- a/anda/apps/youtube-music/youtube-music.spec
+++ b/anda/apps/youtube-music/youtube-music.spec
@@ -13,7 +13,7 @@
 
 Name:           youtube-music
 Version:        3.7.2
-Release:        2%?dist
+Release:        3%?dist
 Summary:        YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
 Source1:        youtube-music.desktop
 License:        MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [youtube-music: fix WMClass (#3324)](https://github.com/terrapkg/packages/pull/3324)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)