### PR TITLE
[f41] Fix: voicevox (#3593)

### DIFF
--- a/anda/apps/voicevox/voicevox.spec
+++ b/anda/apps/voicevox/voicevox.spec
@@ -5,7 +5,7 @@
 %define __strip /bin/true
 
 # do not perform compression in cpio
-%define _source_payload w0.ufdio
+%define _source_payload w19.zstdio
 %define _binary_payload w19.zstdio
 
 # Exclude private libraries
@@ -14,7 +14,7 @@
 
 Name:			voicevox
 Version:		0.23.0
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Free Japanese text-to-speech editor
 License:		LGPL-3.0
 URL:			https://voicevox.hiroshiba.jp
@@ -52,7 +52,7 @@ sed -i "s|Exec=.*|Exec=/usr/share/voicevox/VOICEVOX.AppImage|" squashfs-root/voi
 %install
 install -Dm755 VOICEVOX.AppImage %buildroot%_datadir/voicevox/VOICEVOX.AppImage
 install -Dm755 voicevox.sh %buildroot%_bindir/voicevox
-install -Dm644 squashfs-root%_iconsdir/hicolor/0x0/apps/voicevox.png %buildroot%_iconsdir/hicolor/256x256/apps/voicevox.png
+install -Dm644 squashfs-root%_iconsdir/hicolor/256x256/apps/voicevox.png %buildroot%_iconsdir/hicolor/256x256/apps/voicevox.png
 install -Dm644 squashfs-root/voicevox.desktop %buildroot%_datadir/applications/voicevox.desktop
 
 %files


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix: voicevox (#3593)](https://github.com/terrapkg/packages/pull/3593)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)