### PR TITLE
[f40] fix(lomiri-ui-toolkit): Update patches and Python subpackage build/install steps (#4229)

### DIFF
--- a/anda/desktops/lomiri-unity/lomiri-ui-toolkit/lomiri-ui-toolkit.spec
+++ b/anda/desktops/lomiri-unity/lomiri-ui-toolkit/lomiri-ui-toolkit.spec
@@ -10,8 +10,7 @@ Summary:        QML components to ease the creation of beautiful applications in
 License:        LGPL-3.0
 URL:            https://gitlab.com/ubports/development/core/lomiri-ui-toolkit
 Source0:        %{url}/-/archive/%commit/lomiri-ui-toolkit-%commit.tar.gz
-Patch0:         https://sources.debian.org/data/main/l/lomiri-ui-toolkit/1.3.5010%2Bdfsg-1/debian/patches/0002-fix-tests-on-qt-5.15.5.patch
-Patch1:         https://sources.debian.org/data/main/l/lomiri-ui-toolkit/1.3.5010%2Bdfsg-1/debian/patches/2003_stop-using-Ubuntu-fonts.patch
+Patch0:         https://sources.debian.org/data/main/l/lomiri-ui-toolkit/1.3.5110+dfsg-2/debian/patches/2003_stop-using-Ubuntu-fonts.patch
 
 BuildRequires: pkgconfig
 BuildRequires: make
@@ -31,9 +30,11 @@ BuildRequires: qt5-qtfeedback
 BuildRequires: qt5-qtsystems-devel
 BuildRequires: qt5-qtdeclarative-devel
 BuildRequires: qt5-pim-devel
+BuildRequires: python3-devel
 BuildRequires: python3-rpm-macros
 BuildRequires: qt5-qtsvg-devel
 BuildRequires: fdupes
+BuildRequires: python3dist(setuptools)
 Requires:      qt5-qtgraphicaleffects
 Requires:      qt5-qtfeedback
 
@@ -82,7 +83,9 @@ Examples for Lomiri-ui-toolkit.
 
 %build
 %{qmake_qt5} 'CONFIG+=ubuntu-uitk-compat' 'CONFIG+=test'
-
+pushd tests/autopilot
+%py3_build
+popd
 %make_build
 
 %install
@@ -91,6 +94,11 @@ Examples for Lomiri-ui-toolkit.
 rm -rf %{buildroot}%{_qt5_qmldir}/Extinct
 %fdupes %buildroot%_libdir/qt5/qml/Lomiri/Components/
 %fdupes %buildroot%_libdir/qt5/examples/%name/examples/
+
+pushd tests/autopilot
+%py3_install
+mv lomiriuitoolkit/{tests,_custom_proxy_objects} %{buildroot}%{python3_sitelib}/lomiriuitoolkit/
+popd
 
 %find_lang %{name}
 %find_lang %{name}-gallery
@@ -135,6 +143,8 @@ rm -rf %{buildroot}%{_qt5_qmldir}/Extinct
 %doc README.md
 %dir %{python3_sitelib}/lomiriuitoolkit
 %{python3_sitelib}/lomiriuitoolkit/*.py
+%dir %{python3_sitelib}/lomiriuitoolkit-%{version}-py%{python3_version}.egg-info
+%{python3_sitelib}/lomiriuitoolkit-%{version}-py%{python3_version}.egg-info/*
 %{python3_sitelib}/lomiriuitoolkit/_custom_proxy_objects/
 %{python3_sitelib}/lomiriuitoolkit/__pycache__/
 %{python3_sitelib}/lomiriuitoolkit/tests/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(lomiri-ui-toolkit): Update patches and Python subpackage build/install steps (#4229)](https://github.com/terrapkg/packages/pull/4229)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)