### PR TITLE
[f41] fix(flatpost): update.rhai (#4381) (#4388)

### DIFF
--- a/anda/apps/flatpost/flatpost.spec
+++ b/anda/apps/flatpost/flatpost.spec
@@ -1,13 +1,11 @@
-%global tag 1.0.5
-
 Name:          flatpost
-Version:       %{tag}
+Version:       1.0.5
 Release:       1%?dist
 License:       BSD-2-Clause
 Summary:       Desktop environment agnostic Flathub software center.
 
 URL:            https://github.com/gloriouseggroll/flatpost
-Source0:        %{url}/archive/refs/tags/%{tag}.tar.gz#/%{name}-%{tag}.tar.gz
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
 Source1:        flatpost-mime.xml
 Patch0:         flatpost-desktop-mimetype.patch
 

--- a/anda/apps/flatpost/update.rhai
+++ b/anda/apps/flatpost/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh_rawfile("GloriousEggroll/flatpost", "main", "VERSION.txt"));
+let v = gh_rawfile("GloriousEggroll/flatpost", "main", "VERSION.txt");
+v.trim();
+rpm.version(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `el10` to `f41`:
 - [fix(flatpost): update.rhai (#4381) (#4388)](https://github.com/terrapkg/packages/pull/4388)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)