### PR TITLE
Change (openh264): Wildcard for sonames

### DIFF
--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -94,8 +94,7 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.a
 %files
 %license LICENSE
 %doc README.md
-%{_libdir}/libopenh264.so.8
-%{_libdir}/libopenh264.so.%{version}
+%{_libdir}/libopenh264.so.*
 
 %files devel
 %{_includedir}/wels/


### PR DESCRIPTION
I am honestly not the biggest fan of globs in spec files but since `openh264` changes the version on one of its libraries every release and we do automatic updates this will probably spare some headaches.

No release bump since this is future proofing.