### PR TITLE
[f40] add: nstool (#3367)

### DIFF
--- a/anda/tools/nstool/anda.hcl
+++ b/anda/tools/nstool/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "nstool.spec"
+    }
+}

--- a/anda/tools/nstool/nstool.spec
+++ b/anda/tools/nstool/nstool.spec
@@ -1,0 +1,36 @@
+%global debug_package %{nil}
+
+%global ver v1.9.2
+%global sanitized_ver %(echo "$( tr -d 'v' <<< %{ver} )")
+
+Name:           nstool
+Version:        %{sanitized_ver}
+Release:        1%{?dist}
+Summary:        General purpose read/extract tool for Nintendo Switch file formats
+
+License:        MIT
+URL:            https://github.com/jakcron/nstool
+
+Packager:       sadlerm <lerm@chromebooks.lol>
+
+BuildRequires:  make gcc gcc-c++
+BuildRequires:  anda-srpm-macros
+
+%description
+General purpose reading/extraction tool for Nintendo Switch file formats.
+
+%prep
+%git_clone %{url} %{ver}
+
+%build
+%make_build deps
+%make_build program
+
+%install
+install -Dm755 bin/%{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%license LICENSE
+%doc README.md SWITCH_KEYS.md
+%{_bindir}/%{name}
+

--- a/anda/tools/nstool/update.rhai
+++ b/anda/tools/nstool/update.rhai
@@ -1,0 +1,1 @@
+rpm.global("ver", gh_tag("jakcron/nstool"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: nstool (#3367)](https://github.com/terrapkg/packages/pull/3367)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)