### PR TITLE
[f41] fix(ipu6-camera-bins): Version provides for devel (#4260)

### DIFF
--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -7,7 +7,7 @@
 Name:           ipu6-camera-bins
 Summary:        Libraries for Intel IPU6
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%?dist
 License:        Proprietary
 URL:            https://github.com/intel/ipu6-camera-bins
 Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
@@ -42,6 +42,9 @@ Provides binary libraries for Intel IPU6.
 %package devel
 Summary:        IPU6 development files
 Requires:       %{name}%{?_isa} = %{version}-%{release}
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Provides:       %{name}-devel = %{commit_date}.%{shortcommit}
+%endif
 
 %description devel
 This provides the header files for IPU6 development.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(ipu6-camera-bins): Version provides for devel (#4260)](https://github.com/terrapkg/packages/pull/4260)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)