### PR TITLE
[el10] fix(xone): Dropoff epoch and Conflicts/Obsoletes old versions (#4393)

### DIFF
--- a/anda/system/xone/akmod/xone-kmod.spec
+++ b/anda/system/xone/akmod/xone-kmod.spec
@@ -8,7 +8,10 @@
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          1
+%endif
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
 License:        GPL-2.0-or-later
 URL:            https://github.com/dlundqvist/xone
@@ -19,6 +22,10 @@ Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:       %{modulename}-akmod-modules = %{?epoch:%{epoch}:}%{version}
 Requires:       akmods
 Conflicts:      dkms-%{modulename}
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Conflicts:      %{name} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
+%endif
 Packager:       Gilver E. <rockgrub@disroot.org>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }

--- a/anda/system/xone/dkms/dkms-xone.spec
+++ b/anda/system/xone/dkms/dkms-xone.spec
@@ -7,7 +7,10 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          1
+%endif
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
 License:        GPL-2.0-or-later
 URL:            https://github.com/dlundqvist/xone
@@ -18,6 +21,10 @@ BuildRequires:  systemd-rpm-macros
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
 Conflicts:      akmod-%{modulename}
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Conflicts:      %{name} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
+%endif
 BuildArch:      noarch
 Packager:       Gilver E. <rockgrub@disroot.org>
 

--- a/anda/system/xone/kmod-common/xone.spec
+++ b/anda/system/xone/kmod-common/xone.spec
@@ -8,7 +8,10 @@
 
 Name:           xone
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%?dist
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          1
+%endif
 Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories common files
 License:        GPL-2.0-or-later
 URL:            https://github.com/dlundqvist/xone
@@ -23,13 +26,16 @@ BuildRequires:  cabextract
 BuildRequires:  sed
 BuildRequires:  systemd-rpm-macros
 Requires:       wireless-regdb
-Requires:       %{name}-firmware = %{version}-%{release}
+Requires:       %{name}-firmware = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:       (akmod-%{name} = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = %{?epoch:%{epoch}:}%{version})
 Requires(post): dracut
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
-Obsoletes:      %{name}-kmod-common < %{?epoch:%{epoch}:}%{version}-2%{?dist}
 Conflicts:      xow <= 0.5
 Obsoletes:      xow <= 0.5
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Conflicts:      %{name} < %{?epoch:%{epoch}:}0.3^20250419git.c682b0c
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}0.3^20250419git.c682b0c
+%endif
 BuildArch:      noarch
 Packager:       Gilver E. <rockgrub@disroot.org>
 
@@ -49,7 +55,7 @@ Summary:         Firmware for the XBox One controller dongle
 License:         Proprietary
 Requires:        wireless-regdb
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
-Provides:        %{name}-firmware = %{commitdate}.%{shortcommit}-%{release}
+Obsoletes:      %{name}-firmware < %{?epoch:%{epoch}:}0.3^20250419git.c682b0c
 %endif
 BuildArch:       noarch
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(xone): Dropoff epoch and Conflicts/Obsoletes old versions (#4393)](https://github.com/terrapkg/packages/pull/4393)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)