### PR TITLE
[f41] audacity-freeworld: fix version string (#3340)

### DIFF
--- a/anda/apps/audacity-freeworld/audacity-freeworld.spec
+++ b/anda/apps/audacity-freeworld/audacity-freeworld.spec
@@ -1,8 +1,11 @@
 %global __requires_exclude ^lib-.*.so            
 %global __provides_exclude ^lib-.*.so
 
+%global ver Audacity-3.7.1
+%global sanitized_ver %(echo "$( sed 's/Audacity-//' <<< "%{ver}" )")
+
 Name:    audacity-freeworld
-Version: Audacity.3.7.1
+Version: %{sanitized_ver}
 Release: 1%?dist
 Summary: Multitrack audio editor
 License: GPLv2

--- a/anda/apps/audacity-freeworld/update.rhai
+++ b/anda/apps/audacity-freeworld/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("audacity/audacity"));
+rpm.version(gh_tag("audacity/audacity"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [audacity-freeworld: fix version string (#3340)](https://github.com/terrapkg/packages/pull/3340)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)