### PR TITLE
[f41] fix(audacity, extest, gcm-core, uwufetch): Update scripts (#3933)

### DIFF
--- a/anda/apps/audacity-freeworld/audacity-freeworld.spec
+++ b/anda/apps/audacity-freeworld/audacity-freeworld.spec
@@ -1,8 +1,8 @@
 %global __requires_exclude ^lib-.*.so            
 %global __provides_exclude ^lib-.*.so
 
-%global ver Audacity-3.7.1
-%global sanitized_ver %(echo "$( sed 's/Audacity-//' <<< "%{ver}" )")
+%global ver Audacity-3.7.3
+%global sanitized_ver %(echo %{ver} | sed 's/Audacity-//g')
 
 Name:    audacity-freeworld
 Version: %{sanitized_ver}

--- a/anda/apps/audacity-freeworld/update.rhai
+++ b/anda/apps/audacity-freeworld/update.rhai
@@ -1,1 +1,4 @@
-rpm.global("ver", gh_tag("audacity/audacity"));
+rpm.global("ver", gh("audacity/audacity"));
+if rpm.changed() {
+    rpm.release();
+}

--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -25,7 +25,7 @@ Release:        1%?dist
 Summary:        X11 XTEST reimplementation primarily for Steam Controller on Wayland
 
 License:        MIT
-URL:            https://github.com/KyleGospo/extest
+URL:            https://github.com/bazzite-org/extest
 
 Source0:        %{url}/archive/%{commit}.tar.gz
 

--- a/anda/misc/extest/update.rhai
+++ b/anda/misc/extest/update.rhai
@@ -1,4 +1,4 @@
-rpm.global("commit", gh_commit("KyleGospo/extest"));
+rpm.global("commit", gh_commit("bazzite-org/extest"));
 if rpm.changed() {
 	rpm.global("commit_date", date());
 	rpm.release();

--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("TheDarkBug/uwufetch"));
+rpm.version(gh("ad-oliviero/uwufetch"));

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -3,7 +3,7 @@ Version:       2.1
 Release:       1%?dist
 Summary:       A meme system info tool for Linux, based on nyan/uwu trend on r/linuxmasterrace.
 License:       GPL-3.0
-URL:           https://github.com/TheDarkBug/uwufetch
+URL:           https://github.com/ad-oliviero/uwufetch
 BuildRequires: make gcc git anda-srpm-macros
 
 %description

--- a/anda/tools/gcm-core/gcm-core.spec
+++ b/anda/tools/gcm-core/gcm-core.spec
@@ -3,7 +3,7 @@
 
 %global long_name git-credential-manager
 
-%global forgeurl https://github.com/GitCredentialManager/git-credential-manager
+%global forgeurl https://github.com/git-ecosystem/git-credential-manager
 
 Name:           gcm-core
 Version:        2.6.1

--- a/anda/tools/gcm-core/update.rhai
+++ b/anda/tools/gcm-core/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("GitCredentialManager/git-credential-manager"));
+rpm.version(gh("git-ecosystem/git-credential-manager"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(audacity, extest, gcm-core, uwufetch): Update scripts (#3933)](https://github.com/terrapkg/packages/pull/3933)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)