### PR TITLE
[f41] fix(komikku): Explicitly list CMake as a build dep, fix update.rhai (#4193)

### DIFF
--- a/anda/apps/komikku/komikku.spec
+++ b/anda/apps/komikku/komikku.spec
@@ -3,12 +3,12 @@
 %global gtk4_version        4.14.4
 %global libadwaita_version  1.5.1
 %global pure_protobuf_version 2.0.0
-%global raw_ver 1.74.0
+%global raw_ver v1.74.0
 
 Name:           komikku
-Version:        %(echo %{raw_ver} | sed 's/v//g')
+Version:        1.74.0
 %forgemeta
-Release:        2%?dist
+Release:        3%?dist
 Summary:        A manga reader for GNOME
 
 BuildArch:      noarch
@@ -23,6 +23,7 @@ BuildRequires:  libappstream-glib
 BuildRequires:  meson >= 0.59.0
 BuildRequires:  python3-devel >= 3.8
 BuildRequires:  blueprint-compiler
+BuildRequires:  cmake
 
 BuildRequires:  pkgconfig(gobject-introspection-1.0) >= 1.35.9
 BuildRequires:  pkgconfig(gtk4) >= %{gtk4_version}

--- a/anda/apps/komikku/update.rhai
+++ b/anda/apps/komikku/update.rhai
@@ -1,3 +1,4 @@
 let latest_tag = get("https://codeberg.org/api/v1/repos/valos/Komikku/tags").json_arr()[0].name;
 let new_version = find("([\\.\\d]+)", latest_tag, 1);
-rpm.global("raw_ver", new_version);
+rpm.global("raw_ver", latest_tag);
+rpm.version(new_version);


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix(komikku): Explicitly list CMake as a build dep, fix update.rhai (#4193)](https://github.com/terrapkg/packages/pull/4193)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)