### PR TITLE
fix(pokeshell): Hard dep on chafa

### DIFF
--- a/anda/misc/pokeshell/pokeshell.spec
+++ b/anda/misc/pokeshell/pokeshell.spec
@@ -6,7 +6,7 @@
 
 Name:          pokeshell
 Version:       %{ver}^%{date}git.%{shortcommit}
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       A shell program to show Pokémon sprites in the terminal.
 License:       GPL-3.0-or-later
 URL:           https://github.com/acxz/pokeshell
@@ -17,7 +17,8 @@ Requires:      bash
 Requires:      jq
 Requires:      ImageMagick
 Requires:      python3
-Requires:      (timg or chafa)
+Requires:      chafa
+Recommends:    timg
 BuildArch:     noarch
 Packager:      Gilver E. <rockgrub@disroot.org>
 


### PR DESCRIPTION
The amount of fix PRs I've had to do recently is embarrassing and frustrating but in my defense the docs for this literally list `chafa` as and either/or but it...is not?
![image](https://github.com/user-attachments/assets/c13b15da-cac5-4290-9fb7-dc0f3c83f5cc)

Upon checking the script it checks for `timg` but reverts to `chafa` if not found, but *requires* `chafa` for animations.
![image](https://github.com/user-attachments/assets/4fba6681-0525-4e77-b306-fc18dbe46c17)
![image](https://github.com/user-attachments/assets/54f0744d-b594-4887-a5f4-636fc796db45)

