### PR TITLE
fix(wl-kmod): process 6.13 and 6.14 patches

### DIFF
--- a/anda/system/wl-kmod/wl-kmod.spec
+++ b/anda/system/wl-kmod/wl-kmod.spec
@@ -10,7 +10,7 @@
 
 Name:       wl-kmod
 Version:    6.30.223.271
-Release:    2%{?dist}
+Release:    3%{?dist}
 Summary:    Kernel module for Broadcom wireless devices
 Group:      System Environment/Kernel
 License:    Redistributable, no modification permitted
@@ -99,6 +99,8 @@ pushd %{name}-%{version}-src
 %patch -P 24 -p1 -b .kernel_6.10_adaptation
 %patch -P 25 -p1 -b .wpa_supplicant-2.11_adaptation
 %patch -P 26 -p1 -b .kernel_6.12_adaptation
+%patch -P 27 -p1 -b .kernel_6.13_adaptation
+%patch -P 28 -p1 -b .kernel_6.14_adaptation
 
 ### NOTE: These MUST be added to as new EL versions are released.
 %if 0%{?rhel} == 9


### PR DESCRIPTION
When trying to install `wl-kmod` on my fedora 42 system, I get a build error. I figured out it is because the 6.13 and 6.14 kernel patches aren't being applied. Apply the patches within the spec, and bump release version. 

Tested locally with `anda build anda/system/wl-kmod/pkg` and everything builds alright. 

Fixes: https://github.com/terrapkg/packages/pull/3591
Link: https://github.com/rpmfusion/wl-kmod/commit/5c24789c6b3615acf88301225d2c5dd53bf37772
Link: https://github.com/rpmfusion/wl-kmod/commit/2ec1bd6182d6e30eddd44c629d7c19e4f3856e27