### PR TITLE
[f42] fix(mock-configs): package missing el10 template file (#3408)

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,6 +1,6 @@
 Name:           terra-mock-configs
 Version:        1.4.1
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        Mock configs for Terra repos
 
@@ -27,11 +27,13 @@ Obsoletes: anda-mock-configs < 3-2%{?dist}
 mkdir -p %{buildroot}%{_sysusersdir}
 mkdir -p %{buildroot}%{_sysconfdir}/mock/templates
 
-cp -v terra.tpl %{buildroot}%{_sysconfdir}/mock/templates/
+# not copying terra-el.tpl as that might be a duplicate
+cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el-dev.tpl
 cp -v *.cfg %{buildroot}%{_sysconfdir}/mock/
 
 %files
 %config %{_sysconfdir}/mock/templates/terra.tpl
+%config %{_sysconfdir}/mock/templates/terra-el-dev.tpl
 %config %{_sysconfdir}/mock/terra-*-x86_64.cfg
 %config %{_sysconfdir}/mock/terra-*-aarch64.cfg
 %config %{_sysconfdir}/mock/terra-*-i386.cfg


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(mock-configs): package missing el10 template file (#3408)](https://github.com/terrapkg/packages/pull/3408)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)