### PR TITLE
[f42] Fix: libfreeaptx (#3694)

### DIFF
--- a/anda/lib/libfreeaptx/libfreeaptx.spec
+++ b/anda/lib/libfreeaptx/libfreeaptx.spec
@@ -1,10 +1,11 @@
 %global commit ad6748ac8b2ebbfae7d0c5608434f60592d61edc
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20250303
+%global ver 0.2.1
 
 Name:       libfreeaptx
-Version:    0.1.1.%{commit_date}git%{shortcommit}
-Release:    1%?dist
+Version:    %{ver}^%{commit_date}git.%{shortcommit}
+Release:    2%?dist
 Summary:    Free implementation of Audio Processing Technology codec (aptX)
 License:    LGPLv2+
 URL:        https://github.com/iamthehorker/libfreeaptx
@@ -43,10 +44,11 @@ The %{name}-tools package contains command line encoder and decoder utilities.
 %files
 %license COPYING
 %{_libdir}/%{name}.so.0
-%{_libdir}/%{name}.so.0.1.1
+%{_libdir}/%{name}.so.%{ver}
 
 %files devel
 %{_includedir}/freeaptx.h
+%{_libdir}/%{name}.a
 %{_libdir}/%{name}.so
 %{_libdir}/pkgconfig/%{name}.pc
 

--- a/anda/lib/libfreeaptx/update.rhai
+++ b/anda/lib/libfreeaptx/update.rhai
@@ -2,4 +2,7 @@ rpm.global("commit", gh_commit("iamthehorker/libfreeaptx"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commit_date", date());
+    let v = gh_tag("pali/libopenaptx"));
+    v.crop(1);
+    rpm.global("ver", v);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Fix: libfreeaptx (#3694)](https://github.com/terrapkg/packages/pull/3694)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)