### PR TITLE
fix(ghostty-nightly): New tarball extracted directory

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,4 +1,4 @@
-%global commit bd7c5cc95f872d241ddc8aea4c81c540c6d9c19f
+%global commit 41130ce25f77d3e8b4e4663ba73426b68fdf5d27
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global fulldate 2025-03-18
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
@@ -135,7 +135,7 @@ This package contains files for Ghostty's terminfo. Available for debugging use.
 
 %prep
 /usr/bin/minisign -V -m %{SOURCE0} -x %{SOURCE1} -P %{public_key}
-%autosetup -n %{base_name}-source
+%autosetup -n %{base_name}-%{ver}-main+%{shortcommit}
 
 ZIG_GLOBAL_CACHE_DIR="%{cache_dir}" ./nix/build-support/fetch-zig-cache.sh
 

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
 %global commit 41130ce25f77d3e8b4e4663ba73426b68fdf5d27
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-03-18
+%global fulldate 2025-03-19
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.1.3


### PR DESCRIPTION
Still waiting on Fedora having Zig 0.14.0 or me to get Zig nightly building but this at least fixes the `%prep` step.