### PR TITLE
[frawhide] fix(extest): Remove Mold linker argument (#4136)

### DIFF
--- a/anda/misc/extest/rust-extest.spec
+++ b/anda/misc/extest/rust-extest.spec
@@ -16,12 +16,10 @@
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
-# Use Mold as the linker
-%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 Name:           extest
 Version:        %{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        X11 XTEST reimplementation primarily for Steam Controller on Wayland
 
 License:        MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [fix(extest): Remove Mold linker argument (#4136)](https://github.com/terrapkg/packages/pull/4136)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)