### PR TITLE
Update vo-aacenc URL and source links to HTTPS

### DIFF
--- a/anda/lib/vo-aacenc/vo-aacenc.spec
+++ b/anda/lib/vo-aacenc/vo-aacenc.spec
@@ -3,8 +3,8 @@ Version:        0.1.3
 Release:        1%{?dist}
 Summary:        VisualOn AAC encoder library
 License:        ASL 2.0
-URL:            http://sourceforge.net/projects/opencore-amr/
-Source0:        http://downloads.sourceforge.net/opencore-amr/%{name}/%{name}-%{version}.tar.gz
+URL:            https://sourceforge.net/projects/opencore-amr/
+Source0:        https://downloads.sourceforge.net/opencore-amr/%{name}/%{name}-%{version}.tar.gz
 BuildRequires:  gcc
 
 %description


### PR DESCRIPTION
vo-aacenc URL was http which was a permanent redirect to the https link.