### PR TITLE
[f40] fix(lomiri-system-settings): Update patches (#4199)

### DIFF
--- a/anda/desktops/lomiri-unity/lomiri-system-settings/lomiri-system-settings.spec
+++ b/anda/desktops/lomiri-unity/lomiri-system-settings/lomiri-system-settings.spec
@@ -4,13 +4,12 @@
 
 Name:       lomiri-system-settings
 Version:    1.3.0
-Release:    1%?dist
+Release:    2%?dist
 Summary:    The system settings application for Lomiri
 License:    GPLv3
 URL:        https://gitlab.com/ubports/development/core/lomiri-system-settings
 Source0:    %{url}/-/archive/%commit/lomiri-system-settings-%commit.tar.gz
-Patch0:     https://sources.debian.org/data/main/l/lomiri-system-settings/1.0.1-2/debian/patches/1001_use-maliit-keyboard-for-language-plugin.patch
-Patch1:     https://sources.debian.org/data/main/l/lomiri-system-settings/1.0.1-2/debian/patches/2001_disable-current-language-switching.patch
+Patch0:     https://sources.debian.org/data/main/l/lomiri-system-settings/1.3.0-4/debian/patches/2011_build-without-trust-store.patch
 
 BuildRequires: cmake
 BuildRequires: gcc-c++


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f40`:
 - [fix(lomiri-system-settings): Update patches (#4199)](https://github.com/terrapkg/packages/pull/4199)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)