### PR TITLE
[f40] fix(xone-dkms,xone-akmod): not nightly (#3620)

### DIFF
--- a/anda/system/xone/akmod/anda.hcl
+++ b/anda/system/xone/akmod/anda.hcl
@@ -4,7 +4,6 @@ project pkg {
 	}
 	labels {
 		mock = 1
-                nightly = 1
                 updbranch = 1
 	}
 }

--- a/anda/system/xone/dkms/anda.hcl
+++ b/anda/system/xone/dkms/anda.hcl
@@ -5,7 +5,6 @@ project pkg {
 	}
 	labels {
 		mock = 1
-                nightly = 1
                 updbranch = 1
 	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(xone-dkms,xone-akmod): not nightly (#3620)](https://github.com/terrapkg/packages/pull/3620)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)