### PR TITLE
[el10] Fix: Steam for F41 and below (REAL) (#3477)

### DIFF
--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -5,7 +5,7 @@
 
 Name:           steam
 Version:        1.0.0.82
-Release:        4%?dist
+Release:        5%?dist
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT
@@ -136,8 +136,7 @@ Recommends:     gobject-introspection
 Requires:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 
 # Fix upgrading from old versions
-Provides:       %{name} = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
-Obsoletes:      %{name} < %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+Obsoletes:      %{name} <= %{?epoch:%{epoch}:}1.0.0.82-1%{?dist}.x86_64
 
 %description
 Steam is a software distribution service with an online store, automated
@@ -150,10 +149,10 @@ This package contains the installer for the Steam software distribution service.
 Summary:        Permissions required by Steam for gaming devices
 BuildArch:      noarch
 Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
-Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}
 # Fix upgrading from old versions
-Provides:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
-Obsoletes:      steam-devices < %{?epoch:%{epoch}:}%{version}-%{release}.x86_64
+Provides:       steam-devices <= %{?epoch:%{epoch}:}1.0.0.82-1%{?dist}.x86_64
+Obsoletes:      %{name} <= %{?epoch:%{epoch}:}1.0.0.82-1%{?dist}.x86_64
+Requires:       %{name} = %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description    devices
 Steam is a software distribution service with an online store, automated


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `el10`:
 - [Fix: Steam for F41 and below (REAL) (#3477)](https://github.com/terrapkg/packages/pull/3477)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)