### PR TITLE
[f42] Add: MS-Core Fonts (#3540)

### DIFF
--- a/anda/fonts/cleartype/61-cleartype-calibri.conf
+++ b/anda/fonts/cleartype/61-cleartype-calibri.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Calibri</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Calibri</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/cleartype/61-cleartype-cambria.conf
+++ b/anda/fonts/cleartype/61-cleartype-cambria.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Cambria</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Cambria</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/cleartype/61-cleartype-candara.conf
+++ b/anda/fonts/cleartype/61-cleartype-candara.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Candara</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Candara</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/cleartype/61-cleartype-consolas.conf
+++ b/anda/fonts/cleartype/61-cleartype-consolas.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>monospace</family>
+    <prefer>
+      <family>Consolas</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Consolas</family>
+    <default>
+      <family>monospace</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/cleartype/61-cleartype-constantia.conf
+++ b/anda/fonts/cleartype/61-cleartype-constantia.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Constantia</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Constantia</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/cleartype/61-cleartype-corbel.conf
+++ b/anda/fonts/cleartype/61-cleartype-corbel.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Corbel</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Corbel</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/cleartype/anda.hcl
+++ b/anda/fonts/cleartype/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "cleartype-fonts.spec"
+	}
+}

--- a/anda/fonts/cleartype/cleartype-fonts.spec
+++ b/anda/fonts/cleartype/cleartype-fonts.spec
@@ -1,0 +1,146 @@
+%global debug_package     %{nil}
+%global fontname          cleartype
+%global fontlicense       Microsoft EULA
+%global fontlicenses      EULA eula.txt
+
+%global fontfamily1       ClearType Calibri
+%global fontsummary1      ClearType Calibri TTF font
+%global fontpkgheader1    %{expand:
+Obsoletes: %{name}-common < 1.0-5
+}
+
+%global fonts1            CALIBR*.TTF
+%global fontconfs1        %{SOURCE1}
+%global fontdescription1  %{expand:
+%{common_description}
+Microsoft Calibri font, part of the ClearType collection made available
+in the PowerPointViewer package, still available on the Microsoft website.
+}
+
+%global fontfamily2       ClearType Cambria
+%global fontsummary2      ClearType Cambria TTF font
+%global fontpkgheader2    %{expand:
+Obsoletes: %{name}-common < 1.0-5
+}
+
+%global fonts2            CAMBRI*.TTF
+%global fontconfs2        %{SOURCE2}
+%global fontdescription2  %{expand:
+%{common_description}
+Microsoft Cambria font, part of the ClearType collection made available
+in the PowerPointViewer package, still available on the Microsoft website.
+}
+
+%global fontfamily3       ClearType Candara
+%global fontsummary3      ClearType Candara TTF font
+%global fontpkgheader3    %{expand:
+Obsoletes: %{name}-common < 1.0-5
+}
+
+%global fonts3            CANDAR*.TTF
+%global fontconfs3        %{SOURCE3}
+%global fontdescription3  %{expand:
+%{common_description}
+Microsoft Candara font, part of the ClearType collection made available
+in the PowerPointViewer package, still available on the Microsoft website.
+}
+
+%global fontfamily4       ClearType Consolas
+%global fontsummary4      ClearType Consolas TTF font
+%global fontpkgheader4    %{expand:
+Obsoletes: %{name}-common < 1.0-5
+}
+
+%global fonts4            CONSOL*.TTF
+%global fontconfs4        %{SOURCE4}
+%global fontdescription4  %{expand:
+%{common_description}
+Microsoft Consolas font, part of the ClearType collection made available
+in the PowerPointViewer package, still available on the Microsoft website.
+}
+
+%global fontfamily5       ClearType Constantia
+%global fontsummary5      ClearType Constantia TTF font
+%global fontpkgheader5    %{expand:
+Obsoletes: %{name}-common < 1.0-5
+}
+
+%global fonts5            CONSTAN*.TTF
+%global fontconfs5        %{SOURCE5}
+%global fontdescription5  %{expand:
+%{common_description}
+Microsoft Constantia font, part of the ClearType collection made available
+in the PowerPointViewer package, still available on the Microsoft website.
+}
+
+%global fontfamily6       ClearType Corbel
+%global fontsummary6      ClearType Corbel TTF font
+%global fontpkgheader6    %{expand:
+Obsoletes: %{name}-common < 1.0-5
+}
+
+%global fonts6            CORBEL*.TTF
+%global fontconfs6        %{SOURCE6}
+%global fontdescription6  %{expand:
+%{common_description}
+Microsoft Corbel font, part of the ClearType collection made available
+in the PowerPointViewer package, still available on the Microsoft website.
+}
+
+Name:           %{fontname}-fonts
+Version:        1.0
+Release:        1%{?dist}
+Summary:        Package containing ClearType fonts.
+License:        LicenseRef-MS-Core-Fonts
+URL:            http://mscorefonts2.sourceforge.net
+Group:          User Interface/X
+Source0:        http://sourceforge.net/projects/mscorefonts2/files/cabs/PowerPointViewer.exe
+Source1:        61-%{fontname}-calibri.conf
+Source2:        61-%{fontname}-cambria.conf
+Source3:        61-%{fontname}-candara.conf
+Source4:        61-%{fontname}-consolas.conf
+Source5:        61-%{fontname}-constantia.conf
+Source6:        61-%{fontname}-corbel.conf
+BuildRequires:  cabextract
+BuildRequires:  fontpackages-devel
+Requires:       xorg-x11-font-utils
+Requires:       fontconfig
+Requires:       %{fontname}-calibri-fonts
+Requires:       %{fontname}-cambria-fonts
+Requires:       %{fontname}-candara-fonts
+Requires:       %{fontname}-consolas-fonts
+Requires:       %{fontname}-constantia-fonts
+Requires:       %{fontname}-corbel-fonts
+Requires(post): fontconfig
+BuildArch:      noarch
+Packager:       ShinyGil <rockgrub@disroot.org>
+
+%fontpkg -a
+
+%description
+ClearType fonts made available to the public in the PowerPoint Viewer package in 2006.
+
+%prep
+%setup -cT
+cabextract %{SOURCE0}
+cabextract ppviewer.cab
+%forgesetup -a
+
+%build
+%fontbuild -a
+
+%install
+%fontinstall -a
+
+%check
+%fontcheck -a
+%fontfiles -a
+
+%post
+/usr/bin/fc-cache
+
+%files
+
+%changelog
+* Mon Feb 24 2025 ShinyGil <rockgrub@disroot.org>
+- Initial package

