### PR TITLE
[f41] feat(mesa): patches: two commit backports for game fixes (#3825)

### DIFF
--- a/anda/lib/mesa/13a3f9a972324a72dd507e09ac975b969e6c88e0.patch
+++ b/anda/lib/mesa/13a3f9a972324a72dd507e09ac975b969e6c88e0.patch
@@ -1,0 +1,34 @@
+From 13a3f9a972324a72dd507e09ac975b969e6c88e0 Mon Sep 17 00:00:00 2001
+From: Hans-Kristian Arntzen <post@arntzen-software.no>
+Date: Tue, 25 Feb 2025 12:43:17 +0100
+Subject: [PATCH] radv: Always set 0 dispatch offset for indirect CS.
+
+Fixes severe glitching in Avowed.
+
+Signed-off-by: Hans-Kristian Arntzen <post@arntzen-software.no>
+Reviewed-by: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+Reviewed-by: Natalie Vock <natalie.vock@gmx.de>
+Cc: mesa-stable
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33732>
+---
+ src/amd/vulkan/radv_cmd_buffer.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/amd/vulkan/radv_cmd_buffer.c b/src/amd/vulkan/radv_cmd_buffer.c
+index d8c0c6810524b..d85c0659cb04e 100644
+--- a/src/amd/vulkan/radv_cmd_buffer.c
++++ b/src/amd/vulkan/radv_cmd_buffer.c
+@@ -11722,6 +11722,10 @@ radv_emit_dispatch_packets(struct radv_cmd_buffer *cmd_buffer, const struct radv
+          dispatch_initiator |= S_00B800_USE_THREAD_DIMENSIONS(1);
+       }
+ 
++      /* Indirect CS does not support offsets in the API. Must program this in case there have been
++       * preceding 1D RT dispatch or vkCmdDispatchBase. */
++      dispatch_initiator |= S_00B800_FORCE_START_AT_000(1);
++
+       if (grid_size_offset) {
+          if (device->load_grid_size_from_user_sgpr) {
+             assert(pdev->info.gfx_level >= GFX10_3);
+-- 
+GitLab
+

--- a/anda/lib/mesa/237d8799be3afe9a1e7ca9156a5d44ffe0aae681.patch
+++ b/anda/lib/mesa/237d8799be3afe9a1e7ca9156a5d44ffe0aae681.patch
@@ -1,0 +1,38 @@
+From 237d8799be3afe9a1e7ca9156a5d44ffe0aae681 Mon Sep 17 00:00:00 2001
+From: Natalie Vock <natalie.vock@gmx.de>
+Date: Fri, 28 Feb 2025 14:21:57 +0100
+Subject: [PATCH] radv/rt: Limit monolithic pipelines to 50 stages
+
+Beyond that, monolithic pipelines just bloat to incredible sizes,
+destroying compile times for questionable, if any, runtime perf benefit.
+
+Indiana Jones: The Great Circle has more than 100 stages and takes
+several minutes to compile its RT pipeline on Deck when using monolithic
+compilation, and yet separate shaders still end up faster (probably
+because instruction cache coherency in traversal is better).
+
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33818>
+---
+ src/amd/vulkan/radv_pipeline_rt.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/amd/vulkan/radv_pipeline_rt.c b/src/amd/vulkan/radv_pipeline_rt.c
+index 0658840966c30..bcda4aae5528d 100644
+--- a/src/amd/vulkan/radv_pipeline_rt.c
++++ b/src/amd/vulkan/radv_pipeline_rt.c
+@@ -602,7 +602,11 @@ radv_rt_compile_shaders(struct radv_device *device, struct vk_pipeline_cache *ca
+ 
+    bool library = pipeline->base.base.create_flags & VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR;
+ 
+-   bool monolithic = !library;
++   /* Beyond 50 shader stages, inlining everything bloats the shader a ton, increasing compile times and
++    * potentially even reducing runtime performance because of instruction cache coherency issues in the
++    * traversal loop.
++    */
++   bool monolithic = !library && pipeline->stage_count < 50;
+    for (uint32_t i = 0; i < pCreateInfo->stageCount; i++) {
+       if (rt_stages[i].shader || rt_stages[i].nir)
+          continue;
+-- 
+GitLab
+

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -76,7 +76,7 @@ Summary:        Mesa graphics libraries
 # disabled by default, and has to be enabled manually. See `terra/release/terra-mesa.repo` for details.
 Epoch:          1
 Version:        25.0.1
-Release:        3%?dist
+Release:        4%?dist
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 
@@ -98,6 +98,9 @@ Patch20:        valve.patch
 # Fix issues with Intel Battlemage under Valve's gamescope in DRM mode
 # https://gitlab.freedesktop.org/mesa/mesa/-/issues/12633
 Patch21:        12633.patch
+
+Patch30:        237d8799be3afe9a1e7ca9156a5d44ffe0aae681.patch
+Patch31:        13a3f9a972324a72dd507e09ac975b969e6c88e0.patch
 
 # s390x: fix build
 #Patch100:       https://src.fedoraproject.org/rpms/mesa/raw/e89544b7a4d811a64ca23b402add29524cc6f704/f/fix-egl-on-s390x.patch


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(mesa): patches: two commit backports for game fixes (#3825)](https://github.com/terrapkg/packages/pull/3825)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)