### PR TITLE
[el10] fix(nvidia-driver): Disable comment note stripping (#4444)

### DIFF
--- a/anda/system/nvidia/nvidia-driver/nvidia-driver.spec
+++ b/anda/system/nvidia/nvidia-driver/nvidia-driver.spec
@@ -1,5 +1,6 @@
 %global debug_package %{nil}
 %global __strip %{nil}
+%global __brp_strip_comment_note %{nil}
 %global __brp_ldconfig %{nil}
 %define _build_id_links none
 
@@ -448,14 +449,14 @@ appstream-util validate --nonet %{buildroot}%{_metainfodir}/com.nvidia.driver.me
 %endif
 %ifarch x86_64
 %{_datadir}/vulkansc/icd.d/nvidia_icd.%{_target_cpu}.json
+%if v"%{version}" > v"570.144"
 %{_libdir}/libnvidia-present.so.%{version}
+%endif
 %{_libdir}/libnvidia-vksc-core.so.1
 %{_libdir}/libnvidia-vksc-core.so.%{version}
 %dir %{_libdir}/nvidia
 %dir %{_libdir}/nvidia/wine
-%{_libdir}/nvidia/wine/_nvngx.dll
-%{_libdir}/nvidia/wine/nvngx.dll
-%{_libdir}/nvidia/wine/nvngx_dlssg.dll
+%{_libdir}/nvidia/wine/*.dll
 %endif
 
 %files cuda-libs
@@ -479,9 +480,15 @@ appstream-util validate --nonet %{buildroot}%{_metainfodir}/com.nvidia.driver.me
 %ifarch x86_64 aarch64
 %{_libdir}/libcudadebugger.so.1
 %{_libdir}/libcudadebugger.so.%{version}
+%if v"%{version}" > v"570.144"
 %{_libdir}/libnvidia-nvvm70.so.4
+%endif
+%if v"%{version}" <= v"570.144"
+%ifnarch aarch64
 %{_libdir}/libnvidia-sandboxutils.so.1
 %{_libdir}/libnvidia-sandboxutils.so.%{version}
+%endif
+%endif
 %endif
 %ifarch x86_64
 %if 0%{?rhel} == 8


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(nvidia-driver): Disable comment note stripping (#4444)](https://github.com/terrapkg/packages/pull/4444)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)