### PR TITLE
[f41] Fix: xpadneo and xone update scripts (#3641)

### DIFF
--- a/anda/system/xone/akmod/update.rhai
+++ b/anda/system/xone/akmod/update.rhai
@@ -1,3 +1,13 @@
-import "andax/bump_extras.rhai" as bump;
+let c = sh("cat anda/system/xone/kmod-common/xone-kmod-common.spec | grep '%global commit' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/xone/kmod-common/xone-kmod-common.spec | grep '%global date' | sed -E 's/.+date //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("date", d);
+    let v = sh("cat anda/system/xone/kmod-common/xone-kmod-common.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}
 
-rpm.version(bump::madoguchi("xone-kmod-common", labels.branch));

--- a/anda/system/xone/akmod/xone-kmod.spec
+++ b/anda/system/xone/akmod/xone-kmod.spec
@@ -7,7 +7,7 @@
 %global real_name xone
 
 Name:           %{real_name}-kmod
-Version:        0.3^20241223git.6b9d59a
+Version:        %{ver}^%{date}git.%{shortcommit}
 Release:        1%?dist
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
 License:        GPL-2.0-or-later

--- a/anda/system/xone/dkms/dkms-xone.spec
+++ b/anda/system/xone/dkms/dkms-xone.spec
@@ -6,7 +6,7 @@
 %global dkms_name xone
 
 Name:           dkms-%{dkms_name}
-Version:        0.3^20241223git.6b9d59a
+Version:        %{ver}^%{date}git.%{shortcommit}
 Release:        1%?dist
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
 License:        GPL-2.0-or-later

--- a/anda/system/xone/dkms/update.rhai
+++ b/anda/system/xone/dkms/update.rhai
@@ -1,3 +1,13 @@
-import "andax/bump_extras.rhai" as bump;
+let c = sh("cat anda/system/xone/kmod-common/xone-kmod-common.spec | grep '%global commit' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/xone/kmod-common/xone-kmod-common.spec | grep '%global date' | sed -E 's/.+date //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("date", d);
+    let v = sh("cat anda/system/xone/kmod-common/xone-kmod-common.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}
 
-rpm.version(bump::madoguchi("xone-kmod-common", labels.branch));

--- a/anda/system/xpadneo/akmod/update.rhai
+++ b/anda/system/xpadneo/akmod/update.rhai
@@ -1,3 +1,13 @@
-import "andax/bump_extras.rhai" as bump;
+let c = sh("cat anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec | grep '%global commit' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec | grep '%global date' | sed -E 's/.+date //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("date", d);
+    let v = sh("cat anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}
 
-rpm.version(bump::madoguchi("xpadneo-kmod-common", labels.branch));

--- a/anda/system/xpadneo/akmod/xpadneo-kmod.spec
+++ b/anda/system/xpadneo/akmod/xpadneo-kmod.spec
@@ -7,7 +7,7 @@
 %global real_name xpadneo
 
 Name:           %{real_name}-kmod
-Version:        0.9.7^20241224git.8d20a23
+Version:        %{ver}^%{date}git.%{shortcommit}
 Release:        1%?dist
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad
 License:        GPL-3.0

--- a/anda/system/xpadneo/dkms/dkms-xpadneo.spec
+++ b/anda/system/xpadneo/dkms/dkms-xpadneo.spec
@@ -6,7 +6,7 @@
 %global dkms_name xpadneo
 
 Name:           dkms-%{dkms_name}
-Version:        0.9.7^20241224git.8d20a23
+Version:        %{ver}^%{date}git.%{shortcommit}
 Release:        1%?dist
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad
 License:        GPL-3.0

--- a/anda/system/xpadneo/dkms/update.rhai
+++ b/anda/system/xpadneo/dkms/update.rhai
@@ -1,3 +1,13 @@
-import "andax/bump_extras.rhai" as bump;
+let c = sh("cat anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec | grep '%global commit' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec | grep '%global date' | sed -E 's/.+date //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("date", d);
+    let v = sh("cat anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}
 
-rpm.version(bump::madoguchi("xpadneo-kmod-common", labels.branch));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix: xpadneo and xone update scripts (#3641)](https://github.com/terrapkg/packages/pull/3641)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)