### PR TITLE
[el10] fix(keyd): proper sysusers.d entry format (#4014)

### DIFF
--- a/anda/tools/keyd/keyd.spec
+++ b/anda/tools/keyd/keyd.spec
@@ -1,6 +1,6 @@
 Name:			keyd
 Version:		2.5.0
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Key remapping daemon for linux
 URL:			https://github.com/rvaiya/keyd
 License:		MIT
@@ -15,7 +15,7 @@ level input primitives (evdev, uinput).
 %prep
 %autosetup
 cat<<EOF > keyd.conf
-g keyd
+g keyd -
 EOF
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(keyd): proper sysusers.d entry format (#4014)](https://github.com/terrapkg/packages/pull/4014)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)