### PR TITLE
Fix (extest): Don't build i686 debug packages on F41 due to bug

### DIFF
--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -1,6 +1,11 @@
 %global commit d6863d970d2686dd6282142af57503e1f2d561dc
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20241119
+%if 0%{?fedora} = 41
+%ifarch %ix86
+%global debug_package %{nil}
+%endif
+%endif
 
 # While there's an upstream version at Supreeeme/extest, we're using
 # the same fork as Bazzite so we can use the same patches.

--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -1,7 +1,7 @@
 %global commit d6863d970d2686dd6282142af57503e1f2d561dc
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20241119
-%if 0%{?fedora} = 41
+%if 0%{?fedora} == 41
 %ifarch %ix86
 %global debug_package %{nil}
 %endif


### PR DESCRIPTION
We live in a bizarro world.

See: https://github.com/terrapkg/packages/actions/runs/13643896667/job/38139357011#step:7:3884

No release bump because this is to fix i686 just not building on F41.