### PR TITLE
[f42] fix(lomiri-app-launch): Patch to use the correct standard for atomic builtins (#4272)

### DIFF
--- a/anda/desktops/lomiri-unity/lomiri-app-launch/2004-std-workaround.patch
+++ b/anda/desktops/lomiri-unity/lomiri-app-launch/2004-std-workaround.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2025-04-18 01:46:49.810910663 -0500
++++ b/CMakeLists.txt	2025-04-18 02:07:05.663396088 -0500
+@@ -77,7 +77,7 @@
+ 	-pthread
+ )
+ 
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+ 
+ pkg_check_modules(GLIB2 REQUIRED glib-2.0)

--- a/anda/desktops/lomiri-unity/lomiri-app-launch/lomiri-app-launch.spec
+++ b/anda/desktops/lomiri-unity/lomiri-app-launch/lomiri-app-launch.spec
@@ -4,16 +4,19 @@
 
 Name:           lomiri-app-launch
 Version:        0.1.11
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Provides the Lomiri App Launch user space daemon
 License:        GPL-3.0
 URL:            https://gitlab.com/ubports/development/core/lomiri-app-launch
 Source0:        %{url}/-/archive/%commit/lomiri-app-launch-%commit.tar.gz
+Patch0:         https://sources.debian.org/data/main/l/lomiri-app-launch/0.1.11-1/debian/patches/2003_remove-werror.patch
+Patch1:         2004-std-workaround.patch
 
 BuildRequires: cmake
 BuildRequires: pkgconfig
-BuildRequires: g++
 BuildRequires: gcc
+BuildRequires: gcc-c++
+BuildRequires: libatomic
 BuildRequires: pkgconfig(glib-2.0)
 BuildRequires: pkgconfig(gobject-introspection-1.0)
 BuildRequires: pkgconfig(lttng-ust)
@@ -49,8 +52,6 @@ This package contains development files needed for lomiri-app-launch.
 %autosetup -n lomiri-app-launch-%commit
 
 %build
-sed -i 's/-Werror//' ./CMakeLists.txt
-
 # For some reason the macro of cmake fails on both clang and gcc
 cmake -DLOMIRI_APP_LAUNCH_ARCH=%{_arch} -DENABLE_COVERAGE=OFF -DENABLE_TESTS=OFF -B redhat-linux-build -DCMAKE_INSTALL_PREFIX:PATH=/usr -DENABLE_MIRCLIENT=off -DUSE_SYSTEMD=ON
 %cmake_build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(lomiri-app-launch): Patch to use the correct standard for atomic builtins (#4272)](https://github.com/terrapkg/packages/pull/4272)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)