### PR TITLE
[el10] Add: NeoHtop (#3368)

### DIFF
--- a/anda/apps/neohtop/NeoHtop.desktop
+++ b/anda/apps/neohtop/NeoHtop.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Categories=Utility;
+Comment=A cross-platform system monitor
+Exec=NeoHtop
+Icon=NeoHtop
+Name=NeoHtop
+Terminal=false
+Type=Application

--- a/anda/apps/neohtop/anda.hcl
+++ b/anda/apps/neohtop/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "neohtop.spec"
+    }
+}

--- a/anda/apps/neohtop/neohtop.spec
+++ b/anda/apps/neohtop/neohtop.spec
@@ -1,0 +1,51 @@
+%global __brp_mangle_shebangs %{nil}
+
+Name:           neohtop
+Version:        1.1.2
+Release:        1%?dist
+Summary:        System monitoring on steroids
+License:        MIT
+URL:            https://github.com/Abdenasser/neohtop
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+Source1:        NeoHtop.desktop
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+BuildRequires:  rust
+BuildRequires:  nodejs-npm
+BuildRequires:  webkit2gtk4.1-devel
+BuildRequires:  javascriptcoregtk4.1-devel
+BuildRequires:  libsoup3-devel
+BuildRequires:  gtk3-devel
+BuildRequires:  rust-gdk-pixbuf-sys-devel
+BuildRequires:  glib2-devel
+BuildRequires:  openssl-devel
+
+%description
+%summary.
+
+%prep
+%autosetup -n neohtop-%version
+
+%build
+npm install
+npm run tauri build
+
+%install
+install -Dpm755 src-tauri/target/release/NeoHtop %buildroot%_bindir/NeoHtop
+install -Dpm644 %{SOURCE1} %buildroot%{_datadir}/applications/NeoHtop.desktop
+# don't mind the numbers not matching, this is how the offical rpm installs these files
+install -Dpm644 src-tauri/icons/128x128@2x.png %buildroot%{_iconsdir}/hicolor/256x256@2/apps/NeoHtop.png
+install -Dpm644 src-tauri/icons/32x32.png %buildroot%{_iconsdir}/hicolor/32x32/apps/NeoHtop.png
+install -Dpm644 src-tauri/icons/128x128.png %buildroot%{_iconsdir}/hicolor/128x128/apps/NeoHtop.png
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/NeoHtop
+%{_datadir}/applications/NeoHtop.desktop
+%{_iconsdir}/hicolor/256x256@2/apps/NeoHtop.png
+%{_iconsdir}/hicolor/32x32/apps/NeoHtop.png
+%{_iconsdir}/hicolor/128x128/apps/NeoHtop.png
+
+%changelog
+* Sat Feb 15 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial package

--- a/anda/apps/neohtop/update.rhai
+++ b/anda/apps/neohtop/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Abdenasser/neohtop"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Add: NeoHtop (#3368)](https://github.com/terrapkg/packages/pull/3368)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)