### PR TITLE
[f41] fix(peazip): Install desktop file, icons, and file manager integration (#4098)

### DIFF
--- a/anda/apps/peazip/peazip.spec
+++ b/anda/apps/peazip/peazip.spec
@@ -3,7 +3,7 @@
 
 Name:           peazip
 Version:        10.3.0
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Free Zip / Unzip software and Rar file extractor. Cross-platform file and archive manager
 License:        LGPL-3.0-only
 URL:            https://peazip.github.io
@@ -101,10 +101,19 @@ lazbuild --ws=qt6 dev/project_pea.lpi && cp dev/pea ../pea.qt6
 %install
 install -Dm755 peazip.* -t %buildroot%_bindir
 install -Dm755 pea.* -t %buildroot%_bindir
+install -Dm644 peazip-sources/res/share/batch/freedesktop_integration/peazip.desktop -t %{buildroot}%{_datadir}/applications
+install -Dm644 peazip-sources/res/share/batch/freedesktop_integration/*.png -t %{buildroot}%{_datadir}/pixmaps
+install -Dm644 peazip-sources/res/share/batch/freedesktop_integration/KDE-servicemenus/KDE6-dolphin/peazip-kde6.desktop -t %{buildroot}%{_datadir}/kio/servicemenus
+install -Dm644 peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/* -t %{buildroot}%{_datadir}/nautilus/scripts/PeaZip
 
 %files
 %doc README.md
 %license LICENSE SECURITY.md
+%{_datadir}/applications/peazip.desktop
+%{_datadir}/pixmaps/peazip*.png
+%{_datadir}/kio/servicemenus/peazip-kde6.desktop
+%dir %{_datadir}/nautilus/scripts/PeaZip
+%{_datadir}/nautilus/scripts/PeaZip/*
 
 %files -n pea
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix(peazip): Install desktop file, icons, and file manager integration (#4098)](https://github.com/terrapkg/packages/pull/4098)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)