--- a/anda/fonts/ms-core-tahoma/61-ms-core-tahoma.conf
+++ b/anda/fonts/ms-core-tahoma/61-ms-core-tahoma.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Tahoma</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Tahoma</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core-tahoma/anda.hcl
+++ b/anda/fonts/ms-core-tahoma/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "ms-core-tahoma-fonts.spec"
+	}
+}

--- a/anda/fonts/ms-core-tahoma/ms-core-tahoma-fonts.spec
+++ b/anda/fonts/ms-core-tahoma/ms-core-tahoma-fonts.spec
@@ -1,0 +1,66 @@
+%global fontlicense       Microsoft EULA
+%global fontlicenses      License.txt
+
+%global fontfamily1       MS Core Tahoma
+%global fontsummary1      Tahoma TTF font
+%global fontpkgheader1    %{expand:
+Obsoletes: %{name}-common < 1.0-5
+}
+
+%global fonts1            tahoma.ttf
+%global fontconfs1        %{SOURCE1}
+%global fontdescription1  %{expand:
+%{common_description}
+TTF Tahoma fonts that were made available to the public in the Word Reader
+package.
+}
+
+### Different name because of font package and setup macro weirdness
+Name:           mscore-tahoma-fonts
+Version:        1.0
+Release:        1%{?dist}
+Summary:        Microsoft core Tahoma fonts for better Windows compatibility
+License:        LicenseRef-MS-Core-Fonts
+URL:            https://github.com/leamas/lpf
+Group:          User Interface/X
+Source0:        http://downloads.sourceforge.net/corefonts/the%%20fonts/final/wd97vwr32.exe
+Source1:        61-ms-core-tahoma.conf
+BuildRequires:  cabextract
+BuildRequires:  fontpackages-devel
+Requires:       xorg-x11-font-utils
+Requires:       fontconfig
+BuildArch:      noarch
+Packager:       ShinyGil <rockgrub@disroot.org>
+
+%fontpkg -a
+
+%description
+TTF Tahoma fonts that were made available to the public in the Word Reader package.
+
+Improves the look of Windows documents.
+
+
+%prep
+%setup -cT
+cabextract %{SOURCE0}
+cabextract Viewer1.cab
+%forgesetup -a
+
+%build
+%fontbuild -a
+
+%install
+%fontinstall -a
+
+%check
+%fontcheck -a
+%fontfiles -a
+
+%post
+/usr/bin/fc-cache
+
+%files
+
+%changelog
+* Mon Feb 24 2025 ShinyGil <rockgrub@disroot.org>
+- Initial package

