### PR TITLE
refactor(heroic): Changes for aarch64 preparation, Git clone to install Git hooks

### DIFF
--- a/anda/games/heroic-games-launcher/afterPack.diff
+++ b/anda/games/heroic-games-launcher/afterPack.diff
@@ -1,7 +1,0 @@
---- a/electron-builder.yml
-+++ b/electron-builder.yml
-@@ -3,3 +3,3 @@ appId: com.heroicgameslauncher.hgl
- productName: Heroic
--afterSign: sign/afterSign.js
-+afterPack: sign/afterSign.js
- files:

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -51,7 +51,6 @@ Packager:      Gilver E. <rockgrub@disroot.org>
 Heroic is a Free and Open Source Epic, GOG, and Amazon Prime Games launcher for Linux, Windows, and macOS.
 
 %prep
-rm -rf ./*
 %git_clone https://github.com/%{org_name}/%{git_name} v%{version}
 sed -i 's/Exec=.*%u/Exec=\/usr\/share\/%{shortname}\/%{shortname} %U/g' flatpak/%{reverse_dns}.desktop
 sed -i 's/Icon=.*/Icon=%{shortname}/g' flatpak/%{reverse_dns}.desktop

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -1,105 +1,119 @@
 %global debug_package %{nil}
 %global __provides_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
-%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
+%ifnarch aarch64 
+%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\aarch64*\\.so.*))$
+%elifarch aarch64
+%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\x86_64*\\.so.*)|(.*\\x86-64*\\.so.*))$
+%endif
 %define _build_id_links none
-%global git_name HeroicGamesLauncher
+%global org_name Heroic-Games-Launcher
+%global git_name %(echo %{org_name} | sed 's/-//g')
+%global reverse_dns com.heroicgameslauncher.hgl
+%global shortname heroic
+%global legendary_version 0.20.36
+%global gogdl_version 1.1.2
+%global nile_version 1.1.2
+%global comet_version 0.2.0
 
-Name:          heroic-games-launcher
+Name:          %{shortname}-games-launcher
 Version:       2.16.1
 Release:       1%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com
-Source0:       https://github.com/Heroic-Games-Launcher/%{git_name}/archive/refs/tags/v%{version}.tar.gz
-Source1:       https://raw.githubusercontent.com/Heroic-Games-Launcher/%{git_name}/refs/heads/main/flatpak/com.heroicgameslauncher.hgl.desktop
-### Makes it actually sign the package, though will say it was skipped first.
-Patch0:        afterPack.diff
-BuildRequires: bsdtar
+BuildRequires: anda-srpm-macros
 BuildRequires: desktop-file-utils
-### Electron builder builds some things with GCC(++) and Make
+### Electron builder builds some things with GCC(++), Git, and Make
 BuildRequires: gcc
 BuildRequires: gcc-c++
-BuildRequires: libxcrypt-compat
+BuildRequires: git
 BuildRequires: make
 BuildRequires: nodejs
 BuildRequires: pnpm
 BuildRequires: python3
+BuildRequires: sed
 Requires:      alsa-lib
-Requires:      atk
-Requires:      at-spi2-core
 Requires:      gtk3
 Requires:      hicolor-icon-theme
-Requires:      libXext
-Requires:      libXfixes
 Requires:      nss
 Requires:      python3
 Requires:      which
 Recommends:    gamemode
 Recommends:    mangohud
 Recommends:    umu-launcher
-# Woarkaround for GNOME issues with libei
-Recommends:    (extest if gnome-shell)
-Provides:      bundled(gogdl)
-Provides:      bundled(legendary)
-Provides:      bundled(nile)
-ExclusiveArch: x86_64
-AutoReq:       no
+Provides:      bundled(comet) = %{comet_version}
+Provides:      bundled(gogdl) = %{gogdl_version}
+Provides:      bundled(legendary) = %{legendary_version}
+Provides:      bundled(nile) = %{nile_version}
 Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description
 Heroic is a Free and Open Source Epic, GOG, and Amazon Prime Games launcher for Linux, Windows, and macOS.
 
 %prep
