### PR TITLE
[el10] fix(zed, zed-nightly, zed-preview): Build and licenses (#4198)

### DIFF
--- a/anda/devs/zed/nightly/anda.hcl
+++ b/anda/devs/zed/nightly/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
   }
   labels {
     nightly = 1
+    large = 1
   }
 }

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -7,28 +7,44 @@
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
-# Use Mold as the linker
-%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 %global crate zed
 %global app_id dev.zed.Zed-Nightly
 
+%global rustflags_debuginfo 0
+
+# Zed needs a special approach to fetch the dep licenses
+%global zed_license_online %{shrink:                                        \
+    %{__cargo} tree                                                         \
+    -Z avoid-dev-deps                                                       \
+    --workspace                                                             \
+    --edges no-build,no-dev,no-proc-macro                                   \
+    --target all                                                            \
+    %{__cargo_parse_opts %{-n} %{-a} %{-f:-f%{-f*}}}                        \
+    --prefix none                                                           \
+    --format "{l}: {p}"                                                     \
+    | sed -e "s: ($(pwd)[^)]*)::g" -e "s: / :/:g" -e "/\/.*:/{s/\// OR /}"  \
+    | sed -e '/.*(\*).*/d' -e '/^: pet/ s/./MIT&/'                          \
+    | sort -u                                                               \
+}\
+
 Name:           zed-nightly
 Version:        %ver^%commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
-
-License:        MIT
+SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
+License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
 URL:            https://zed.dev/
-Source0:        https://github.com/zed-industries/zed/archive/%{commit}.zip
+Source0:        https://github.com/zed-industries/zed/archive/%{commit}.tar.gz
 
 Conflicts:      zed
-Provides:       zed
+Conflicts:      zed-preview
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
 BuildRequires:  gcc
-BuildRequires:  g++
+BuildRequires:  gcc-c++
+BuildRequires:  gettext-envsubst
 BuildRequires:  clang
 BuildRequires:  mold
 BuildRequires:  cmake
@@ -87,18 +103,33 @@ install -Dm644 crates/zed/resources/app-icon-nightly.png %{buildroot}%{_datadir}
 
 install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
 
+# The license generation script doesn't generate licenses for ALL compiled dependencies, just direct deps of Zed, and it does not "group" licenses
+%{zed_license_online} > LICENSE.dependencies
+mv assets/icons/LICENSES LICENSE.icons
+mv assets/themes/LICENSES LICENSE.themes
+mv assets/fonts/plex-mono/license.txt LICENSE.fonts
+
 %if %{with check}
 %check
 %cargo_test
 %endif
 
 %files
+%doc CODE_OF_CONDUCT.md
+%doc README.md
+%license LICENSE-AGPL
+%license LICENSE-APACHE
+%license LICENSE-GPL
+%license LICENSE.dependencies
+%license LICENSE.fonts
+%license LICENSE.icons
+%license LICENSE.themes
+%license assets/licenses.md
 %{_libexecdir}/zed-editor
 %{_bindir}/zed
 %{_datadir}/applications/%app_id.desktop
 %{_datadir}/pixmaps/%app_id.png
 %{_metainfodir}/%app_id.metainfo.xml
-%license assets/licenses.md
 
 %changelog
 %autochangelog

--- a/anda/devs/zed/preview/anda.hcl
+++ b/anda/devs/zed/preview/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "zed-preview.spec"
   }
+  labels {
+    large = 1
+  }
 }

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -3,28 +3,44 @@
 %global ver 0.183.7-pre
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
-# Use Mold as the linker
-%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 %global crate zed
 %global app_id dev.zed.Zed-Preview
 
+%global rustflags_debuginfo 0
+
+# Zed needs a special approach to fetch the dep licenses
+%global zed_license_online %{shrink:                                        \
+    %{__cargo} tree                                                         \
+    -Z avoid-dev-deps                                                       \
+    --workspace                                                             \
+    --edges no-build,no-dev,no-proc-macro                                   \
+    --target all                                                            \
+    %{__cargo_parse_opts %{-n} %{-a} %{-f:-f%{-f*}}}                        \
+    --prefix none                                                           \
+    --format "{l}: {p}"                                                     \
+    | sed -e "s: ($(pwd)[^)]*)::g" -e "s: / :/:g" -e "/\/.*:/{s/\// OR /}"  \
+    | sed -e '/.*(\*).*/d' -e '/^: pet/ s/./MIT&/'                          \
+    | sort -u                                                               \
+}\
+
 Name:           zed-preview
 Version:        %(echo %ver | sed 's/-/~/')
-Release:        pre1%?dist
+Release:        pre2%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
-
-License:        MIT
+SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
+License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
 URL:            https://zed.dev/
 Source0:        https://github.com/zed-industries/zed/archive/refs/tags/v%{ver}.tar.gz
 
 Conflicts:      zed
