### PR TITLE
[el10] Change (openh264): Wildcard for sonames (#3629)

### DIFF
--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -94,8 +94,7 @@ rm $RPM_BUILD_ROOT%{_libdir}/*.a
 %files
 %license LICENSE
 %doc README.md
-%{_libdir}/libopenh264.so.8
-%{_libdir}/libopenh264.so.%{version}
+%{_libdir}/libopenh264.so.*
 
 %files devel
 %{_includedir}/wels/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Change (openh264): Wildcard for sonames (#3629)](https://github.com/terrapkg/packages/pull/3629)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)