### PR TITLE
chore(cuda-gcc): Remove from NVIDIA subrepo to use with packages that need CUDA compatible compilers

### DIFF
--- a/anda/lib/nvidia/cuda-gcc/anda.hcl
+++ b/anda/lib/nvidia/cuda-gcc/anda.hcl
@@ -5,6 +5,5 @@ project pkg {
 	}
     labels {
         updbranch = 1
-        subrepo = "nvidia"
     }
 }


### PR DESCRIPTION
This isn't directly a CUDA package (only dep is GCC) so is fine to move. Needed for #3489.