### PR TITLE
[f41] refactor(pokeget-rs): Bundled provides and use &#x60;%git_clone&#x60; (#3772)

### DIFF
--- a/anda/misc/pokeget-rs/pokeget-rs.spec
+++ b/anda/misc/pokeget-rs/pokeget-rs.spec
@@ -1,34 +1,26 @@
 %global pname pokesprite
 %global pcommit c5aaa610ff2acdf7fd8e2dccd181bca8be9fcb3e
-%global pshortcommit %(c=%{pcommit}; echo ${c:0:7})
-%global pcommit_date 20220622
 %global shortname pokeget
 
 Name:          %{shortname}-rs
 Version:       1.6.3
-Release:       2%{?dist}
+Release:       3%{?dist}
 SourceLicense: MIT
 License:       MIT AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 Summary:       A better Rust version of pokeget.
 URL:           https://github.com/talwat/%{name}
-Source0:       %{url}/archive/refs/tags/%{version}.tar.gz
-Source1:       https://github.com/msikma/%{pname}/archive/%{pcommit}/%{pname}-%{pcommit}.tar.gz#/%{pname}-%{pshortcommit}.tar.gz
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo-rpm-macros
 BuildRequires: mold
 Provides:      pokeget = %{version}-%{release}
-Provides:      bundled(%{pname}) = 2.7.0^%{pcommit_date}.%{pshortcommit}
+Provides:      bundled(%{pname}) = %{pcommit}
 Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description
 Successor to pokeget, written in Rust.
 
 %prep
-%autosetup -n %{name}-%{version}
-mkdir -p data/%{pname}
-pushd data/%{pname}
-/usr/bin/gzip -dc '%{SOURCE1}' | /usr/bin/tar -xof - --strip-components=1
-popd
+%git_clone %{url} %{version}
 %cargo_prep_online
 
 %build

--- a/anda/misc/pokeget-rs/update.rhai
+++ b/anda/misc/pokeget-rs/update.rhai
@@ -5,5 +5,4 @@ if rpm.changed () {
      let json = get(url).json();
      let c = json.2.sha;
      rpm.global("pcommit", c);
-     rpm.global("pcommit_date", date()); // could potentially result in the wrong date, fix if it becomes a problem
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [refactor(pokeget-rs): Bundled provides and use &#x60;%git_clone&#x60; (#3772)](https://github.com/terrapkg/packages/pull/3772)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)