### PR TITLE
fix(uwufetch): Make Git based and fix Git cloning

### DIFF
--- a/anda/misc/uwufetch/anda.hcl
+++ b/anda/misc/uwufetch/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "uwufetch.spec"
 	}
+        labels {
+                nightly = 1
+        }
 }

--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -1,1 +1,8 @@
-rpm.version(gh("ad-oliviero/uwufetch"));
+rpm.global("commit", gh_commit("ad-oliviero/uwufetch"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+    let ver = gh_tag("ad-oliviero/uwufetch");
+    ver.crop(1);
+    rpm.global("ver", ver);
+}

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -10,20 +10,19 @@ Release:       1%?dist
 Summary:       A meme system info tool for Linux, based on nyan/uwu trend on r/linuxmasterrace.
 License:       GPL-3.0
 URL:           https://github.com/ad-oliviero/uwufetch
+Source0:       %{url}/archive/%{commit}.tar.gz
 BuildRequires: make gcc git anda-srpm-macros
 
 %description
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
 
 %prep
-%git_clone %{url} %{commit}
+%autosetup -n %{name)-%{commit}
 
 %build
 %make_build
 
 %install
-export DESTDIR=%{_prefix}
-export LIBDIR=%{_libdir}
 %make_install
 
 %files

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -27,6 +27,7 @@ Requires:      %{name}
 
 %install
 make install DESTDIR=%{buildroot}%{_prefix}
+mkdir -p %{buildroot}%{_libdir}
 mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
 
 %files

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -17,7 +17,7 @@ BuildRequires: make gcc git anda-srpm-macros
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
 
 %prep
-%autosetup -n %{name)-%{commit}
+%autosetup -n %{name}-%{commit}
 
 %build
 %make_build

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -36,11 +36,12 @@ mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
 %files
 %dir %{_prefix}/lib/uwufetch
 %{_prefix}/lib/uwufetch/*
-%{_libdir}/libfetch.so
 %{_mandir}/man1/uwufetch.1.gz
 %{_bindir}/uwufetch
 
 %files devel
+%{_libdir}/libfetch.so
+%{_includedir}/fetch.h
 
 %changelog
 * Thu Jun 22 2023 Alyxia Sother <alyxia@riseup.net>

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -32,11 +32,16 @@ This package contains delevoplent files for UwUFetch.
 %make_build
 
 %install
+mv res/COPYRIGHT.md .
 %make_install DESTDIR=%{buildroot}%{_prefix}
 mkdir -p %{buildroot}%{_libdir}
 mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
 
 %files
+%doc CODE_OF_CONDUCT.md
+%doc README.md
+%license LICENSE
+%license COPYRIGHT.md
 %dir %{_prefix}/lib/uwufetch
 %{_prefix}/lib/uwufetch/*
 %{_mandir}/man1/uwufetch.1.gz

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -32,7 +32,6 @@ This package contains delevoplent files for UwUFetch.
 %make_build
 
 %install
-mv res/COPYRIGHT.md .
 %make_install DESTDIR=%{buildroot}%{_prefix}
 mkdir -p %{buildroot}%{_libdir}
 mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
@@ -41,7 +40,7 @@ mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
 %doc CODE_OF_CONDUCT.md
 %doc README.md
 %license LICENSE
-%license COPYRIGHT.md
+%license res/COPYRIGHT.md
 %dir %{_prefix}/lib/uwufetch
 %{_prefix}/lib/uwufetch/*
 %{_mandir}/man1/uwufetch.1.gz

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -32,7 +32,7 @@ This package contains delevoplent files for UwUFetch.
 %make_build
 
 %install
-make install DESTDIR=%{buildroot}%{_prefix}
+%make_install DESTDIR=%{buildroot}%{_prefix}
 mkdir -p %{buildroot}%{_libdir}
 mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
 

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,7 +22,7 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
-sed -i 's/DESTDIR=.*/usr/DESTDIR=%{buildroot}%{_prefix}/g' Makefile
+sed -i 's/DESTDIR=.*\/usr/DESTDIR=%(echo %{buildroot}%{_prefix}| sed 's/\//\\\//g')/g' Makefile
 sed -i 's/= lib/= %{_libdir}/g' Makefile
 %make_install
 

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,7 +22,8 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
-export DESTDIR=%{buildroot}%{_prefix}
+sed -i 's/DESTDIR=.*/usr/DESTDIR=%{buildroot}%{_prefix}/g'
+sed -i 's/= lib/= %{_libdir}/g'
 %make_install
 
 %files

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,6 +22,7 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
+export DESTDIR=%{buildroot}%{_prefix}
 %make_install
 
 %files

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,8 +22,8 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
-sed -i 's/DESTDIR=.*/usr/DESTDIR=%{buildroot}%{_prefix}/g'
-sed -i 's/= lib/= %{_libdir}/g'
+sed -i 's/DESTDIR=.*/usr/DESTDIR=%{buildroot}%{_prefix}/g' Makefile
+sed -i 's/= lib/= %{_libdir}/g' Makefile
 %make_install
 
 %files

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,7 +22,7 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
-sed -i 's/DESTDIR=.*\/usr/DESTDIR=%(echo %{buildroot}%{_prefix}| sed 's/\//\\\//g')/g' Makefile
+sed -i 's/DESTDIR=.*\/usr/DESTDIR=\/%(echo %{buildroot}/usr| sed 's/\//\\\//g')/g' Makefile
 sed -i 's/= lib/= %(echo %{_libdir} | sed 's/\//\\\//g')/g' Makefile
 %make_install
 

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -2,6 +2,7 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20240423
 %global ver 2.1
+%global debug_package %{nil}
 
 Name:          uwufetch
 Version:       %{ver}^%{commit_date}git.%{shortcommit}

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -38,7 +38,6 @@ mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
 %{_bindir}/uwufetch
 
 %files devel
-%{_includedir}/
 
 %changelog
 * Thu Jun 22 2023 Alyxia Sother <alyxia@riseup.net>

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,10 +22,12 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
+export DESTDIR=%{_prefix}
+export LIBDIR=%{_libdir}
 %make_install
 
 %files
-%{_prefix}/lib/uwufetch/*
+%{_libdir}/uwufetch/*
 %{_libdir}/libfetch.so
 %{_mandir}/man1/uwufetch.1.gz
 %{_bindir}/uwufetch

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -15,6 +15,10 @@ BuildRequires: make gcc git anda-srpm-macros
 %description
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
 
+%package       devel
+Summary:       Development files for UwUFetch.
+Requires:      %{name}
+
 %prep
 %git_clone %{url} %{commit}
 
@@ -22,14 +26,18 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
-sed -i 's/= lib/= lib64/g' Makefile
-DESTDIR=%{buildroot}%{_prefix} make install
+make install DESTDIR=%{buildroot}%{_prefix}
+mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
 
 %files
-%{_libdir}/uwufetch/*
+%dir %{_prefix}/lib/uwufetch
+%{_prefix}/lib/uwufetch/*
 %{_libdir}/libfetch.so
 %{_mandir}/man1/uwufetch.1.gz
 %{_bindir}/uwufetch
+
+%files devel
+%{_includedir}/
 
 %changelog
 * Thu Jun 22 2023 Alyxia Sother <alyxia@riseup.net>

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -19,6 +19,9 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 Summary:       Development files for UwUFetch.
 Requires:      %{name}
 
+%description    devel
+This package contains delevoplent files for UwUFetch.
+
 %prep
 %git_clone %{url} %{commit}
 

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -23,7 +23,7 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 
 %install
 sed -i 's/DESTDIR=.*\/usr/DESTDIR=%(echo %{buildroot}%{_prefix}| sed 's/\//\\\//g')/g' Makefile
-sed -i 's/= lib/= %{_libdir}/g' Makefile
+sed -i 's/= lib/= %(echo %{_libdir} | sed 's/\//\\\//g')/g' Makefile
 %make_install
 
 %files

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -10,14 +10,13 @@ Release:       1%?dist
 Summary:       A meme system info tool for Linux, based on nyan/uwu trend on r/linuxmasterrace.
 License:       GPL-3.0
 URL:           https://github.com/ad-oliviero/uwufetch
-Source0:       %{url}/archive/%{commit}.tar.gz
 BuildRequires: make gcc git anda-srpm-macros
 
 %description
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
 
 %prep
-%autosetup -n %{name}-%{commit}
+%git_clone %{url} %{commit}
 
 %build
 %make_build

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,7 +22,8 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
-DESTDIR=%{buildroot}%{_prefix} LIBDIR=%{buildroot}%{_libdir} make install
+sed -i 's/= lib/= lib64/g' Makefile
+DESTDIR=%{buildroot}%{_prefix} make install
 
 %files
 %{_libdir}/uwufetch/*

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,9 +22,7 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
-sed -i 's/DESTDIR=.*\/usr/DESTDIR=\/%(echo %{buildroot}/usr| sed 's/\//\\\//g')/g' Makefile
-sed -i 's/= lib/= %(echo %{_libdir} | sed 's/\//\\\//g')/g' Makefile
-%make_install
+DESTDIR=%{buildroot}%{_prefix} LIBDIR=%{buildroot}%{_libdir} make install
 
 %files
 %{_libdir}/uwufetch/*

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -22,10 +22,7 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 %make_build
 
 %install
-make install DESTDIR=%{?buildroot}%{_prefix}
-mkdir %{?buildroot}%{_libdir}
-mv %{?buildroot}%{_prefix}/lib/libfetch.so %{?buildroot}%{_libdir}/libfetch.so
-rm -rf %{?buildroot}%{_includedir}
+%make_install
 
 %files
 %{_prefix}/lib/uwufetch/*

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -11,6 +11,9 @@ Summary:       A meme system info tool for Linux, based on nyan/uwu trend on r/l
 License:       GPL-3.0
 URL:           https://github.com/ad-oliviero/uwufetch
 BuildRequires: make gcc git anda-srpm-macros
+Requires:      freecolor
+Requires:      xwininfo
+Recommends:    lshw
 
 %description
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
@@ -19,7 +22,7 @@ A meme system info tool for (almost) all your Linux/Unix-based systems, based on
 Summary:       Development files for UwUFetch.
 Requires:      %{name}
 
-%description    devel
+%description   devel
 This package contains delevoplent files for UwUFetch.
 
 %prep

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -10,8 +10,7 @@ BuildRequires: make gcc git anda-srpm-macros
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
 
 %prep
-git clone https://github.com/TheDarkBug/uwufetch.git .
-git checkout %{version}
+%git_clone %{url} %{version}
 
 %build
 %make_build

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -1,5 +1,10 @@
+%global commit 28b471b813d1c9aab77eeeb61f65304e586fb275
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20240423
+%global ver 2.1
+
 Name:          uwufetch
-Version:       
+Version:       %{ver}^%{commit_date}git.%{shortcommit}
 Release:       1%?dist
 Summary:       A meme system info tool for Linux, based on nyan/uwu trend on r/linuxmasterrace.
 License:       GPL-3.0
@@ -10,7 +15,7 @@ BuildRequires: make gcc git anda-srpm-macros
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
 
 %prep
-%git_clone %{url} %{version}
+%git_clone %{url} %{commit}
 
 %build
 %make_build


### PR DESCRIPTION
The last few releases of Uwufetch were Git commits only and included a couple bug fixes, so this seemed the best option as the project is dead and those fixes will likely never see a release.