### PR TITLE
Fix (seto-fonts): URL

### DIFF
--- a/anda/fonts/seto/seto-fonts.spec
+++ b/anda/fonts/seto/seto-fonts.spec
@@ -1,11 +1,11 @@
-Name:			seto-fonts
+Name:			  seto-fonts
 Version:		6.20
 Release:		3%?dist
-URL:			https://setofont.osdn.jp/
+URL:			  https://ja.osdn.net/projects/setofont/
 Source0:		https://github.com/terrapkg/pkg-seto-fonts/archive/refs/tags/%version.tar.gz
 License:		OFL-1.1
 Summary:		A handwritten font that contains kanji up to JIS 4th level and difficult kanji
-BuildArch:		noarch
+BuildArch:	noarch
 
 
 %description

--- a/anda/fonts/seto/seto-fonts.spec
+++ b/anda/fonts/seto/seto-fonts.spec
@@ -1,11 +1,11 @@
-Name:			  seto-fonts
-Version:		6.20
-Release:		3%?dist
-URL:			  https://ja.osdn.net/projects/setofont/
-Source0:		https://github.com/terrapkg/pkg-seto-fonts/archive/refs/tags/%version.tar.gz
-License:		OFL-1.1
-Summary:		A handwritten font that contains kanji up to JIS 4th level and difficult kanji
-BuildArch:	noarch
+Name:      seto-fonts
+Version:   6.20
+Release:   3%?dist
+URL:       https://ja.osdn.net/projects/setofont/
+Source0:   https://github.com/terrapkg/pkg-seto-fonts/archive/refs/tags/%version.tar.gz
+License:   OFL-1.1
+Summary:   A handwritten font that contains kanji up to JIS 4th level and difficult kanji
+BuildArch: noarch
 
 
 %description


### PR DESCRIPTION
All of their pages are so poorly maintained WTF

This is the only page on their site related to the font that still connects. Better than nothing, I guess?

This one also exists but often throws a 504. https://osdn.net/projects/setofont/releases