### PR TITLE
fix(andax/nvidia.rhai): Track stable NVIDIA drivers

### DIFF
--- a/andax/nvidia.rhai
+++ b/andax/nvidia.rhai
@@ -12,6 +12,6 @@ fn nvidia_component_version(component) {
 }
 
 fn nvidia_driver_version() {
-    let driver = get(`https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&osID=12&languageCode=1033&numberOfResults=1&beta=0`);
+    let driver = get("https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&osID=12&languageCode=1033&numberOfResults=1&beta=0").json().IDS[0].downloadInfo.DisplayVersion);
     return(driver);
 }

--- a/andax/nvidia.rhai
+++ b/andax/nvidia.rhai
@@ -12,6 +12,7 @@ fn nvidia_component_version(component) {
 }
 
 fn nvidia_driver_version() {
-    let matches = find_all(`(?m)^\s+<span class='dir'><a href='([\d.]+)/'>[\d.]+/</a></span>`, get("https://download.nvidia.com/XFree86/Linux-x86_64/"));
-    return(matches[matches.len() - 1][1]);
+    let url = get(`https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&osID=12&languageCode=1033&numberOfResults=1&beta=0`);
+    let matches = find("\"DisplayVersion\" : \"([\\d.]+)\"", url, 1);
+    return(matches);
 }

--- a/andax/nvidia.rhai
+++ b/andax/nvidia.rhai
@@ -12,6 +12,6 @@ fn nvidia_component_version(component) {
 }
 
 fn nvidia_driver_version() {
-    let driver = get("https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&osID=12&languageCode=1033&numberOfResults=1&beta=0").json().IDS[0].downloadInfo.DisplayVersion);
+    let driver = get("https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&osID=12&languageCode=1033&numberOfResults=1&beta=0").json().IDS[0].downloadInfo.DisplayVersion;
     return(driver);
 }

--- a/andax/nvidia.rhai
+++ b/andax/nvidia.rhai
@@ -12,7 +12,6 @@ fn nvidia_component_version(component) {
 }
 
 fn nvidia_driver_version() {
-    let url = get(`https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&osID=12&languageCode=1033&numberOfResults=1&beta=0`);
-    let matches = find("\"DisplayVersion\" : \"([\\d.]+)\"", url, 1);
-    return(matches);
+    let driver = get(`https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&osID=12&languageCode=1033&numberOfResults=1&beta=0`);
+    return(driver);
 }


### PR DESCRIPTION
This *appears* correct (see image below), but please let me know if there's any issues since I don't trust myself with the actual Anda functions.
![image](https://github.com/user-attachments/assets/3ab077a7-a14c-4679-a070-e60cd0eac8a4)
