### PR TITLE
[el10] Feat (steam): Better Extest weak dep (#3735)

### DIFF
--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -5,7 +5,7 @@
 
 Name:           steam
 Version:        1.0.0.82
-Release:        5%?dist
+Release:        6%?dist
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT

--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -135,8 +135,13 @@ Recommends:     gobject-introspection
 
 Requires:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 
+<<<<<<< HEAD
 # Fix upgrading from old versions
 Obsoletes:      %{name} <= %{?epoch:%{epoch}:}1.0.0.82-1%{?dist}.x86_64
+=======
+# Workaround for GNOME issues with libei
+Recommends:     (extest-%{name} if gnome-shell)
+>>>>>>> a380de5a6 (Feat (steam): Better Extest weak dep (#3735))
 
 %description
 Steam is a software distribution service with an online store, automated

--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -135,13 +135,10 @@ Recommends:     gobject-introspection
 
 Requires:       steam-devices = %{?epoch:%{epoch}:}%{version}-%{release}
 
-<<<<<<< HEAD
 # Fix upgrading from old versions
 Obsoletes:      %{name} <= %{?epoch:%{epoch}:}1.0.0.82-1%{?dist}.x86_64
-=======
 # Workaround for GNOME issues with libei
 Recommends:     (extest-%{name} if gnome-shell)
->>>>>>> a380de5a6 (Feat (steam): Better Extest weak dep (#3735))
 
 %description
 Steam is a software distribution service with an online store, automated


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Feat (steam): Better Extest weak dep (#3735)](https://github.com/terrapkg/packages/pull/3735)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)