### PR TITLE
[f42] add: curl-impersonate-chrome (#3515)

### DIFF
--- a/anda/tools/curl-impersonate/anda.hcl
+++ b/anda/tools/curl-impersonate/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "curl-impersonate-chrome.spec"
+    }
+}

--- a/anda/tools/curl-impersonate/curl-impersonate-chrome.spec
+++ b/anda/tools/curl-impersonate/curl-impersonate-chrome.spec
@@ -1,0 +1,81 @@
+%global build_cxxflags %(echo "%{__build_flags_lang_cxx} %{?_distro_extra_cxxflags}" | sed 's@-Werror=format-security@@')
+
+Name:           curl-impersonate-chrome
+Version:        0.7.0
+Release:        1%{?dist}
+Summary:        A series of patches that make curl requests look like Chrome
+
+License:        MIT
+URL:            https://github.com/lexiforest/curl-impersonate
+Source0:        %{url}/archive/v%{version}.tar.gz
+Patch0:         remove-werror-in-boringssl-build.patch
+Patch1:         install-sh-scripts-to-buildroot.patch
+
+Packager:       sadlerm <lerm@chromebooks.lol>
+
+BuildRequires:  autoconf automake make cmake ninja-build
+BuildRequires:  gcc gcc-c++ libtool
+BuildRequires:  golang
+BuildRequires:  unzip
+BuildRequires:  zlib-ng-compat-devel
+BuildRequires:  zstd libzstd-devel
+
+%global _description %{expand:
+A special build of curl that can impersonate Chrome, Edge and Safari. curl-impersonate is able to perform TLS and HTTP handshakes that are identical to that of a real browser.
+
+curl-impersonate can be used either as a command line tool, similar to the regular curl, or as a library that can be integrated instead of the regular libcurl.}
+
+%description %_description
+
+
+%package libs
+Summary:        Shared libraries for %{name}
+Provides:       libcurl-impersonate-chrome = %{version}-%{release}
+
+%description libs
+%_description
+
+This package provides the libcurl-impersonate-chrome shared object file, which is libcurl compiled with the same changes as the curl-impersonate binary.
+
+%package devel
+Summary:        Development files for %{name}
+Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
+
+%description devel
+%_description
+
+This package contains the object files necessary to develop %{name}.
+
+
+%prep
+%autosetup -n curl-impersonate-%{version} -p1
+
+%build
+%configure
+%{__make} chrome-build
+
+%check
+%{__make} chrome-checkbuild
+
+%install
+%{__make} DESTDIR=%{buildroot} chrome-install 
+
+%files
+%license LICENSE
+%doc README.md docs/
+%{_bindir}/%{name}
+%{_bindir}/%{name}-config
+%{_bindir}/curl_*
+
+%files libs
+%license LICENSE
+%{_prefix}/lib/libcurl-impersonate-chrome.so.4
+%{_prefix}/lib/libcurl-impersonate-chrome.so.4.[0-9].[0-9]
+
+%files devel
+%{_prefix}/lib/libcurl-impersonate-chrome.a
+%{_prefix}/lib/libcurl-impersonate-chrome.so
+
+%changelog
+* Sun Feb 23 2025 sadlerm <lerm@chromebooks.lol>
+- Initial package

--- a/anda/tools/curl-impersonate/install-sh-scripts-to-buildroot.patch
+++ b/anda/tools/curl-impersonate/install-sh-scripts-to-buildroot.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index 41d7324..56a029e 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -83,7 +83,7 @@ chrome-install: ## Install the Chrome version of curl-impersonate after build
+ 	cd $(CURL_VERSION)
+ 	$(MAKE) install-exec MAKEFLAGS=
+ 	# Wrapper scripts for the Chrome version (e.g. 'curl_chrome99')
+-	install $(srcdir)/chrome/curl_* @bindir@
++	install $(srcdir)/chrome/curl_* $(DESTDIR)@bindir@
+ .PHONY: chrome-install
+ 
+ chrome-install-strip: ## Like 'chrome-install', but strip binaries for smaller size

--- a/anda/tools/curl-impersonate/remove-werror-in-boringssl-build.patch
+++ b/anda/tools/curl-impersonate/remove-werror-in-boringssl-build.patch
@@ -1,0 +1,18 @@
+diff --git a/chrome/patches/boringssl.patch b/chrome/patches/boringssl.patch
+index d3adf2d..a7cf3a6 100644
+--- a/chrome/patches/boringssl.patch
++++ b/chrome/patches/boringssl.patch
+@@ -8,6 +8,13 @@ index 000000000..678d1ca41
+ +
+ +git diff d24a382 > boringssl.patch
+ +mv boringssl.patch ../curl-impersonate/chrome/patches/boringssl.patch
++diff --git a/CMakeLists.txt b/CMakeLists.txt
++index ee5cc0466..32d1c8cca 100644
++--- a/CMakeLists.txt
+++++ b/CMakeLists.txt
++@@ -143 +143 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CLANG)
++-  set(C_CXX_FLAGS "-Werror -Wformat=2 -Wsign-compare -Wwrite-strings -Wvla -Wshadow -Wtype-limits")
+++  set(C_CXX_FLAGS "-Wformat=2 -Wsign-compare -Wwrite-strings -Wvla -Wshadow -Wtype-limits")
+ diff --git a/include/openssl/ssl.h b/include/openssl/ssl.h
+ index e500dd76e..e75bca26b 100644
+ --- a/include/openssl/ssl.h


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: curl-impersonate-chrome (#3515)](https://github.com/terrapkg/packages/pull/3515)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)