### PR TITLE
[f42] fix(vo-aacenc): Update URL and source links to HTTPS (#3433)

### DIFF
--- a/anda/lib/vo-aacenc/vo-aacenc.spec
+++ b/anda/lib/vo-aacenc/vo-aacenc.spec
@@ -3,8 +3,8 @@ Version:        0.1.3
 Release:        1%{?dist}
 Summary:        VisualOn AAC encoder library
 License:        ASL 2.0
-URL:            http://sourceforge.net/projects/opencore-amr/
-Source0:        http://downloads.sourceforge.net/opencore-amr/%{name}/%{name}-%{version}.tar.gz
+URL:            https://sourceforge.net/projects/opencore-amr/
+Source0:        https://downloads.sourceforge.net/opencore-amr/%{name}/%{name}-%{version}.tar.gz
 BuildRequires:  gcc
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(vo-aacenc): Update URL and source links to HTTPS (#3433)](https://github.com/terrapkg/packages/pull/3433)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)