### PR TITLE
[f41] Fix: stardust server  (#3595)

### DIFF
--- a/anda/stardust/server/stardust-server.spec
+++ b/anda/stardust/server/stardust-server.spec
@@ -5,11 +5,11 @@
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-server
-Version:        0.45.1
-Release:        1%?dist
+Version:        %commit_date.%shortcommit
+Release:        2%?dist
 Summary:        Usable Linux display server that reinvents human-computer interaction for all kinds of XR.
 URL:            https://github.com/StardustXR/server
-Source0:        %url/archive/refs/tags/%version.tar.gz
+Source0:        %url/archive/%commit/server-%commit.tar.gz
 License:        GPL-2.0-only
 
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros gcc-c++ mold
@@ -24,7 +24,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 Usable Linux display server that reinvents human-computer interaction for all kinds of XR, from putting 2D/XR apps into various 3D shells for varying uses to SDF-based interaction.
 
 %prep
-%autosetup -n server-%version
+%autosetup -n server-%commit
 %cargo_prep_online
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix: stardust server  (#3595)](https://github.com/terrapkg/packages/pull/3595)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)