### PR TITLE
[f42] fix(ipu6-camera-bins): Sed command (#4228)

### DIFF
--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -7,17 +7,17 @@
 Name:           ipu6-camera-bins
 Summary:        Libraries for Intel IPU6
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 License:        Proprietary
 URL:            https://github.com/intel/ipu6-camera-bins
 Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
-BuildRequires:  systemd-rpm-macros
 BuildRequires:  chrpath
 BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
 Requires:       gstreamer1-plugin-icamerasrc
-Requires:       v4l2-relayd
 Requires:       intel-ipu6-kmod
 Requires:       intel-vsc-firmware >= 20240513
+Requires:       v4l2-relayd
 Obsoletes:      ipu6-camera-bins-firmware < 0.0-11
 # < 6.10 is falling out of third party and official support on Fedora
 %if 0%{?fedora}
@@ -66,7 +66,7 @@ pushd %{buildroot}%{_libdir}
     ln -s $i `echo $i | sed -e "s|\.so\.0|\.so|"`
   done
   for i in pkgconfig/*.pc; do
-    sed -i -e "s|libdir=\${prefix}/lib|libdir=%{_libdir}|g" "$i"
+    sed -i -e "s|libdir=\${exec_prefix}/lib|libdir=%{_libdir}|g" "$i"
   done
 popd
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(ipu6-camera-bins): Sed command (#4228)](https://github.com/terrapkg/packages/pull/4228)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)