### PR TITLE
[f41] Fix: inputplumber (#3592)

### DIFF
--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -1,6 +1,8 @@
+%global __brp_mangle_shebangs %{nil}
+
 Name:           inputplumber
 Version:        0.49.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Open source input router and remapper daemon for Linux
 License:        GPL-3.0-or-later
 URL:            https://github.com/ShadowBlip/InputPlumber


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix: inputplumber (#3592)](https://github.com/terrapkg/packages/pull/3592)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)