### PR TITLE
Fix removal of el10 custom template

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           dir=$(dirname ${{ matrix.pkg.pkg }})
           dnf builddep -y ${dir}/*.spec
+          
+      - name: Include custom build template instead of package default
+      run: |
+        cp -v mock-configs/terra-el-dev.tpl /etc/mock/templates/
 
       - name: Build with Andaman
         run: anda build ${{ matrix.pkg.pkg }} -c terra-el${{ matrix.version }}-dev-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}


### PR DESCRIPTION
So I think Mado tried to fix the issue where autobuild.yml tried to look for terra-el.tpl but it wasn't there (we weren't copying it because it's not relevant since el10 is technically beta rn). This actually removed the part where the builder copies the CORRECT template. I believe this is how it's supposed to be set up. Should fix what made me notice terrapkg/builder#5 (I think that bootstrap will still be broken though).