### PR TITLE
[f41] fix(kf6-kio): update spec file from upstream (#3484)

### DIFF
--- a/anda/desktops/kde/kf6-kio/kf6-kio.spec
+++ b/anda/desktops/kde/kf6-kio/kf6-kio.spec
@@ -5,7 +5,7 @@
 
 Name:    kf6-%{framework}
 Version: %{majmin_ver_kf6}.0
-Release: 1%{?dist}.switcheroo
+Release: 2%{?dist}.switcheroo
 Summary: KDE Frameworks 6 Tier 3 solution for filesystem abstraction
 
 License: BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND LGPL-3.0-only AND (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only) AND MIT
@@ -187,6 +187,7 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 %{_kf6_plugindir}/kio/
 %{_kf6_plugindir}/kded/
 %{_kf6_plugindir}/kiod/
+%{_kf6_plugindir}/kio_dnd/
 %{_kf6_datadir}/kf6/searchproviders/*.desktop
 %{_kf6_datadir}/applications/*.desktop
 %{_datadir}/dbus-1/services/org.kde.*.service
@@ -223,6 +224,9 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 %{_qt6_docdir}/*.qch
 
 %changelog
+* Fri Feb 07 2025 Marc Deop i Argemí <marcdeop@fedoraproject.org> - 6.11.0-1
+- 6.11.0
+
 * Fri Jan 17 2025 Fedora Release Engineering <releng@fedoraproject.org> - 6.10.0-3
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_42_Mass_Rebuild
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(kf6-kio): update spec file from upstream (#3484)](https://github.com/terrapkg/packages/pull/3484)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)