### PR TITLE
[f41] fix(uutils-coreutils-replace): Update patch (#4083)

### DIFF
--- a/anda/system/uutils-coreutils-replace/coreutils-fix-metadata.diff
+++ b/anda/system/uutils-coreutils-replace/coreutils-fix-metadata.diff
@@ -2,39 +2,52 @@
 +++ coreutils-*/Cargo.toml
 @@ -18,6 +18,7 @@
  categories = ["command-line-utilities"]
- rust-version = "1.79.0"
+ rust-version = "1.82.0"
  edition = "2021"
 +autobins = false
-
+ 
  build = "build.rs"
-
-@@ -325,7 +326,7 @@
- rand_core = "0.6.4"
+ 
+@@ -25,7 +26,11 @@
+ all-features = true
+ 
+ [features]
+-default = ["feat_common_core"]
++default = [
++  "feat_acl",
++  "feat_common_core",
++  "feat_selinux",
++]
+ ## OS feature shortcodes
+ macos = ["feat_os_macos"]
+ unix = ["feat_os_unix"]
+@@ -325,7 +330,7 @@
+ rand_core = "0.9.0"
  rayon = "1.10"
  regex = "1.10.4"
--rstest = "0.24.0"
-+rstest = ">=0.24"
+-rstest = "0.25.0"
++rstest = ">=0.25,<0.28"
  rust-ini = "0.21.0"
  same-file = "1.0.6"
  self_cell = "1.0.4"
-@@ -514,7 +515,7 @@
+@@ -516,7 +521,7 @@
  rstest = { workspace = true }
-
+ 
  [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
 -procfs = { version = "0.17", default-features = false }
-+procfs = { version = ">=0.16, <0.18", default-features = false }
-
++procfs = { version = ">=0.17, <0.18", default-features = false }
+ 
  [target.'cfg(unix)'.dev-dependencies]
  nix = { workspace = true, features = ["process", "signal", "user", "term"] }
-@@ -537,11 +538,6 @@
+@@ -538,11 +543,6 @@
  name = "coreutils"
  path = "src/bin/coreutils.rs"
--
+ 
 -[[bin]]
 -name = "uudoc"
 -path = "src/bin/uudoc.rs"
 -required-features = ["uudoc"]
-
+-
  # The default release profile. It contains all optimizations, without
  # sacrificing debug info. With this profile (like in the standard
  # release profile), the debug info and the stack traces will still be available.


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix(uutils-coreutils-replace): Update patch (#4083)](https://github.com/terrapkg/packages/pull/4083)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)