### PR TITLE
[el10] fix(fluent-icon-theme): maybe conflicts itself? (#3927)

### DIFF
--- a/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
+++ b/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
@@ -2,7 +2,7 @@
 
 Name:           fluent-icon-theme
 Version:        20250226
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Fluent icon theme for linux desktops
 
 License:        GPL-3.0
@@ -11,6 +11,7 @@ Source0:        %{url}/archive/refs/tags/%{tag}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  gtk-update-icon-cache fdupes
+Conflicts:      %name
 
 %description
 Fluent icon theme for linux desktops.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(fluent-icon-theme): maybe conflicts itself? (#3927)](https://github.com/terrapkg/packages/pull/3927)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)