### PR TITLE
[f42] Add: xpad-noone (#3787)

### DIFF
--- a/anda/system/xpad-noone/akmod/0000.patch
+++ b/anda/system/xpad-noone/akmod/0000.patch
@@ -1,0 +1,43 @@
+--- a/xpad.c
++++ b/xpad.c
+@@ -117,6 +117,7 @@ static const struct xpad_device {
+ 	u8 xtype;
+ } xpad_device[] = {
+ 	{ 0x0079, 0x18d4, "GPD Win 2 X-Box Controller", 0, XTYPE_XBOX360 },
++	{ 0x16d0, 0x10bc, "Cyborg Compact Gamingkeypad", 0, XTYPE_XBOX360 },
+ 	{ 0x03eb, 0xff01, "Wooting One (Legacy)", 0, XTYPE_XBOX360 },
+ 	{ 0x03eb, 0xff02, "Wooting Two (Legacy)", 0, XTYPE_XBOX360 },
+ 	{ 0x044f, 0x0f00, "Thrustmaster Wheel", 0, XTYPE_XBOX },
+@@ -303,6 +304,7 @@ static const struct xpad_device {
+ 	{ 0x24c6, 0xfafe, "Rock Candy Gamepad for Xbox 360", 0, XTYPE_XBOX360 },
+ 	{ 0x2563, 0x058d, "OneXPlayer Gamepad", 0, XTYPE_XBOX360 },
+ 	{ 0x2dc8, 0x3106, "8BitDo Pro 2 Wired Controller", 0, XTYPE_XBOX360 },
++	{ 0x2dc8, 0x3109, "8BitDo Ultimate Wireless Bluetooth", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1100, "Wooting One", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1200, "Wooting Two", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1210, "Wooting Lekker", 0, XTYPE_XBOX360 },
+@@ -311,7 +313,8 @@ static const struct xpad_device {
+ 	{ 0x31e3, 0x1310, "Wooting 60HE (ARM)", 0, XTYPE_XBOX360 },
+ 	{ 0x3285, 0x0607, "Nacon GC-100", 0, XTYPE_XBOX360 },
+ 	{ 0x3537, 0x1004, "GameSir T4 Kaleid", 0, XTYPE_XBOX360 },
++	{ 0x413d, 0x2104, "Black Shark Green Ghost Gamepad", 0, XTYPE_XBOX360 },
+ 	{ 0x3767, 0x0101, "Fanatec Speedster 3 Forceshock Wheel", 0, XTYPE_XBOX },
+ 	{ 0xffff, 0xffff, "Chinese-made Xbox Controller", 0, XTYPE_XBOX },
+ 	{ 0x0000, 0x0000, "Generic X-Box pad", 0, XTYPE_UNKNOWN }
+ };
+@@ -384,6 +387,7 @@ static const signed short xpad_abs_triggers[] = {
+ 
+ static const struct usb_device_id xpad_table[] = {
+ 	{ USB_INTERFACE_INFO('X', 'B', 0) },	/* Xbox USB-IF not-approved class */
++	XPAD_XBOX360_VENDOR(0x16d0),            /* Azeron Custom Gamingkeypad Vendor */
+ 	XPAD_XBOX360_VENDOR(0x0079),		/* GPD Win 2 controller */
+ 	XPAD_XBOX360_VENDOR(0x03eb),		/* Wooting Keyboards (Legacy) */
+ 	XPAD_XBOX360_VENDOR(0x044f),		/* Thrustmaster Xbox 360 controllers */
+@@ -420,6 +424,7 @@
+ 	XPAD_XBOX360_VENDOR(0x31e3),		/* Wooting Keyboards */
+ 	XPAD_XBOX360_VENDOR(0x3285),		/* Nacon GC-100 */
+ 	XPAD_XBOX360_VENDOR(0x3537),		/* GameSir Controllers */
++	XPAD_XBOX360_VENDOR(0x413d),		/* Black Shark Green Ghost Controller */
+ 	{ }
+ };
+

--- a/anda/system/xpad-noone/akmod/anda.hcl
+++ b/anda/system/xpad-noone/akmod/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "xpad-noone-kmod.spec"
+	}
+	labels {
+		mock = 1
+	}
+}

--- a/anda/system/xpad-noone/akmod/update.rhai
+++ b/anda/system/xpad-noone/akmod/update.rhai
@@ -1,0 +1,12 @@
+let c = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global commit' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commit_date", d);
+    let v = sh("cat anda/system/xpad-noone/kmod-common/xpadneo-noone.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}

--- a/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
+++ b/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
@@ -1,0 +1,60 @@
+%global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20240109
+%global ver 1.0
+%global modulename xpad-noone
+%global debug_package %{nil}
+%global buildforkernels akmod
+%global _description %{expand:
+This is the original upstream xpad driver from the Linux kernel with support for XBox One controllers removed. If you are running the xone driver you may have to replace the xpad kernel module with this one to retain the functionality of XBox and XBox 360 controllers.}
+
+Name:          %{modulename}-kmod
+Version:       %{ver}^%{commit_date}git.%{shortcommit}
+Release:       1%{?dist}
+License:       GPL-2.0-or-later
+Summary:       xpad driver with support for XBox One controllers removed
+URL:           https://github.com/medusalix/xpad-noone
+Source0:       %{url}/archive/%{commit}/%{modulename}-%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
+# Extra support for controllers that register as XBox 360 controllers
+Patch0:        0000.patch
+BuildRequires: gcc
+BuildRequires: kmodtool
+BuildRequires: make
+BuildRequires: systemd-rpm-macros
+Requires:      %{modulename} = %{?epoch:%{epoch}:}%{version}
+Requires:      %{modulename}-akmod-modules
+Requires:      akmods
+Conflicts:     dkms-%{modulename}
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description %_description
+
+%prep
+%{?kmodtool_check}
+
+kmodtool --target %{_target_cpu} --repo terra --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%autosetup -n %{modulename}-%{commit} -p1
+
+for kernel_version  in %{?kernel_versions} ; do
+  cp -a %{modulename}-%{commit} _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version  in %{?kernel_versions} ; do
+  make V=1 %{?_smp_mflags} -C ${kernel_version##*___} M=${PWD}/_kmod_build_${kernel_version%%___*} VERSION=v%{version} modules
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+ mkdir -p %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ install -D -m 755 _kmod_build_${kernel_version%%___*}/%{modulename}.ko %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ chmod a+x %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/%{modulename}.ko
+done
+%{?akmod_install}
+
+%changelog
+* Fri Mar 07 2025 Gilver E. <rockgrub@disroot.org>
+- Initial package

--- a/anda/system/xpad-noone/dkms/0000.patch
+++ b/anda/system/xpad-noone/dkms/0000.patch
@@ -1,0 +1,43 @@
+--- a/xpad.c
++++ b/xpad.c
+@@ -117,6 +117,7 @@ static const struct xpad_device {
+ 	u8 xtype;
+ } xpad_device[] = {
+ 	{ 0x0079, 0x18d4, "GPD Win 2 X-Box Controller", 0, XTYPE_XBOX360 },
++	{ 0x16d0, 0x10bc, "Cyborg Compact Gamingkeypad", 0, XTYPE_XBOX360 },
+ 	{ 0x03eb, 0xff01, "Wooting One (Legacy)", 0, XTYPE_XBOX360 },
+ 	{ 0x03eb, 0xff02, "Wooting Two (Legacy)", 0, XTYPE_XBOX360 },
+ 	{ 0x044f, 0x0f00, "Thrustmaster Wheel", 0, XTYPE_XBOX },
+@@ -303,6 +304,7 @@ static const struct xpad_device {
+ 	{ 0x24c6, 0xfafe, "Rock Candy Gamepad for Xbox 360", 0, XTYPE_XBOX360 },
+ 	{ 0x2563, 0x058d, "OneXPlayer Gamepad", 0, XTYPE_XBOX360 },
+ 	{ 0x2dc8, 0x3106, "8BitDo Pro 2 Wired Controller", 0, XTYPE_XBOX360 },
++	{ 0x2dc8, 0x3109, "8BitDo Ultimate Wireless Bluetooth", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1100, "Wooting One", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1200, "Wooting Two", 0, XTYPE_XBOX360 },
+ 	{ 0x31e3, 0x1210, "Wooting Lekker", 0, XTYPE_XBOX360 },
+@@ -311,7 +313,8 @@ static const struct xpad_device {
+ 	{ 0x31e3, 0x1310, "Wooting 60HE (ARM)", 0, XTYPE_XBOX360 },
+ 	{ 0x3285, 0x0607, "Nacon GC-100", 0, XTYPE_XBOX360 },
+ 	{ 0x3537, 0x1004, "GameSir T4 Kaleid", 0, XTYPE_XBOX360 },
++	{ 0x413d, 0x2104, "Black Shark Green Ghost Gamepad", 0, XTYPE_XBOX360 },
+ 	{ 0x3767, 0x0101, "Fanatec Speedster 3 Forceshock Wheel", 0, XTYPE_XBOX },
+ 	{ 0xffff, 0xffff, "Chinese-made Xbox Controller", 0, XTYPE_XBOX },
+ 	{ 0x0000, 0x0000, "Generic X-Box pad", 0, XTYPE_UNKNOWN }
+ };
+@@ -384,6 +387,7 @@ static const signed short xpad_abs_triggers[] = {
+ 
+ static const struct usb_device_id xpad_table[] = {
+ 	{ USB_INTERFACE_INFO('X', 'B', 0) },	/* Xbox USB-IF not-approved class */
++	XPAD_XBOX360_VENDOR(0x16d0),            /* Azeron Custom Gamingkeypad Vendor */
+ 	XPAD_XBOX360_VENDOR(0x0079),		/* GPD Win 2 controller */
+ 	XPAD_XBOX360_VENDOR(0x03eb),		/* Wooting Keyboards (Legacy) */
+ 	XPAD_XBOX360_VENDOR(0x044f),		/* Thrustmaster Xbox 360 controllers */
+@@ -420,6 +424,7 @@
+ 	XPAD_XBOX360_VENDOR(0x31e3),		/* Wooting Keyboards */
+ 	XPAD_XBOX360_VENDOR(0x3285),		/* Nacon GC-100 */
+ 	XPAD_XBOX360_VENDOR(0x3537),		/* GameSir Controllers */
++	XPAD_XBOX360_VENDOR(0x413d),		/* Black Shark Green Ghost Controller */
+ 	{ }
+ };
+

--- a/anda/system/xpad-noone/dkms/anda.hcl
+++ b/anda/system/xpad-noone/dkms/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "dkms-xpad-noone.spec"
+	}
+	labels {
+		mock = 1
+	}
+}

--- a/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
+++ b/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
@@ -1,0 +1,57 @@
+%global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20240109
+%global ver 1.0
+%global modulename xpad-noone
+%global _description %{expand:
+This is the original upstream xpad driver from the Linux kernel with support for XBox One controllers removed. If you are running the xone driver you may have to replace the xpad kernel module with this one to retain the functionality of XBox and XBox 360 controllers.}
+
+Name:          dkms-%{modulename}
+Version:       %{ver}^%{commit_date}git.%{shortcommit}
+Release:       1%{?dist}
+License:       GPL-2.0-or-later
+Summary:       xpad driver with support for XBox One controllers removed
+URL:           https://github.com/medusalix/xpad-noone
+Source0:       %{url}/archive/%{commit}/%{modulename}-%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
+Source1:       no-weak-modules.conf
+# Extra support for controllers that register as XBox 360 controllers
+Patch0:        0000.patch
+Requires:      %{modulename} = %{?epoch:%{epoch}:}%{version}
+Requires:      dkms
+Conflicts:     akmod-%{modulename}
+BuildArch:     noarch
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%description %_description
+
+%prep
+%autosetup -n %{modulename}-%{commit}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+rm -rf LICENSE README.md
+cp -fr ./* %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+
+%if 0%{?fedora}
+install -Dpm644 %{SOURCE1} %{buildroot}%{_sysconfdir}/dkms/%{modulename}.conf
+%endif
+
+%post
+dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+dkms build -m %{modulename} -v %{version} -q || :
+dkms install -m %{modulename} -v %{version} -q --force || :
+
+%preun
+dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
+
+%files
+%{_usrsrc}/%{modulename}-%{version}
+%if 0%{?fedora}
+%{_sysconfdir}/dkms/%{modulename}.conf
+%endif
+
+%changelog
+* Fri Mar 07 2025 Gilver E. <rockgrub@disroot.org>
+- Initial package

--- a/anda/system/xpad-noone/dkms/no-weak-modules.conf
+++ b/anda/system/xpad-noone/dkms/no-weak-modules.conf
@@ -1,0 +1,1 @@
+NO_WEAK_MODULES="yes"

--- a/anda/system/xpad-noone/dkms/update.rhai
+++ b/anda/system/xpad-noone/dkms/update.rhai
@@ -1,0 +1,12 @@
+let c = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global commit' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commit_date", d);
+    let v = sh("cat anda/system/xpad-noone/kmod-common/xpadneo-noone.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}

--- a/anda/system/xpad-noone/kmod-common/anda.hcl
+++ b/anda/system/xpad-noone/kmod-common/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "xpad-noone.spec"
+	}
+	labels {
+	    nightly = 1
+	}
+}

--- a/anda/system/xpad-noone/kmod-common/update.rhai
+++ b/anda/system/xpad-noone/kmod-common/update.rhai
@@ -1,0 +1,8 @@
+rpm.global("commit", gh_commit("medusalix/xpad-noone"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+    let html = get(`https://raw.githubusercontent.com/medusalix/xpad-noone/refs/heads/master/dkms.conf`);
+    let v = find("PACKAGE_VERSION=\"([\\d.]+)\"", html, 1);
+    rpm.global("ver", v);
+}

--- a/anda/system/xpad-noone/kmod-common/xpad-noone.spec
+++ b/anda/system/xpad-noone/kmod-common/xpad-noone.spec
@@ -1,0 +1,52 @@
+%global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20240109
+%global ver 1.0
+%global _description %{expand:
+This is the original upstream xpad driver from the Linux kernel with support for XBox One controllers removed. If you are running the xone driver you may have to replace the xpad kernel module with this one to retain the functionality of XBox and XBox 360 controllers.}
+
+Name:          xpad-noone
+Version:       %{ver}^%{commit_date}git.%{shortcommit}
+Release:       1%{?dist}
+License:       GPL-2.0-or-later
+Summary:       xpad driver with support for XBox One controllers removed
+URL:           https://github.com/medusalix/xpad-noone
+Source0:       %{url}/archive/%{commit}/%{name}-%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
+BuildRequires: sed
+BuildRequires: systemd-rpm-macros
+Provides:      %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Requires:      (akmod-%{name} = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = %{?epoch:%{epoch}:}%{version})
+Conflicts:     xow <= 0.5
+Obsoletes:     xow <= 0.5
+BuildArch:     noarch
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%description %_description
+
+%package      akmod-modules
+Summary:      Modules for Akmods
+Requires:     akmod-%{name}
+BuildArch:    noarch
+
+%description   akmod-modules
+Akmods modules for the akmod-%{name} package.
+
+%prep
+%autosetup -n %{name}-%{commit}
+/usr/bin/sed -nE '/^BUILT_MODULE_NAME/{s@^.+"(.+)"@\1@; s|-|_|g; p}' dkms.conf > %{name}.conf
+
+%build
+
+%install
+install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
+
+%files
+%doc README.md
+%license LICENSE
+
+%files akmod-modules
+%{_modulesloaddir}/%{name}.conf
+
+%changelog
+* Fri Mar 07 2025 Gilver E. <rockgrub@disroot.org>
+- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Add: xpad-noone (#3787)](https://github.com/terrapkg/packages/pull/3787)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)