### PR TITLE
[el10] chore(devpod): add update script (#3724)

### DIFF
--- a/anda/devs/devpod/DevPod.desktop
+++ b/anda/devs/devpod/DevPod.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Type=Application
 Name=DevPod
-Comment=DevPod
+Comment=Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker
 Exec=/usr/bin/DevPod
 Icon=devpod.png
 Terminal=false

--- a/anda/devs/devpod/golang-github-loft-sh-devpod.spec
+++ b/anda/devs/devpod/golang-github-loft-sh-devpod.spec
@@ -3,7 +3,7 @@
 
 # https://github.com/loft-sh/devpod
 %global goipath         github.com/loft-sh/devpod
-Version:                0.6.9
+Version:                0.6.13
 
 %gometa -f
 
@@ -17,7 +17,7 @@ and lets you use any cloud, kubernetes or just localhost docker.}
                         loadtest/README.md
 
 Name:           devpod
-Release:        %autorelease
+Release:        1%?dist
 Summary:        Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker
 Provides:       golang-github-loft-sh-devpod
 BuildRequires:  anda-srpm-macros mold

--- a/anda/devs/devpod/update.rhai
+++ b/anda/devs/devpod/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("loft-sh/devpod"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(devpod): add update script (#3724)](https://github.com/terrapkg/packages/pull/3724)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)