### PR TITLE
[f40] fix(ghostty-nightly): Add gtk4-layer-shell build dependency (#3789)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -14,7 +14,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif
@@ -37,6 +37,7 @@ BuildRequires:  pkgconfig(bzip2)
 BuildRequires:  pkgconfig(freetype2)
 BuildRequires:  pkgconfig(fontconfig)
 BuildRequires:  pkgconfig(gtk4)
+BuildRequires:  pkgconfig(gtk4-layer-shell-0)
 BuildRequires:  pkgconfig(harfbuzz)
 BuildRequires:  pkgconfig(libadwaita-1)
 BuildRequires:  pkgconfig(libpng)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(ghostty-nightly): Add gtk4-layer-shell build dependency (#3789)](https://github.com/terrapkg/packages/pull/3789)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)