### PR TITLE
fix(egl-wayland,egl-x11): Needs an i686 build, remove the update script

### DIFF
--- a/anda/lib/nvidia/egl-wayland/anda.hcl
+++ b/anda/lib/nvidia/egl-wayland/anda.hcl
@@ -1,8 +1,10 @@
 project pkg {
+        arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "egl-wayland.spec"
     }
     labels {
         subrepo = "nvidia"
+        mock = 1
     }
 }

--- a/anda/lib/nvidia/egl-wayland/update.rhai
+++ b/anda/lib/nvidia/egl-wayland/update.rhai
@@ -1,1 +1,0 @@
-rpm.version(gh("NVIDIA/egl-wayland"));

--- a/anda/lib/nvidia/egl-x11/anda.hcl
+++ b/anda/lib/nvidia/egl-x11/anda.hcl
@@ -1,8 +1,10 @@
 project pkg {
+        arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "egl-x11.spec"
     }
     labels {
         subrepo = "nvidia"
+        mock = 1
     }
 }

--- a/anda/lib/nvidia/egl-x11/update.rhai
+++ b/anda/lib/nvidia/egl-x11/update.rhai
@@ -1,1 +1,0 @@
-rpm.version(gh_tag("NVIDIA/egl-x11"));


### PR DESCRIPTION
Negativo is upstreaming this to Fedora so after this they can handle it.