### PR TITLE
[f42] fix(gnome-shell-extension-appmenu-is-back): bump gnome-shell requires (#4048)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
@@ -13,7 +13,7 @@ BuildArch:      noarch
 Source0:        https://github.com/fthx/appmenu-is-back/archive/refs/tags/v%{version}.tar.gz
 Patch0:         https://github.com/fthx/appmenu-is-back/compare/v2..703a31acf900eb7bcab3462baeefa815ec7f13ab.patch
 
-Requires:       (gnome-shell >= 46~ with gnome-shell < 48~)
+Requires:       (gnome-shell >= 47~ with gnome-shell < 49~)
 Recommends:     gnome-extensions-app
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(gnome-shell-extension-appmenu-is-back): bump gnome-shell requires (#4048)](https://github.com/terrapkg/packages/pull/4048)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)