### PR TITLE
[f40] fix(subtitleedit): dejavu mono dep (#4349)

### DIFF
--- a/anda/apps/subtitleedit/subtitleedit.spec
+++ b/anda/apps/subtitleedit/subtitleedit.spec
@@ -3,7 +3,7 @@
 
 Name:           %realname.bin
 Version:        4.0.12
-Release:        1%?dist
+Release:        2%?dist
 Summary:        An advanced subtitle editor and converter
 License:        GPL-3.0-only
 URL:            https://www.nikse.dk/SubtitleEdit
@@ -13,7 +13,7 @@ Packager:       madonuko <mado@fyralabs.com>
 Provides:       %realname = %evr
 Conflicts:      %realname
 BuildRequires:  unzip anda-srpm-macros
-Requires:       mono dejavu-fonts
+Requires:       dejavu-sans-mono-fonts
 
 %description
 %summary.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(subtitleedit): dejavu mono dep (#4349)](https://github.com/terrapkg/packages/pull/4349)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)