### PR TITLE
[el10] refactor(ivsc-firmware): Specify exclusive arch in anda.hcl (#4131)

### DIFF
--- a/anda/system/ivsc-firmware/anda.hcl
+++ b/anda/system/ivsc-firmware/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+    arches = ["x86_64"]
   rpm {
     spec = "ivsc-firmware.spec"
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [refactor(ivsc-firmware): Specify exclusive arch in anda.hcl (#4131)](https://github.com/terrapkg/packages/pull/4131)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)