### PR TITLE
[f40] fix(ghostty-nightly): Changes for localization support (#3765)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -4,13 +4,15 @@
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.1.3
+%global base_name ghostty
+%global reverse_dns com.mitchellh.%{base_name}
 %if 0%{?fedora} <= 40
 %global cache_dir %{_builddir}/zig-cache
 %else
 %global cache_dir %{builddir}/zig-cache
 %endif
 
-Name:           ghostty-nightly
+Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
 Release:        1%?dist
 %if 0%{?fedora} <= 41
@@ -18,9 +20,10 @@ Epoch:          1
 %endif
 Summary:        A fast, native terminal emulator written in Zig; this is the Tip (nightly) build.
 License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
-URL:            https://ghostty.org/
-Source0:        https://github.com/ghostty-org/ghostty/releases/download/tip/ghostty-source.tar.gz
-Source1:        https://github.com/ghostty-org/ghostty/releases/download/tip/ghostty-source.tar.gz.minisig
+URL:            https://%{base_name}.org
+Source0:        https://github.com/%{base_name}-org/%{base_name}/releases/download/tip/%{base_name}-source.tar.gz
+Source1:        https://github.com/%{base_name}-org/%{base_name}/releases/download/tip/%{base_name}-source.tar.gz.minisig
+BuildRequires:  gettext
 BuildRequires:  gtk4-devel
 BuildRequires:  libadwaita-devel
 BuildRequires:  libX11-devel
@@ -44,8 +47,8 @@ Requires:       %{name}-terminfo
 Requires:       %{name}-shell-integration
 Requires:       gtk4
 Requires:       libadwaita
-Conflicts:      ghostty
-Provides:       ghostty-tip = %{version}-%{release}
+Conflicts:      %{base_name}
+Provides:       %{base_name}-tip = %{ver}^%{commit_date}git%{shortcommit}
 %if 0%{?fedora} <= 41
 Provides:       %{name} = %{commit_date}.%{shortcommit}
 %endif
@@ -127,7 +130,7 @@ This package contains files for Ghostty's terminfo. Available for debugging use.
 
 %prep
 /usr/bin/minisign -V -m %{SOURCE0} -x %{SOURCE1} -P %{public_key}
-%autosetup -n ghostty-source
+%autosetup -n %{base_name}-source
 
 ZIG_GLOBAL_CACHE_DIR="%{cache_dir}" ./nix/build-support/fetch-zig-cache.sh
 
@@ -150,64 +153,72 @@ zig build \
     -Demit-termcap \
     -Demit-terminfo
 
-%files
+%find_lang %{reverse_dns}
+
+%files -f %{reverse_dns}.lang
 %doc README.md
 %license LICENSE
-%_bindir/ghostty
-%_datadir/applications/com.mitchellh.ghostty.desktop
-%_datadir/bat/syntaxes/ghostty.sublime-syntax
-%_datadir/ghostty/
-%_datadir/kio/servicemenus/com.mitchellh.ghostty.desktop
-%_datadir/nautilus-python/extensions/ghostty.py
-%_datadir/nvim/site/compiler/ghostty.vim
-%_datadir/nvim/site/ftdetect/ghostty.vim
-%_datadir/nvim/site/ftplugin/ghostty.vim
-%_datadir/nvim/site/syntax/ghostty.vim
-%_datadir/vim/vimfiles/compiler/ghostty.vim
-%_datadir/vim/vimfiles/ftdetect/ghostty.vim
-%_datadir/vim/vimfiles/ftplugin/ghostty.vim
-%_datadir/vim/vimfiles/syntax/ghostty.vim
-%_iconsdir/hicolor/16x16/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/16x16@2/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/32x32/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/32x32@2/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/128x128/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/128x128@2/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/256x256/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/256x256@2/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/512x512/apps/com.mitchellh.ghostty.png
-%_iconsdir/hicolor/1024x1024/apps/com.mitchellh.ghostty.png
-%_mandir/man1/ghostty.1.gz
-%_mandir/man5/ghostty.5.gz
+%{_bindir}/%{base_name}
+%{_datadir}/applications/%{reverse_dns}.desktop
+%{_datadir}/bat/syntaxes/%{base_name}.sublime-syntax
+%dir %{_datadir}/%{base_name}
+%{_datadir}/%{base_name}/doc
+%{_datadir}/%{base_name}/themes
+%{_datadir}/kio/servicemenus/%{reverse_dns}.desktop
+%{_datadir}/nautilus-python/extensions/%{base_name}.py
+%{_datadir}/nvim/site/compiler/%{base_name}.vim
+%{_datadir}/nvim/site/ftdetect/%{base_name}.vim
+%{_datadir}/nvim/site/ftplugin/%{base_name}.vim
+%{_datadir}/nvim/site/syntax/%{base_name}.vim
+%{_datadir}/vim/vimfiles/compiler/%{base_name}.vim
+%{_datadir}/vim/vimfiles/ftdetect/%{base_name}.vim
+%{_datadir}/vim/vimfiles/ftplugin/%{base_name}.vim
+%{_datadir}/vim/vimfiles/syntax/%{base_name}.vim
+%{_iconsdir}/hicolor/16x16/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/16x16@2/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/32x32/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/32x32@2/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/128x128/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/128x128@2/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/256x256/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/256x256@2/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/512x512/apps/%{reverse_dns}.png
+%{_iconsdir}/hicolor/1024x1024/apps/%{reverse_dns}.png
+%{_mandir}/man1/%{base_name}.1.gz
+%{_mandir}/man5/%{base_name}.5.gz
 
 %files bash-completion
-%bash_completions_dir/ghostty.bash
+%{bash_completions_dir}/%{base_name}.bash
 
 %files fish-completion
-%fish_completions_dir/ghostty.fish
+%{fish_completions_dir}/%{base_name}.fish
 
 %files zsh-completion
-%zsh_completions_dir/_ghostty
+%{zsh_completions_dir}/_%{base_name}
 
 %files shell-integration
-%_datadir/ghostty/shell-integration/bash/bash-preexec.sh
-%_datadir/ghostty/shell-integration/bash/ghostty.bash
-%_datadir/ghostty/shell-integration/elvish/lib/ghostty-integration.elv
-%_datadir/ghostty/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
-%_datadir/ghostty/shell-integration/zsh/.zshenv
-%_datadir/ghostty/shell-integration/zsh/ghostty-integration
+%dir %{_datadir}/%{base_name}/shell-integration
+%{_datadir}/%{base_name}/shell-integration/bash/bash-preexec.sh
+%{_datadir}/%{base_name}/shell-integration/bash/%{base_name}.bash
+%{_datadir}/%{base_name}/shell-integration/elvish/lib/%{base_name}-integration.elv
+%{_datadir}/%{base_name}/shell-integration/fish/vendor_conf.d/%{base_name}-shell-integration.fish
+%{_datadir}/%{base_name}/shell-integration/zsh/.zshenv
+%{_datadir}/%{base_name}/shell-integration/zsh/%{base_name}-integration
 
 %files terminfo
-%_datadir/terminfo/g/ghostty
-%_datadir/terminfo/x/xterm-ghostty
+%{_datadir}/terminfo/g/%{base_name}
+%{_datadir}/terminfo/x/xterm-%{base_name}
 
 %files terminfo-source
-%_datadir/terminfo/ghostty.termcap
-%_datadir/terminfo/ghostty.terminfo
+%{_datadir}/terminfo/%{base_name}.termcap
+%{_datadir}/terminfo/%{base_name}.terminfo
 
 %changelog
+* Wed Mar 05 2025 Gilver E. <rockgrub@disroot.org>
+- Update to 1.1.3~tip^20250305git66e8d91-2%{?dist}
+ * Ghostty now has localization support via gettext as well as corresponding localization files
 * Fri Jan 31 2025 Gilver E. <rockgrub@disroot.org>
-- Update to 1.1.1-1%{?dist}.20250131tipc5508e7
+- Update to 1.1.1~tip^20250131git5508e7-1%{?dist}
  * Low GHSA-98wc-794w-gjx3: Ghostty leaked file descriptors allowing the shell and any of its child processes to impact other Ghostty terminal instances
  * Better Git versioning scheme
  * Ghostty terminfo source files are now a subpackage


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(ghostty-nightly): Changes for localization support (#3765)](https://github.com/terrapkg/packages/pull/3765)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)