### PR TITLE
[el10] fix: micro-nightly (#3563)

### DIFF
--- a/anda/devs/micro/update.rhai
+++ b/anda/devs/micro/update.rhai
@@ -1,5 +1,7 @@
 rpm.global("commit_hash", gh_commit("zyedidia/micro"));
+let v = gh("zyedidia/micro");
 if rpm.changed() {
     rpm.global("commit_date", date());
-    rpm.global("ver", gh("zyedidia/micro"));
+    v.crop(1);
+    rpm.global("ver", v);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: micro-nightly (#3563)](https://github.com/terrapkg/packages/pull/3563)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)