### PR TITLE
[f42] feat(youtube-music, voicevox): Re-enable AutoReq with appropriate libraries excluded (#3871)

### DIFF
--- a/anda/apps/voicevox/voicevox.spec
+++ b/anda/apps/voicevox/voicevox.spec
@@ -9,8 +9,8 @@
 %define _binary_payload w19.zstdio
 
 # Exclude private libraries
-%global __requires_exclude libffmpeg.so
-%global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
+%global __provides_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
+%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
 
 Name:			voicevox
 Version:		0.23.0
@@ -24,7 +24,6 @@ Source2:        https://github.com/VOICEVOX/voicevox/releases/download/%version/
 Packager:       madonuko <mado@fyralabs.com>
 BuildRequires:  p7zip-plugins
 ExclusiveArch:  x86_64
-AutoReq:        no
 
 %description
 VOICEVOX is a free Japanese text-to-speech software with medium output quality.

--- a/anda/apps/youtube-music/youtube-music.spec
+++ b/anda/apps/youtube-music/youtube-music.spec
@@ -13,7 +13,7 @@
 
 Name:           youtube-music
 Version:        3.7.5
-Release:        3%?dist
+Release:        4%?dist
 Summary:        YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)
 Source1:        youtube-music.desktop
 License:        MIT
@@ -35,7 +35,6 @@ BuildRequires:  pnpm nodejs20
 Requires:       nss
 Requires:       libXext
 Requires:       libXfixes
-AutoReq:        no
 
 %description
 YouTube Music Desktop App bundled with custom plugins (and built-in ad blocker / downloader)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(youtube-music, voicevox): Re-enable AutoReq with appropriate libraries excluded (#3871)](https://github.com/terrapkg/packages/pull/3871)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)