### PR TITLE
[f40] fix(umu-launcher): builddep python3-hatch-vcs (#3355)

### DIFF
--- a/anda/games/umu/umu-launcher.spec
+++ b/anda/games/umu/umu-launcher.spec
@@ -6,7 +6,6 @@ Summary:        A tool for launching non-steam games with proton
 License:        GPL-3.0-only
 URL:            https://github.com/Open-Wine-Components/umu-launcher
 
-BuildArch:      noarch
 BuildRequires:  anda-srpm-macros
 BuildRequires:  meson >= 0.54.0
 BuildRequires:  ninja-build
@@ -21,7 +20,13 @@ BuildRequires:  python3-installer
 BuildRequires:  python3-hatchling
 BuildRequires:  python
 BuildRequires:  python3
-
+BuildRequires:  python3-pip
+BuildRequires:  libzstd-devel
+BuildRequires:  python3-hatch-vcs
+BuildRequires:  python3-wheel
+BuildRequires:  python3-xlib
+BuildRequires:  python3-pyzstd
+BuildRequires:  cargo
 Requires:	python
 Requires:	python3
 Requires:	python3-xlib
@@ -35,8 +40,8 @@ Requires:	python3-filelock
 %git_clone %url %version
 
 %build
-./configure.sh --prefix=%_prefix
-%make_build
+./configure.sh --prefix=%_prefix --use-system-pyzstd
+%{make_build}
 
 %install
 %make_install PYTHONDIR=%python3_sitelib


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(umu-launcher): builddep python3-hatch-vcs (#3355)](https://github.com/terrapkg/packages/pull/3355)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)