### PR TITLE
[f42] fix: fuc (#3354)

### DIFF
--- a/anda/tools/fuc/fuc.spec
+++ b/anda/tools/fuc/fuc.spec
@@ -8,11 +8,11 @@ URL:			https://github.com/SUPERCILEX/fuc
 Source0:		https://raw.githubusercontent.com/SUPERCILEX/fuc/%{version}/README.md
 Source1:		https://raw.githubusercontent.com/SUPERCILEX/fuc/%{version}/LICENSE
 %ifarch x86_64
-Source2:		%{url}/releases/download/%{version}/rmz-x86_64-unknown-linux-gnu
-Source3:		%{url}/releases/download/%{version}/cpz-x86_64-unknown-linux-gnu
+Source2:		%{url}/releases/download/%{version}/x86_64-unknown-linux-gnu-rmz
+Source3:		%{url}/releases/download/%{version}/x86_64-unknown-linux-gnu-cpz
 %elifarch aarch64
-Source2:		%{url}/releases/download/%{version}/rmz-aarch64-unknown-linux-gnu
-Source3:		%{url}/releases/download/%{version}/cpz-aarch64-unknown-linux-gnu
+Source2:		%{url}/releases/download/%{version}/aarch64-unknown-linux-gnu-rmz
+Source3:		%{url}/releases/download/%{version}/aarch64-unknown-linux-gnu-cpz
 %endif
 License:		Apache-2.0
 Requires:		cpz rmz
@@ -60,7 +60,3 @@ install -Dm755 %{SOURCE3} %{buildroot}/usr/bin/cpz
 %doc README.md
 %license LICENSE
 /usr/bin/cpz
-
-%changelog
-* Wed Jan 18 2023 windowsboy111 <windowsboy111@fyralabs.com> - 1.1.3-1
-- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: fuc (#3354)](https://github.com/terrapkg/packages/pull/3354)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)