### PR TITLE
[f42] Add: Rio (#3788)

### DIFF
--- a/anda/devs/rio/anda.hcl
+++ b/anda/devs/rio/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "rio.spec"
+    }
+}

--- a/anda/devs/rio/rio.spec
+++ b/anda/devs/rio/rio.spec
@@ -1,0 +1,51 @@
+%global _description %{expand:
+A hardware-accelerated terminal emulator focusing to run in desktops and browsers.}
+
+Name:          rio
+Version:       0.2.8
+Release:       1%{?dist}
+Summary:       A hardware-accelerated terminal written in Rust.
+SourceLicense: MIT
+License:       ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND BSD-2-Clause AND BSL-1.0 AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND ISC AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR GPL-3.0-only) AND MPL-2.0+ AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
+URL:           http://rioterm.com
+Source0:       https://github.com/raphamorim/%{name}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires: anda-srpm-macros
+BuildRequires: cargo-rpm-macros
+BuildRequires: freetype-devel
+BuildRequires: cmake
+BuildRequires: gcc-c++
+BuildRequires: libxcb-devel
+BuildRequires: libxkbcommon-devel
+BuildRequires: mold
+Requires:      freetype
+Requires:      fontconfig
+Requires:      hicolor-icon-theme
+Requires:      libgcc
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%description %_description
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build -a
+
+%install
+install -Dm755 target/rpm/%{name} %{buildroot}%{_bindir}/%{name}
+install -Dm644 misc/%{name}.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop
+install -Dm644 misc/logo.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/%{name}.svg
+%{cargo_license_online -a} > LICENSE.dependencies
+
+%files
+%doc README.md
+%license LICENSE
+%license LICENSE.dependencies
+%{_bindir}/%{name}
+%{_datadir}/applications/%{name}.desktop
+%{_iconsdir}/hicolor/scalable/apps/%{name}.svg
+
+%changelog
+* Sat Mar 8 2025 Gilver E. <rockgrub@disroot.org>
+- Initial package

--- a/anda/devs/rio/update.rhai
+++ b/anda/devs/rio/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(crates("rioterm"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Add: Rio (#3788)](https://github.com/terrapkg/packages/pull/3788)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)