### PR TITLE
[f42] Fix: Change corefonts URLs to HTTPS (#3689)

### DIFF
--- a/anda/fonts/cleartype/cleartype-fonts.spec
+++ b/anda/fonts/cleartype/cleartype-fonts.spec
@@ -92,9 +92,9 @@ Version:        1.0
 Release:        1%{?dist}
 Summary:        Package containing ClearType fonts.
 License:        LicenseRef-MS-Core-Fonts
-URL:            http://mscorefonts2.sourceforge.net
+URL:            https://mscorefonts2.sourceforge.net
 Group:          User Interface/X
-Source0:        http://sourceforge.net/projects/mscorefonts2/files/cabs/PowerPointViewer.exe
+Source0:        https://sourceforge.net/projects/mscorefonts2/files/cabs/PowerPointViewer.exe
 Source1:        61-%{fontname}-calibri.conf
 Source2:        61-%{fontname}-cambria.conf
 Source3:        61-%{fontname}-candara.conf

--- a/anda/fonts/ms-core-tahoma/ms-core-tahoma-fonts.spec
+++ b/anda/fonts/ms-core-tahoma/ms-core-tahoma-fonts.spec
@@ -21,9 +21,9 @@ Version:        1.0
 Release:        1%{?dist}
 Summary:        Microsoft core Tahoma fonts for better Windows compatibility
 License:        LicenseRef-MS-Core-Fonts
-URL:            https://github.com/leamas/lpf
+URL:            https://mscorefonts2.sourceforge.net
 Group:          User Interface/X
-Source0:        http://downloads.sourceforge.net/corefonts/the%%20fonts/final/wd97vwr32.exe
+Source0:        https://downloads.sourceforge.net/corefonts/the%%20fonts/final/wd97vwr32.exe
 Source1:        61-ms-core-tahoma.conf
 BuildRequires:  cabextract
 BuildRequires:  fontpackages-devel

--- a/anda/fonts/ms-core/ms-core-fonts.spec
+++ b/anda/fonts/ms-core/ms-core-fonts.spec
@@ -1,5 +1,5 @@
 %global                   fontname ms-core
-%global sf_corefonts      http://downloads.sourceforge.net/corefonts/the%20fonts/final
+%global sf_url            https://downloads.sourceforge.net/corefonts/the%20fonts/final
 %global fontlicense       Microsoft EULA
 %global fontlicenses      Licen.TXT
 
@@ -156,16 +156,16 @@ Version:         2.2
 Release:         1%{?dist}
 Summary:         Microsoft core fonts
 License:         LicenseRef-MS-Core-Fonts
-URL:             http://mscorefonts2.sourceforge.net
+URL:             https://mscorefonts2.sourceforge.net
 Group:           User Interface/X
-Source0:         http://sourceforge.net/projects/mscorefonts2/files/cabs/EUupdate.EXE
-Source1:         %{sf_corefonts}/andale32.exe
-Source2:         %{sf_corefonts}/arialb32.exe
-Source3:         %{sf_corefonts}/comic32.exe
-Source4:         %{sf_corefonts}/courie32.exe
-Source5:         %{sf_corefonts}/georgi32.exe
-Source6:         %{sf_corefonts}/impact32.exe
-Source7:         %{sf_corefonts}/webdin32.exe
+Source0:         https://sourceforge.net/projects/mscorefonts2/files/cabs/EUupdate.EXE
+Source1:         %{sf_url}/andale32.exe
+Source2:         %{sf_url}/arialb32.exe
+Source3:         %{sf_url}/comic32.exe
+Source4:         %{sf_url}/courie32.exe
+Source5:         %{sf_url}/georgi32.exe
+Source6:         %{sf_url}/impact32.exe
+Source7:         %{sf_url}/webdin32.exe
 Source8:         61-ms-core-andale.conf
 Source9:         61-ms-core-arial.conf
 Source10:        61-ms-core-comic.conf


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Fix: Change corefonts URLs to HTTPS (#3689)](https://github.com/terrapkg/packages/pull/3689)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)