### PR TITLE
[el10] feat: DKMS NVIDIA Package (#4137)

### DIFF
--- a/anda/system/nvidia/dkms-nvidia/anda.hcl
+++ b/anda/system/nvidia/dkms-nvidia/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "dkms-nvidia.spec"
+	}
+	labels {
+		subrepo = "nvidia"
+	}
+}

--- a/anda/system/nvidia/dkms-nvidia/dkms-nvidia.conf
+++ b/anda/system/nvidia/dkms-nvidia/dkms-nvidia.conf
@@ -1,0 +1,29 @@
+PACKAGE_NAME="nvidia"
+PACKAGE_VERSION="__VERSION_STRING"
+AUTOINSTALL="yes"
+
+. /etc/nvidia/kernel.conf
+
+# Quote make to avoid DKMS replacing it with "make -j$parallel_jobs KERNELRELEASE=$kernelver"
+CLEAN="'make' -j$(nproc) -C ${MODULE_VARIANT} clean"
+MAKE[0]="'make' -j$(nproc) -C ${MODULE_VARIANT} KERNEL_UNAME=${kernelver} modules"
+
+BUILT_MODULE_NAME[0]="nvidia"
+BUILT_MODULE_LOCATION[0]="${MODULE_VARIANT}"
+DEST_MODULE_LOCATION[0]="/extra"
+
+BUILT_MODULE_NAME[1]="nvidia-modeset"
+BUILT_MODULE_LOCATION[1]="${MODULE_VARIANT}"
+DEST_MODULE_LOCATION[1]="/extra"
+
+BUILT_MODULE_NAME[2]="nvidia-drm"
+BUILT_MODULE_LOCATION[2]="${MODULE_VARIANT}"
+DEST_MODULE_LOCATION[2]="/extra"
+
+BUILT_MODULE_NAME[3]="nvidia-uvm"
+BUILT_MODULE_LOCATION[3]="${MODULE_VARIANT}"
+DEST_MODULE_LOCATION[3]="/extra"
+
+BUILT_MODULE_NAME[4]="nvidia-peermem"
+BUILT_MODULE_LOCATION[4]="${MODULE_VARIANT}"
+DEST_MODULE_LOCATION[4]="/extra"

--- a/anda/system/nvidia/dkms-nvidia/dkms-nvidia.spec
+++ b/anda/system/nvidia/dkms-nvidia/dkms-nvidia.spec
@@ -1,0 +1,55 @@
+## NVIDIA DKMS package, based on the work of Negativo17 with tweaks for Terra.
+
+%global debug_package %{nil}
+%global modulename nvidia
+
+Name:           dkms-%{modulename}
+Version:        570.133.07
+Release:        1%{?dist}
+Summary:        NVIDIA display driver kernel module
+Epoch:          3
+License:        NVIDIA License
+URL:            https://www.nvidia.com/object/unix.html
+Source0:        https://download.nvidia.com/XFree86/Linux-%{_arch}/%{version}/NVIDIA-Linux-%{_arch}-%{version}.run
+Source1:        %{name}.conf
+BuildRequires:  sed
+Provides:       %{modulename}-kmod = %{?epoch:%{epoch}:}%{version}
+Requires:       %{modulename}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Requires:       dkms
+Conflicts:      akmod-nvidia
+# Unlike most DKMS packages, this package is NOT noarch!
+ExclusiveArch:  x86_64 aarch64
+
+%description
+This package provides the proprietary NVIDIA kernel driver modules.
+
+%prep
+sh %{SOURCE0} -x --target dkms-nvidia-%{version}-%{_arch}
+%setup -T -D -n dkms-nvidia-%{version}-%{_arch}
+
+cp -f %{SOURCE1} dkms.conf
+
+sed -i -e 's/__VERSION_STRING/%{version}/g' dkms.conf
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+cp -fr * %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+rm -f %{buildroot}%{_usrsrc}/%{modulename}-%{version}/*/dkms.conf
+
+%post
+dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{modulename} -v %{version} -q || :
+dkms install -m %{modulename} -v %{version} -q --force || :
+
+%preun
+# Remove all versions from DKMS registry:
+dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
+
+%files
+%{_usrsrc}/%{modulename}-%{version}
+
+%changelog
+%autochangelog

--- a/anda/system/nvidia/dkms-nvidia/modules.conf
+++ b/anda/system/nvidia/dkms-nvidia/modules.conf
@@ -1,0 +1,1 @@
+NO_WEAK_MODULES="yes"

--- a/anda/system/nvidia/dkms-nvidia/update.rhai
+++ b/anda/system/nvidia/dkms-nvidia/update.rhai
@@ -1,0 +1,3 @@
+import "andax/nvidia.rhai" as nvidia;
+
+rpm.version(nvidia::nvidia_driver_version());


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [feat: DKMS NVIDIA Package (#4137)](https://github.com/terrapkg/packages/pull/4137)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)