--- a/anda/fonts/ms-core-tahoma/post.rhai
+++ b/anda/fonts/ms-core-tahoma/post.rhai
@@ -1,0 +1,2 @@
+// Remove empty build package
+sh("rm anda-build/rpm/rpms/mscore-*.rpm", #{});

--- a/anda/fonts/ms-core/61-ms-core-andale.conf
+++ b/anda/fonts/ms-core/61-ms-core-andale.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>monospace</family>
+    <prefer>
+      <family>Andale Mono</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Andale Mono</family>
+    <default>
+      <family>monospace</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-arial.conf
+++ b/anda/fonts/ms-core/61-ms-core-arial.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Arial</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Arial</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-comic.conf
+++ b/anda/fonts/ms-core/61-ms-core-comic.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>cursive</family>
+    <prefer>
+      <family>Comic Sans MS</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Comic Sans MS</family>
+    <default>
+      <family>cursive</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-courier.conf
+++ b/anda/fonts/ms-core/61-ms-core-courier.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>monospace</family>
+    <prefer>
+      <family>Courier New</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Courier New</family>
+    <default>
+      <family>monospace</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-georgia.conf
+++ b/anda/fonts/ms-core/61-ms-core-georgia.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Georgia</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Georgia</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-impact.conf
+++ b/anda/fonts/ms-core/61-ms-core-impact.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Impact</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Impact</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-times.conf
+++ b/anda/fonts/ms-core/61-ms-core-times.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>serif</family>
+    <prefer>
+      <family>Times New Roman</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Times New Roman</family>
+    <default>
+      <family>serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-trebuchet.conf
+++ b/anda/fonts/ms-core/61-ms-core-trebuchet.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Trebuchet MS</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Trebuchet MS</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-verdana.conf
+++ b/anda/fonts/ms-core/61-ms-core-verdana.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>sans-serif</family>
+    <prefer>
+      <family>Verdana</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Verdana</family>
+    <default>
+      <family>sans-serif</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/61-ms-core-webdings.conf
+++ b/anda/fonts/ms-core/61-ms-core-webdings.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <alias>
+    <family>dingbats</family>
+    <prefer>
+      <family>Webdings</family>
+    </prefer>
+  </alias>
+  <alias>
+    <family>Webdings</family>
+    <default>
+      <family>dingbats</family>
+    </default>
+  </alias>
+</fontconfig>

--- a/anda/fonts/ms-core/anda.hcl
+++ b/anda/fonts/ms-core/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+                arches = ["x86_64"]
+	rpm {
+		spec = "ms-core-fonts.spec"
+	}
+}

