### PR TITLE
fix(ipu6-camera-bins): Setup and install steps

### DIFF
--- a/anda/lib/ipu6-camera-bins/anda.hcl
+++ b/anda/lib/ipu6-camera-bins/anda.hcl
@@ -4,6 +4,6 @@ project pkg {
     spec = "ipu6-camera-bins.spec"
   }
   labels {
-        weekly = 1
+        nightly = 1
     }
 }

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -63,7 +63,7 @@ install -Dm644 lib/pkgconfig/* -t %{buildroot}%{_libdir}/pkgconfig
 %{_libdir}/*.so.*
 
 %files devel
-%{_includedir}/ipu6
+%{_includedir}/ipu6*
 %{_libdir}/pkgconfig/*
 %{_libdir}/*.a
 %dnl %{_libdir}/*.so

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -23,9 +23,9 @@ Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
 %if 0%{?fedora}
 # Versioning scheme quirk
 %if 0%{?fedora} <= 43
-Obsoletes:      ivsc-firmware < 20250326.3377801-2
+Obsoletes:      ivsc-firmware < 20250326.3377801-3
 %endif
-Obsoletes:      ivsc-firmware < 0^20250326git.3377801-2
+Obsoletes:      ivsc-firmware < 0^20250326git.3377801-3
 %endif
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -21,11 +21,11 @@ Requires:       intel-vsc-firmware >= 20240513
 Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
 # < 6.10 is falling out of third party and official support on Fedora
 %if 0%{?fedora}
-Obsoletes:      ivsc-firmware < 0^20250326git.3377801-2
-%endif
 # Versioning scheme quirk
 %if 0%{?fedora} <= 43
 Obsoletes:      ivsc-firmware < 20250326.3377801-2
+%endif
+Obsoletes:      ivsc-firmware < 0^20250326git.3377801-2
 %endif
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
@@ -81,7 +81,6 @@ popd
 %{_libdir}/pkgconfig/*.pc
 %{_libdir}/*.a
 %{_libdir}/*.so
-
 
 %changelog
 %autochangelog

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -6,7 +6,7 @@
 
 Name:           ipu6-camera-bins
 Summary:        Binary libraries for Intel IPU6
-Version:        %{ver}^%{commitdate}git.%{shortcommit}
+Version:        %{ver}^%{commit_date}git.%{shortcommit}
 Release:        1%?dist
 License:        Proprietary
 URL:            https://github.com/intel/ipu6-camera-bins
@@ -22,7 +22,7 @@ Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes
 %if %{?fedora} <= 42 || %{?rhel} <= 10
-Provides:       %{name} = %{commitdate}.%{shortcommit}
+Provides:       %{name} = %{commit_date}.%{shortcommit}
 %endif
 ExclusiveArch:  x86_64
 Packager:       Gilver E. <rockgrub@disroot.org>

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -1,25 +1,31 @@
 %global debug_package %{nil}
 %global commit 3c1cdd3e634bb4668a900d75efd4d6292b8c7d1d
-%global commitdate 20240507
+%global commit_date 20240507
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global ver 1.0.1
 
 Name:           ipu6-camera-bins
 Summary:        Binary libraries for Intel IPU6
-Version:        %{commitdate}.%{shortcommit}
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
 Release:        1%?dist
 License:        Proprietary
 URL:            https://github.com/intel/ipu6-camera-bins
-Source0:        https://github.com/intel/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
+Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  chrpath
-#Requires:       gstreamer1-plugin-icamerasrc
+Requires:       gstreamer1-plugin-icamerasrc
 Requires:       v4l2-relayd
 Requires:       intel-ipu6-kmod
 Requires:       intel-vsc-firmware >= 20240513
 Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
+# Fix the stupid issue when changing versioning schemes
+%if %{?fedora} <= 42 || %{?rhel} <= 10
+Provides:       %{name} = %{commitdate}.%{shortcommit}
+%endif
 ExclusiveArch:  x86_64
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 Provides binaries for Intel IPU6, including libraries and firmware.
@@ -45,20 +51,22 @@ sed -i \
 mkdir -p %{buildroot}%{_includedir}/
 mkdir -p %{buildroot}%{_libdir}/
 cp -pr include/* %{buildroot}%{_includedir}/
-cp -pr lib/lib* lib/pkgconfig %{buildroot}%{_libdir}/
-chmod 755 %{buildroot}%{_libdir}/$target/*.so*
+install -Dm755 lib/*.so* -t %{buildroot}%{_libdir}
+install -Dm644 lib/*.a -t %{buildroot}%{_libdir}
+install -Dm644 lib/pkgconfig/* -t %{buildroot}%{_libdir}/pkgconfig
 
 
 %files
 %license LICENSE
-%doc README.md SECURITY.md
-%{_libdir}/*.so*
+%doc README.md 
+%doc SECURITY.md
+%{_libdir}/*.so.*
 
 %files devel
-%{_includedir}/*
+%{_includedir}/ia_*
 %{_libdir}/pkgconfig/*
 %{_libdir}/*.a
-%{_libdir}/*.so*
+%dnl %{_libdir}/*.so
 
 
 %changelog

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -21,7 +21,7 @@ Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes
-%if %{?fedora} <= 42 || %{?rhel} <= 10
+%if 0%{?fedora} <= 42 || 0%{?rhel} <= 10
 Provides:       %{name} = %{commit_date}.%{shortcommit}
 %endif
 ExclusiveArch:  x86_64

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -42,7 +42,6 @@ Provides binary libraries for Intel IPU6.
 %package devel
 Summary:        IPU6 development files
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-BuildArch:      noarch
 
 %description devel
 This provides the header files for IPU6 development.

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -5,7 +5,7 @@
 %global ver 1.0.1
 
 Name:           ipu6-camera-bins
-Summary:        Binary libraries for Intel IPU6
+Summary:        Libraries for Intel IPU6
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
 Release:        1%?dist
 License:        Proprietary
@@ -37,7 +37,7 @@ ExclusiveArch:  x86_64
 Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
-Provides binaries for Intel IPU6, including libraries and firmware.
+Provides binary libraries for Intel IPU6..
 
 %package devel
 Summary:        IPU6 development files

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -18,6 +18,7 @@ Requires:       v4l2-relayd
 Requires:       intel-ipu6-kmod
 Requires:       intel-vsc-firmware >= 20240513
 Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
+Obsoletes:      ivsc-firmware < 0^20250326git.3377801-2
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes
@@ -30,31 +31,37 @@ Packager:       Gilver E. <rockgrub@disroot.org>
 %description
 Provides binaries for Intel IPU6, including libraries and firmware.
 
-
 %package devel
 Summary:        IPU6 development files
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+BuildArch:      noarch
 
 %description devel
 This provides the header files for IPU6 development.
 
 %prep
-%setup -q -n %{name}-%{commit}
-chrpath --delete lib/*.so.*
-sed -i \
-    -e "s|libdir=\${exec_prefix}/lib|libdir=\${prefix}/%{_lib}|g" \
-    lib/pkgconfig/*.pc
+%autosetup -n %{name}-%{commit}
+chrpath --delete lib/*.so.0
+chmod +x lib/*.so.0
+# The firmware is part of linux-firmware!
+rm -r lib/firmware
 
 %build
 
 %install
 mkdir -p %{buildroot}%{_includedir}/
-mkdir -p %{buildroot}%{_libdir}/
 cp -pr include/* %{buildroot}%{_includedir}/
 install -Dm755 lib/*.so* -t %{buildroot}%{_libdir}
 install -Dm644 lib/*.a -t %{buildroot}%{_libdir}
+pushd %{buildroot}%{_libdir}
+  for i in *.so.0; do
+    ln -s $i `echo $i | sed -e "s|\.so\.0|\.so|"`
+  done
+  for i in pkgconfig/*.pc; do
+    sed -i -e "s|libdir=\${prefix}/lib|libdir=%{_libdir}|g" "$i"
+  done
+popd
 install -Dm644 lib/pkgconfig/* -t %{buildroot}%{_libdir}/pkgconfig
-
 
 %files
 %license LICENSE
@@ -64,9 +71,9 @@ install -Dm644 lib/pkgconfig/* -t %{buildroot}%{_libdir}/pkgconfig
 
 %files devel
 %{_includedir}/ipu6*
-%{_libdir}/pkgconfig/*
+%{_libdir}/pkgconfig/*.pc
 %{_libdir}/*.a
-%dnl %{_libdir}/*.so
+%{_libdir}/*.so
 
 
 %changelog

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -22,7 +22,7 @@ Obsoletes:      ivsc-firmware < 0^20250326git.3377801-2
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes
-%if 0%{?fedora} <= 42 || 0%{?rhel} <= 10
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Provides:       %{name} = %{commit_date}.%{shortcommit}
 %endif
 ExclusiveArch:  x86_64

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -29,7 +29,7 @@ Obsoletes:      ivsc-firmware < 20250326.3377801-2
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes
-%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+%if 0%{?fedora} <= 43
 Provides:       %{name} = %{commit_date}.%{shortcommit}
 %endif
 ExclusiveArch:  x86_64

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -13,6 +13,7 @@ URL:            https://github.com/intel/ipu6-camera-bins
 Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  chrpath
+BuildRequires:  sed
 Requires:       gstreamer1-plugin-icamerasrc
 Requires:       v4l2-relayd
 Requires:       intel-ipu6-kmod

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -22,6 +22,10 @@ Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
 %if 0%{?fedora}
 Obsoletes:      ivsc-firmware < 0^20250326git.3377801-2
 %endif
+# Versioning scheme quirk
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Obsoletes:      ivsc-firmware < 20250326.3377801-2
+%endif
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes
@@ -56,6 +60,7 @@ mkdir -p %{buildroot}%{_includedir}/
 cp -pr include/* %{buildroot}%{_includedir}/
 install -Dm755 lib/*.so* -t %{buildroot}%{_libdir}
 install -Dm644 lib/*.a -t %{buildroot}%{_libdir}
+install -Dm644 lib/pkgconfig/* -t %{buildroot}%{_libdir}/pkgconfig
 pushd %{buildroot}%{_libdir}
   for i in *.so.0; do
     ln -s $i `echo $i | sed -e "s|\.so\.0|\.so|"`
@@ -64,7 +69,6 @@ pushd %{buildroot}%{_libdir}
     sed -i -e "s|libdir=\${prefix}/lib|libdir=%{_libdir}|g" "$i"
   done
 popd
-install -Dm644 lib/pkgconfig/* -t %{buildroot}%{_libdir}/pkgconfig
 
 %files
 %license LICENSE

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -37,7 +37,7 @@ ExclusiveArch:  x86_64
 Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
-Provides binary libraries for Intel IPU6..
+Provides binary libraries for Intel IPU6.
 
 %package devel
 Summary:        IPU6 development files

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -18,7 +18,10 @@ Requires:       v4l2-relayd
 Requires:       intel-ipu6-kmod
 Requires:       intel-vsc-firmware >= 20240513
 Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
+# < 6.10 is falling out of third party and official support on Fedora
+%if 0%{?fedora}
 Obsoletes:      ivsc-firmware < 0^20250326git.3377801-2
+%endif
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -23,13 +23,13 @@ Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
 Obsoletes:      ivsc-firmware < 0^20250326git.3377801-2
 %endif
 # Versioning scheme quirk
-%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+%if 0%{?fedora} <= 43
 Obsoletes:      ivsc-firmware < 20250326.3377801-2
 %endif
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes
-%if 0%{?fedora} <= 43
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Provides:       %{name} = %{commit_date}.%{shortcommit}
 %endif
 ExclusiveArch:  x86_64

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -63,7 +63,7 @@ install -Dm644 lib/pkgconfig/* -t %{buildroot}%{_libdir}/pkgconfig
 %{_libdir}/*.so.*
 
 %files devel
-%{_includedir}/ia_*
+%{_includedir}/ipu6
 %{_libdir}/pkgconfig/*
 %{_libdir}/*.a
 %dnl %{_libdir}/*.so

--- a/anda/lib/ipu6-camera-bins/update.rhai
+++ b/anda/lib/ipu6-camera-bins/update.rhai
@@ -2,4 +2,8 @@ rpm.global("commit", gh_commit("intel/ipu6-camera-bins"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commit_date", date());
+    let v = gh("intel/ipu6-camera-bins");
+    v.truncate(6);
+    v.crop(1);
+    rpm.global("ver", v);
 }


### PR DESCRIPTION
Also added back `gstreamer1-plugin-icamerasrc` as a dep since Fusion did but prepared to chuck it again whenever they inevitably bump soname again.