### PR TITLE
[f42] add: XONE (#3510)

### DIFF
--- a/anda/system/xone/akmod/anda.hcl
+++ b/anda/system/xone/akmod/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+	rpm {
+		spec = "xone-kmod.spec"
+	}
+	labels {
+		mock = 1
+                nightly = 1
+                updbranch = 1
+	}
+}

--- a/anda/system/xone/akmod/update.rhai
+++ b/anda/system/xone/akmod/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::madoguchi("xone-kmod-common", labels.branch));

--- a/anda/system/xone/akmod/xone-kmod.spec
+++ b/anda/system/xone/akmod/xone-kmod.spec
@@ -1,0 +1,63 @@
+%global commit 6b9d59aed71f6de543c481c33df4705d4a590a31
+%global date 20241223
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global ver 0.3
+%define buildforkernels akmod
+%global debug_package %{nil}
+%global real_name xone
+
+Name:           %{real_name}-kmod
+Version:        %{ver}^%{date}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
+License:        GPL-2.0-or-later
+URL:            https://github.com/dlundqvist/xone
+Source0:        %{url}/archive/%{commit}.tar.gz#/xone-%{shortcommit}.tar.gz
+BuildRequires:  kmodtool
+BuildRequires:  systemd-rpm-macros
+Requires:       %{real_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Packager:       ShinyGil <rockgrub@disroot.org>
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories.
+
+%prep
+%{?kmodtool_check}
+kmodtool  --target %{_target_cpu}  --repo terra --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%autosetup -p1 -n %{real_name}-%{commit}
+
+/usr/bin/sed -nE '/^BUILT_MODULE_NAME/{s@^.+"(.+)"@\1@; s|-|_|g; p}' dkms.conf > %{real_name}.conf
+
+find . -type f -name '*.c' -exec sed -i "s/#VERSION#/%{version}/" {} \;
+
+for kernel_version in %{?kernel_versions}; do
+    mkdir _kmod_build_${kernel_version%%___*}
+    cp -fr auth bus driver transport Kbuild _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version in %{?kernel_versions}; do
+    pushd _kmod_build_${kernel_version%%___*}/
+        %make_build -C "${kernel_version##*___}" M=$(pwd) VERSION="v%{version}" modules
+    popd
+done
+
+%install
+install -Dm644 %{real_name}.conf -t %{buildroot}%{_modulesloaddir}
+
+for kernel_version in %{?kernel_versions}; do
+    mkdir -p %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+    install -p -m 0755 _kmod_build_${kernel_version%%___*}/*.ko \
+        %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+done
+%{?akmod_install}
+
+%files
+%{_modulesloaddir}/%{real_name}.conf
+
+%changelog
+* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+- Initial package

--- a/anda/system/xone/dkms/anda.hcl
+++ b/anda/system/xone/dkms/anda.hcl
@@ -1,0 +1,11 @@
+project pkg {
+               arches=["x86_64"]
+	rpm {
+		spec = "dkms-xone.spec"
+	}
+	labels {
+		mock = 1
+                nightly = 1
+                updbranch = 1
+	}
+}

--- a/anda/system/xone/dkms/dkms-no-weak-modules.conf
+++ b/anda/system/xone/dkms/dkms-no-weak-modules.conf
@@ -1,0 +1,1 @@
+NO_WEAK_MODULES="yes"

--- a/anda/system/xone/dkms/dkms-xone.spec
+++ b/anda/system/xone/dkms/dkms-xone.spec
@@ -1,0 +1,64 @@
+%global commit 6b9d59aed71f6de543c481c33df4705d4a590a31
+%global date 20241223
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global ver 0.3
+%global debug_package %{nil}
+%global dkms_name xone
+
+Name:           dkms-%{dkms_name}
+Version:        %{ver}^%{date}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
+License:        GPL-2.0-or-later
+URL:            https://github.com/dlundqvist/xone
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{dkms_name}-%{shortcommit}.tar.gz
+Source1:        dkms-no-weak-modules.conf
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       %{dkms_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Requires:       dkms
+BuildArch:      noarch
+Packager:       ShinyGil <rockgrub@disroot.org>
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories.
+
+%prep
+%autosetup -p1 -n %{dkms_name}-%{commit}
+
+sed -i \
+    -e 's|#VERSION#|%{version}|g' \
+    -e 's|kernel/drivers/input/joystick|extra|g' \
+    dkms.conf
+
+find . -type f -name '*.c' -exec sed -i "s/#VERSION#/%{version}/" {} \;
+
+%install
+# Create empty tree:
+mkdir -p %{buildroot}%{_usrsrc}/%{dkms_name}-%{version}/
+cp -fr auth bus driver transport Kbuild dkms.conf %{buildroot}%{_usrsrc}/%{dkms_name}-%{version}/
+
+%if 0%{?fedora}
+# Do not enable weak modules support in Fedora (no kABI):
+install -Dpm644 %{SOURCE1} %{buildroot}%{_sysconfdir}/dkms/%{dkms_name}.conf
+%endif
+
+%post
+dkms add -m %{dkms_name} -v %{version} -q --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{dkms_name} -v %{version} -q || :
+dkms install -m %{dkms_name} -v %{version} -q --force || :
+
+%preun
+# Remove all versions from DKMS registry:
+dkms remove -m %{dkms_name} -v %{version} -q --all --rpm_safe_upgrade || :
+
+%files
+%{_usrsrc}/%{dkms_name}-%{version}
+%if 0%{?fedora}
+%{_sysconfdir}/dkms/%{dkms_name}.conf
+%endif
+
+%changelog
+* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+- Initial package

--- a/anda/system/xone/dkms/update.rhai
+++ b/anda/system/xone/dkms/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::madoguchi("xone-kmod-common", labels.branch));

--- a/anda/system/xone/kmod-common/anda.hcl
+++ b/anda/system/xone/kmod-common/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+               arches = ["x86_64"]
+	rpm {
+		spec = "xone-kmod-common.spec"
+	}
+	labels {
+		mock = 1
+                nightly = 1
+	}
+}

--- a/anda/system/xone/kmod-common/modules.conf
+++ b/anda/system/xone/kmod-common/modules.conf
@@ -1,0 +1,1 @@
+add_drivers+=" snd-pcm snd-seq "

--- a/anda/system/xone/kmod-common/update.rhai
+++ b/anda/system/xone/kmod-common/update.rhai
@@ -1,0 +1,8 @@
+rpm.global("commit", gh_commit("dlundqvist/xone"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("date", date());
+    let ver = gh_tag("dlundqvist/xone");
+    ver.crop(1);
+    rpm.global("ver", ver);
+}

--- a/anda/system/xone/kmod-common/xone-kmod-common.spec
+++ b/anda/system/xone/kmod-common/xone-kmod-common.spec
@@ -1,0 +1,81 @@
+%global commit 6b9d59aed71f6de543c481c33df4705d4a590a31
+%global date 20241223
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global ver 0.3
+%global real_name xone
+%global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
+%global firmware_hash 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
+
+Name:           %{real_name}-kmod-common
+Version:        %{ver}^%{date}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories common files
+License:        GPL-2.0-or-later
+URL:            https://github.com/dlundqvist/xone
+Source0:        %{url}/archive/%{commit}.tar.gz#/xone-%{shortcommit}.tar.gz
+Source1:        modules.conf
+### Windows driver and firmware file:
+Source2:        http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
+### Microsoft TOU copy:
+Source3:        https://www.microsoft.com/en-us/legal/terms-of-use
+BuildRequires:  cabextract
+BuildRequires:  systemd-rpm-macros
+Requires:       wireless-regdb
+Requires:       %{real_name}-firmware = 1.0.46.1
+Requires(post): dracut
+Provides:       %{real_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+BuildArch:      noarch
+Packager:       ShinyGil <rockgrub@disroot.org>
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.
+
+%package -n     %{real_name}-firmware
+Version:        1.0.46.1
+Summary:        Firmware for the XBox One controller dongle
+License:        Proprietary
+Requires:       wireless-regdb
+BuildArch:      noarch
+
+%description -n %{real_name}-firmware
+Proprietary firmware for XBox controller dongles.
+ 
+%prep
+%autosetup -p1 -n xone-%{commit}
+/usr/bin/cp %{SOURCE3} .
+
+# Firmware:
+cabextract -F FW_ACC_00U.bin %{SOURCE2}
+echo %{firmware_hash} FW_ACC_00U.bin | sha256sum -c
+
+%install
+# xone-gip-headset module should have the snd-pcm and snd-seq modules be preloaded or it will give errors on boot due to injecting late.
+# It still loads afterwards, but this error is easily fixable by just loading the modules in the initramfs.
+install -Dpm644 %{SOURCE1} %{buildroot}%{_dracutconfdir}/60-xone-snd.conf
+
+# Blacklist:
+install -Dpm644 install/modprobe.conf %{buildroot}%{_modprobedir}/60-%{real_name}.conf
+
+# Firmware:
+install -Dpm644 FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xow_dongle.bin
+
+%files
+%license LICENSE
+%doc README.md
+%{_modprobedir}/60-%{real_name}.conf
+%{_dracutconfdir}/60-%{real_name}-snd.conf
+
+%files -n xone-firmware
+%license terms-of-use
+%{_prefix}/lib/firmware/xow_dongle.bin
+
+%post
+/usr/bin/dracut -f
+
+%post -n xone-firmware
+echo "The firmware for the wireless dongle is subject to Microsoft's Terms of Use:"
+echo 'https://www.microsoft.com/en-us/legal/terms-of-use'
+
+%changelog
+* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: XONE (#3510)](https://github.com/terrapkg/packages/pull/3510)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)