### PR TITLE
[f42] fix(uwufetch): Make Git based and fix Git cloning (#3951)

### DIFF
--- a/anda/misc/uwufetch/anda.hcl
+++ b/anda/misc/uwufetch/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "uwufetch.spec"
 	}
+        labels {
+                nightly = 1
+        }
 }

--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -1,1 +1,8 @@
-rpm.version(gh("ad-oliviero/uwufetch"));
+rpm.global("commit", gh_commit("ad-oliviero/uwufetch"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+    let ver = gh_tag("ad-oliviero/uwufetch");
+    ver.crop(1);
+    rpm.global("ver", ver);
+}

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -1,32 +1,54 @@
+%global commit 28b471b813d1c9aab77eeeb61f65304e586fb275
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20240423
+%global ver 2.1
+%global debug_package %{nil}
+
 Name:          uwufetch
-Version:       2.1
+Version:       %{ver}^%{commit_date}git.%{shortcommit}
 Release:       1%?dist
 Summary:       A meme system info tool for Linux, based on nyan/uwu trend on r/linuxmasterrace.
 License:       GPL-3.0
 URL:           https://github.com/ad-oliviero/uwufetch
 BuildRequires: make gcc git anda-srpm-macros
+Requires:      freecolor
+Requires:      xwininfo
+Recommends:    lshw
 
 %description
 A meme system info tool for (almost) all your Linux/Unix-based systems, based on the nyan/UwU trend on r/linuxmasterrace.
 
+%package       devel
+Summary:       Development files for UwUFetch.
+Requires:      %{name}
+
+%description   devel
+This package contains delevoplent files for UwUFetch.
+
 %prep
-git clone https://github.com/TheDarkBug/uwufetch.git .
-git checkout %{version}
+%git_clone %{url} %{commit}
 
 %build
 %make_build
 
 %install
-make install DESTDIR=%{?buildroot}%{_prefix}
-mkdir %{?buildroot}%{_libdir}
-mv %{?buildroot}%{_prefix}/lib/libfetch.so %{?buildroot}%{_libdir}/libfetch.so
-rm -rf %{?buildroot}%{_includedir}
+%make_install DESTDIR=%{buildroot}%{_prefix}
+mkdir -p %{buildroot}%{_libdir}
+mv %{buildroot}%{_prefix}/lib/libfetch.so %{buildroot}%{_libdir}/libfetch.so
 
 %files
+%doc CODE_OF_CONDUCT.md
+%doc README.md
+%license LICENSE
+%license res/COPYRIGHT.md
+%dir %{_prefix}/lib/uwufetch
 %{_prefix}/lib/uwufetch/*
-%{_libdir}/libfetch.so
 %{_mandir}/man1/uwufetch.1.gz
 %{_bindir}/uwufetch
+
+%files devel
+%{_libdir}/libfetch.so
+%{_includedir}/fetch.h
 
 %changelog
 * Thu Jun 22 2023 Alyxia Sother <alyxia@riseup.net>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(uwufetch): Make Git based and fix Git cloning (#3951)](https://github.com/terrapkg/packages/pull/3951)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)