### PR TITLE
[f40] fix(umu-launcher): urllib3 dependency issues on &lt;&#x3D; 41 (#3380)

### DIFF
--- a/anda/games/umu/anda.hcl
+++ b/anda/games/umu/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+    arches = ["x86_64"]
     rpm {
         spec = "umu-launcher.spec"
     }

--- a/anda/games/umu/umu-launcher.spec
+++ b/anda/games/umu/umu-launcher.spec
@@ -1,6 +1,6 @@
 Name:           umu-launcher
 Version:        1.2.3
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A tool for launching non-steam games with proton
 
 License:        GPL-3.0-only
@@ -27,11 +27,18 @@ BuildRequires:  python3-wheel
 BuildRequires:  python3-xlib
 BuildRequires:  python3-pyzstd
 BuildRequires:  cargo
+
 Requires:	python
 Requires:	python3
+%if %{?fedora} <= 41
 Requires:	python3-xlib
 Requires:	python3-filelock
+Requires:       python3-pyzstd
 
+AutoReqProv:    no
+%endif
+
+BuildArch:      x86_64
 
 %description
 %summary.
@@ -40,7 +47,11 @@ Requires:	python3-filelock
 %git_clone %url %version
 
 %build
+%if %{?fedora} <= 41
 ./configure.sh --prefix=%_prefix --use-system-pyzstd
+%else
+./configure.sh --prefix=%_prefix --use-system-pyzstd --use-system-urllib
+%endif
 %{make_build}
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(umu-launcher): urllib3 dependency issues on &lt;&#x3D; 41 (#3380)](https://github.com/terrapkg/packages/pull/3380)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)