### PR TITLE
[f42] -r option has been removed (#3341)

### DIFF
--- a/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
+++ b/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
@@ -22,7 +22,7 @@ Fluent icon theme for linux desktops.
 
 %install
 mkdir -p %{buildroot}%{_datadir}/themes
-./install.sh -r -a -d %{buildroot}%{_datadir}/icons
+./install.sh -a -d %{buildroot}%{_datadir}/icons
 
 %fdupes %buildroot%_datadir/icons/
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [-r option has been removed (#3341)](https://github.com/terrapkg/packages/pull/3341)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)