### PR TITLE
[f40] fix(chromebook-usbc-fix): specify x86_64 arch in spec (#3352)

### DIFF
--- a/anda/system/chromebook-usbc-fix/anda.hcl
+++ b/anda/system/chromebook-usbc-fix/anda.hcl
@@ -1,8 +1,9 @@
 project pkg {
-	rpm {
-		spec = "chromebook-usbc-fix.spec"
-	}
-  labels {
-    nightly = "1"
-  }
+    arches = ["x86_64"]
+    rpm {
+        spec = "chromebook-usbc-fix.spec"
+    }
+    labels {
+        nightly = "1"
+    }
 }

--- a/anda/system/chromebook-usbc-fix/chromebook-usbc-fix.spec
+++ b/anda/system/chromebook-usbc-fix/chromebook-usbc-fix.spec
@@ -19,6 +19,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{?systemd_requires}
 BuildRequires:  systemd-rpm-macros
 
+ExclusiveArch:  x86_64
+
 %description
 %summary
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(chromebook-usbc-fix): specify x86_64 arch in spec (#3352)](https://github.com/terrapkg/packages/pull/3352)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)