### PR TITLE
[el10] fix?(ipu6*, ivsc*): Add an epoch (#4264)

### DIFF
--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -1,13 +1,16 @@
 %global debug_package %{nil}
 %global commit 3c1cdd3e634bb4668a900d75efd4d6292b8c7d1d
-%global commit_date 20240507
+%global commit_date 20241127
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 1.0.1
 
 Name:           ipu6-camera-bins
 Summary:        Libraries for Intel IPU6
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        3%?dist
+Release:        1%?dist
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          1
+%endif
 License:        Proprietary
 URL:            https://github.com/intel/ipu6-camera-bins
 Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
@@ -31,7 +34,8 @@ Obsoletes:      ivsc-firmware < 0^20250326git.3377801-3
 Provides:       intel-ipu6-kmod-common = %{version}
 # Fix the stupid issue when changing versioning schemes
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
-Provides:       %{name} = %{commit_date}.%{shortcommit}
+Provides:       %{name} = %{?epoch:%{epoch}:}%{commit_date}.%{shortcommit}-%{release}
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}%{commit_date}.%{shortcommit}-2
 %endif
 ExclusiveArch:  x86_64
 Packager:       Gilver E. <rockgrub@disroot.org>
@@ -43,7 +47,8 @@ Provides binary libraries for Intel IPU6.
 Summary:        IPU6 development files
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
-Provides:       %{name}-devel = %{commit_date}.%{shortcommit}
+Provides:       %{name}-devel = %{?epoch:%{epoch}:}%{commit_date}.%{shortcommit}-%{release}
+Obsoletes:      %{name}-devel < %{?epoch:%{epoch}:}%{commit_date}.%{shortcommit}-2
 %endif
 
 %description devel

--- a/anda/system/ivsc-firmware/ivsc-firmware.spec
+++ b/anda/system/ivsc-firmware/ivsc-firmware.spec
@@ -7,13 +7,17 @@ Name:           ivsc-firmware
 Summary:        Intel iVSC firmware
 URL:            https://github.com/intel/ivsc-firmware
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%?dist
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          1
+%endif
 License:        Proprietary
 Source0:        https://github.com/intel/%{name}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 Requires:       ipu6-camera-bins
 # Fix the stupid issue when changing versioning schemes
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
-Provides:       %{name} = %{commit_date}.%{shortcommit}
+Provides:       %{name} = %{?epoch:%{epoch}:}%{commit_date}.%{shortcommit}-%{release}
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}20230811.74a01d1-2
 %endif
 ExclusiveArch:  x86_64
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix?(ipu6*, ivsc*): Add an epoch (#4264)](https://github.com/terrapkg/packages/pull/4264)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)