### PR TITLE
[f42] feat(readymade): make rdm build on commit (#4476)

### DIFF
--- a/anda/system/readymade/nightly/anda.hcl
+++ b/anda/system/readymade/nightly/anda.hcl
@@ -3,6 +3,5 @@ project pkg {
     spec = "readymade-nightly.spec"
   }
   labels {
-    nightly = 1
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(readymade): make rdm build on commit (#4476)](https://github.com/terrapkg/packages/pull/4476)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)