### PR TITLE
[f42] fix(xpadneo, xone, xpad-noone): Update scripts (#3824)

### DIFF
--- a/anda/system/xone/akmod/anda.hcl
+++ b/anda/system/xone/akmod/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		mock = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/xone/akmod/update.rhai
+++ b/anda/system/xone/akmod/update.rhai
@@ -3,9 +3,9 @@ c.pop();
 rpm.global("commit", c);
 if rpm.changed() {
     rpm.release();
-    let d = sh("cat anda/system/xone/kmod-common/xone.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    let d = sh("cat anda/system/xone/kmod-common/xone.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
     d.pop();
-    rpm.global("commit_date", d);
+    rpm.global("commitdate", d);
     let v = sh("cat anda/system/xone/kmod-common/xone.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
     v.pop();
     rpm.global("ver", v);

--- a/anda/system/xone/akmod/xone-kmod.spec
+++ b/anda/system/xone/akmod/xone-kmod.spec
@@ -1,13 +1,13 @@
 %global commit 6b9d59aed71f6de543c481c33df4705d4a590a31
-%global commit_date 20241223
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20241223
 %global ver 0.3
 %define buildforkernels akmod
 %global debug_package %{nil}
 %global modulename xone
 
 Name:           %{modulename}-kmod
-Version:        %{ver}^%{commit_date}git.%{shortcommit}
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
 Release:        1%?dist
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
 License:        GPL-2.0-or-later

--- a/anda/system/xone/dkms/anda.hcl
+++ b/anda/system/xone/dkms/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
 	}
 	labels {
 		mock = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/xone/dkms/dkms-xone.spec
+++ b/anda/system/xone/dkms/dkms-xone.spec
@@ -1,12 +1,12 @@
 %global commit 6b9d59aed71f6de543c481c33df4705d4a590a31
-%global commit_date 20241223
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20241223
 %global ver 0.3
 %global debug_package %{nil}
 %global modulename xone
 
 Name:           dkms-%{modulename}
-Version:        %{ver}^%{commit_date}git.%{shortcommit}
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
 Release:        1%?dist
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
 License:        GPL-2.0-or-later

--- a/anda/system/xone/kmod-common/update.rhai
+++ b/anda/system/xone/kmod-common/update.rhai
@@ -1,7 +1,7 @@
 rpm.global("commit", gh_commit("dlundqvist/xone"));
 if rpm.changed() {
     rpm.release();
-    rpm.global("commit_date", date());
+    rpm.global("commitdate", date());
     let ver = gh_tag("dlundqvist/xone");
     ver.crop(1);
     rpm.global("ver", ver);

--- a/anda/system/xone/kmod-common/xone.spec
+++ b/anda/system/xone/kmod-common/xone.spec
@@ -1,12 +1,12 @@
 %global commit 6b9d59aed71f6de543c481c33df4705d4a590a31
-%global commit_date 20241223
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20241223
 %global ver 0.3
 %global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
 %global firmware_hash 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
 
 Name:           xone
-Version:        %{ver}^%{commit_date}git.%{shortcommit}
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
 Release:        2%{?dist}
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories common files
 License:        GPL-2.0-or-later

--- a/anda/system/xpad-noone/akmod/anda.hcl
+++ b/anda/system/xpad-noone/akmod/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		mock = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/xpad-noone/akmod/update.rhai
+++ b/anda/system/xpad-noone/akmod/update.rhai
@@ -3,10 +3,10 @@ c.pop();
 rpm.global("commit", c);
 if rpm.changed() {
     rpm.release();
-    let d = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    let d = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
     d.pop();
-    rpm.global("commit_date", d);
-    let v = sh("cat anda/system/xpad-noone/kmod-common/xpadneo-noone.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    rpm.global("commitdate", d);
+    let v = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
     v.pop();
     rpm.global("ver", v);
 }

--- a/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
+++ b/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
@@ -1,6 +1,6 @@
 %global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20240109
+%global commitdate 20240109
 %global ver 1.0
 %global modulename xpad-noone
 %global debug_package %{nil}
@@ -9,8 +9,8 @@
 This is the original upstream xpad driver from the Linux kernel with support for XBox One controllers removed. If you are running the xone driver you may have to replace the xpad kernel module with this one to retain the functionality of XBox and XBox 360 controllers.}
 
 Name:          %{modulename}-kmod
-Version:       %{ver}^%{commit_date}git.%{shortcommit}
-Release:       1%{?dist}
+Version:       %{ver}^%{commitdate}git.%{shortcommit}
+Release:       1%?dist
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
 URL:           https://github.com/medusalix/xpad-noone

--- a/anda/system/xpad-noone/dkms/anda.hcl
+++ b/anda/system/xpad-noone/dkms/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
 	}
 	labels {
 		mock = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
+++ b/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
@@ -1,14 +1,14 @@
 %global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20240109
+%global commitdate 20240109
 %global ver 1.0
 %global modulename xpad-noone
 %global _description %{expand:
 This is the original upstream xpad driver from the Linux kernel with support for XBox One controllers removed. If you are running the xone driver you may have to replace the xpad kernel module with this one to retain the functionality of XBox and XBox 360 controllers.}
 
 Name:          dkms-%{modulename}
-Version:       %{ver}^%{commit_date}git.%{shortcommit}
-Release:       1%{?dist}
+Version:       %{ver}^%{commitdate}git.%{shortcommit}
+Release:       1%?dist
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
 URL:           https://github.com/medusalix/xpad-noone

--- a/anda/system/xpad-noone/dkms/update.rhai
+++ b/anda/system/xpad-noone/dkms/update.rhai
@@ -3,10 +3,10 @@ c.pop();
 rpm.global("commit", c);
 if rpm.changed() {
     rpm.release();
-    let d = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    let d = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
     d.pop();
-    rpm.global("commit_date", d);
-    let v = sh("cat anda/system/xpad-noone/kmod-common/xpadneo-noone.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    rpm.global("commitdate", d);
+    let v = sh("cat anda/system/xpad-noone/kmod-common/xpad-noone.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
     v.pop();
     rpm.global("ver", v);
 }

--- a/anda/system/xpad-noone/kmod-common/update.rhai
+++ b/anda/system/xpad-noone/kmod-common/update.rhai
@@ -1,7 +1,7 @@
 rpm.global("commit", gh_commit("medusalix/xpad-noone"));
 if rpm.changed() {
     rpm.release();
-    rpm.global("commit_date", date());
+    rpm.global("commitdate", date());
     let html = get(`https://raw.githubusercontent.com/medusalix/xpad-noone/refs/heads/master/dkms.conf`);
     let v = find("PACKAGE_VERSION=\"([\\d.]+)\"", html, 1);
     rpm.global("ver", v);

--- a/anda/system/xpad-noone/kmod-common/xpad-noone.spec
+++ b/anda/system/xpad-noone/kmod-common/xpad-noone.spec
@@ -1,12 +1,12 @@
 %global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20240109
+%global commitdate 20240109
 %global ver 1.0
 %global _description %{expand:
 This is the original upstream xpad driver from the Linux kernel with support for XBox One controllers removed. If you are running the xone driver you may have to replace the xpad kernel module with this one to retain the functionality of XBox and XBox 360 controllers.}
 
 Name:          xpad-noone
-Version:       %{ver}^%{commit_date}git.%{shortcommit}
+Version:       %{ver}^%{commitdate}git.%{shortcommit}
 Release:       1%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed

--- a/anda/system/xpadneo/akmod/anda.hcl
+++ b/anda/system/xpadneo/akmod/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		mock = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/xpadneo/akmod/update.rhai
+++ b/anda/system/xpadneo/akmod/update.rhai
@@ -3,9 +3,9 @@ c.pop();
 rpm.global("commit", c);
 if rpm.changed() {
     rpm.release();
-    let d = sh("cat anda/system/xpadneo/kmod-common/xpadneo.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    let d = sh("cat anda/system/xpadneo/kmod-common/xpadneo.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
     d.pop();
-    rpm.global("commit_date", d);
+    rpm.global("commitdate", d);
     let v = sh("cat anda/system/xpadneo/kmod-common/xpadneo.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
     v.pop();
     rpm.global("ver", v);

--- a/anda/system/xpadneo/akmod/xpadneo-kmod.spec
+++ b/anda/system/xpadneo/akmod/xpadneo-kmod.spec
@@ -1,14 +1,14 @@
 %global commit 8d20a23e38883f45c78f48c8574ac93945b4cb03
-%global commit_date 20241224
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20241224
 %global ver 0.9.7
 %define buildforkernels akmod
 %global debug_package %{nil}
 %global modulename xpadneo
 
 Name:           %{modulename}-kmod
-Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
+Release:        1%?dist
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/xpadneo

--- a/anda/system/xpadneo/dkms/anda.hcl
+++ b/anda/system/xpadneo/dkms/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
 	}
 	labels {
 		mock = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/xpadneo/dkms/dkms-xpadneo.spec
+++ b/anda/system/xpadneo/dkms/dkms-xpadneo.spec
@@ -1,12 +1,12 @@
 %global commit 8d20a23e38883f45c78f48c8574ac93945b4cb03
-%global commit_date 20241224
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20241224
 %global ver 0.9.7
 %global debug_package %{nil}
 %global modulename xpadneo
 
 Name:           dkms-%{modulename}
-Version:        %{ver}^%{commit_date}git.%{shortcommit}
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
 Release:        1%?dist
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad
 License:        GPL-3.0

--- a/anda/system/xpadneo/dkms/update.rhai
+++ b/anda/system/xpadneo/dkms/update.rhai
@@ -3,9 +3,9 @@ c.pop();
 rpm.global("commit", c);
 if rpm.changed() {
     rpm.release();
-    let d = sh("cat anda/system/xpadneo/kmod-common/xpadneo.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    let d = sh("cat anda/system/xpadneo/kmod-common/xpadneo.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
     d.pop();
-    rpm.global("commit_date", d);
+    rpm.global("commitdate", d);
     let v = sh("cat anda/system/xpadneo/kmod-common/xpadneo.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
     v.pop();
     rpm.global("ver", v);

--- a/anda/system/xpadneo/kmod-common/update.rhai
+++ b/anda/system/xpadneo/kmod-common/update.rhai
@@ -1,7 +1,7 @@
 rpm.global("commit", gh_commit("atar-axis/xpadneo"));
 if rpm.changed() {
     rpm.release();
-    rpm.global("commit_date", date());
+    rpm.global("commitdate", date());
     let ver = gh("atar-axis/xpadneo");
     ver.crop(1);
     rpm.global("ver", ver);

--- a/anda/system/xpadneo/kmod-common/xpadneo.spec
+++ b/anda/system/xpadneo/kmod-common/xpadneo.spec
@@ -1,10 +1,10 @@
 %global commit 8d20a23e38883f45c78f48c8574ac93945b4cb03
-%global commit_date 20241224
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20241224
 %global ver 0.9.7
 
 Name:           xpadneo
-Version:        %{ver}^%{commit_date}git.%{shortcommit}
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
 Release:        4%{?dist}
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad common files
 License:        GPL-3.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(xpadneo, xone, xpad-noone): Update scripts (#3824)](https://github.com/terrapkg/packages/pull/3824)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)