### PR TITLE
[f42] Fix: abuild macro (#4286)

### DIFF
--- a/anda/tools/abuild/abuild.spec
+++ b/anda/tools/abuild/abuild.spec
@@ -4,7 +4,7 @@ Release:        1%?dist
 Summary:        coreboot autobuild script builds coreboot images for all available targets.
 URL:            https://doc.coreboot.org/util/abuild/index.html
 License:        GPLv2
-BuildRequires:  git
+BuildRequires:  anda-srpm-macros
 BuildArch:      noarch
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
@@ -12,10 +12,10 @@ Packager:	    Owen Zimmerman <owen@fyralabs.com>
 %summary 
 
 %prep
-git clone https://review.coreboot.org/coreboot.git -b %version
+%git_clone https://review.coreboot.org/coreboot.git %version
 
 %install
-install -Dm 777 coreboot/util/abuild/abuild %buildroot%_bindir/abuild
+install -Dm 777 util/abuild/abuild %buildroot%_bindir/abuild
 
 %files
 /usr/bin/abuild


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Fix: abuild macro (#4286)](https://github.com/terrapkg/packages/pull/4286)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)