### PR TITLE
[f42] bump: envision (#4281)

### DIFF
--- a/anda/apps/envision/envision.spec
+++ b/anda/apps/envision/envision.spec
@@ -1,4 +1,4 @@
-%global commit 2f5ec57a0a95bdf889094d459a4a3fcb4de2dd97
+%global commit 7a02fcc5d109d2d06bb115f93811424bd88343aa
 %global commit_date 20250408
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [bump: envision (#4281)](https://github.com/terrapkg/packages/pull/4281)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)