### PR TITLE
fix(ghostty-nightly): Add gtk4-layer-shell dep

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -14,7 +14,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        1%?dist
+Release:        3%?dist
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -14,7 +14,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif
@@ -47,6 +47,7 @@ BuildRequires:  pkgconfig(zlib)
 Requires:       %{name}-terminfo
 Requires:       %{name}-shell-integration
 Requires:       gtk4
+Requires:       gtk4-layer-shell
 Requires:       libadwaita
 Conflicts:      %{base_name}
 Provides:       %{base_name}-tip = %{ver}^%{commit_date}git%{shortcommit}


### PR DESCRIPTION
Turns out it *is* a runtime dep.
![image](https://github.com/user-attachments/assets/bf1ada5d-dccb-44d0-9015-3e2726505d9d)

Needs #3878 to bump Ghostty on F40 first.