### PR TITLE
[f41] Fix (extest): Don&#x27;t build i686 debug packages on F41 due to bug (#3734)

### DIFF
--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -1,6 +1,11 @@
 %global commit d6863d970d2686dd6282142af57503e1f2d561dc
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20241119
+%if 0%{?fedora} == 41
+%ifarch %ix86
+%global debug_package %{nil}
+%endif
+%endif
 
 # While there's an upstream version at Supreeeme/extest, we're using
 # the same fork as Bazzite so we can use the same patches.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Fix (extest): Don&#x27;t build i686 debug packages on F41 due to bug (#3734)](https://github.com/terrapkg/packages/pull/3734)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)