### PR TITLE
[f41] fix(xpadneo): Hardcode obsolete version (#4310)

### DIFF
--- a/anda/system/xpadneo/kmod-common/xpadneo.spec
+++ b/anda/system/xpadneo/kmod-common/xpadneo.spec
@@ -5,7 +5,7 @@
 
 Name:           xpadneo
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad common files
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/%{name}
@@ -15,7 +15,7 @@ BuildRequires:  sed
 BuildRequires:  systemd-rpm-macros
 Requires:       (akmod-%{name} = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = %{?epoch:%{epoch}:}%{version})
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
-Obsoletes:      %{name}-kmod-common < %{?epoch:%{epoch}:}%{version}-3%{?dist}
+Obsoletes:      %{name}-kmod-common < %{?epoch:%{epoch}:}0.9.7^20241224git.8d20a23-4%{?dist}
 BuildArch:      noarch
 Packager:       Gilver E. <rockgrub@disroot.org>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(xpadneo): Hardcode obsolete version (#4310)](https://github.com/terrapkg/packages/pull/4310)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)