### PR TITLE
Fix (extest): Versioning

### DIFF
--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -15,7 +15,7 @@
 %global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 Name:           extest
-Version:        %commit_date.git~%{shortcommit}
+Version:        %{commit_date}git.%{shortcommit}
 Release:        1%?dist
 Summary:        X11 XTEST reimplementation primarily for Steam Controller on Wayland
 


### PR DESCRIPTION
Due to `~` Extest's commit date was filtering *below* the commit meaning there was technically no newest version.

Didn't do my usual stablever~date.commit thing since this isn't my package but wanted to fix the versioning regardless.