### PR TITLE
[el10] Fix (wl-kmod): Patches for kernels 6.13 and 6.14 (#3591)

### DIFF
--- a/anda/system/wl-kmod/anda.hcl
+++ b/anda/system/wl-kmod/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
-    arches = ["x86_64", "i386"]
+    arches = ["x86_64"]
     rpm {
         spec = "wl-kmod.spec"
     }

--- a/anda/system/wl-kmod/wl-kmod-029_kernel_6.13_adaptation.patch
+++ b/anda/system/wl-kmod/wl-kmod-029_kernel_6.13_adaptation.patch
@@ -1,0 +1,30 @@
+From d38877279728c4e5711ae4dd373486bf2148ee48 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Tue, 17 Dec 2024 20:19:49 +0100
+Subject: [PATCH] linuxver.h: net/lib80211.h dropped from includes for kernel
+ >= 6.13.x
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ src/include/linuxver.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/include/linuxver.h b/src/include/linuxver.h
+index b05bc32..bbe1d3c 100644
+--- a/src/include/linuxver.h
++++ b/src/include/linuxver.h
+@@ -147,7 +147,7 @@ typedef irqreturn_t(*FN_ISR) (int irq, void *dev_id, struct pt_regs *ptregs);
+ #include <linux/sched.h>
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+ #include <net/lib80211.h>
+ #endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
+-- 
+2.47.1
+

--- a/anda/system/wl-kmod/wl-kmod-030_kernel_6.14_adaptation.patch
+++ b/anda/system/wl-kmod/wl-kmod-030_kernel_6.14_adaptation.patch
@@ -1,0 +1,46 @@
+From 5c323385615ec555d628fd0dd2ae532ec91a0556 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Fri, 7 Feb 2025 20:39:02 +0100
+Subject: [PATCH] wl_cfg80211_hybrid.c: new parameter for get_tx_power
+ introduced in "wifi: cfg80211: send MLO links tx power info in GET_INTERFACE"
+ for kernel >= 6.14.x
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ src/wl/sys/wl_cfg80211_hybrid.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index 5ffa0b3..5a7f0c4 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -101,7 +101,10 @@ static s32 wl_cfg80211_set_tx_power(struct wiphy *wiphy,
+            enum tx_power_setting type, s32 dbm);
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++                                    unsigned int link_id, s32 *dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm);
+ #else
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm);
+@@ -1225,7 +1228,10 @@ wl_cfg80211_set_tx_power(struct wiphy *wiphy, enum tx_power_setting type, s32 db
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++                                    unsigned int link_id, s32 *dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev, s32 *dbm)
+ #else
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, s32 *dbm)
+-- 
+2.48.1
+

--- a/anda/system/wl-kmod/wl-kmod.spec
+++ b/anda/system/wl-kmod/wl-kmod.spec
@@ -10,7 +10,7 @@
 
 Name:       wl-kmod
 Version:    6.30.223.271
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    Kernel module for Broadcom wireless devices
 Group:      System Environment/Kernel
 License:    Redistributable, no modification permitted
@@ -45,6 +45,8 @@ Patch23:    wl-kmod-025_kernel_6.5_adaptation.patch
 Patch24:    wl-kmod-026_kernel_6.10_fix_empty_body_in_if_warning.patch
 Patch25:    wl-kmod-027_wpa_supplicant-2.11_add_max_scan_ie_len.patch
 Patch26:    wl-kmod-028_kernel_6.12_adaptation.patch
+Patch27:    wl-kmod-029_kernel_6.13_adaptation.patch
+Patch28:    wl-kmod-030_kernel_6.14_adaptation.patch
 ExclusiveArch:  i686 x86_64
 BuildRequires:  kmodtool
 BuildRequires:  elfutils-libelf-devel
@@ -119,6 +121,8 @@ pushd %{name}-%{version}-src
    %{__sed} -i 's/ >= KERNEL_VERSION(6, [01], 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
   %endif
   %if %{kvr} >= 427
+  %endif
+  %if %{kvr} >= 503
   %endif
  %endif
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Fix (wl-kmod): Patches for kernels 6.13 and 6.14 (#3591)](https://github.com/terrapkg/packages/pull/3591)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)