### PR TITLE
[f41] fix(audacity-freeworld): update.rhai function (#3351)

### DIFF
--- a/anda/apps/audacity-freeworld/audacity-freeworld.spec
+++ b/anda/apps/audacity-freeworld/audacity-freeworld.spec
@@ -5,7 +5,7 @@
 %global sanitized_ver %(echo "$( sed 's/Audacity-//' <<< "%{ver}" )")
 
 Name:    audacity-freeworld
-Version: split.3.0.3
+Version: %{sanitized_ver}
 Release: 1%?dist
 Summary: Multitrack audio editor
 License: GPLv2

--- a/anda/apps/audacity-freeworld/update.rhai
+++ b/anda/apps/audacity-freeworld/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("audacity/audacity"));
+rpm.global("ver", gh_tag("audacity/audacity"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(audacity-freeworld): update.rhai function (#3351)](https://github.com/terrapkg/packages/pull/3351)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)