### PR TITLE
[F41] chore: Bump nightly packages

### DIFF
--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,5 +1,5 @@
-%global commit 1833760c8be5b5fd4a76bbcd0cf1632d7bff0216
-%global commit_date 20250215
+%global commit 13c3ca026bb143ff13d5c560e34603153ab16677
+%global commit_date 20250315
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %define debug_package %nil
 

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,6 +1,6 @@
-%global commit ae3420fe6674295cc732933332336cdb3afd81ec
+%global commit d9dadf07ae9425ad3cc6cc2ee9464038224efdcb
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250313
+%global commit_date 20250314
 %global ver 0.39.0
 
 Name:           mpv-nightly

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,11 +1,11 @@
-%global commit d9dadf07ae9425ad3cc6cc2ee9464038224efdcb
+%global commit a8f5beb5a38e0ed169a9fb9faff6c5ca0a43dfee
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250314
+%global commit_date 20250315
 %global ver 0.39.0
 
 Name:           mpv-nightly
 Version:        %ver^%commit_date.%shortcommit
-Release:        2%?dist
+Release:        1%?dist
 
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later
 Summary:        Movie player playing most video formats and DVDs

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 5ae0e0ff9a6974453c1aba41ddc8442d12ac9264
+%global commit ae3420fe6674295cc732933332336cdb3afd81ec
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250226
+%global commit_date 20250313
 %global ver 0.39.0
 
 Name:           mpv-nightly

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 73c7943fff38f679a9a434457b5089bc5722411d
+%global commit 234b804872af665ca8091892ff3ea35ea278b32c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-03-13
+%global fulldate 2025-03-14
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.1.3

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 95daca616db5c24d7bb37fd5a3ac2f8762bb4ead
+%global commit 73c7943fff38f679a9a434457b5089bc5722411d
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-03-10
+%global fulldate 2025-03-13
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.1.3
@@ -14,7 +14,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        3%?dist
+Release:        1%?dist
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif

--- a/anda/devs/micro/micro-nightly.spec
+++ b/anda/devs/micro/micro-nightly.spec
@@ -12,8 +12,8 @@
 
 # Naming variable as something other than "commit" is necessary
 # to stop %%gometa from putting commit hash in release
-%global commit_hash c93747926d2e5ead9adf0039f6bf34f48ba3263d
-%global commit_date 20250225
+%global commit_hash fa317456e91c97af1b2c68f1e657ab426d035929
+%global commit_date 20250313
 %global shortcommit %{sub %{commit_hash} 1 7}
 %global ver 2.0.14
 

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 22ad7b17c53596f54aa6429822adf03adac0f012
+%global commit 7c1405db379487f00e6e4eee9735e79f5a24b279
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250314
+%global commit_date 20250315
 %global ver 0.179.0
 
 %bcond_with check

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 0081b816fecf59ae7351a14eb7249e600389d508
+%global commit 22ad7b17c53596f54aa6429822adf03adac0f012
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250313
+%global commit_date 20250314
 %global ver 0.179.0
 
 %bcond_with check

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,7 @@
-%global commit a5698a430d1a99fdfa5278b013401dc0429c64c6
+%global commit 0081b816fecf59ae7351a14eb7249e600389d508
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250226
-%global ver 0.176.0
+%global commit_date 20250313
+%global ver 0.179.0
 
 %bcond_with check
 

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -4,6 +4,7 @@
 %global commit 1a1bc14a73f80b105dfefa5e3efdf1c593582e22
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global libnbtplusplus_commit 23b955121b8217c1c348a9ed2483167a6f3ff4ad
+
 %global commit_date 20250315
 %global snapshot_info %{commit_date}.%{shortcommit}
 

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -1,11 +1,10 @@
 %global real_name prismlauncher
 %global nice_name PrismLauncher
 
-%global commit 0af021fef2628e35ff9ebaa8340e080d0ddd6556
+%global commit 1a1bc14a73f80b105dfefa5e3efdf1c593582e22
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global libnbtplusplus_commit 23b955121b8217c1c348a9ed2483167a6f3ff4ad
-
-%global commit_date 20250220
+%global commit_date 20250315
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit a7a8e364ea466223cb212dcefd5ff401266f5250
+%global commit fb93295344b78d2d45c81bc78bdba8526a893a09
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20250226
+%global commit_date 20250313
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/lib/astal/astal/astal.spec
+++ b/anda/lib/astal/astal/astal.spec
@@ -1,7 +1,7 @@
 
-%global commit e9c4963334ca0924cb9a14482a1e61a1bac4736e
+%global commit 69efb4c91e590adcb5a3d8938454f987982e3891
 %global shortcommit %{sub %commit 1 7}
-%global commit_date 20250313
+%global commit_date 20250314
 
 Name:			astal
 Version:		0^%commit_date.%shortcommit

--- a/anda/lib/astal/astal/astal.spec
+++ b/anda/lib/astal/astal/astal.spec
@@ -1,7 +1,7 @@
 
-%global commit dfd1f23c7562694e571d44c45aa74fcea9b1ba01
+%global commit e9c4963334ca0924cb9a14482a1e61a1bac4736e
 %global shortcommit %{sub %commit 1 7}
-%global commit_date 20250301
+%global commit_date 20250313
 
 Name:			astal
 Version:		0^%commit_date.%shortcommit

--- a/anda/system/xone/kmod-common/xone.spec
+++ b/anda/system/xone/kmod-common/xone.spec
@@ -1,13 +1,13 @@
-%global commit 6b9d59aed71f6de543c481c33df4705d4a590a31
+%global commit aeb27e6d98f7b22b3672701af6171612254a4d0c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20241223
+%global commitdate 20250313
 %global ver 0.3
 %global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
 %global firmware_hash 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
 
 Name:           xone
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        1%?dist
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories common files
 License:        GPL-2.0-or-later
 URL:            https://github.com/dlundqvist/xone

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -1,7 +1,6 @@
-%global commit 61e4becfd5338e3eb2bb8c54cdd0b9b96a8afbf8
-%global commit_date 20250301
+%global commit 685afa8c0d6f2310eaefe1b528627a8bf3154ca0
+%global commit_date 20250315
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-
 %define _unpackaged_files_terminate_build 0
 
 Name:			rpi-utils

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -1,6 +1,7 @@
 %global commit 685afa8c0d6f2310eaefe1b528627a8bf3154ca0
 %global commit_date 20250315
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+
 %define _unpackaged_files_terminate_build 0
 
 Name:			rpi-utils

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,5 +1,5 @@
-%global commit c3d4b777081b3cdb52d52b43ac1589c349c87173
-%global commit_date 20250314
+%global commit f6e102798220026f54b2bb387fb3c4b96aaf9c57
+%global commit_date 20250315
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           spotx-bash

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,5 +1,5 @@
-%global commit d83897ee597f19adca9221918cebce6ed3353e8a
-%global commit_date 20250313
+%global commit c3d4b777081b3cdb52d52b43ac1589c349c87173
+%global commit_date 20250314
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           spotx-bash

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,5 +1,5 @@
-%global commit 176fc61d6d96cfc22ca844e25c94e5419965b329
-%global commit_date 20250226
+%global commit d83897ee597f19adca9221918cebce6ed3353e8a
+%global commit_date 20250313
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           spotx-bash


### PR DESCRIPTION
Needs #3866 (so the DKMS/Akmod packages update from the common package correctly).

Includes a pretty major fix for Xone for current kernels.