### PR TITLE
[f41] fix(mesa): Obsolete by Epoch (#3926)

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -259,7 +259,7 @@ Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{rel
 %if 0%{?with_va}
 Recommends:     %{name}-va-drivers%{?_isa}
 %endif
-Obsoletes:      %{name}-libglapi < 25.0.0~rc2-1
+Obsoletes:      %{name}-libglapi < 1:25.0.0~rc2-1
 
 %description dri-drivers
 %{summary}.
@@ -268,7 +268,7 @@ Obsoletes:      %{name}-libglapi < 25.0.0~rc2-1
 %package        va-drivers
 Summary:        Mesa-based VA-API video acceleration drivers
 Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Obsoletes:      %{name}-vaapi-drivers < 22.2.0-5
+Obsoletes:      %{name}-vaapi-drivers < 1:22.2.0-5
 
 %description va-drivers
 %{summary}.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(mesa): Obsolete by Epoch (#3926)](https://github.com/terrapkg/packages/pull/3926)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)