### PR TITLE
Refactor (pokeget-rs): Bundled provides and use `%git_clone`

### DIFF
--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -22,7 +22,6 @@ Packager:      Gilver E. <rockgrub@disroot.org>
 Successor to pokeget, written in Rust.
 
 %prep
-rm -rf ./*
 %git_clone https://github.com/talwat/%{name} %{version}
 %cargo_prep_online
 

--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -1,7 +1,5 @@
 %global pname pokesprite
 %global pcommit c5aaa610ff2acdf7fd8e2dccd181bca8be9fcb3e
-%global pshortcommit %(c=%{pcommit}; echo ${c:0:7})
-%global pcommit_date 20220622
 %global shortname pokeget
 
 Name:          %{shortname}-rs

--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -6,7 +6,7 @@
 
 Name:          %{shortname}-rs
 Version:       1.6.3
-Release:       2%{?dist}
+Release:       3%{?dist}
 SourceLicense: MIT
 License:       MIT AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 Summary:       A better Rust version of pokeget.
@@ -17,7 +17,7 @@ BuildRequires: anda-srpm-macros
 BuildRequires: cargo-rpm-macros
 BuildRequires: mold
 Provides:      pokeget = %{version}-%{release}
-Provides:      bundled(%{pname}) = 2.7.0^%{pcommit_date}.%{pshortcommit}
+Provides:      bundled(%{pname}) = %{pcommit}
 Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description

--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -25,7 +25,7 @@ Successor to pokeget, written in Rust.
 %prep
 %autosetup -n %{name}-%{version}
 pushd data
-%git_clone https://github.com/msikma/%{pname} %{pcommit} data/%{pname}
+%git_clone https://github.com/msikma/%{pname} %{pcommit}
 popd
 %cargo_prep_online
 

--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -11,7 +11,6 @@ SourceLicense: MIT
 License:       MIT AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 Summary:       A better Rust version of pokeget.
 URL:           https://github.com/talwat/%{name}
-Source0:       %{url}/archive/refs/tags/%{version}.tar.gz
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo-rpm-macros
 BuildRequires: mold
@@ -23,10 +22,8 @@ Packager:      Gilver E. <rockgrub@disroot.org>
 Successor to pokeget, written in Rust.
 
 %prep
-%autosetup -n %{name}-%{version}
-pushd data
-%git_clone https://github.com/msikma/%{pname} %{pcommit}
-popd
+rm -rf ./*
+%git_clone https://github.com/talwat/%{name} %{version}
 %cargo_prep_online
 
 %build

--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -12,7 +12,6 @@ License:       MIT AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) A
 Summary:       A better Rust version of pokeget.
 URL:           https://github.com/talwat/%{name}
 Source0:       %{url}/archive/refs/tags/%{version}.tar.gz
-Source1:       https://github.com/msikma/%{pname}/archive/%{pcommit}/%{pname}-%{pcommit}.tar.gz#/%{pname}-%{pshortcommit}.tar.gz
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo-rpm-macros
 BuildRequires: mold
@@ -25,10 +24,7 @@ Successor to pokeget, written in Rust.
 
 %prep
 %autosetup -n %{name}-%{version}
-mkdir -p data/%{pname}
-pushd data/%{pname}
-/usr/bin/gzip -dc '%{SOURCE1}' | /usr/bin/tar -xof - --strip-components=1
-popd
+%git_clone https://github.com/msikma/%{pname} %{pcommit} data/%{pname}
 %cargo_prep_online
 
 %build

--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -20,7 +20,7 @@ Packager:      Gilver E. <rockgrub@disroot.org>
 Successor to pokeget, written in Rust.
 
 %prep
-%git_clone https://github.com/talwat/%{name} %{version}
+%git_clone %{url} %{version}
 %cargo_prep_online
 
 %build

--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -24,7 +24,9 @@ Successor to pokeget, written in Rust.
 
 %prep
 %autosetup -n %{name}-%{version}
+pushd data
 %git_clone https://github.com/msikma/%{pname} %{pcommit} data/%{pname}
+popd
 %cargo_prep_online
 
 %build

--- a/anda/misc/pokeget-rs/update.rhai
+++ b/anda/misc/pokeget-rs/update.rhai
@@ -5,5 +5,4 @@ if rpm.changed () {
      let json = get(url).json();
      let c = json.2.sha;
      rpm.global("pcommit", c);
-     rpm.global("pcommit_date", date()); // could potentially result in the wrong date, fix if it becomes a problem
 }


### PR DESCRIPTION
Bundled provides when Git based should be versioned by full commit, I was mistaken on how Fedora handles this. Very, very minor refactor but fixes a potential UX discrepancy if users look at bundled provides I suppose.

Since `%git_clone` does `recurse-submodules` it fetches the correct build of the deps without any manual intervention.