### PR TITLE
[frawhide] fix(ipu6-camera-bins): Setup and install steps (#4217)

### DIFF
--- a/anda/lib/ipu6-camera-bins/anda.hcl
+++ b/anda/lib/ipu6-camera-bins/anda.hcl
@@ -4,6 +4,6 @@ project pkg {
     spec = "ipu6-camera-bins.spec"
   }
   labels {
-        weekly = 1
+        nightly = 1
     }
 }

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -1,29 +1,43 @@
 %global debug_package %{nil}
 %global commit 3c1cdd3e634bb4668a900d75efd4d6292b8c7d1d
-%global commitdate 20240507
+%global commit_date 20240507
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global ver 1.0.1
 
 Name:           ipu6-camera-bins
-Summary:        Binary libraries for Intel IPU6
-Version:        %{commitdate}.%{shortcommit}
+Summary:        Libraries for Intel IPU6
+Version:        %{ver}^%{commit_date}git.%{shortcommit}
 Release:        1%?dist
 License:        Proprietary
 URL:            https://github.com/intel/ipu6-camera-bins
-Source0:        https://github.com/intel/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
+Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  chrpath
-#Requires:       gstreamer1-plugin-icamerasrc
+BuildRequires:  sed
+Requires:       gstreamer1-plugin-icamerasrc
 Requires:       v4l2-relayd
 Requires:       intel-ipu6-kmod
 Requires:       intel-vsc-firmware >= 20240513
 Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
+# < 6.10 is falling out of third party and official support on Fedora
+%if 0%{?fedora}
+# Versioning scheme quirk
+%if 0%{?fedora} <= 43
+Obsoletes:      ivsc-firmware < 20250326.3377801-3
+%endif
+Obsoletes:      ivsc-firmware < 0^20250326git.3377801-3
+%endif
 ### For Akmods package
 Provides:       intel-ipu6-kmod-common = %{version}
+# Fix the stupid issue when changing versioning schemes
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Provides:       %{name} = %{commit_date}.%{shortcommit}
+%endif
 ExclusiveArch:  x86_64
+Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
-Provides binaries for Intel IPU6, including libraries and firmware.
-
+Provides binary libraries for Intel IPU6.
 
 %package devel
 Summary:        IPU6 development files
@@ -33,33 +47,40 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 This provides the header files for IPU6 development.
 
 %prep
-%setup -q -n %{name}-%{commit}
-chrpath --delete lib/*.so.*
-sed -i \
-    -e "s|libdir=\${exec_prefix}/lib|libdir=\${prefix}/%{_lib}|g" \
-    lib/pkgconfig/*.pc
+%autosetup -n %{name}-%{commit}
+chrpath --delete lib/*.so.0
+chmod +x lib/*.so.0
+# The firmware is part of linux-firmware!
+rm -r lib/firmware
 
 %build
 
 %install
 mkdir -p %{buildroot}%{_includedir}/
-mkdir -p %{buildroot}%{_libdir}/
 cp -pr include/* %{buildroot}%{_includedir}/
-cp -pr lib/lib* lib/pkgconfig %{buildroot}%{_libdir}/
-chmod 755 %{buildroot}%{_libdir}/$target/*.so*
-
+install -Dm755 lib/*.so* -t %{buildroot}%{_libdir}
+install -Dm644 lib/*.a -t %{buildroot}%{_libdir}
+install -Dm644 lib/pkgconfig/* -t %{buildroot}%{_libdir}/pkgconfig
+pushd %{buildroot}%{_libdir}
+  for i in *.so.0; do
+    ln -s $i `echo $i | sed -e "s|\.so\.0|\.so|"`
+  done
+  for i in pkgconfig/*.pc; do
+    sed -i -e "s|libdir=\${prefix}/lib|libdir=%{_libdir}|g" "$i"
+  done
+popd
 
 %files
 %license LICENSE
-%doc README.md SECURITY.md
-%{_libdir}/*.so*
+%doc README.md 
+%doc SECURITY.md
+%{_libdir}/*.so.*
 
 %files devel
-%{_includedir}/*
-%{_libdir}/pkgconfig/*
+%{_includedir}/ipu6*
+%{_libdir}/pkgconfig/*.pc
 %{_libdir}/*.a
-%{_libdir}/*.so*
-
+%{_libdir}/*.so
 
 %changelog
 %autochangelog

--- a/anda/lib/ipu6-camera-bins/update.rhai
+++ b/anda/lib/ipu6-camera-bins/update.rhai
@@ -2,4 +2,8 @@ rpm.global("commit", gh_commit("intel/ipu6-camera-bins"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commit_date", date());
+    let v = gh("intel/ipu6-camera-bins");
+    v.truncate(6);
+    v.crop(1);
+    rpm.global("ver", v);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [fix(ipu6-camera-bins): Setup and install steps (#4217)](https://github.com/terrapkg/packages/pull/4217)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)