### PR TITLE
[f42] fix: arduino (#3562)

### DIFF
--- a/anda/tools/arduino-cli/arduino-cli.spec
+++ b/anda/tools/arduino-cli/arduino-cli.spec
@@ -1,35 +1,47 @@
-%define _build_shell /bin/bash
-%define debug_package %nil
+# https://github.com/arduino/arduino-cli
+%global goipath github.com/arduino/arduino-cli
+Version:        1.2.0
 
-Name:          arduino-cli
-Version:       1.2.0
-Release:       1%?dist
-Summary:       Arduino command line tool.
-License:       GPLv3
-Packager:      Owen Zimmerman <owen@fyralabs.com>
-Url:           https://github.com/arduino/arduino-cli
-Source0:       %url/archive/refs/tags/v%version.tar.gz
-BuildRequires: golang git go-rpm-macros anda-srpm-macros
+%gometa -f
 
-%description
-%summary
+
+%global common_description %{expand:
+Arduino CLI is an all-in-one solution that provides Boards/Library Managers, sketch builder, board detection, uploader, and many other tools needed to use any Arduino compatible board and platform from command line or machine interfaces.}
+
+%global golicenses      LICENSE.txt
+%global godocs          README.md
+
+Name:           arduino-cli
+Release:        2%?dist
+Summary:        Arduino command line tool
+License:        GPL-3.0
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+URL:            %{gourl}
+Source:         %{gosource}
+BuildRequires:  anda-srpm-macros
+
+%description %{common_description}
+
+%gopkg
 
 %prep
-%autosetup -n arduino-cli-%version
+%goprep
+%go_prep_online
 
 %build
-mkdir -p bin
-%go_build_online
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/arduino-cli %{goipath}
 
 %install
-mkdir -p %{buildroot}%{_bindir}
-install -Dm 755 build/bin/arduino-cli %buildroot%{_bindir}/arduino-cli
+install -Dm755 %{gobuilddir}/bin/arduino-cli -t %buildroot%{_bindir}
 
 %files
 %license LICENSE.txt
-%doc README.md 
+%doc README.md
 %{_bindir}/arduino-cli
 
 %changelog
 * Thu Dec 5 2024 Owen Zimmerman <owen@fyralabs.com>
 - Package arduino-cli
+

--- a/anda/tools/arduino-create-agent/arduino-create-agent.spec
+++ b/anda/tools/arduino-create-agent/arduino-create-agent.spec
@@ -1,29 +1,43 @@
-%define debug_package %nil
+# https://github.com/arduino/arduino-create-agent
+%global goipath github.com/arduino/arduino-create-agent
+Version:        1.6.1
 
-Name:          arduino-create-agent
-Version:       1.6.1
-Release:       1%?dist
-Summary:       Arduino Cloud Agent.
-License:       AGPLv3
-Packager:      Owen Zimmerman <owen@fyralabs.com>
-Url:           https://github.com/arduino/arduino-create-agent
-Source0:       %url/archive/refs/tags/%version.tar.gz
-Patch0:        update.patch
-BuildRequires: golang git go-rpm-macros anda-srpm-macros 
+%gometa -f
 
-%description
+
+%global common_description %{expand:
 The Arduino Cloud Agent is a single binary that will sit on the traybar and work in the background.
-It allows you to use the Arduino Cloud to seamlessly upload code to any USB connected Arduino board (or Yún in LAN) directly from the browser.
+It allows you to use the Arduino Cloud to seamlessly upload code to any USB connected Arduino board (or Yún in LAN) directly from the browser.}
+
+%global golicenses      LICENSE.txt
+%global godocs          README.md
+
+Name:           arduino-create-agent
+Release:        2%?dist
+Summary:        Arduino Cloud Agent
+License:        AGPL-3.0
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+URL:            %{gourl}
+Source:         %{url}/archive/%{version}.tar.gz
+Patch0:         update.patch
+BuildRequires:  anda-srpm-macros
+
+%description %{common_description}
+
+%gopkg
 
 %prep
-%autosetup -n arduino-create-agent-%version -p1
+%goprep
+%autopatch -p1
+%go_prep_online
 
 %build
-%go_build_online
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/arduino-create-agent %{goipath}
 
 %install
-mkdir -p %{buildroot}%{_bindir}
-install -Dm 755 build/bin/arduino-create-agent %buildroot%{_bindir}/arduino-create-agent
+install -Dm755 %{gobuilddir}/bin/arduino-create-agent -t %buildroot%{_bindir}
 
 %files
 %license LICENSE.txt
@@ -33,3 +47,4 @@ install -Dm 755 build/bin/arduino-create-agent %buildroot%{_bindir}/arduino-crea
 %changelog
 * Sat Jan 25 2025 Owen Zimmerman <owen@fyralabs.com>
 - Package arduino-create-agent
+

--- a/anda/tools/arduino-fwuploader/arduino-fwuploader.spec
+++ b/anda/tools/arduino-fwuploader/arduino-fwuploader.spec
@@ -1,28 +1,41 @@
-%define debug_package %nil
+# https://github.com/arduino/arduino-fwuploader
+%global goipath github.com/arduino/arduino-fwuploader
+Version:        2.4.1
 
-Name:          arduino-fwuploader
-Version:       2.4.1
-Release:       1%?dist
-Summary:       A Command Line Tool made to update the firmware and/or add SSL certificates for any Arduino board equipped with WINC or NINA Wi-Fi module.
-License:       AGPLv3
-Packager:      Owen Zimmerman <owen@fyralabs.com>
-Url:           https://github.com/arduino/arduino-fwuploader
-Source0:       %url/archive/refs/tags/%version.tar.gz
-BuildRequires: golang git go-rpm-macros anda-srpm-macros python3 go-task
+%gometa -f
+
+
+%global common_description %{expand:
+The Arduino Firmware Uploader is a tool made to update the firmware and/or add SSL certificates for any Arduino board equipped with ESP32-S3 or NINA Wi-Fi module.}
+
+%global golicenses      LICENSE.txt
+%global godocs          README.md
+
+Name:           arduino-fwuploader
+Release:        2%?dist
+Summary:        Update the firmware and/or add SSL certificates for any Arduino board equipped with WINC or NINA Wi-Fi module
+License:        AGPL-3.0
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+URL:            %{gourl}
+Source:         %{url}/archive/%{version}.tar.gz
+BuildRequires:  anda-srpm-macros python3-devel go-task
 
 %description
-%summary
+%{common_description}
+
+%gopkg
 
 %prep
-%autosetup -n arduino-fwuploader-%version
+%goprep
+%go_prep_online
 
 %build
-mkdir -p bin
-%go_build_online
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/arduino-fwuploader %{goipath}
 
 %install
-mkdir -p %{buildroot}%{_bindir}
-install -Dm 755 build/bin/arduino-fwuploader %buildroot%{_bindir}/arduino-fwuploader
+install -Dm755 %{gobuilddir}/bin/arduino-fwuploader -t %buildroot%{_bindir}
 
 %files
 %license LICENSE.txt

--- a/anda/tools/arduino-language-server/arduino-language-server.spec
+++ b/anda/tools/arduino-language-server/arduino-language-server.spec
@@ -1,28 +1,41 @@
-%define debug_package %nil
+# https://github.com/arduino/arduino-language-server
+%global goipath github.com/arduino/arduino-language-server
+Version:        0.7.6
 
-Name:          arduino-language-server
-Version:       0.7.6
-Release:       1%?dist
-Summary:       Arduino command line tool.
-License:       AGPLv3
-Packager:      Owen Zimmerman <owen@fyralabs.com>
-Url:           https://github.com/arduino/arduino-language-server
-Source0:       %url/archive/refs/tags/%version.tar.gz
-BuildRequires: golang git go-rpm-macros anda-srpm-macros clang arduino-cli
+%gometa -f
+
+
+%global common_description %{expand:
+The Arduino Language Server is the tool that powers the autocompletion of the new Arduino IDE 2. It implements the standard Language Server Protocol so it can be used with other IDEs as well.}
+
+%global golicenses      LICENSE.txt
+%global godocs          README.md
+
+Name:           arduino-language-server
+Release:        2%?dist
+Summary:        An Arduino Language Server based on Clangd for Arduino code autocompletion
+License:        AGPL-3.0
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+URL:            %{gourl}
+Source:         %{url}/archive/%{version}.tar.gz
+BuildRequires:  anda-srpm-macros clang
 
 %description
-%summary
+%{common_description}
+
+%gopkg
 
 %prep
-%autosetup -n arduino-language-server-%version
+%goprep
+%go_prep_online
 
 %build
-mkdir -p bin
-%go_build_online
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/arduino-language-server %{goipath}
 
 %install
-mkdir -p %{buildroot}%{_bindir}
-install -Dm 755 build/bin/arduino-language-server %buildroot%{_bindir}/arduino-language-server
+install -Dm755 %{gobuilddir}/bin/arduino-language-server -t %buildroot%{_bindir}
 
 %files
 %license LICENSE.txt
@@ -32,3 +45,4 @@ install -Dm 755 build/bin/arduino-language-server %buildroot%{_bindir}/arduino-l
 %changelog
 * Fri Dec 27 2024 Owen Zimmerman <owen@fyralabs.com>
 - Package arduino-language-server
+

--- a/anda/tools/arduino-lint/arduino-lint.spec
+++ b/anda/tools/arduino-lint/arduino-lint.spec
@@ -1,27 +1,44 @@
-%define debug_package %nil
+# https://github.com/arduino/arduino-lint
+%global goipath github.com/arduino/arduino-lint
+Version:        1.3.0
 
-Name:          arduino-lint
-Version:       1.3.0
-Release:       1%?dist
-Summary:       Tool to check for problems with Arduino projects.
-License:       GPLv3
-Packager:      Owen Zimmerman <owen@fyralabs.com>
-Url:           https://github.com/arduino/arduino-lint
-Source0:       %url/archive/refs/tags/%version.tar.gz
-BuildRequires: golang git go-rpm-macros anda-srpm-macros
+%gometa -f
+
+
+%global common_description %{expand:
+Arduino Lint is a command line tool that checks for common problems in Arduino projects:
+ Sketches
+ Libraries
+ Boards platforms}
+
+%global golicenses      LICENSE.txt
+%global godocs          README.md
+
+Name:           arduino-lint
+Release:        2%?dist
+Summary:        Tool to check for problems with Arduino projects
+License:        GPL-3.0
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+URL:            %{gourl}
+Source:         %{url}/archive/%{version}.tar.gz
+BuildRequires:  anda-srpm-macros
 
 %description
-%summary
+%{common_description}
+
+%gopkg
 
 %prep
-%autosetup -n arduino-lint-%version
+%goprep
+%go_prep_online
 
 %build
-go build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/arduino-lint %{goipath}
 
 %install
-mkdir -p %{buildroot}%{_bindir}
-install -Dm 755 arduino-lint %buildroot%{_bindir}/arduino-lint
+install -Dm755 %{gobuilddir}/bin/arduino-lint -t %buildroot%{_bindir}
 
 %files
 %license LICENSE.txt
@@ -31,3 +48,4 @@ install -Dm 755 arduino-lint %buildroot%{_bindir}/arduino-lint
 %changelog
 * Thu Dec 5 2024 Owen Zimmerman <owen@fyralabs.com>
 - Package arduino-lint
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: arduino (#3562)](https://github.com/terrapkg/packages/pull/3562)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)