### PR TITLE
[f41] fix(komikku): Version format (#4188)

### DIFF
--- a/anda/apps/komikku/komikku.spec
+++ b/anda/apps/komikku/komikku.spec
@@ -3,18 +3,19 @@
 %global gtk4_version        4.14.4
 %global libadwaita_version  1.5.1
 %global pure_protobuf_version 2.0.0
+%global raw_ver v1.74.0
 
 Name:           komikku
-Version:        1.74.0
+Version:        %(echo %{raw_ver} | sed 's/v//g')
 %forgemeta
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A manga reader for GNOME
 
 BuildArch:      noarch
 
 License:        GPL-3.0-or-later
 URL:            https://valos.gitlab.io/Komikku
-Source0:        https://codeberg.org/valos/%{appname}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source0:        https://codeberg.org/valos/%{appname}/archive/%{raw_ver}.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  intltool

--- a/anda/apps/komikku/update.rhai
+++ b/anda/apps/komikku/update.rhai
@@ -1,3 +1,3 @@
 let latest_tag = get("https://codeberg.org/api/v1/repos/valos/Komikku/tags").json_arr()[0].name;
 let new_version = find("([\\.\\d]+)", latest_tag, 1);
-rpm.version(new_version);
+rpm.global("raw_ver", new_version);


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix(komikku): Version format (#4188)](https://github.com/terrapkg/packages/pull/4188)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)