### PR TITLE
[f40] fix({dkms-}v4l2loopback{-kmod}): Requires help2man (#4429)

### DIFF
--- a/anda/system/v4l2loopback/akmod/v4l2loopback-kmod.spec
+++ b/anda/system/v4l2loopback/akmod/v4l2loopback-kmod.spec
@@ -18,7 +18,7 @@ This module allows you to create \"virtual video devices.\" Normal \(v4l2\) appl
 Name:           %{modulename}-kmod
 Summary:        Kernel module (kmod) for V4L2 loopback devices
 Version:        0.14.0
-Release:        3%?dist
+Release:        4%?dist
 License:        GPL-2.0-or-later
 URL:            https://github.com/v4l2loopback/v4l2loopback
 Source0:        %{url}/archive/v%{version}/%{modulename}-%{version}.tar.gz
@@ -30,6 +30,7 @@ BuildRequires:  kmodtool
 Requires:       akmods
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:       %{modulename}-akmod-modules = %{?epoch:%{epoch}:}%{version}
+Requires:       help2man
 Requires:       kernel-devel
 Conflicts:      dkms-%{modulename}
 Packager:       Cappy Ishihara <cappy@fyralabs.com>

--- a/anda/system/v4l2loopback/dkms/dkms-v4l2loopback.spec
+++ b/anda/system/v4l2loopback/dkms/dkms-v4l2loopback.spec
@@ -5,7 +5,7 @@ This module allows you to create \"virtual video devices.\" Normal \(v4l2\) appl
 
 Name:           dkms-%{modulename}
 Version:        0.14.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Utils for V4L2 loopback devices
 License:        GPL-2.0-or-later
 URL:            https://github.com/v4l2loopback/v4l2loopback
@@ -14,6 +14,7 @@ Source1:        no-weak-modules.conf
 BuildRequires:  systemd-rpm-macros
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
+Requires:       help2man
 Conflicts:      akmod-%{modulename}
 BuildArch:      noarch
 Packager:       Gilver E. <rockgrub@disroot.org>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix({dkms-}v4l2loopback{-kmod}): Requires help2man (#4429)](https://github.com/terrapkg/packages/pull/4429)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)