### PR TITLE
[f42] fix(andax/nvidia.rhai): Track stable NVIDIA drivers (#4428)

### DIFF
--- a/andax/nvidia.rhai
+++ b/andax/nvidia.rhai
@@ -12,6 +12,6 @@ fn nvidia_component_version(component) {
 }
 
 fn nvidia_driver_version() {
-    let matches = find_all(`(?m)^\s+<span class='dir'><a href='([\d.]+)/'>[\d.]+/</a></span>`, get("https://download.nvidia.com/XFree86/Linux-x86_64/"));
-    return(matches[matches.len() - 1][1]);
+    let driver = get("https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&osID=12&languageCode=1033&numberOfResults=1&beta=0").json().IDS[0].downloadInfo.DisplayVersion;
+    return(driver);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(andax/nvidia.rhai): Track stable NVIDIA drivers (#4428)](https://github.com/terrapkg/packages/pull/4428)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)