### PR TITLE
[f42] fix(lightly-qt*): make update.rhai scripts actually function (#3430)

### DIFF
--- a/anda/themes/lightly-qt5/anda.hcl
+++ b/anda/themes/lightly-qt5/anda.hcl
@@ -3,4 +3,7 @@ project "pkg" {
     rpm {
         spec = "lightly-qt5.spec"
     }
+    labels {
+        updbranch = 1
+    }
 }

--- a/anda/themes/lightly-qt5/update.rhai
+++ b/anda/themes/lightly-qt5/update.rhai
@@ -1,7 +1,12 @@
-let repos = get("https://repology.org/api/v1/project/qt").json_arr();
-let branch = sh("git rev-parse --abbrev-ref HEAD", #{"stdout": "piped"}).ctx.stdout;
-branch.crop(1);
-branch.trim();
-let vers = repos.filter(|r| r.repo == `fedora_${branch}`).map(|r| [find("^(\\d+)\\.(\\d+)\\..+$", r.version, 1), find("^(\\d+)\\.(\\d+)\\..+$", r.version, 2)]);
-let ver = vers.find(|v| v[0] == "5")[1]; // assume there is only 1 package for v5.x
-open_file("anda/themes/lightly-qt5/VER5.txt").write(`${ver}`); // will trig rebuild when changed
+fn main() {
+    let branch = bump::as_bodhi_ver(labels.branch);
+    let url = `https://bodhi.fedoraproject.org/updates/?search=qt5-5.&status=stable&releases=${branch}&rows_per_page=1&page=1`;
+    for entry in get(url).json().updates[0].title.split(' ') {
+        let matches = find_all(`qt5-([\d.]+)-(\d+)\.[\w\d]+$`, entry);
+        if matches.len() != 0 {
+            return matches[0][1].split(".")[1];
+        }
+    }
+}
+
+open_file("anda/themes/lightly-qt5/VER5.txt").write(`${main()}`); // will trig rebuild when changed

--- a/anda/themes/lightly-qt6/anda.hcl
+++ b/anda/themes/lightly-qt6/anda.hcl
@@ -3,4 +3,7 @@ project "pkg" {
     rpm {
         spec = "lightly-qt6.spec"
     }
+    labels {
+        updbranch = 1
+    }
 }

--- a/anda/themes/lightly-qt6/update.rhai
+++ b/anda/themes/lightly-qt6/update.rhai
@@ -1,7 +1,12 @@
-let repos = get("https://repology.org/api/v1/project/qt").json_arr();
-let branch = sh("git rev-parse --abbrev-ref HEAD", #{"stdout": "piped"}).ctx.stdout;
-branch.crop(1);
-branch.trim();
-let vers = repos.filter(|r| r.repo == `fedora_${branch}`).map(|r| [find("^(\\d+)\\.(\\d+)\\..+$", r.version, 1), find("^(\\d+)\\.(\\d+)\\..+$", r.version, 2)]);
-let ver = vers.find(|v| v[0] == "6")[1]; // assume there is only 1 package for v6.x
-open_file("anda/themes/lightly-qt6/VER6.txt").write(`${ver}`); // will trig rebuild when changed
+fn main() {
+    let branch = bump::as_bodhi_ver(labels.branch);
+    let url = `https://bodhi.fedoraproject.org/updates/?search=qt6-6.&status=stable&releases=${branch}&rows_per_page=1&page=1`;
+    for entry in get(url).json().updates[0].title.split(' ') {
+        let matches = find_all(`qt6-([\d.]+)-(\d+)\.[\w\d]+$`, entry);
+        if matches.len() != 0 {
+            return matches[0][1].split(".")[1];
+        }
+    }
+}
+
+open_file("anda/themes/lightly-qt6/VER6.txt").write(`${main()}`); // will trig rebuild when changed


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(lightly-qt*): make update.rhai scripts actually function (#3430)](https://github.com/terrapkg/packages/pull/3430)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)