### PR TITLE
[f40] fix(gcm-core): missing version…?? (#4115)

### DIFF
--- a/anda/tools/gcm-core/gcm-core.spec
+++ b/anda/tools/gcm-core/gcm-core.spec
@@ -7,9 +7,10 @@
 
 Name:           gcm-core
 Version:        2.6.1
-%forgemeta
 Release:        1%?dist
 Summary:        Secure, cross-platform Git credential storage
+
+%forgemeta
 
 License:        MIT
 URL:            %{forgeurl}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(gcm-core): missing version…?? (#4115)](https://github.com/terrapkg/packages/pull/4115)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)