### PR TITLE
[f42] fix(davs2): update logic (#3332)

### DIFF
--- a/anda/lib/davs2/davs2.spec
+++ b/anda/lib/davs2/davs2.spec
@@ -1,15 +1,15 @@
 %global commit0 b41cf117452e2d73d827f02d3e30aa20f1c721ac
 %global date 20220903
-%global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
+%global shortcommit %(c=%{commit0}; echo ${c:0:7})
 
 Name:       davs2
 Version:    1.6
-Release:    5%{?shortcommit0:.%{date}git%{shortcommit0}}%{?dist}
+Release:    5%{?shortcommit:.%{date}git%{shortcommit}}%{?dist}
 Summary:    An open-source decoder of AVS2-P2/IEEE1857.4 video coding standard
 URL:        https://github.com/pkuvcl/%{name}
 License:    GPLv2
 
-%if "%{?shortcommit0}"
+%if ! "%len %{commit0}" == 0
 Source0:    https://github.com/pkuvcl/%{name}/archive/%{commit0}/%{name}-%{commit0}.tar.gz#/%{name}-%{shortcommit0}.tar.gz
 %else
 Source0:    https://github.com/pkuvcl/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
@@ -44,7 +44,7 @@ This package contains the shared library development files.
 
 %prep
 # Use flat condition or it fails on EPEL 7
-%if "%{?shortcommit0}"
+%if ! "%len %{commit0}" == 0
 %autosetup -n %{name}-%{commit0}
 %else
 %autosetup

--- a/anda/lib/davs2/update.rhai
+++ b/anda/lib/davs2/update.rhai
@@ -1,1 +1,5 @@
-rpm.version(gh("pkuvcl/davs2"));
+rpm.version(gh_tag("pkuvcl/davs2"));
+if rpm.changed() {
+    rpm.global("commit0", "");
+    rpm.release();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(davs2): update logic (#3332)](https://github.com/terrapkg/packages/pull/3332)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)