### PR TITLE
[frawhide] fix(kf6-kio): rename back without .switcheroo tag suffix (#4316)

### DIFF
--- a/anda/desktops/kde/kf6-kio/kf6-kio.spec
+++ b/anda/desktops/kde/kf6-kio/kf6-kio.spec
@@ -3,10 +3,13 @@
 %global stable_kf6 stable
 %global majmin_ver_kf6 6.13
 
-Name:    kf6-%{framework}.switcheroo
+Name:    kf6-%{framework}
 Version: %{majmin_ver_kf6}.0
-Release: 1%{?dist}.switcheroo
+Release: 2%{?dist}.switcheroo
 Summary: KDE Frameworks 6 Tier 3 solution for filesystem abstraction
+
+Provides: kf6-%{framework}.switcheroo = %version-%release
+Obsoletes: kf6-%{framework}.switcheroo < 6.13.0-2
 
 License: BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND LGPL-3.0-only AND (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only) AND MIT
 URL:     https://invent.kde.org/frameworks/%{framework}


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `frawhide`:
 - [fix(kf6-kio): rename back without .switcheroo tag suffix (#4316)](https://github.com/terrapkg/packages/pull/4316)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)