### PR TITLE
[f41] chore(.backportrc.json): Drop F39 since it&#x27;s EOL, add EL10 and F42 (#3823)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
   "repoOwner": "terrapkg",
   "repoName": "packages",
   "resetAuthor": true,
-  "targetBranchChoices": ["f39", "f40", "frawhide"],
+  "targetBranchChoices": ["el10", "f40", "f41", "f42", "frawhide"],
   "branchLabelMapping": {
     "^sync-(.+)$": "$1"
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(.backportrc.json): Drop F39 since it&#x27;s EOL, add EL10 and F42 (#3823)](https://github.com/terrapkg/packages/pull/3823)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)