### PR TITLE
[f42] add: pokemon-colorscripts, krabby (#3573)

### DIFF
--- a/anda/misc/krabby/anda.hcl
+++ b/anda/misc/krabby/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "krabby.spec"
+	}
+}

--- a/anda/misc/krabby/krabby.spec
+++ b/anda/misc/krabby/krabby.spec
@@ -1,0 +1,34 @@
+Name:          krabby
+Version:       0.3.0
+Release:       1%{?dist}
+SourceLicense: GPL-3.0-or-later
+License:       (MIT OR Apache-2.0) AND GPL-3.0-or-later AND MIT AND (Unlicense OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND MPL-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
+Summary:       Print Pokémon sprites in your terminal
+URL:           https://github.com/yannjor/krabby
+Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires: anda-srpm-macros
+BuildRequires: cargo-rpm-macros
+BuildRequires: mold
+Packager:      ShinyGil <rockgrub@disroot.org>
+
+%description
+Krabby is mostly a Rust rewrite of phoney badger's pokemon-colorscripts with some extra features.
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+
+%install
+%cargo_install
+%{cargo_license_online} > LICENSE.dependencies
+
+%files
+%license LICENSE LICENSE.dependencies
+%doc README.md
+%{_bindir}/%{name}
+
+%changelog
+* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+- Initial package

--- a/anda/misc/krabby/update.rhai
+++ b/anda/misc/krabby/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(crates("krabby"));

--- a/anda/misc/pokemon-colorscripts/anda.hcl
+++ b/anda/misc/pokemon-colorscripts/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "pokemon-colorscripts.spec"
+	}
+}

--- a/anda/misc/pokemon-colorscripts/pokemon-colorscripts.spec
+++ b/anda/misc/pokemon-colorscripts/pokemon-colorscripts.spec
@@ -1,0 +1,46 @@
+%global commit 5802ff67520be2ff6117a0abc78a08501f6252ad
+%global commit_date 20241018
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:          pokemon-colorscripts
+Version:       0^%{commit_date}git.%{shortcommit}
+Release:       1%{?dist}
+License:       MIT
+Summary:       CLI utility to print out images of Pokémon to the terminal
+URL:           https://gitlab.com/phoneybadger/%{name}
+Source0:       %{url}/-/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
+BuildArch:     noarch
+Requires:      python3
+Packager:      ShinyGil <rockgrub@disroot.org>
+
+%description
+A utility that prints unicode sprites of images of Pokémon to the terminal.
+
+%prep
+%autosetup -n %{name}-%{commit}
+
+%build
+
+%install
+install -Dm644 colorscripts/small/regular/* -t "%{buildroot}%{_datadir}/%{name}/colorscripts/small/regular"
+install -Dm644 colorscripts/small/shiny/* -t "%{buildroot}%{_datadir}/%{name}/colorscripts/small/shiny"
+install -Dm644 colorscripts/large/regular/* -t "%{buildroot}%{_datadir}/%{name}/colorscripts/large/regular"
+install -Dm644 colorscripts/large/shiny/* -t "%{buildroot}%{_datadir}/%{name}/colorscripts/large/shiny"
+install -Dm644 pokemon.json "%{buildroot}%{_datadir}/%{name}/pokemon.json"
+install -Dm755 pokemon-colorscripts.py "%{buildroot}%{_datadir}/%{name}/pokemon-colorscripts.py"
+install -Dm644 pokemon-colorscripts.1 "%{buildroot}%{_mandir}/man1/pokemon-colorscripts.1"
+# Make name executable
+mkdir -p %{buildroot}%{_bindir}
+ln -sf "%{_datadir}/%{name}/pokemon-colorscripts.py" "%{buildroot}%{_bindir}/pokemon-colorscripts"
+
+%files
+%license LICENSE.txt
+%doc README.md
+%dir %{_datadir}/%{name}
+%{_datadir}/%{name}/*
+%{_bindir}/pokemon-colorscripts
+%{_mandir}/man1/pokemon-colorscripts.1.gz
+
+%changelog
+* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+- Initial package

--- a/anda/misc/pokemon-colorscripts/update.rhai
+++ b/anda/misc/pokemon-colorscripts/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gitlab_commit("gitlab.com", "28721344", "main"));
+if rpm.changed() {
+	rpm.global("commit_date", date());
+	rpm.release();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: pokemon-colorscripts, krabby (#3573)](https://github.com/terrapkg/packages/pull/3573)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)