### PR TITLE
[f42] fix(ghostty-nightly): Add gtk4-layer-shell dep (#3879)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -14,7 +14,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        2%?dist
+Release:        3%?dist
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif
@@ -47,6 +47,7 @@ BuildRequires:  pkgconfig(zlib)
 Requires:       %{name}-terminfo
 Requires:       %{name}-shell-integration
 Requires:       gtk4
+Requires:       gtk4-layer-shell
 Requires:       libadwaita
 Conflicts:      %{base_name}
 Provides:       %{base_name}-tip = %{ver}^%{commit_date}git%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(ghostty-nightly): Add gtk4-layer-shell dep (#3879)](https://github.com/terrapkg/packages/pull/3879)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)