### PR TITLE
[f42] bump: readymade (#4324)

### DIFF
--- a/anda/system/readymade/readymade.spec
+++ b/anda/system/readymade/readymade.spec
@@ -1,8 +1,8 @@
 Name:           readymade
 Version:        0.12.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Install ready-made distribution images!
-License:        MIT
+License:        GPL-3.0-or-later
 URL:            https://github.com/FyraLabs/readymade
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires:	anda-srpm-macros rust-packaging mold
@@ -21,7 +21,6 @@ It is created as a replacement to Red Hat's Anaconda installer.
 
 %package config-ultramarine
 Summary:        Readymade Configuration for Ultramarine Linux
-License:        MIT
 Requires:       readymade
 Provides:       readymade-config
 
@@ -40,13 +39,13 @@ This package contains the configuration files for Readymade to install Ultramari
 ./install.sh %buildroot
 ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_datadir}/applications/liveinst.desktop
 
-%find_lang com.fyralabs.Readymade
 
 %files config-ultramarine
 %_sysconfdir/readymade.toml
 
 
-%files -f com.fyralabs.Readymade.lang
+%files
+%license LICENSE
 %_bindir/readymade
 %_datadir/polkit-1/actions/com.fyralabs.pkexec.readymade.policy
 %_datadir/applications/com.fyralabs.Readymade.desktop


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [bump: readymade (#4324)](https://github.com/terrapkg/packages/pull/4324)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)