### PR TITLE
Fix (youtube-music): Handle AutoReqProv Electron issues

### DIFF
--- a/anda/apps/youtube-music/youtube-music.spec
+++ b/anda/apps/youtube-music/youtube-music.spec
@@ -32,6 +32,11 @@ BuildRequires:  python3 gcc-c++
 BuildRequires:  pnpm nodejs20
 %endif
 
+Requires:       nss
+Requires:       libXext
+Requires:       libXfixes
+AutoReq:        no
+
 %description
 YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
 

--- a/anda/apps/youtube-music/youtube-music.spec
+++ b/anda/apps/youtube-music/youtube-music.spec
@@ -13,7 +13,7 @@
 
 Name:           youtube-music
 Version:        3.7.5
-Release:        2%?dist
+Release:        3%?dist
 Summary:        YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
 Source1:        youtube-music.desktop
 License:        MIT

--- a/anda/apps/youtube-music/youtube-music.spec
+++ b/anda/apps/youtube-music/youtube-music.spec
@@ -1,8 +1,8 @@
 %define debug_package %nil
 
 # Exclude private libraries since this is bundled with electron
-%global __requires_exclude libffmpeg.so
-%global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
+%global __provides_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
+%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
 
 # macro shorthand for calling pnpm
 %global pnpm npx pnpm@%{pnpm_version}


### PR DESCRIPTION
I noticed Electron bundled libraries including `libffmpeg.so` would slip through sometimes with the old exclusion method, this one seems to catch them better.

Also disables AutoReq because RPM thinks Electron apps need half of GCC now?