### PR TITLE
[f40] fix(lightly-qt5): update.rhai (#4045)

### DIFF
--- a/anda/themes/lightly-qt5/update.rhai
+++ b/anda/themes/lightly-qt5/update.rhai
@@ -1,4 +1,4 @@
-fn main() {
+fn main(labels) {
     let branch = bump::as_bodhi_ver(labels.branch);
     let url = `https://bodhi.fedoraproject.org/updates/?search=qt5-5.&status=stable&releases=${branch}&rows_per_page=1&page=1`;
     for entry in get(url).json().updates[0].title.split(' ') {
@@ -9,4 +9,4 @@ fn main() {
     }
 }
 
-open_file("anda/themes/lightly-qt5/VER5.txt").write(`${main()}`); // will trig rebuild when changed
+open_file("anda/themes/lightly-qt5/VER5.txt").write(`${main(labels)}`); // will trig rebuild when changed


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(lightly-qt5): update.rhai (#4045)](https://github.com/terrapkg/packages/pull/4045)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)