### PR TITLE
[f42] fix(pokeget-rs): Change update script to JSON array (#3826)

### DIFF
--- a/anda/misc/pokeget-rs/update.rhai
+++ b/anda/misc/pokeget-rs/update.rhai
@@ -2,7 +2,7 @@ rpm.version(crates("pokeget"));
 // pokesprites has not received an update in years but let's keep the dep commit current just in case
 if rpm.changed () {
      let url = `https://api.github.com/repos/talwat/pokeget-rs/contents/data`;
-     let json = get(url).json();
-     let c = json.2.sha;
+     let json = get(url).json_arr();
+     let c = json[2].sha;
      rpm.global("pcommit", c);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(pokeget-rs): Change update script to JSON array (#3826)](https://github.com/terrapkg/packages/pull/3826)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)