### PR TITLE
[frawhide] fix(open-huninn-fonts): Renamed license file (#4133)

### DIFF
--- a/anda/fonts/open-huninn/open-huninn-fonts.spec
+++ b/anda/fonts/open-huninn/open-huninn-fonts.spec
@@ -1,6 +1,6 @@
 Name:		open-huninn-fonts
 Version:	2.1
-Release:	1%?dist
+Release:	2%?dist
 URL:		https://github.com/justfont/open-huninn-font
 Source0:	%url/archive/refs/tags/v%version.tar.gz
 License:	OFL-1.1
@@ -23,7 +23,7 @@ install -Dm644 font/jf-openhuninn-%version.ttf %buildroot/%_datadir/fonts/open-h
 
 %files
 %doc README.md
-%license license.txt
+%license LICENSE
 /%{_datadir}/fonts/open-huninn/
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [fix(open-huninn-fonts): Renamed license file (#4133)](https://github.com/terrapkg/packages/pull/4133)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)