### PR TITLE
[f41] Fix (YouTube Music): Vendor PNPM again (#3590)

### DIFF
--- a/anda/apps/youtube-music/youtube-music.spec
+++ b/anda/apps/youtube-music/youtube-music.spec
@@ -9,11 +9,11 @@
 
 # Try to vendor PNPM directly from Fedora
 # but if this fails, you can try setting this to 1 to vendor PNPM directly from upstream
-%global vendor_pnpm 0
+%global vendor_pnpm 1
 
 Name:           youtube-music
 Version:        3.7.5
-Release:        1%?dist
+Release:        2%?dist
 Summary:        YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
 Source1:        youtube-music.desktop
 License:        MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix (YouTube Music): Vendor PNPM again (#3590)](https://github.com/terrapkg/packages/pull/3590)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)