### PR TITLE
[el10] fix(codium-marketplace): sed the json properly (#3827)

### DIFF
--- a/anda/devs/codium-marketplace/codium-marketplace.spec
+++ b/anda/devs/codium-marketplace/codium-marketplace.spec
@@ -2,7 +2,7 @@
 
 Name:       codium-marketplace
 Version:    1.65.0
-Release:    1%?dist
+Release:    2%?dist
 Summary:    Enable vscode marketplace in vscodium
 License:    MIT
 BuildArch:  noarch
@@ -22,7 +22,7 @@ if [ $1 -gt 1 ]; then  # update/install
   sed -i -e 's/^[[:blank:]]*"serviceUrl":.*/    "serviceUrl": "https:\/\/marketplace.visualstudio.com\/_apis\/public\/gallery",/' \
     -e '/^[[:blank:]]*"cacheUrl/d' \
     -e '/^[[:blank:]]*"serviceUrl/a\    "cacheUrl": "https:\/\/vscode.blob.core.windows.net\/gallery\/index",' \
-    -e 's/^[[:blank:]]*"itemUrl":.*/    "itemUrl": "https:\/\/marketplace.visualstudio.com\/items"/' \
+    -e 's/^[[:blank:]]*"itemUrl":.*/    "itemUrl": "https:\/\/marketplace.visualstudio.com\/items",/' \
     -e '/^[[:blank:]]*"linkProtectionTrustedDomains/d' \
     /usr/share/codium/resources/app/product.json || true
 fi
@@ -30,7 +30,7 @@ fi
 %preun
 sed -i -e 's/^[[:blank:]]*"serviceUrl":.*/    "serviceUrl": "https:\/\/open-vsx.org\/vscode\/gallery",/' \
   -e '/^[[:blank:]]*"cacheUrl/d' \
-  -e 's/^[[:blank:]]*"itemUrl":.*/    "itemUrl": "https:\/\/open-vsx.org\/vscode\/item"/' \
+  -e 's/^[[:blank:]]*"itemUrl":.*/    "itemUrl": "https:\/\/open-vsx.org\/vscode\/item",/' \
   -e '/^[[:blank:]]*"linkProtectionTrustedDomains/d' \
   -e '/^[[:blank:]]*"documentationUrl/i\  "linkProtectionTrustedDomains": ["https://open-vsx.org"],' \
   /usr/share/codium/resources/app/product.json || true
@@ -39,7 +39,7 @@ sed -i -e 's/^[[:blank:]]*"serviceUrl":.*/    "serviceUrl": "https:\/\/open-vsx.
 sed -i -e 's/^[[:blank:]]*"serviceUrl":.*/    "serviceUrl": "https:\/\/marketplace.visualstudio.com\/_apis\/public\/gallery",/' \
   -e '/^[[:blank:]]*"cacheUrl/d' \
   -e '/^[[:blank:]]*"serviceUrl/a\    "cacheUrl": "https:\/\/vscode.blob.core.windows.net\/gallery\/index",' \
-  -e 's/^[[:blank:]]*"itemUrl":.*/    "itemUrl": "https:\/\/marketplace.visualstudio.com\/items"/' \
+  -e 's/^[[:blank:]]*"itemUrl":.*/    "itemUrl": "https:\/\/marketplace.visualstudio.com\/items",/' \
   -e '/^[[:blank:]]*"linkProtectionTrustedDomains/d' \
   /usr/share/codium/resources/app/product.json || true
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(codium-marketplace): sed the json properly (#3827)](https://github.com/terrapkg/packages/pull/3827)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)