### PR TITLE
[f42] fix(ghostty-nightly): update.rhai mistake (#3497)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -3,7 +3,7 @@
 %global fulldate 2025-02-22
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
-%global base_ver v1.1.2
+%global base_ver 1.1.2
 %global dev_ver 1.1.3
 %if 0%{?fedora} <= 40
 %global cache_dir %{_builddir}/zig-cache
@@ -13,7 +13,7 @@
 
 Name:           ghostty-nightly
 Version:        %{base_ver}~tip^%{commit_date}git%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif

--- a/anda/devs/ghostty/nightly/update.rhai
+++ b/anda/devs/ghostty/nightly/update.rhai
@@ -7,7 +7,10 @@ if rpm.changed() {
     date.truncate(10);
     let html = get(`https://raw.githubusercontent.com/ghostty-org/ghostty/refs/heads/main/build.zig.zon`);
     let ver = find(".version = \"([\\d.]+)\"", html, 1);
-    rpm.global("base_ver", gh_tag("ghostty-org/ghostty"));
+    let base = gh_tag("ghostty-org/ghostty");
+    base.crop(1);
+    rpm.global("base_ver", base);
     rpm.global("fulldate", date);
-    rpm.global("dev_ver", ver)
+    rpm.global("dev_ver", ver);
+    rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(ghostty-nightly): update.rhai mistake (#3497)](https://github.com/terrapkg/packages/pull/3497)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)