### PR TITLE
[f41] fix: scenefx (#3407)

### DIFF
--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -6,7 +6,7 @@ Summary:        A drop-in replacement for the wlroots scene API that allows wayl
 URL:            https://github.com/wlrfx/scenefx
 License:        MIT
 
-Source0:        %{url}/archive/refs/tags/%version.tar.gz
+Source0:        %{url}/archive/%{version}.tar.gz
 
 
 BuildRequires:  cmake
@@ -55,22 +55,19 @@ MESON_OPTIONS=(
     -Dexamples=false
     -Dwerror=false
 )
-%{meson} "${MESON_OPTIONS[@]}"
-%{meson_build}
+%meson "${MESON_OPTIONS[@]}"
+%meson_build
 
 %install
-%{meson_install}
-
-%check
-%{meson_test}
+%meson_install
 
 
 %files
 %license LICENSE
 %doc README.md
-%{_libdir}/lib%{name}-%{version}.so
+%{_libdir}/lib%{name}-0.2.so
 
 
 %files  devel
-%{_includedir}/scenefx
-%{_libdir}/pkgconfig/%{name}.pc
+%{_includedir}/%{name}-0.2/*
+%{_libdir}/pkgconfig/%{name}-0.2.pc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: scenefx (#3407)](https://github.com/terrapkg/packages/pull/3407)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)