### PR TITLE
fix(extest): Remove redundant Mold linker argument

### DIFF
--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -16,12 +16,10 @@
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
-# Use Mold as the linker
-%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 Name:           extest
 Version:        %{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        X11 XTEST reimplementation primarily for Steam Controller on Wayland
 
 License:        MIT


### PR DESCRIPTION
This is set already (I believe by `anda-srpm-macros`?) and setting it twice via macro recursion was really confusing EL10 and breaking builds.