### PR TITLE
fix(umu-launcher): update dependencies

### DIFF
--- a/anda/games/umu/umu-launcher.spec
+++ b/anda/games/umu/umu-launcher.spec
@@ -33,6 +33,7 @@ Requires:	python3
 %if %{?fedora} <= 41
 Requires:	python3-xlib
 Requires:       python3-pyzstd
+Requires:       python3-xxhash
 
 AutoReqProv:    no
 %endif

--- a/anda/games/umu/umu-launcher.spec
+++ b/anda/games/umu/umu-launcher.spec
@@ -34,6 +34,7 @@ Requires:	python3
 Requires:	python3-xlib
 Requires:       python3-pyzstd
 Requires:       python3-xxhash
+Requires:       python3-cbor2
 
 AutoReqProv:    no
 %endif

--- a/anda/games/umu/umu-launcher.spec
+++ b/anda/games/umu/umu-launcher.spec
@@ -32,7 +32,6 @@ Requires:	python
 Requires:	python3
 %if %{?fedora} <= 41
 Requires:	python3-xlib
-Requires:	python3-filelock
 Requires:       python3-pyzstd
 
 AutoReqProv:    no


### PR DESCRIPTION
The dependencies for the umu-launcher package were incorrectly specified. See https://github.com/Open-Wine-Components/umu-launcher/blob/cbe73a164aa6e08ddf71047eb0e9af71f81c00d2/pyproject.toml#L40

python3-filelock has been dropped since 1.2.0, and the cbor2 and xxhash packages were missing.
