### PR TITLE
[f41] bump(flashprog): 1.4 (#4049)

### DIFF
--- a/anda/tools/flashprog/flashprog.spec
+++ b/anda/tools/flashprog/flashprog.spec
@@ -4,7 +4,7 @@ flashprog is a utility for detecting, reading, writing, verifying and erasing fl
 It supports a wide range of flash chips (most commonly found in SOIC8, DIP8, SOIC16, WSON8, PLCC32, DIP32, TSOP32, and TSOP40 packages), which use various protocols such as LPC, FWH, parallel flash, or SPI.}
 
 Name:           flashprog
-Version:        1.3
+Version:        1.4
 Release:        1%{?dist}
 Summary:        Utility for detecting, reading, writing, verifying and erasing flash chips
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [bump(flashprog): 1.4 (#4049)](https://github.com/terrapkg/packages/pull/4049)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)