### PR TITLE
[el10] fix(extest): revert the weird anda update bug (#3938)

### DIFF
--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -102,4 +102,3 @@ install -D -p -m 0755 %{SOURCE1} %{buildroot}%{_libexecdir}/extest/override_stea
 
 %changelog
 %autochangelog
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(extest): revert the weird anda update bug (#3938)](https://github.com/terrapkg/packages/pull/3938)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)