### PR TITLE
[f41] fix: change xavs URL to https from http (#3432)

### DIFF
--- a/anda/lib/xavs/xavs.spec
+++ b/anda/lib/xavs/xavs.spec
@@ -3,7 +3,7 @@ Version:        0.1.55
 Release:        1%{?dist}
 Summary:        AVS1 (First-generation AVS Standards) library
 License:        GPLv2
-URL:            http://xavs.sourceforge.net/
+URL:            https://xavs.sourceforge.net/
 Patch0:         %{name}-cflags.patch
 BuildRequires:  autoconf
 BuildRequires:  automake


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: change xavs URL to https from http (#3432)](https://github.com/terrapkg/packages/pull/3432)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)