### PR TITLE
Fix (pokeshell): Fix install issues

### DIFF
--- a/anda/misc/pokeshell/pokeshell.spec
+++ b/anda/misc/pokeshell/pokeshell.spec
@@ -12,6 +12,7 @@ License:     GPL-3.0-or-later
 URL:         https://github.com/acxz/pokeshell
 Source0:     %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
 Source1:     HELPER_ALIASES
+Requires:    bash
 Requires:    jq
 Requires:    ImageMagick
 Requires:    python3
@@ -24,6 +25,7 @@ A featureful shell program to show Pokémon sprites in the terminal.
 
 %package     helper-scripts
 Summary:     This package contains helper scripts for Pokéshell
+Requires:    bash
 Requires:    %{name}
 Requires:    uv
 Recommends:  hyperfine

--- a/anda/misc/pokeshell/pokeshell.spec
+++ b/anda/misc/pokeshell/pokeshell.spec
@@ -56,7 +56,7 @@ Basic Zsh completion support for Pokéshell.
 %prep
 %autosetup -n %{name}-%{commit}
 cp %{SOURCE1} .
-sed -i 's/MY_DIR=.*/\MY_DIR=\/usr\/share\/%{name}/g' bin/pokeshell
+sed -i 's/MY_DIR=.*/MY_DIR=\/usr\/share\/%{name}/g' bin/pokeshell
 sed -i 's/\.\.\/share\///' bin/pokeshell
 
 %build

--- a/anda/misc/pokeshell/pokeshell.spec
+++ b/anda/misc/pokeshell/pokeshell.spec
@@ -4,55 +4,56 @@
 %global date 20241124
 %global ver 1.0.0
 
-Name:        pokeshell
-Version:     %{ver}^%{date}git.%{shortcommit}
-Release:     2%{?dist}
-Summary:     A shell program to show Pokémon sprites in the terminal.
-License:     GPL-3.0-or-later
-URL:         https://github.com/acxz/pokeshell
-Source0:     %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
-Source1:     HELPER_ALIASES
-Requires:    bash
-Requires:    jq
-Requires:    ImageMagick
-Requires:    python3
-Requires:    (timg or chafa)
-BuildArch:   noarch
-Packager:    Gilver E. <rockgrub@disroot.org>
+Name:          pokeshell
+Version:       %{ver}^%{date}git.%{shortcommit}
+Release:       2%{?dist}
+Summary:       A shell program to show Pokémon sprites in the terminal.
+License:       GPL-3.0-or-later
+URL:           https://github.com/acxz/pokeshell
+Source0:       %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
+Source1:       HELPER_ALIASES
+BuildRequires: sed
+Requires:      bash
+Requires:      jq
+Requires:      ImageMagick
+Requires:      python3
+Requires:      (timg or chafa)
+BuildArch:     noarch
+Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description
 A featureful shell program to show Pokémon sprites in the terminal.
 
-%package     helper-scripts
-Summary:     This package contains helper scripts for Pokéshell
-Requires:    bash
-Requires:    %{name}
-Requires:    uv
-Recommends:  hyperfine
-Recommends:  pokeget-rs
-Recommends:  pokemon-colorscripts
+%package       helper-scripts
+Summary:       This package contains helper scripts for Pokéshell
+Requires:      bash
+Requires:      %{name}
+Requires:      uv
+Recommends:    hyperfine
+Recommends:    pokeget-rs
+Recommends:    pokemon-colorscripts
 
 %description helper-scripts
 Generates pokemon identifiers (such as localized names) using PokeAPI that the sprite backends do not support natively.
 
 See included README for what these scripts can do.
 
-%package     bash-completion
-Summary:     Bash completion for Pokéshell
-Requires:    bash
-Requires:    %{name}
-Supplements: (%{name} and bash)
+%package       bash-completion
+Summary:       Bash completion for Pokéshell
+Requires:      bash
+Requires:      %{name}
+Supplements:   (%{name} and bash)
 
