### PR TITLE
[el10] fix(andax/bump_extras): funny error (#3532)

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -23,7 +23,6 @@ fn bodhi(pkg, branch) {
 
 
 fn madoguchi_json(pkg, branch) {
-    let branch = labels.branch;
     if branch.starts_with("f") {
 	    branch.crop(1);
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(andax/bump_extras): funny error (#3532)](https://github.com/terrapkg/packages/pull/3532)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)