### PR TITLE
[f41] chore: bump bodhi rawhide ver (#4028)

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -6,7 +6,7 @@ fn as_bodhi_ver(branch) {
         }
         return `EPEL-${release}`;
     } else if branch == "frawhide" {
-        return "F42";
+        return "F43";
     } else if branch.starts_with("f") {
         branch.crop(1);
         return `F${branch}`;


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore: bump bodhi rawhide ver (#4028)](https://github.com/terrapkg/packages/pull/4028)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)