### PR TITLE
[f42] fix(carla): version string (#3401)

### DIFF
--- a/anda/multimedia/carla/Carla-nightly.spec
+++ b/anda/multimedia/carla/Carla-nightly.spec
@@ -5,7 +5,7 @@
 %global commit_date 20241205
 
 Name:           Carla-nightly
-Version:        %ver^%commit_date.git~%shortcommit
+Version:        %(echo %ver | tr -d 'v')^%commit_date.git~%shortcommit
 Release:        1%?dist
 Summary:        Audio plugin host
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(carla): version string (#3401)](https://github.com/terrapkg/packages/pull/3401)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)