### PR TITLE
[f41] feat(mpv-nightly): Make shell completions subpackages (#3907)

### DIFF
--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -5,7 +5,7 @@
 
 Name:           mpv-nightly
 Version:        %ver^%commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later
 Summary:        Movie player playing most video formats and DVDs
@@ -124,6 +124,33 @@ Requires: mpv-nightly-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 %description devel
 This package contains development header files and libraries for Mpv.
 
+%package bash-completion
+Summary: MPV Bash completion
+Requires: bash
+Requires: %{name}
+Supplements: (%{name} and bash)
+
+%description bash-completion
+Bash shell completion for MPV.
+
+%package fish-completion
+Summary: MPV Fish completion
+Requires: fish
+Requires: %{name}
+Supplements: (%{name} and fish)
+
+%description fish-completion
+Fish shell completion for MPV.
+
+%package zsh-completion
+Summary: MPV Zsh completion
+Requires: zsh
+Requires: %{name}
+Supplements: (%{name} and zsh)
+
+%description zsh-completion
+Zsh shell completion for MPV.
+
 %prep
 %autosetup -p1 -n mpv-%commit
 sed -e "s|/usr/local/etc|%{_sysconfdir}/mpv|" -i etc/mpv.conf
@@ -205,14 +232,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/mpv.desktop
 %{_docdir}/mpv/
 %{_bindir}/mpv
 %{_datadir}/applications/mpv.desktop
-%dir %{_datadir}/bash-completion/
-%dir %{_datadir}/bash-completion/completions/
-%{_datadir}/bash-completion/completions/mpv
 %{_datadir}/icons/hicolor/*/apps/mpv*.*
-%{_datadir}/fish/vendor_completions.d/mpv.fish
-%dir %{_datadir}/zsh/
-%dir %{_datadir}/zsh/site-functions/
-%{_datadir}/zsh/site-functions/_mpv
 %{_mandir}/man1/mpv.*
 %{_metainfodir}/mpv.metainfo.xml
 %dir %{_sysconfdir}/mpv/
@@ -226,6 +246,15 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/mpv.desktop
 %{_includedir}/mpv/
 %{_libdir}/libmpv.so
 %{_libdir}/pkgconfig/mpv.pc
+
+%files bash-completion
+%{bash_completions_dir}/mpv
+
+%files fish-completion
+%{fish_completions_dir}/mpv.fish
+
+%files zsh-completion
+%{zsh_completions_dir}/_mpv
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(mpv-nightly): Make shell completions subpackages (#3907)](https://github.com/terrapkg/packages/pull/3907)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)