### PR TITLE
[f42] fix um_commit (#4120)

### DIFF
--- a/anda/system/cros-keyboard-map/update.rhai
+++ b/anda/system/cros-keyboard-map/update.rhai
@@ -1,6 +1,6 @@
 if filters.contains("nightly") {
   rpm.global("tree_commit", gh_commit("WeirdTreeThing/cros-keyboard-map"));
-  rpm.global("commit", gh_commit("WeirdTreeThing/cros-keyboard-map"));
+  rpm.global("um_commit", gh_commit("Ultramarine-Linux/cros-keyboard-map"));
   if rpm.changed() {
     rpm.release();
     rpm.global("commit_date", date());


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix um_commit (#4120)](https://github.com/terrapkg/packages/pull/4120)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)