### PR TITLE
[el10] Fix (seto-fonts): URL (#3695)

### DIFF
--- a/anda/fonts/seto/seto-fonts.spec
+++ b/anda/fonts/seto/seto-fonts.spec
@@ -1,11 +1,11 @@
-Name:			seto-fonts
-Version:		6.20
-Release:		3%?dist
-URL:			https://setofont.osdn.jp/
-Source0:		https://github.com/terrapkg/pkg-seto-fonts/archive/refs/tags/%version.tar.gz
-License:		OFL-1.1
-Summary:		A handwritten font that contains kanji up to JIS 4th level and difficult kanji
-BuildArch:		noarch
+Name:      seto-fonts
+Version:   6.20
+Release:   3%?dist
+URL:       https://ja.osdn.net/projects/setofont/
+Source0:   https://github.com/terrapkg/pkg-seto-fonts/archive/refs/tags/%version.tar.gz
+License:   OFL-1.1
+Summary:   A handwritten font that contains kanji up to JIS 4th level and difficult kanji
+BuildArch: noarch
 
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Fix (seto-fonts): URL (#3695)](https://github.com/terrapkg/packages/pull/3695)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)