-Provides:       zed
+Conflicts:      zed-nightly
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
 BuildRequires:  gcc
-BuildRequires:  g++
+BuildRequires:  gcc-c++
+BuildRequires:  gettext-envsubst
 BuildRequires:  clang
 BuildRequires:  cmake
 BuildRequires:  mold
@@ -83,18 +99,33 @@ install -Dm644 crates/zed/resources/app-icon-preview.png %{buildroot}%{_datadir}
 
 install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
 
+# The license generation script doesn't generate licenses for ALL compiled dependencies, just direct deps of Zed, and it does not "group" licenses
+%{zed_license_online} > LICENSE.dependencies
+mv assets/icons/LICENSES LICENSE.icons
+mv assets/themes/LICENSES LICENSE.themes
+mv assets/fonts/plex-mono/license.txt LICENSE.fonts
+
 %if %{with check}
 %check
 %cargo_test
 %endif
 
 %files
+%doc CODE_OF_CONDUCT.md
+%doc README.md
+%license LICENSE-AGPL
+%license LICENSE-APACHE
+%license LICENSE-GPL
+%license LICENSE.dependencies
+%license LICENSE.fonts
+%license LICENSE.icons
+%license LICENSE.themes
+%license assets/licenses.md
 %{_libexecdir}/zed-editor
 %{_bindir}/zed
 %{_datadir}/applications/%app_id.desktop
 %{_datadir}/pixmaps/%app_id.png
 %{_metainfodir}/%app_id.metainfo.xml
-%license assets/licenses.md
 
 %changelog
 %autochangelog

--- a/anda/devs/zed/stable/anda.hcl
+++ b/anda/devs/zed/stable/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "zed.spec"
   }
+  labels {
+    large = 1
+  }
 }

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -2,28 +2,44 @@
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
-# Use Mold as the linker
-%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 
 %global crate zed
 %global app_id dev.zed.Zed
+
+%global rustflags_debuginfo 0
+
+# Zed needs a special approach to fetch the dep licenses
+%global zed_license_online %{shrink:                                        \
+    %{__cargo} tree                                                         \
+    -Z avoid-dev-deps                                                       \
+    --workspace                                                             \
+    --edges no-build,no-dev,no-proc-macro                                   \
+    --target all                                                            \
+    %{__cargo_parse_opts %{-n} %{-a} %{-f:-f%{-f*}}}                        \
+    --prefix none                                                           \
+    --format "{l}: {p}"                                                     \
+    | sed -e "s: ($(pwd)[^)]*)::g" -e "s: / :/:g" -e "/\/.*:/{s/\// OR /}"  \
+    | sed -e '/.*(\*).*/d' -e '/^: pet/ s/./MIT&/'                          \
+    | sort -u                                                               \
+}\
 
 Name:           zed
 Version:        0.182.11
 Release:        1%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
-
-License:        MIT
+SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
+License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
 URL:            https://zed.dev/
 Source0:        https://github.com/zed-industries/zed/archive/refs/tags/v%{version}.tar.gz
 
-Conflicts:      zed
-Provides:       zed
+Conflicts:      zed-nightly
+Conflicts:      zed-preview
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
 BuildRequires:  gcc
-BuildRequires:  g++
+BuildRequires:  gcc-c++
+BuildRequires:  gettext-envsubst
 BuildRequires:  clang
 BuildRequires:  cmake
 BuildRequires:  mold
@@ -83,18 +99,33 @@ install -Dm644 crates/zed/resources/app-icon.png %{buildroot}%{_datadir}/pixmaps
 
 install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
 
+# The license generation script doesn't generate licenses for ALL compiled dependencies, just direct deps of Zed, and it does not "group" licenses
+%{zed_license_online} > LICENSE.dependencies
+mv assets/icons/LICENSES LICENSE.icons
+mv assets/themes/LICENSES LICENSE.themes
+mv assets/fonts/plex-mono/license.txt LICENSE.fonts
+
 %if %{with check}
 %check
 %cargo_test
 %endif
 
 %files
+%doc CODE_OF_CONDUCT.md
+%doc README.md
+%license LICENSE-AGPL
+%license LICENSE-APACHE
+%license LICENSE-GPL
+%license LICENSE.dependencies
+%license LICENSE.fonts
+%license LICENSE.icons
+%license LICENSE.themes
+%license assets/licenses.md
 %{_libexecdir}/zed-editor
 %{_bindir}/zed
 %{_datadir}/applications/%app_id.desktop
 %{_datadir}/pixmaps/%app_id.png
 %{_metainfodir}/%app_id.metainfo.xml
-%license assets/licenses.md
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [fix(zed, zed-nightly, zed-preview): Build and licenses (#4198)](https://github.com/terrapkg/packages/pull/4198)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)