### PR TITLE
[f41] komikku: fix license path (#3961)

### DIFF
--- a/anda/apps/komikku/komikku.spec
+++ b/anda/apps/komikku/komikku.spec
@@ -7,7 +7,7 @@
 Name:           komikku
 Version:        1.72.0
 %forgemeta
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A manga reader for GNOME
 
 BuildArch:      noarch
@@ -92,7 +92,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 
 
 %files -f %{name}.lang
-%license LICENSE
+%license LICENSES/*
 %doc README.md
 %{_bindir}/%{name}
 %{_datadir}/%{name}/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [komikku: fix license path (#3961)](https://github.com/terrapkg/packages/pull/3961)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)