### PR TITLE
[f41] fix(ghostty-nightly): New tarball extracted directory (#4021)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -135,7 +135,7 @@ This package contains files for Ghostty's terminfo. Available for debugging use.
 
 %prep
 /usr/bin/minisign -V -m %{SOURCE0} -x %{SOURCE1} -P %{public_key}
-%autosetup -n %{base_name}-source
+%autosetup -n %{base_name}-%{ver}-main+%{shortcommit}
 
 ZIG_GLOBAL_CACHE_DIR="%{cache_dir}" ./nix/build-support/fetch-zig-cache.sh
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix(ghostty-nightly): New tarball extracted directory (#4021)](https://github.com/terrapkg/packages/pull/4021)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)