### PR TITLE
[f42] fix(subtitleedit): wrong path to exe (#4362)

### DIFF
--- a/anda/apps/subtitleedit/subtitleedit.spec
+++ b/anda/apps/subtitleedit/subtitleedit.spec
@@ -13,7 +13,7 @@ Packager:       madonuko <mado@fyralabs.com>
 Provides:       %realname = %evr
 Conflicts:      %realname
 BuildRequires:  unzip anda-srpm-macros
-Requires:       dejavu-sans-mono-fonts
+Requires:       dejavu-sans-mono-fonts mono-core
 
 %description
 %summary.
@@ -33,7 +33,7 @@ EOF
 
 cat<<EOF > subtitleedit
 #!/usr/bin/sh
-exec mono /opt/subtitleedit/SubtitleEdit.exe "$@"
+exec mono /usr/share/subtitleedit/SubtitleEdit.exe "$@"
 EOF
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(subtitleedit): wrong path to exe (#4362)](https://github.com/terrapkg/packages/pull/4362)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)