### PR TITLE
[f40] fix: mise (#3655)

### DIFF
--- a/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
+++ b/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- mise-2025.2.3/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ mise-2025.2.3/Cargo.toml	2025-02-09T16:23:06.178985+00:00
-@@ -476,18 +476,6 @@
+--- mise-2025.3.0/Cargo.toml	1970-01-01T00:00:01+00:00
++++ mise-2025.3.0/Cargo.toml	2025-03-02T07:08:39.544459+00:00
+@@ -469,18 +469,6 @@
  optional = true
  default-features = false
  
@@ -20,7 +20,7 @@
  borrowed_box = "allow"
  
 @@ -495,3 +483,4 @@
- level = "warn"
- priority = 0
- check-cfg = ["cfg(coverage,coverage_nightly)"]
+ [profile.serious]
+ lto = true
+ inherits = "release"
 +


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix: mise (#3655)](https://github.com/terrapkg/packages/pull/3655)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)