### PR TITLE
[frawhide] refactor(intel-ipu6-kmod): Specify exclusive arch in anda.hcl (#4132)

### DIFF
--- a/anda/system/intel-ipu6-kmod/anda.hcl
+++ b/anda/system/intel-ipu6-kmod/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+        arches = ["x86_64"]
     rpm {
         spec = "intel-ipu6-kmod.spec"
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [refactor(intel-ipu6-kmod): Specify exclusive arch in anda.hcl (#4132)](https://github.com/terrapkg/packages/pull/4132)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)