### PR TITLE
[f40] add: astal (#3490)

### DIFF
--- a/anda/lib/astal/astal/anda.hcl
+++ b/anda/lib/astal/astal/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "astal.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/lib/astal/astal/astal.spec
+++ b/anda/lib/astal/astal/astal.spec
@@ -1,0 +1,62 @@
+
+%global commit 3620d51bc6c23ada1bd4b7c9cf1c458c138e68df
+%global shortcommit %{sub %commit 1 7}
+%global commit_date 20250222
+
+Name:			astal
+Version:		0^%commit_date.%shortcommit
+Release:		1%?dist
+Summary:		Building blocks for creating custom desktop shells
+License:		LGPL-2.1-only
+URL:			https://aylur.github.io/astal
+Source0:		https://github.com/Aylur/astal/archive/%commit.tar.gz
+Provides:		astal
+Requires:		%{name}-io-libs%{?_isa} = %{version}-%{release}
+BuildRequires:	meson gobject-introspection vala valadoc 
+
+%description
+The Linux Suite and Framework to Craft Desktop Shells and beautiful functional Wayland Widgets with GTK!
+
+%package	io-libs
+Summary:	Shared libraries of libastal-io
+
+%description io-libs
+%summary. (IO)
+
+This package contains shared libraries for astal-io.
+
+%package	io-devel
+Summary:	Development libraries of libastal-io
+Requires:	%{name}-io-libs%{?_isa} = %{version}-%{release}
+
+%description io-devel
+%summary. (IO)
+This package contains development files and documentation for astal-io.
+
+%prep
+%autosetup -n astal-%commit
+
+%build
+cd lib/astal/io
+%meson
+%meson_build
+
+%install
+cd lib/astal/io
+%meson_install
+
+%files
+%_bindir/astal
+
+%files io-libs
+%license LICENSE
+%_libdir/libastal-io.so.0
+%_libdir/libastal-io.so.0.1.0
+
+%files io-devel
+%_datadir/gir-1.0/AstalIO-0.1.gir
+%_datadir/vala/vapi/astal-io-0.1.vapi
+%_includedir/astal-io.h
+%_libdir/girepository-1.0/AstalIO-0.1.typelib
+%_libdir/libastal-io.so
+%_libdir/pkgconfig/astal-io-0.1.pc

--- a/anda/lib/astal/astal/update.rhai
+++ b/anda/lib/astal/astal/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("Aylur/astal"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}

--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -20,3 +20,16 @@ fn bodhi(pkg, branch) {
     let url = `https://bodhi.fedoraproject.org/updates/?search=${pkg}&status=stable&releases=${branch}&rows_per_page=1&page=1`;
     return find(`^${pkg}-([\d.]+)-\d+\.[\w\d]+$`, get(url).json().updates[0].title, 1);
 }
+
+
+fn madoguchi_json(pkg, branch) {
+    let branch = labels.branch;
+    if branch.starts_with("f") {
+	    branch.crop(1);
+    }
+    return get(`https://madoguchi.fyralabs.com/v4/terra${branch}/packages/${pkg}`).json();
+}
+
+fn madoguchi(pkg, branch) {
+    return madoguchi_json(pkg, branch).ver;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: astal (#3490)](https://github.com/terrapkg/packages/pull/3490)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)