### PR TITLE
[el10] fix(ffmpeg): update script (#4044)

### DIFF
--- a/anda/multimedia/ffmpeg/update.rhai
+++ b/anda/multimedia/ffmpeg/update.rhai
@@ -8,7 +8,7 @@ if branch.starts_with("f") {
 }
 
 let ffmpeg_ver = get(`https://madoguchi.fyralabs.com/v4/terra${branch}/packages/x265`).json().ver;
-open_file("anda/fusion/ffmpeg/VERSION_x265.txt", "w").write(ffmpeg_ver);
+open_file("anda/multimedia/ffmpeg/VERSION_x265.txt", "w").write(ffmpeg_ver);
 
 let tesseract_ver = bump::bodhi("tesseract", bump::as_bodhi_ver(labels.branch));
-open_file("anda/fusion/ffmpeg/VERSION_tesseract.txt", "w").write(tesseract_ver);
+open_file("anda/multimedia/ffmpeg/VERSION_tesseract.txt", "w").write(tesseract_ver);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(ffmpeg): update script (#4044)](https://github.com/terrapkg/packages/pull/4044)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)