### PR TITLE
[f41] fix(protobuf): Remove obsolete file (#3889)

### DIFF
--- a/anda/langs/python/protobuf/python3-protobuf.spec
+++ b/anda/langs/python/protobuf/python3-protobuf.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        6.30.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Protocol Buffers
 
 License:        BSD-3-Clause
@@ -39,7 +39,6 @@ rm -rf %{pypi_name}.egg-info
 %doc README.md
 %{python3_sitearch}/google
 %{python3_sitearch}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
-%{python3_sitearch}/%{pypi_name}-%{version}-py%{python3_version}-nspkg.pth
 
 %changelog
 * Sun Feb 19 2023 windowsboy111 <wboy111@outlook.com> - 4.22.0-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(protobuf): Remove obsolete file (#3889)](https://github.com/terrapkg/packages/pull/3889)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)