-%autosetup -n %{git_name}-%{version} -p1
-sed -i 's/Exec=.*%u/Exec=\/usr\/share\/heroic\/heroic %u/g' %{SOURCE1}
-sed -i 's/Icon=.*/Icon=heroic/g' %{SOURCE1}
+rm -rf ./*
+%git_clone https://github.com/%{org_name}/%{git_name} v%{version}
+sed -i 's/Exec=.*%u/Exec=\/usr\/share\/%{shortname}\/%{shortname} %U/g' flatpak/%{reverse_dns}.desktop
+sed -i 's/Icon=.*/Icon=%{shortname}/g' flatpak/%{reverse_dns}.desktop
 
 %build
 pnpm install
 pnpm run download-helper-binaries
-### RPM doesn't work and it needs a package format to generate icons, AppImage isn't a good option for packaging because it will try to self update
-pnpm dist:linux pacman
+pnpm dist:linux
 
 %install
-mkdir -p %{buildroot}%{_datadir}/heroic
-mv dist/linux-unpacked/* %{buildroot}%{_datadir}/heroic
+mkdir -p %{buildroot}%{_datadir}/%{shortname}
+mv $(find . -iname "*LICENSE*" -not -path "./node_modules/*" -and -not -path "./public/*") .
+%ifarch aarch64
+### Needs testing once aarch64 Heroic is complete:
+#rm -rf dist/linux-unpacked/resources/app.asar.unpacked/build/bin/x64
+mv dist/linux-arm64-unpacked/* %{buildroot}%{_datadir}/%{shortname}
+%else
+rm -rf dist/linux-unpacked/resources/app.asar.unpacked/build/bin/arm64
+mv dist/linux-unpacked/* %{buildroot}%{_datadir}/%{shortname}
+%endif
 mkdir -p %{buildroot}%{_bindir}
-ln -sr %{_datadir}/heroic/heroic %{buildroot}%{_bindir}/%{name}
-install -Dm644 public/icon.png %{buildroot}%{_datadir}/pixmaps/heroic.png
-install -Dm644 dist/.icon-set/icon_16x16.png %{buildroot}%{_iconsdir}/hicolor/16x16/heroic.png
-install -Dm644 dist/.icon-set/icon_32x32.png %{buildroot}%{_iconsdir}/hicolor/32x32/heroic.png
-install -Dm644 dist/.icon-set/icon_48x48.png %{buildroot}%{_iconsdir}/hicolor/48x48/heroic.png
-install -Dm644 dist/.icon-set/icon_64x64.png %{buildroot}%{_iconsdir}/hicolor/64x64/heroic.png
-install -Dm644 dist/.icon-set/icon_128x128.png %{buildroot}%{_iconsdir}/hicolor/128x128/heroic.png
-install -Dm644 dist/.icon-set/icon_256x256.png %{buildroot}%{_iconsdir}/hicolor/256x256/heroic.png
-install -Dm644 dist/.icon-set/icon_512x512.png %{buildroot}%{_iconsdir}/hicolor/512x512/heroic.png
-install -Dm644 dist/.icon-set/icon_1024.png %{buildroot}%{_iconsdir}/hicolor/1024x1024/heroic.png
-install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/applications/heroic.desktop
+# Make names executable
+ln -sr %{_datadir}/%{shortname}/%{shortname} %{buildroot}%{_bindir}/%{name}
+ln -sr %{_datadir}/%{shortname}/%{shortname} %{buildroot}%{_bindir}/%{shortname}
+install -Dm644 dist/.icon-set/icon_16x16.png %{buildroot}%{_iconsdir}/hicolor/16x16/%{shortname}.png
+install -Dm644 dist/.icon-set/icon_32x32.png %{buildroot}%{_iconsdir}/hicolor/32x32/%{shortname}.png
+install -Dm644 dist/.icon-set/icon_48x48.png %{buildroot}%{_iconsdir}/hicolor/48x48/%{shortname}.png
+install -Dm644 dist/.icon-set/icon_64x64.png %{buildroot}%{_iconsdir}/hicolor/64x64/%{shortname}.png
+install -Dm644 dist/.icon-set/icon_128x128.png %{buildroot}%{_iconsdir}/hicolor/128x128/%{shortname}.png
+install -Dm644 dist/.icon-set/icon_256x256.png %{buildroot}%{_iconsdir}/hicolor/256x256/%{shortname}.png
+install -Dm644 dist/.icon-set/icon_512x512.png %{buildroot}%{_iconsdir}/hicolor/512x512/%{shortname}.png
+install -Dm644 dist/.icon-set/icon_1024.png %{buildroot}%{_iconsdir}/hicolor/1024x1024/%{shortname}.png
+install -Dm644 flatpak/%{reverse_dns}.desktop %{buildroot}%{_datadir}/applications/%{shortname}.desktop
 
 %check
-desktop-file-validate %{buildroot}%{_datadir}/applications/heroic.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{shortname}.desktop
 
 %files
 %doc     README.md
 %doc     CODE_OF_CONDUCT.md
 %license COPYING
-%_datadir/heroic
-%_datadir/pixmaps/heroic.png
-%_bindir/heroic-games-launcher
-%_datadir/applications/heroic.desktop
-%_iconsdir/hicolor/16x16/heroic.png
-%_iconsdir/hicolor/32x32/heroic.png
-%_iconsdir/hicolor/48x48/heroic.png
-%_iconsdir/hicolor/64x64/heroic.png
-%_iconsdir/hicolor/128x128/heroic.png
-%_iconsdir/hicolor/256x256/heroic.png
-%_iconsdir/hicolor/512x512/heroic.png
-%_iconsdir/hicolor/1024x1024/heroic.png
+%license LICENSE
+%license legendary.LICENSE
+%license LICENSE.electron.txt
+%license LICENSES.chromium.html
+%dir %{_datadir}/%{shortname}
+%{_datadir}/%{shortname}/*
+%{_bindir}/%{shortname}
+%{_bindir}/%{name}
+%{_datadir}/applications/%{shortname}.desktop
+%{_iconsdir}/hicolor/16x16/%{shortname}.png
+%{_iconsdir}/hicolor/32x32/%{shortname}.png
+%{_iconsdir}/hicolor/48x48/%{shortname}.png
+%{_iconsdir}/hicolor/64x64/%{shortname}.png
+%{_iconsdir}/hicolor/128x128/%{shortname}.png
+%{_iconsdir}/hicolor/256x256/%{shortname}.png
+%{_iconsdir}/hicolor/512x512/%{shortname}.png
+%{_iconsdir}/hicolor/1024x1024/%{shortname}.png
 
 %changelog
-* Thu Jan 30 2025 Gilver E. <rockgrub@disroot.org>
-- Initial package
 * Sun Mar 02 2025 Gilver E. <rockgrub@disroot.org>
 - Update to 2.16.0
 - Fix incorrect RPM dependencies
-
+* Thu Jan 30 2025 Gilver E. <rockgrub@disroot.org>
+- Initial package

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -17,7 +17,7 @@
 
 Name:          %{shortname}-games-launcher
 Version:       2.16.1
-Release:       1%?dist
+Release:       2%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com

--- a/anda/games/heroic-games-launcher/update.rhai
+++ b/anda/games/heroic-games-launcher/update.rhai
@@ -1,1 +1,17 @@
-rpm.version(gh("Heroic-Games-Launcher/HeroicGamesLauncher"));
+let v = gh("Heroic-Games-Launcher/HeroicGamesLauncher");
+// Store for later
+let vv = v;
+v.crop(1);
+rpm.version(v);
+// Versions for bundled binaries. Most important for Legendary as Fedora packages this.
+if rpm.changed() {
+    let html = gh_rawfile("Heroic-Games-Launcher/HeroicGamesLauncher", vv, "meta/downloadHelperBinaries.ts");
+    let lv = find("legendary: '([\\d.]+)'", html, 1);
+    let gv = find("gogdl: 'v([\\d.]+)'", html, 1);
+    let nv = find("nile: 'v([\\d.]+)'", html, 1);
+    let cv = find("comet: 'v([\\d.]+)'", html, 1);
+    rpm.global("legendary_version", lv);
+    rpm.global("gogdl_version", gv);
+    rpm.global("nile_version", nv);
+    rpm.global("comet_version", cv);
+}

--- a/anda/games/heroic-games-launcher/update.rhai
+++ b/anda/games/heroic-games-launcher/update.rhai
@@ -1,15 +1,13 @@
-let v = gh("Heroic-Games-Launcher/HeroicGamesLauncher");
-// Store for later
-let vv = v;
-v.crop(1);
+let json = gh_rawfile("Heroic-Games-Launcher/HeroicGamesLauncher", "main", "package.json");
+let v = find("\"version\": \"([\\d.]+)\"", json, 1);
 rpm.version(v);
 // Versions for bundled binaries. Most important for Legendary as Fedora packages this.
 if rpm.changed() {
-    let html = gh_rawfile("Heroic-Games-Launcher/HeroicGamesLauncher", vv, "meta/downloadHelperBinaries.ts");
-    let lv = find("legendary: '([\\d.]+)'", html, 1);
-    let gv = find("gogdl: 'v([\\d.]+)'", html, 1);
-    let nv = find("nile: 'v([\\d.]+)'", html, 1);
-    let cv = find("comet: 'v([\\d.]+)'", html, 1);
+    let ts = gh_rawfile("Heroic-Games-Launcher/HeroicGamesLauncher", `v${v}`, "meta/downloadHelperBinaries.ts");
+    let lv = find("legendary: '([\\d.]+)'", ts, 1);
+    let gv = find("gogdl: 'v([\\d.]+)'", ts, 1);
+    let nv = find("nile: 'v([\\d.]+)'", ts, 1);
+    let cv = find("comet: 'v([\\d.]+)'", ts, 1);
     rpm.global("legendary_version", lv);
     rpm.global("gogdl_version", gv);
     rpm.global("nile_version", nv);

--- a/anda/games/heroic-games-launcher/update.rhai
+++ b/anda/games/heroic-games-launcher/update.rhai
@@ -1,5 +1,4 @@
-let json = gh_rawfile("Heroic-Games-Launcher/HeroicGamesLauncher", "main", "package.json");
-let v = find("\"version\": \"([\\d.]+)\"", json, 1);
+let v = gh_rawfile("Heroic-Games-Launcher/HeroicGamesLauncher", "main", "package.json").json()["version"];
 rpm.version(v);
 // Versions for bundled binaries. Most important for Legendary as Fedora packages this.
 if rpm.changed() {


### PR DESCRIPTION
This spec is very cursed now. Heroic does *not* build as aarch64 yet but they are beginning to work towards it on Linux and some aarch64 binaries now build (regrettably, regardless of architecture, which confused RPM AutoReq pretty badly).

Changes:
- Make Heroic not dep on GCC or incorrect architecture deps *without* disabling AutoReq (!!!)
- Git clone Heroic so Husky Git hooks install (Heroic uses these to check for updates, as far as I can tell both for itself but also its WINE manager)
- Drop the afterPack patch since this is kinda useless when not on Mac anyway
- Install (almost, there's a ton of duplicate, exactly the same ones for Node modules but not Heroic or its Electron runtime I excluded) *all* licenses for Heroic in the license dir
- Remove the incorrect architecture binaries
- Removed ExclusiveArch in preparation for whenever Heroic gets an aarch64 release (anda.hcl remains the same)
- Add bundled binaries with versions (this sort of matters mostly because Fedora packages Legendary)
- Removed the `extest` weak dep for now since while I've heard when built as x86_64 it helps with launchers like Heroic I can't confirm for sure at this time (needs GNOME testing maybe?)
- Fixed the changelog order blunder
- Switch from Pacman target to generic Linux target, this builds for both AppImage *and* Snap right now so the unpacked binary *shouldn't* attempt to self update and it requires less build deps and build time
- Added a symlink to make `heroic` executable mainly because of what the actual binary is called