### PR TITLE
[f40] Fix (extest): Versioning (#3723)

### DIFF
--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -15,7 +15,7 @@
 %global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 Name:           extest
-Version:        %commit_date.git~%{shortcommit}
+Version:        %{commit_date}git.%{shortcommit}
 Release:        1%?dist
 Summary:        X11 XTEST reimplementation primarily for Steam Controller on Wayland
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [Fix (extest): Versioning (#3723)](https://github.com/terrapkg/packages/pull/3723)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)