### PR TITLE
Fix (heroic): Handle AutoReqProv Electron issues

### DIFF
--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -1,8 +1,6 @@
 %global debug_package %{nil}
-%global __requires_exclude libffmpeg.so
-%global __requires_exclude ld-linux-*.so.*
-%global __provides_exclude_from %{_datadir}/heroic/.*\\.so
-%global __provides_exclude_from %{_datadir}/heroic/.*\\.so.1
+%global __provides_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
+%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
 %define _build_id_links none
 %global git_name HeroicGamesLauncher
 
@@ -27,15 +25,22 @@ BuildRequires: nodejs
 BuildRequires: pnpm
 BuildRequires: python3
 Requires:      alsa-lib
+Requires:      atk
+Requires:      at-spi2-core
 Requires:      gtk3
 Requires:      hicolor-icon-theme
+Requires:      libXext
+Requires:      libXfixes
 Requires:      nss
 Requires:      python3
 Requires:      which
 Recommends:    gamemode
 Recommends:    mangohud
 Recommends:    umu-launcher
+# Woarkaround for GNOME issues with libei
+Recommends:    (extest if gnome-shell)
 ExclusiveArch: x86_64
+AutoReq:       no
 Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -8,7 +8,7 @@
 
 Name:          heroic-games-launcher
 Version:       2.16.0
-Release:       1%?dist
+Release:       2%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -1,5 +1,6 @@
 %global debug_package %{nil}
 %global __requires_exclude libffmpeg.so
+%global __requires_exclude ld-linux-aarch64.so.1
 %global __provides_exclude_from %{_datadir}/heroic/.*\\.so
 %global __provides_exclude_from %{_datadir}/heroic/.*\\.so.1
 %define _build_id_links none

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -1,6 +1,6 @@
 %global debug_package %{nil}
 %global __requires_exclude libffmpeg.so
-%global __requires_exclude ld-linux-aarch64.so.1
+%global __requires_exclude ld-linux-*.so.*
 %global __provides_exclude_from %{_datadir}/heroic/.*\\.so
 %global __provides_exclude_from %{_datadir}/heroic/.*\\.so.1
 %define _build_id_links none

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -99,4 +99,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/heroic.desktop
 %changelog
 * Thu Jan 30 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package
+* Sun Mar 02 2025 Gilver E. <rockgrub@disroot.org>
+- Update to 2.16.0
+- Fix incorrect RPM dependencies
 

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -39,6 +39,9 @@ Recommends:    mangohud
 Recommends:    umu-launcher
 # Woarkaround for GNOME issues with libei
 Recommends:    (extest if gnome-shell)
+Provides:      bundled(gogdl)
+Provides:      bundled(legendary)
+Provides:      bundled(nile)
 ExclusiveArch: x86_64
 AutoReq:       no
 Packager:      Gilver E. <rockgrub@disroot.org>

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -35,6 +35,7 @@ Requires:      which
 Recommends:    gamemode
 Recommends:    mangohud
 Recommends:    umu-launcher
+ExclusiveArch: x86_64
 Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description


### PR DESCRIPTION
The automatic dep system saw an x86_64 exclusive program and said "You know what this needs? `ld-linux-aarch64.so.1`"