### PR TITLE
[f41] bump: electron (#4230)

### DIFF
--- a/anda/tools/electron/electron.spec
+++ b/anda/tools/electron/electron.spec
@@ -12,7 +12,7 @@
 %global __provides_exclude_from %{_libdir}/%{name}/.*\\.so
 
 Name:			electron
-Version:		35.0.1
+Version:		35.1.3
 Release:		1%?dist
 Summary:		Build cross platform desktop apps with web technologies
 License:		MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [bump: electron (#4230)](https://github.com/terrapkg/packages/pull/4230)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)