### PR TITLE
[frawhide] fix(ivsc-firmware): Macro and date (#4212)

### DIFF
--- a/anda/system/ivsc-firmware/anda.hcl
+++ b/anda/system/ivsc-firmware/anda.hcl
@@ -3,7 +3,4 @@ project pkg {
   rpm {
     spec = "ivsc-firmware.spec"
   }
-  labels {
-        weekly = 1
-    }
 }

--- a/anda/system/ivsc-firmware/ivsc-firmware.spec
+++ b/anda/system/ivsc-firmware/ivsc-firmware.spec
@@ -1,16 +1,20 @@
 %global debug_package %{nil}
 %global commit 3377801f46b86e03c464bfb03ca3c486e9b0db00
-%global commitdate 20230811
+%global commit_date 20250326
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           ivsc-firmware
 Summary:        Intel iVSC firmware
 URL:            https://github.com/intel/ivsc-firmware
-Version:        %{commitdate}.%{shortcommit}
+Version:        0^%{commit_date}git.%{shortcommit}
 Release:        1%?dist
 License:        Proprietary
 Source0:        https://github.com/intel/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 Requires:       ipu6-camera-bins
+# Fix the stupid issue when changing versioning schemes
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Provides:       %{name} = %{commit_date}.%{shortcommit}
+%endif
 ExclusiveArch:  x86_64
 
 %description

--- a/anda/system/ivsc-firmware/update.rhai
+++ b/anda/system/ivsc-firmware/update.rhai
@@ -1,5 +1,0 @@
-rpm.global("commit", gh_commit("intel/ivsc-firmware"));
-if rpm.changed() {
-    rpm.release();
-    rpm.global("commit_date", date());
-}


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [fix(ivsc-firmware): Macro and date (#4212)](https://github.com/terrapkg/packages/pull/4212)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)