### PR TITLE
[f40] bump(opentabletdriver): .net dependency (#3767)

### DIFF
--- a/anda/system/opentabletdriver/opentabletdriver.spec
+++ b/anda/system/opentabletdriver/opentabletdriver.spec
@@ -6,11 +6,11 @@
 %global __requires_exclude_from ^/usr/lib/opentabletdriver/.*$
 %global __os_install_post %{nil}
 %global dotnet_sdk_version 8.0
-%global dotnet_runtime_version 6.0
+%global dotnet_runtime_version 8.0
 
 Name: opentabletdriver
 Version: 0.6.5.1
-Release: 1%?dist
+Release: 2%?dist
 Summary: A cross-platform open source tablet driver
 License: LGPLv3
 URL: https://github.com/OpenTabletDriver/OpenTabletDriver
@@ -19,7 +19,7 @@ Packager: Cappy Ishihara <cappy@fyralabs.com>
 
 
 # This package can be built using a newer .NET SDK version, but you
-# specifically need .NET 6.0 to run it.
+# specifically need .NET 8.0 to run it.
 BuildRequires: dotnet-sdk-%{dotnet_sdk_version}
 BuildRequires: git jq systemd-rpm-macros
 BuildRequires: gtk3-devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [bump(opentabletdriver): .net dependency (#3767)](https://github.com/terrapkg/packages/pull/3767)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)