### PR TITLE
[el10] feat(v4l2loopback): Compatibility with Nobara and CachyOS COPR kernel (#4162)

### DIFF
--- a/anda/system/v4l2loopback/kmod-common/v4l2loopback.spec
+++ b/anda/system/v4l2loopback/kmod-common/v4l2loopback.spec
@@ -6,7 +6,7 @@
 Name:           v4l2loopback
 Summary:        Utils for V4L2 loopback devices
 Version:        0.14.0
-Release:        3%?dist
+Release:        4%?dist
 License:        GPL-2.0-or-later
 URL:            https://github.com/v4l2loopback/v4l2loopback
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
@@ -16,7 +16,7 @@ BuildRequires:  make
 BuildRequires:  help2man
 BuildRequires:  sed
 BuildRequires:  systemd-rpm-macros
-Requires:       (akmod-%{name} = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = %{?epoch:%{epoch}:}%{version})
+Requires:       (%{name}-kmod = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = %{?epoch:%{epoch}:}%{version})
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
 ### For compatibility with older names
 Provides:       %{name}-utils = %{version}-%{release}


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [feat(v4l2loopback): Compatibility with Nobara and CachyOS COPR kernel (#4162)](https://github.com/terrapkg/packages/pull/4162)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)