### PR TITLE
[f41] feat(mpv-nightly): include fish completions (#3894)

### DIFF
--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -209,6 +209,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/mpv.desktop
 %dir %{_datadir}/bash-completion/completions/
 %{_datadir}/bash-completion/completions/mpv
 %{_datadir}/icons/hicolor/*/apps/mpv*.*
+%{_datadir}/fish/vendor_completions.d/mpv.fish
 %dir %{_datadir}/zsh/
 %dir %{_datadir}/zsh/site-functions/
 %{_datadir}/zsh/site-functions/_mpv


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(mpv-nightly): include fish completions (#3894)](https://github.com/terrapkg/packages/pull/3894)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)