### PR TITLE
[el10] fix(klassy): 6.3.1 (#3557)

### DIFF
--- a/anda/themes/klassy/klassy.spec
+++ b/anda/themes/klassy/klassy.spec
@@ -2,16 +2,17 @@ Name:           klassy
 
 %global forgeurl https://github.com/paulmcauley/%{name}
 %global tag 6.2.breeze6.2.1
-%global date 20241018
+%global date 20250226
 %forgemeta
 
 Version:        %{tag}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Window Decoration, Application Style and Global Theme plugin for recent versions of the KDE Plasma desktop.
 License:        GPL-2.0-or-later
 Group:          System/GUI/KDE
 URL:            %{forgeurl}
 Source:         %{forgesource}
+Patch0:         https://github.com/paulmcauley/klassy/pull/178.patch
 
 Obsoletes:      classikstyles <= %{version}
 Obsoletes:      classik <= %{version}
@@ -65,7 +66,7 @@ BuildRequires:  cmake(KF6KirigamiPlatform)
 BuildRequires:  cmake(KF6Package)
 BuildRequires:  cmake(KF6WindowSystem)
 
-BuildRequires:  cmake(KDecoration2)
+BuildRequires:  cmake(KDecoration3)
 BuildRequires:  cmake(Plasma)
 BuildRequires:  cmake(Plasma5Support)
 
@@ -99,8 +100,8 @@ Klassy (formerly ClassiK/ClassikStyles) is a highly customizable binary Window D
 %{_kf6_qtplugindir}/styles/klassy6.so
 
 %{_kf6_qtplugindir}/kstyle_config/klassystyleconfig.so
-%{_kf6_qtplugindir}/org.kde.kdecoration2/org.kde.klassy.so
-%{_kf6_qtplugindir}/org.kde.kdecoration2.kcm/kcm_klassydecoration.so
+%{_kf6_qtplugindir}/org.kde.kdecoration3/org.kde.klassy.so
+%{_kf6_qtplugindir}/org.kde.kdecoration3.kcm/kcm_klassydecoration.so
 %{_kf6_qtplugindir}/org.kde.kdecoration2.kcm/klassydecoration/presets/*
 
 %{_kf6_datadir}/applications/kcm_klassydecoration.desktop


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(klassy): 6.3.1 (#3557)](https://github.com/terrapkg/packages/pull/3557)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)