### PR TITLE
[frawhide] feat(mesa): Add patch for vram issue in Mesa 25 (#3880)

### DIFF
--- a/anda/lib/mesa/34005.patch
+++ b/anda/lib/mesa/34005.patch
@@ -1,0 +1,46 @@
+From c6270978411609f52afb8c6a2219fcb94f9013bb Mon Sep 17 00:00:00 2001
+From: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+Date: Tue, 11 Mar 2025 15:29:37 +0100
+Subject: [PATCH] radv/amdgpu: fix device deduplication
+
+To correctly deduplicate device inside the winsys, it should use the
+fd or amdgpu_device_handle. Using the allocated ac_drm_device as key
+is obviously broken.
+
+Not deduplicating devices breaks memory budget and a bunch of games
+were broken.
+
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12686
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12775
+Fixes: a565f2994fe ("amd: move all uses of libdrm_amdgpu to ac_linux_drm")
+Signed-off-by: Samuel Pitoiset <samuel.pitoiset@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34005>
+---
+ src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.c b/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.c
+index be8df8708c813..8b57abeb0b1ca 100644
+--- a/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.c
++++ b/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.c
+@@ -234,7 +234,7 @@ radv_amdgpu_winsys_create(int fd, uint64_t debug_flags, uint64_t perftest_flags,
+       goto fail;
+    }
+ 
+-   struct hash_entry *entry = _mesa_hash_table_search(winsyses, dev);
++   struct hash_entry *entry = _mesa_hash_table_search(winsyses, (void *)ac_drm_device_get_cookie(dev));
+    if (entry) {
+       ws = (struct radv_amdgpu_winsys *)entry->data;
+       ++ws->refcount;
+@@ -325,7 +325,7 @@ radv_amdgpu_winsys_create(int fd, uint64_t debug_flags, uint64_t perftest_flags,
+    radv_amdgpu_bo_init_functions(ws);
+    radv_amdgpu_cs_init_functions(ws);
+ 
+-   _mesa_hash_table_insert(winsyses, dev, ws);
++   _mesa_hash_table_insert(winsyses, (void *)ac_drm_device_get_cookie(dev), ws);
+    simple_mtx_unlock(&winsys_creation_mutex);
+ 
+    return &ws->base;
+-- 
+GitLab
+

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -76,7 +76,7 @@ Summary:        Mesa graphics libraries
 # disabled by default, and has to be enabled manually. See `terra/release/terra-mesa.repo` for details.
 Epoch:          1
 Version:        25.0.1
-Release:        4%?dist
+Release:        5%?dist
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 
@@ -98,6 +98,10 @@ Patch20:        valve.patch
 # Fix issues with Intel Battlemage under Valve's gamescope in DRM mode
 # https://gitlab.freedesktop.org/mesa/mesa/-/issues/12633
 Patch21:        12633.patch
+
+# radv/amdgpu: fix device deduplication
+# https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34005/diffs
+Patch22:        34005.patch
 
 Patch30:        237d8799be3afe9a1e7ca9156a5d44ffe0aae681.patch
 Patch31:        13a3f9a972324a72dd507e09ac975b969e6c88e0.patch


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `frawhide`:
 - [feat(mesa): Add patch for vram issue in Mesa 25 (#3880)](https://github.com/terrapkg/packages/pull/3880)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)