### PR TITLE
[frawhide] fix(dotherside): dep on cmake(Qt6XcbQpaPrivate) (#3476)

### DIFF
--- a/anda/lib/dotherside/DOtherSide.spec
+++ b/anda/lib/dotherside/DOtherSide.spec
@@ -13,6 +13,7 @@ BuildRequires:  cmake(Qt6Gui)
 BuildRequires:  cmake(Qt6Quick)
 BuildRequires:  cmake(Qt6QuickControls2)
 BuildRequires:  cmake(Qt6Widgets)
+BuildRequires:  cmake(Qt6XcbQpaPrivate)
 
 %description
 %summary.


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `frawhide`:
 - [fix(dotherside): dep on cmake(Qt6XcbQpaPrivate) (#3476)](https://github.com/terrapkg/packages/pull/3476)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)