### PR TITLE
[f40] fix(komikku): Fetch correct archive URL (#4087)

### DIFF
--- a/anda/apps/komikku/komikku.spec
+++ b/anda/apps/komikku/komikku.spec
@@ -7,14 +7,14 @@
 Name:           komikku
 Version:        1.73.0
 %forgemeta
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A manga reader for GNOME
 
 BuildArch:      noarch
 
 License:        GPL-3.0-or-later
 URL:            https://valos.gitlab.io/Komikku
-Source0:        https://codeberg.org/valos/%{appname}/archive/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
+Source0:        https://codeberg.org/valos/%{appname}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  intltool


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f40`:
 - [fix(komikku): Fetch correct archive URL (#4087)](https://github.com/terrapkg/packages/pull/4087)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)