--- a/anda/fonts/ms-core/ms-core-fonts.spec
+++ b/anda/fonts/ms-core/ms-core-fonts.spec
@@ -1,0 +1,229 @@
+%global                   fontname ms-core
+%global sf_corefonts      http://downloads.sourceforge.net/corefonts/the%20fonts/final
+%global fontlicense       Microsoft EULA
+%global fontlicenses      Licen.TXT
+
+%global fontfamily1       MS Core Andale
+%global fontsummary1      Microsoft Andale Mono TTF font
+%global fontpkgheader1    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts1            AndaleMo.TTF
+%global fontconfs1        %{SOURCE8}
+%global fontdescription1  %{expand:
+%{common_description}
+Andale Mono font for the web that prior to 2002 was available from
+http://www.microsoft.com/typography/fontpack.
+}
+
+%global fontfamily2       MS Core Arial
+%global fontsummary2      Microsoft Arial TTF font
+%global fontpkgheader2    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts2            Arial*.ttf AriBlk.TTF
+%global fontconfs2        %{SOURCE9}
+%global fontdescription2  %{expand:
+%{common_description}
+Microsoft Arial font for the web that prior to 2002 was available from
+http://www.microsoft.com/typography/fontpack/, updated in the European
+Union Expansion Update circa May 2007, still available on the Microsoft
+website.
+}
+
+%global fontfamily3       MS Core Comic
+%global fontsummary3      Microsoft Comic Sans TTF font
+%global fontpkgheader3    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts3            Comic*.TTF
+%global fontconfs3        %{SOURCE10}
+%global fontdescription3  %{expand:
+%{common_description}
+Comic Sans bold and regular font for the web that prior to 2002 was available
+from http://www.microsoft.com/typography/fontpack.
+}
+
+%global fontfamily4       MS Core Courier
+%global fontsummary4      Microsoft Courier New TTF font
+%global fontpkgheader4    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts4            cour*ttf
+%global fontconfs4        %{SOURCE11}
+%global fontdescription4  %{expand:
+%{common_description}
+Courier New bold, bold italic, italic and regular font for the web that prior
+to 2002 was available from http://www.microsoft.com/typography/fontpack.
+}
+
+%global fontfamily5       MS Core Georgia
+%global fontsummary5      Microsoft Georgia TTF font
+%global fontpkgheader5    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts5            Georgi*TTF
+%global fontconfs5        %{SOURCE12}
+%global fontdescription5  %{expand:
+%{common_description}
+Georgia font for the web that prior to 2002 was available from
+http://www.microsoft.com/typography/fontpack.
+}
+
+%global fontfamily6       MS Core Impact
+%global fontsummary6      Microsoft Impact TTF font
+%global fontpkgheader6    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts6            Impact.TTF
+%global fontconfs6        %{SOURCE13}
+%global fontdescription6  %{expand:
+%{common_description}
+Impact font for the web that prior to 2002 was available from
+http://www.microsoft.com/typography/fontpack.
+}
+
+%global fontfamily7       MS Core Times
+%global fontsummary7      Microsoft Times New Roman TTF font
+%global fontpkgheader7    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts7            Times*.ttf
+%global fontconfs7        %{SOURCE14}
+%global fontdescription7  %{expand:
+%{common_description}
+Microsoft Times New Roman font for the web that prior to 2002 was available from
+http://www.microsoft.com/typography/fontpack/, updated in the European
+Union Expansion Update circa May 2007, still available on the Microsoft
+website.
+}
+
+%global fontfamily8       MS Core Trebuchet
+%global fontsummary8      Microsoft Trebuchet TTF font
+%global fontpkgheader8    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts8            trebuc*.ttf
+%global fontconfs8        %{SOURCE15}
+%global fontdescription8  %{expand:
+%{common_description}
+Microsoft Trebuchet font for the web that prior to 2002 was available
+from http://www.microsoft.com/typography/fontpack, updated
+in the European Union Expansion Update circa May 2007, still available
+on the Microsoft website.
+}
+
+%global fontfamily9       MS Core Verdana
+%global fontsummary9      Microsoft Verdana TTF font
+%global fontpkgheader9    %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts9            Verdana*.ttf
+%global fontconfs9        %{SOURCE16}
+%global fontdescription9  %{expand:
+%{common_description}
+Microsoft Verdana font for the web that prior to 2002 was available from
+http://www.microsoft.com/typography/fontpack/, updated in the European
+Union Expansion Update circa May 2007, still available on the Microsoft
+website.
+}
+
+%global fontfamily10      MS Core Webdings
+%global fontsummary10     Microsoft Verdana TTF font
+%global fontpkgheader10   %{expand:
+Obsoletes: %{name}-common <= 2.2-4
+}
+
+%global fonts10           Webdings.TTF
+%global fontconfs10       %{SOURCE17}
+%global fontdescription10 %{expand:
+%{common_description}
+Webdings font for the web that prior to 2002 was available from
+http://www.microsoft.com/typography/fontpack.
+}
+
+Name:            ms-core-fonts
+Version:         2.2
+Release:         1%{?dist}
+Summary:         Microsoft core fonts
+License:         LicenseRef-MS-Core-Fonts
+URL:             http://mscorefonts2.sourceforge.net
+Group:           User Interface/X
+Source0:         http://sourceforge.net/projects/mscorefonts2/files/cabs/EUupdate.EXE
+Source1:         %{sf_corefonts}/andale32.exe
+Source2:         %{sf_corefonts}/arialb32.exe
+Source3:         %{sf_corefonts}/comic32.exe
+Source4:         %{sf_corefonts}/courie32.exe
+Source5:         %{sf_corefonts}/georgi32.exe
+Source6:         %{sf_corefonts}/impact32.exe
+Source7:         %{sf_corefonts}/webdin32.exe
+Source8:         61-ms-core-andale.conf
+Source9:         61-ms-core-arial.conf
+Source10:        61-ms-core-comic.conf
+Source11:        61-ms-core-courier.conf
+Source12:        61-ms-core-georgia.conf
+Source13:        61-ms-core-impact.conf
+Source14:        61-ms-core-times.conf
+Source15:        61-ms-core-trebuchet.conf
+Source16:        61-ms-core-verdana.conf
+Source17:        61-ms-core-webdings.conf
+BuildRequires:   cabextract
+BuildRequires:   fontpackages-devel
+Requires:        fontconfig
+Requires:        %{fontname}-andale-fonts
+Requires:        %{fontname}-arial-fonts
+Requires:        %{fontname}-comic-fonts
+Requires:        %{fontname}-courier-fonts
+Requires:        %{fontname}-georgia-fonts
+Requires:        %{fontname}-impact-fonts
+Requires:        %{fontname}-times-fonts
+Requires:        %{fontname}-trebuchet-fonts
+Requires:        %{fontname}-verdana-fonts
+Requires:        %{fontname}-webdings-fonts
+Requires:        xorg-x11-font-utils
+Requires(post):  fontconfig
+BuildArch:       noarch
+Packager:        ShinyGil <rockgrub@disroot.org>
+
+%fontpkg -a
+
+%description
+TrueType core fonts that prior to 2002 were available from http://www.microsoft.com/typography/fontpack/
+
+Updated in the European Union Expansion Update circa May 2007.
+
+Still available on the Microsoft website.
+
+%prep
+%setup -cT
+cabextract %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} \
+    %{SOURCE4} %{SOURCE5} %{SOURCE6} %{SOURCE7}
+%forgesetup -a
+
+%build
+%fontbuild -a
+
+%install
+%fontinstall -a
+
+%check
+%fontcheck -a
+%fontfiles -a
+
+%post
+/usr/bin/fc-cache
+
+%files
+
+%changelog
+* Mon Feb 24 2025 ShinyGil <rockgrub@disroot.org>
+- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Add: MS-Core Fonts (#3540)](https://github.com/terrapkg/packages/pull/3540)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)