### PR TITLE
[f42] fix(prismlauncher): use mock (#4285)

### DIFF
--- a/anda/games/prismlauncher-nightly/anda.hcl
+++ b/anda/games/prismlauncher-nightly/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
 	}
 	labels {
 		nightly = "1"
+		mock = 1
 	}
 }

--- a/anda/games/prismlauncher/anda.hcl
+++ b/anda/games/prismlauncher/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
 		spec = "prismlauncher.spec"
         extra_repos = ["https://packages.adoptium.net/artifactory/rpm/fedora/\\$releasever/\\$basearch"]
 	}
+	labels {
+		mock = 1
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(prismlauncher): use mock (#4285)](https://github.com/terrapkg/packages/pull/4285)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)