### PR TITLE
[f42] Fix: cbfstool (#4231)

### DIFF
--- a/anda/tools/cbfstool/cbfstool.spec
+++ b/anda/tools/cbfstool/cbfstool.spec
@@ -4,7 +4,10 @@ Release:        1%?dist
 Summary:        Management utility for CBFS formatted ROM images
 URL:            https://doc.coreboot.org/lib/fw_config.html#cbfs
 License:        GPLv2
-BuildRequires:  gcc g++ gcc-gnat make cmake ncurses-devel iasl git
+BuildRequires:  gcc g++ gcc-gnat make cmake ncurses-devel iasl anda-srpm-macros
+%if 0%{?fedora} >= 42
+BuildRequires: gcc14 gcc14-c++
+%endif
 Requires:       glibc
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
@@ -12,17 +15,23 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 Management utility for CBFS formatted ROM images.
 
 %prep
-git clone https://review.coreboot.org/coreboot.git -b %version
+%git_clone https://review.coreboot.org/coreboot.git
 
 %build
-make -C coreboot/util/cbfstool
+%if 0%{?fedora} >= 42
+export CC=gcc-14
+export CXX=g++-14
+%endif
+%make_build -C util/cbfstool
 
 %install
-install -Dm 777 coreboot/util/cbfstool/cbfstool %buildroot%_bindir/cbfstool
+install -Dm 777 util/cbfstool/cbfstool %buildroot%_bindir/cbfstool
 
 %files
 /usr/bin/cbfstool
 
 %changelog
+* Wed Apr 02 2025 Owen Zimmerman <owen@fyralabs.com>
+- Add macros and specify fedora version release exports
 * Sun Aug 25 2024 Owen Zimmerman <owen@fyralabs.com>
 - Initial Package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Fix: cbfstool (#4231)](https://github.com/terrapkg/packages/pull/4231)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)