### PR TITLE
[f42] Fix (xpadneo-kmod-common): Obsoletes instead due to name change (#3755)

### DIFF
--- a/anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec
+++ b/anda/system/xpadneo/kmod-common/xpadneo-kmod-common.spec
@@ -6,7 +6,7 @@
 
 Name:           %{real_name}-kmod-common
 Version:        %{ver}^%{date}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad common files
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/%{real_name}
@@ -14,7 +14,7 @@ Source0:        https://github.com/atar-axis/%{real_name}/archive/%{commit}.tar.
 Source1:        io.github.xpadneo.metainfo.xml
 BuildRequires:  systemd-rpm-macros
 Provides:       %{real_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
-Provides:       %{real_name} = %{version}-%{release}
+Obsoletes:      %{real_name} < %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
 Packager:       Gilver E. <rockgrub@disroot.org>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Fix (xpadneo-kmod-common): Obsoletes instead due to name change (#3755)](https://github.com/terrapkg/packages/pull/3755)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)