### PR TITLE
[el10] Fix: libayatana-common (#3594)

### DIFF
--- a/anda/lib/libayatana-common/libayatana-common.spec
+++ b/anda/lib/libayatana-common/libayatana-common.spec
@@ -1,7 +1,7 @@
 Name:       libayatana-common
 Summary:    Common functions for Ayatana System Indicators
 Version:    0.9.11
-Release:    1%?dist
+Release:    2%?dist
 License:    GPL-3.0
 URL:        https://github.com/AyatanaIndicators/libayatana-common
 Source0:    %{url}/archive/refs/tags/%{version}.tar.gz
@@ -48,12 +48,12 @@ This package contains the development header files for %{name}.
 %license COPYING
 %{_userunitdir}/ayatana-indicators.target
 %{_libdir}/libayatana-common.so.*
-%{_libdir}/girepository-1.0/AyatanaCommon-0.0.typelib
+%{_libdir}/girepository-1.0/AyatanaCommon-0.*.typelib
 %{_datadir}/glib-2.0/schemas/org.ayatana.common.gschema.xml
 
 %files devel
 %{_libdir}/libayatana-common.so
-%{_datadir}/gir-1.0/AyatanaCommon-0.0.gir
+%{_datadir}/gir-1.0/AyatanaCommon-0.*.gir
 %{_libdir}/pkgconfig/libayatana-common.pc
 %dir %{_includedir}/ayatana
 %dir %{_includedir}/ayatana/common


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Fix: libayatana-common (#3594)](https://github.com/terrapkg/packages/pull/3594)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)