### PR TITLE
[f42] fix(gnome-shell): rename back without .switcheroo tag suffix (#4317)

### DIFF
--- a/anda/desktops/gnome/gnome-shell/gnome-shell.spec
+++ b/anda/desktops/gnome/gnome-shell/gnome-shell.spec
@@ -8,12 +8,14 @@
 %global portal_helper 1
 %endif
 
-Name:           gnome-shell.switcheroo
+Name:           gnome-shell
 Version:        %{major_version}.%{minor_version}
-Release:        1%{?dist}.switcheroo
+Release:        2%{?dist}.switcheroo
 Summary:        Window management and application launching for GNOME
 
 Provides:       gnome-shell = %version-%release
+Provides:       gnome-shell.switcheroo = %version-%release
+Obsoletes:      gnome-shell.switcheroo <= 47.3-2
 License:        GPL-2.0-or-later
 URL:            https://wiki.gnome.org/Projects/GnomeShell
 Source0:        https://download.gnome.org/sources/gnome-shell/%{major_version}/gnome-shell-%{tarball_version}.tar.xz


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `f42`:
 - [fix(gnome-shell): rename back without .switcheroo tag suffix (#4317)](https://github.com/terrapkg/packages/pull/4317)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)