### PR TITLE
[f42] fix: Add patch for Intel Battlemage + Valve Gamescope (#3420)

### DIFF
--- a/anda/lib/mesa/12633.patch
+++ b/anda/lib/mesa/12633.patch
@@ -1,0 +1,26 @@
+commit d0279e717ee740746f0770c5a9870d752108e756 (HEAD -> makepkg)
+Author: Maarten Lankhorst <maarten.lankhorst@intel.com>
+Date:   Mon Feb 17 14:55:29 2025 -0800
+
+    HACK: drm/xe gamescope fix
+    
+    Workaround gamescope DRM issues on Xe by allocating ANV_BO_ALLOC_SCANOUT
+    when using VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT
+    
+    Link: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues/4292#note_2784316
+    Signed-off-by: Matthew Schwartz <matthew.schwartz@linux.dev>
+
+diff --git a/src/intel/vulkan/anv_device.c b/src/intel/vulkan/anv_device.c
+index 1884932bbc7..cbc1b4aad87 100644
+--- a/src/intel/vulkan/anv_device.c
++++ b/src/intel/vulkan/anv_device.c
+@@ -1533,6 +1533,9 @@ VkResult anv_AllocateMemory(
+           dedicated_info->image != VK_NULL_HANDLE) {
+          ANV_FROM_HANDLE(anv_image, image, dedicated_info->image);
+ 
++         if (image->vk.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)
++            alloc_flags |= ANV_BO_ALLOC_SCANOUT;
++
+          /* Apply implicit sync to be compatible with clients relying on
+           * implicit fencing. This matches the behavior in iris i915_batch
+           * submit. An example client is VA-API (iHD), so only dedicated

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -76,7 +76,7 @@ Summary:        Mesa graphics libraries
 # disabled by default, and has to be enabled manually. See `terra/release/terra-mesa.repo` for details.
 Epoch:          1
 Version:        24.3.4
-Release:        4%?dist
+Release:        5%?dist
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 
@@ -94,6 +94,10 @@ Source1:        Mesa-MLAA-License-Clarification-Email.txt
 
 # https://gitlab.com/evlaV/mesa/
 Patch20:        valve.patch
+
+# Fix issues with Intel Battlemage under Valve's gamescope in DRM mode
+# https://gitlab.freedesktop.org/mesa/mesa/-/issues/12633
+Patch21:        12633.patch
 
 # s390x: fix build
 #Patch100:       https://src.fedoraproject.org/rpms/mesa/raw/e89544b7a4d811a64ca23b402add29524cc6f704/f/fix-egl-on-s390x.patch


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `f42`:
 - [fix: Add patch for Intel Battlemage + Valve Gamescope (#3420)](https://github.com/terrapkg/packages/pull/3420)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)