-%description bash-completion
+%description   bash-completion
 Pokéshell Bash completion.
 
-%package     zsh-completion
-Summary:     Zsh completion for Pokéshell
-Requires:    %{name}
-Requires:    zsh
-Supplements: (%{name} and zsh)
+%package       zsh-completion
+Summary:       Zsh completion for Pokéshell
+Requires:      %{name}
+Requires:      zsh
+Supplements:   (%{name} and zsh)
 
-%description zsh-completion
+%description   zsh-completion
 Basic Zsh completion support for Pokéshell.
 
 %prep

--- a/anda/misc/pokeshell/pokeshell.spec
+++ b/anda/misc/pokeshell/pokeshell.spec
@@ -6,7 +6,7 @@
 
 Name:        pokeshell
 Version:     %{ver}^%{date}git.%{shortcommit}
-Release:     1%{?dist}
+Release:     2%{?dist}
 Summary:     A shell program to show Pokémon sprites in the terminal.
 License:     GPL-3.0-or-later
 URL:         https://github.com/acxz/pokeshell
@@ -56,6 +56,8 @@ Basic Zsh completion support for Pokéshell.
 %prep
 %autosetup -n %{name}-%{commit}
 cp %{SOURCE1} .
+sed -i 's/\$MY_DIR\/\.\.\/share/\/usr\/share\/%{name}/' bin/pokeshell
+sed -i 's/\$MY_DIR\/imageshell\/imageshell.sh/\/usr\/share\/%{name}\/imageshell\/imageshell.sh/' bin/pokeshell
 
 %build
 
@@ -68,8 +70,6 @@ install -Dm644 scripts/*.sh -t %{buildroot}%{_datadir}/%{name}/scripts
 # Bash and Zsh completion share a single file, Zsh completion is pretty rudimentary
 install -Dm644 share/bash-completion/completions/pokeshell -t %{buildroot}%{bash_completions_dir}
 install -Dm644 share/bash-completion/completions/pokeshell %{buildroot}%{zsh_completions_dir}/_%{name}
-# Keep actual directories out of /usr/bin
-ln -sf %{_datadir}/%{name}/imageshell %{buildroot}%{_bindir}/imageshell
 # Make helper scripts directly executable
 ln -sf %{_datadir}/%{name}/scripts/create_pokemon_identifiers.py %{buildroot}%{_bindir}/create-pokemon-identifiers
 ln -sf %{_datadir}/%{name}/scripts/timing.sh %{buildroot}%{_bindir}/pokeget-timing
@@ -78,7 +78,6 @@ ln -sf %{_datadir}/%{name}/scripts/timing.sh %{buildroot}%{_bindir}/pokeget-timi
 %license LICENSE.md
 %doc README.md
 %{_bindir}/%{name}
-%{_bindir}/imageshell
 %dir %{_datadir}/%{name}
 %{_datadir}/%{name}/pokemon_identifiers.json
 %dir %{_datadir}/%{name}/imageshell

--- a/anda/misc/pokeshell/pokeshell.spec
+++ b/anda/misc/pokeshell/pokeshell.spec
@@ -56,8 +56,8 @@ Basic Zsh completion support for Pokéshell.
 %prep
 %autosetup -n %{name}-%{commit}
 cp %{SOURCE1} .
-sed -i 's/\$MY_DIR\/\.\.\/share/\/usr\/share\/%{name}/' bin/pokeshell
-sed -i 's/\$MY_DIR\/imageshell\/imageshell.sh/\/usr\/share\/%{name}\/imageshell\/imageshell.sh/' bin/pokeshell
+sed -i 's/MY_DIR=.*/\MY_DIR=\/usr\/share\/%{name}/g' bin/pokeshell
+sed -i 's/\.\.\/share\///' bin/pokeshell
 
 %build
 


### PR DESCRIPTION
Turns out the official install method is...odd so some changes to that and the executable script.

Also less symlinks and `sed` to the rescue.
![image](https://github.com/user-attachments/assets/edae4905-0940-47ce-b6e6-d23f61cba005)