### PR TITLE
[f42] chore: bulk update RockGrub specs (#3646)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -50,7 +50,7 @@ Provides:       ghostty-tip = %{version}-%{release}
 Provides:       %{name} = %{commit_date}.%{shortcommit}
 %endif
 Obsoletes:      %{name} = 20250130.04d3636
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 👻 Ghostty is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration.
@@ -206,16 +206,15 @@ zig build \
 %_datadir/terminfo/ghostty.terminfo
 
 %changelog
-* Fri Jan 31 2025 ShinyGil <rockgrub@disroot.org>
+* Fri Jan 31 2025 Gilver E. <rockgrub@disroot.org>
 - Update to 1.1.1-1%{?dist}.20250131tipc5508e7
  * Low GHSA-98wc-794w-gjx3: Ghostty leaked file descriptors allowing the shell and any of its child processes to impact other Ghostty terminal instances
  * Better Git versioning scheme
  * Ghostty terminfo source files are now a subpackage
  * Shell integration and completion and terminfo subpackages are now properly noarch
-* Tue Dec 31 2024 ShinyGil <rockgrub@disroot.org>
+* Tue Dec 31 2024 Gilver E. <rockgrub@disroot.org>
 - Update to 20241231.3f7c3af
  * High CVE-2003-0063: Allows execution of arbitrary commands
  * Medium CVE-2003-0070: Allows execution of arbitrary commands
-
-* Thu Dec 26 2024 ShinyGil <rockgrub@disroot.org>
+* Thu Dec 26 2024 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -37,7 +37,7 @@ Requires:       %{name}-shell-integration = %{version}-%{release}
 Requires:       gtk4
 Requires:       libadwaita
 Conflicts:      ghostty-nightly
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 👻 Ghostty is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration.
@@ -181,15 +181,15 @@ zig build \
 %_datadir/terminfo/ghostty.terminfo
 
 %changelog
-* Fri Jan 31 2025 ShinyGil <rockgrub@disroot.org>
+* Fri Jan 31 2025 Gilver E. <rockgrub@disroot.org>
 - Update to 1.1.0-1%{?dist}
  * Low GHSA-98wc-794w-gjx3: Ghostty leaked file descriptors allowing the shell and any of its child processes to impact other Ghostty terminal instances
  * Ghostty terminfo source files are now a subpackage
  * Shell integration and completion and terminfo subpackages are now properly noarch
-* Tue Dec 31 2024 ShinyGil <rockgrub@disroot.org>
+* Tue Dec 31 2024 Gilver E. <rockgrub@disroot.org>
 - Update to 1.0.1
  * High CVE-2003-0063: Allows execution of arbitrary commands
  * Medium CVE-2003-0070: Allows execution of arbitrary commands
 
-* Thu Dec 26 2024 ShinyGil <rockgrub@disroot.org>
+* Thu Dec 26 2024 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/fonts/cleartype/cleartype-fonts.spec
+++ b/anda/fonts/cleartype/cleartype-fonts.spec
@@ -113,7 +113,7 @@ Requires:       %{fontname}-constantia-fonts
 Requires:       %{fontname}-corbel-fonts
 Requires(post): fontconfig
 BuildArch:      noarch
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %fontpkg -a
 
@@ -142,5 +142,5 @@ cabextract ppviewer.cab
 %files
 
 %changelog
-* Mon Feb 24 2025 ShinyGil <rockgrub@disroot.org>
+* Mon Feb 24 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/fonts/ms-core-tahoma/ms-core-tahoma-fonts.spec
+++ b/anda/fonts/ms-core-tahoma/ms-core-tahoma-fonts.spec
@@ -30,7 +30,7 @@ BuildRequires:  fontpackages-devel
 Requires:       xorg-x11-font-utils
 Requires:       fontconfig
 BuildArch:      noarch
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %fontpkg -a
 
@@ -62,5 +62,5 @@ cabextract Viewer1.cab
 %files
 
 %changelog
-* Mon Feb 24 2025 ShinyGil <rockgrub@disroot.org>
+* Mon Feb 24 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/fonts/ms-core/ms-core-fonts.spec
+++ b/anda/fonts/ms-core/ms-core-fonts.spec
@@ -192,7 +192,7 @@ Requires:        %{fontname}-webdings-fonts
 Requires:        xorg-x11-font-utils
 Requires(post):  fontconfig
 BuildArch:       noarch
-Packager:        ShinyGil <rockgrub@disroot.org>
+Packager:        Gilver E. <rockgrub@disroot.org>
 
 %fontpkg -a
 
@@ -225,5 +225,5 @@ cabextract %{SOURCE0} %{SOURCE1} %{SOURCE2} %{SOURCE3} \
 %files
 
 %changelog
-* Mon Feb 24 2025 ShinyGil <rockgrub@disroot.org>
+* Mon Feb 24 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -34,7 +34,7 @@ Requires:      which
 Recommends:    gamemode
 Recommends:    mangohud
 Recommends:    umu-launcher
-Packager:      ShinyGil <rockgrub@disroot.org>
+Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description
 Heroic is a Free and Open Source Epic, GOG, and Amazon Prime Games launcher for Linux, Windows, and macOS.
@@ -87,6 +87,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/heroic.desktop
 %_iconsdir/hicolor/1024x1024/heroic.png
 
 %changelog
-* Thu Jan 30 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Jan 30 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package
 

--- a/anda/misc/krabby/krabby.spec
+++ b/anda/misc/krabby/krabby.spec
@@ -9,7 +9,7 @@ Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo-rpm-macros
 BuildRequires: mold
-Packager:      ShinyGil <rockgrub@disroot.org>
+Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description
 Krabby is mostly a Rust rewrite of phoney badger's pokemon-colorscripts with some extra features.
@@ -30,5 +30,5 @@ Krabby is mostly a Rust rewrite of phoney badger's pokemon-colorscripts with som
 %{_bindir}/%{name}
 
 %changelog
-* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -1,6 +1,3 @@
-%global __brp_mangle_shebangs %{nil}
-%bcond_without mold
-
 %global _description %{expand:
 pbcli is a command line client which allows to upload and download pastes from privatebin directly from the command line.}
 
@@ -9,24 +6,22 @@ Version:        2.8.0
 Release:        1%?dist
 Summary:        A PrivateBin commandline upload and download utility
 SourceLicense:  Unlicense OR MIT
-License:        (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
+License:        (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 OR MIT) AND BSD-3-Clause) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:            https://github.com/Mydayyy/pbcli
-Source0:        %url/archive/refs/tags/v%version.tar.gz
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros >= 24
-BuildRequires:  anda-srpm-macros mold
-BuildRequires:  perl-IPC-Cmd perl-ExtUtils-MM-Utils perl-FindBin perl-lib perl-File-Compare perl-File-Copy
-BuildRequires:  openssl-libs openssl-devel
-Packager:       ShinyGil <rockgrub@protonmail.com>
+BuildRequires:  mold
+BuildRequires:  perl-ExtUtils-MM-Utils
+BuildRequires:  perl-FindBin
+BuildRequires:  perl-File-Compare
+BuildRequires:  perl-File-Copy
+BuildRequires:  perl-IPC-Cmd
+BuildRequires:  perl-lib
+BuildRequires:  openssl-libs
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description %_description
-
-%files
-%doc README.md
-%license LICENSE-MIT
-%license LICENSE-UNLICENSE
-%license LICENSE.dependencies
-%_bindir/pbcli
-%_libdir/libpbcli.so
 
 %prep
 %autosetup -n pbcli-%version
@@ -40,6 +35,14 @@ Packager:       ShinyGil <rockgrub@protonmail.com>
 install -Dm755 target/rpm/pbcli %{buildroot}%{_bindir}/pbcli
 install -Dm755 target/rpm/libpbcli.so %{buildroot}%{_libdir}/libpbcli.so
 
+%files
+%doc README.md
+%license LICENSE-MIT
+%license LICENSE-UNLICENSE
+%license LICENSE.dependencies
+%{_bindir}/pbcli
+%{_libdir}/libpbcli.so
+
 %changelog
-* Sat Dec 21 2024 ShinyGil <rockgrub@protonmail.com>
+* Sat Dec 21 2024 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/misc/pokemon-colorscripts/pokemon-colorscripts.spec
+++ b/anda/misc/pokemon-colorscripts/pokemon-colorscripts.spec
@@ -11,7 +11,7 @@ URL:           https://gitlab.com/phoneybadger/%{name}
 Source0:       %{url}/-/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 BuildArch:     noarch
 Requires:      python3
-Packager:      ShinyGil <rockgrub@disroot.org>
+Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description
 A utility that prints unicode sprites of images of Pokémon to the terminal.
@@ -42,5 +42,5 @@ ln -sf "%{_datadir}/%{name}/pokemon-colorscripts.py" "%{buildroot}%{_bindir}/pok
 %{_mandir}/man1/pokemon-colorscripts.1.gz
 
 %changelog
-* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xone/akmod/xone-kmod.spec
+++ b/anda/system/xone/akmod/xone-kmod.spec
@@ -16,7 +16,7 @@ Source0:        %{url}/archive/%{commit}.tar.gz#/xone-%{shortcommit}.tar.gz
 BuildRequires:  kmodtool
 BuildRequires:  systemd-rpm-macros
 Requires:       %{real_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 
@@ -59,5 +59,5 @@ done
 %{_modulesloaddir}/%{real_name}.conf
 
 %changelog
-* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xone/dkms/dkms-xone.spec
+++ b/anda/system/xone/dkms/dkms-xone.spec
@@ -18,7 +18,7 @@ BuildRequires:  systemd-rpm-macros
 Requires:       %{dkms_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
 BuildArch:      noarch
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 Linux kernel driver for Xbox One and Xbox Series X|S accessories.
@@ -60,5 +60,5 @@ dkms remove -m %{dkms_name} -v %{version} -q --all --rpm_safe_upgrade || :
 %endif
 
 %changelog
-* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xone/kmod-common/xone-kmod-common.spec
+++ b/anda/system/xone/kmod-common/xone-kmod-common.spec
@@ -25,7 +25,7 @@ Requires:       %{real_name}-firmware = 1.0.46.1
 Requires(post): dracut
 Provides:       %{real_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.
@@ -77,5 +77,5 @@ echo "The firmware for the wireless dongle is subject to Microsoft's Terms of Us
 echo 'https://www.microsoft.com/en-us/legal/terms-of-use'
 
 %changelog
-* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xpadneo/akmod/xpadneo-kmod.spec
+++ b/anda/system/xpadneo/akmod/xpadneo-kmod.spec
@@ -18,7 +18,7 @@ BuildRequires:  systemd-rpm-macros
 Requires:       bluez
 Requires:       bluez-tools
 Requires:       %{real_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 
@@ -59,5 +59,5 @@ done
 %{_modulesloaddir}/%{real_name}.conf
 
 %changelog
-* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Package refactoring for alternative DKMS package compatibility

--- a/anda/system/xpadneo/dkms/dkms-xpadneo.spec
+++ b/anda/system/xpadneo/dkms/dkms-xpadneo.spec
@@ -20,7 +20,7 @@ Requires:       bluez-tools
 Requires:       %{dkms_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
 BuildArch:      noarch
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 Advanced Linux Driver for Xbox One Wireless Gamepad.
@@ -63,5 +63,5 @@ dkms remove -m %{dkms_name} -v %{version} -q --all --rpm_safe_upgrade || :
 %endif
 
 %changelog
-* Thu Feb 27 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec
+++ b/anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec
@@ -15,7 +15,7 @@ Source1:        io.github.xpadneo.metainfo.xml
 BuildRequires:  systemd-rpm-macros
 Provides:       %{real_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 Advanced Linux Driver for Xbox One Wireless Gamepad common files.

--- a/anda/tools/java-binfmt/java-binfmt.spec
+++ b/anda/tools/java-binfmt/java-binfmt.spec
@@ -18,7 +18,7 @@ Source5:        https://raw.githubusercontent.com/terrapkg/pkg-java-binfmt/%{com
 Source6:        https://raw.githubusercontent.com/terrapkg/pkg-java-binfmt/%{commit}/Applet-lib64.conf
 BuildRequires:  gcc
 BuildRequires:  systemd-rpm-macros
-Packager:       ShinyGil <rockgrub@disroot.org>
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 This package installs binfmt files for use with Java wrappers.
@@ -109,5 +109,5 @@ install -Dpm644 %{SOURCE6} %{buildroot}%{_binfmtdir}/Applet-lib64.conf
 /bin/systemctl --system try-restart systemd-binfmt.service &>/dev/null || :
 
 %changelog
-* Thu Jan 30 2025 ShinyGil <rockgrub@disroot.org>
+* Thu Jan 30 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: bulk update RockGrub specs (#3646)](https://github.com/terrapkg/packages/pull/3646)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)