### PR TITLE
[f41] rebuild: rust-jellyfin-rpc-cli (#4052)

### DIFF
--- a/anda/langs/rust/jellyfin-rpc/rust-jellyfin-rpc-cli.spec
+++ b/anda/langs/rust/jellyfin-rpc/rust-jellyfin-rpc-cli.spec
@@ -6,7 +6,7 @@
 
 Name:           rust-jellyfin-rpc-cli
 Version:        1.3.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Displays the content you're currently watching on Discord!
 
 License:        GPL-3.0-or-later


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [rebuild: rust-jellyfin-rpc-cli (#4052)](https://github.com/terrapkg/packages/pull/4052)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)