### PR TITLE
[f42] feat(kf6-kio,gnome-shell): comply with new tag policies (#3533)

### DIFF
--- a/anda/desktops/gnome/gnome-shell/gnome-shell.spec
+++ b/anda/desktops/gnome/gnome-shell/gnome-shell.spec
@@ -8,14 +8,15 @@
 %global portal_helper 1
 %endif
 
-Name:           gnome-shell
+Name:           gnome-shell.switcheroo
 Version:        %{major_version}.%{minor_version}
 Release:        1%{?dist}.switcheroo
 Summary:        Window management and application launching for GNOME
 
+Provides:       gnome-shell = %version-%release
 License:        GPL-2.0-or-later
 URL:            https://wiki.gnome.org/Projects/GnomeShell
-Source0:        https://download.gnome.org/sources/gnome-shell/%{major_version}/%{name}-%{tarball_version}.tar.xz
+Source0:        https://download.gnome.org/sources/gnome-shell/%{major_version}/gnome-shell-%{tarball_version}.tar.xz
 
 # Replace Epiphany with Firefox in the default favourite apps list
 Patch: gnome-shell-favourite-apps-firefox.patch
@@ -178,7 +179,7 @@ innovative user interface concepts to provide a visually attractive and
 easy to use experience.
 
 %prep
-%autosetup -S git -n %{name}-%{tarball_version}
+%autosetup -S git -n gnome-shell-%{tarball_version}
 
 %build
 %meson \
@@ -198,7 +199,7 @@ easy to use experience.
 mkdir -p %{buildroot}%{_datadir}/gnome-shell/extensions
 mkdir -p %{buildroot}%{_datadir}/gnome-shell/search-providers
 
-%find_lang %{name}
+%find_lang gnome-shell
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/org.gnome.Shell.desktop
@@ -208,7 +209,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.gnome.Shell.Exten
 desktop-file-validate %{buildroot}%{_datadir}/applications/org.gnome.Shell.PortalHelper.desktop
 %endif
 
-%files -f %{name}.lang
+%files -f gnome-shell.lang
 %license COPYING
 %doc NEWS README.md
 %{_bindir}/gnome-shell

--- a/anda/desktops/kde/kf6-kio/kf6-kio.spec
+++ b/anda/desktops/kde/kf6-kio/kf6-kio.spec
@@ -3,9 +3,9 @@
 %global stable_kf6 stable
 %global majmin_ver_kf6 6.11
 
-Name:    kf6-%{framework}
+Name:    kf6-%{framework}.switcheroo
 Version: %{majmin_ver_kf6}.0
-Release: 1%{?dist}.switcheroo
+Release: 1%{?dist}
 Summary: KDE Frameworks 6 Tier 3 solution for filesystem abstraction
 
 License: BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND LGPL-3.0-only AND (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only) AND MIT
@@ -28,6 +28,7 @@ Patch101: kio-no-help-protocol.patch
 # https://invent.kde.org/frameworks/kio/-/merge_requests/1556
 Patch201: 1556.patch
 
+Provides:       kf6-%{framework}
 BuildRequires:  extra-cmake-modules
 BuildRequires:  gcc-c++
 BuildRequires:  kf6-rpm-macros
@@ -98,6 +99,7 @@ Requires:       cmake(KF6Solid)
 Requires:       cmake(KF6XmlGui)
 Requires:       cmake(KF6WindowSystem)
 Requires:       qt6-qtbase-devel
+Provides:       kf6-kio-devel = %version-%release
 %description    devel
 The %{name}-devel package contains libraries and header files for
 developing applications that use %{name}.
@@ -106,6 +108,7 @@ developing applications that use %{name}.
 Summary:        Documentation files for %{name}
 Requires:       %{name}-core = %{version}-%{release}
 BuildArch:      noarch
+Provides:       kf6-kio-doc = %version-%release
 %description    doc
 Documentation for %{name}.
 
@@ -116,12 +119,14 @@ Requires:       %{name}-core-libs%{?_isa} = %{version}-%{release}
 Requires:       %{name}-doc = %{version}-%{release}
 Requires:       kf6-filesystem
 Recommends:     switcheroo-control
+Provides:       kf6-kio-core = %version-%release
 %description    core
 KIOCore library provides core non-GUI components for working with KIO.
 
 %package        core-libs
 Summary:        Runtime libraries for KIO Core
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
+Provides:       kf6-kio-core-libs = %version-%release
 %description    core-libs
 %{summary}.
 
@@ -131,6 +136,7 @@ Summary:        Widgets for KIO Framework
 ## included here for completeness, even those -core already has a dependency.
 %{?kf6_kinit_requires}
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
+Provides:       kf6-kio-widgets = %version-%release
 %description    widgets
 KIOWidgets contains classes that provide generic job control, progress
 reporting, etc.
@@ -138,12 +144,14 @@ reporting, etc.
 %package        widgets-libs
 Summary:        Runtime libraries for KIO Widgets library
 Requires:       %{name}-widgets%{?_isa} = %{version}-%{release}
+Provides:       kf6-kio-widgets-libs = %version-%release
 %description    widgets-libs
 %{summary}.
 
 %package        file-widgets
 Summary:        Widgets for file-handling for KIO Framework
 Requires:       %{name}-widgets%{?_isa} = %{version}-%{release}
+Provides:       kf6-kio-file-widgets = %version-%release
 %description    file-widgets
 The KIOFileWidgets library provides the file selection dialog and
 its components.
@@ -151,12 +159,14 @@ its components.
 %package        gui
 Summary:        Gui components for the KIO Framework
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
+Provides:       kf6-kio-gui = %version-%release
 %description    gui
 %{summary}.
 
 %package        qch-doc
 Summary:        Developer Documentation files for %{name}
 BuildArch:      noarch
+Provides:       kf6-kio-qch-doc = %version-%release
 %description    qch-doc
 Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 
@@ -172,7 +182,7 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 
 %install
 %cmake_install
-%find_lang %{name} --all-name --with-man --with-html
+%find_lang kf6-kio --all-name --with-man --with-html
 
 %files
 %license LICENSES/*.txt
@@ -196,7 +206,7 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 %files core-libs
 %{_kf6_libdir}/libKF6KIOCore.so.*
 
-%files doc -f %{name}.lang
+%files doc -f kf6-kio.lang
 
 %files gui
 %{_kf6_libdir}/libKF6KIOGui.so.*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(kf6-kio,gnome-shell): comply with new tag policies (#3533)](https://github.com/terrapkg/packages/pull/3533)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)