### PR TITLE
[el10] add: readymade (#4295)

### DIFF
--- a/anda/system/readymade/anda.hcl
+++ b/anda/system/readymade/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+	spec = "readymade.spec"
+  }
+}

--- a/anda/system/readymade/readymade.spec
+++ b/anda/system/readymade/readymade.spec
@@ -1,0 +1,56 @@
+Name:           readymade
+Version:        0.11.2
+Release:        1%?dist
+Summary:        Install ready-made distribution images!
+License:        MIT
+URL:            https://github.com/FyraLabs/readymade
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires:	anda-srpm-macros rust-packaging mold
+BuildRequires:  pkgconfig(libhelium-1)
+BuildRequires:  pkgconfig(gnome-desktop-4)
+BuildRequires:  clang-devel
+BuildRequires:  cmake
+
+Requires:  efibootmgr
+
+%description
+Readymade is a simple Linux Distribution installer.
+
+It is created as a replacement to Red Hat's Anaconda installer.
+
+
+%package config-ultramarine
+Summary:        Readymade Configuration for Ultramarine Linux
+License:        MIT
+Requires:       readymade
+Provides:       readymade-config
+
+%description config-ultramarine
+This package contains the configuration files for Readymade to install Ultramarine Linux.
+
+
+%prep
+%autosetup
+%cargo_prep_online
+
+%build
+
+%install
+%cargo_install
+./install.sh %buildroot
+ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_datadir}/applications/liveinst.desktop
+
+%find_lang com.fyralabs.Readymade
+
+%files config-ultramarine
+%_sysconfdir/readymade.toml
+
+
+%files -f com.fyralabs.Readymade.lang
+%_bindir/readymade
+%_datadir/polkit-1/actions/com.fyralabs.pkexec.readymade.policy
+%_datadir/applications/com.fyralabs.Readymade.desktop
+%_datadir/applications/liveinst.desktop
+%_datadir/readymade
+%_datadir/icons/hicolor/scalable/apps/com.fyralabs.Readymade.svg
+

--- a/anda/system/readymade/update.rhai
+++ b/anda/system/readymade/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("FyraLabs/readymade"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: readymade (#4295)](https://github.com/terrapkg/packages/pull/4295)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)