### PR TITLE
[f40] UX (pokeget-rs): Make both names executable (#3722)

### DIFF
--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -2,10 +2,11 @@
 %global pcommit c5aaa610ff2acdf7fd8e2dccd181bca8be9fcb3e
 %global pshortcommit %(c=%{pcommit}; echo ${c:0:7})
 %global pcommit_date 20220622
+%global shortname pokeget
 
-Name:          pokeget-rs
+Name:          %{shortname}-rs
 Version:       1.6.3
-Release:       1%{?dist}
+Release:       2%{?dist}
 SourceLicense: MIT
 License:       MIT AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 Summary:       A better Rust version of pokeget.
@@ -34,13 +35,15 @@ popd
 %cargo_build
 
 %install
-install -Dpm755 target/rpm/pokeget %{buildroot}%{_bindir}/%{name}
+install -Dpm755 target/rpm/%{shortname} -t %{buildroot}%{_bindir}
+ln -sf %{shortname} %{buildroot}%{_bindir}/%{name}
 %{cargo_license_online} > LICENSE.dependencies
 
 %files
 %license LICENSE LICENSE.dependencies data/%{pname}/license.md
 %doc README.md
 %{_bindir}/%{name}
+%{_bindir}/%{shortname}
 
 %changelog
 * Sat Mar 01 2025 Gilver E. <rockgrub@disroot.org>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [UX (pokeget-rs): Make both names executable (#3722)](https://github.com/terrapkg/packages/pull/3722)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)