### PR TITLE
[el10] chore(cuda-gcc): Remove from NVIDIA subrepo to use with packages that need CUDA compatible compilers (#4471)

### DIFF
--- a/anda/lib/nvidia/cuda-gcc/anda.hcl
+++ b/anda/lib/nvidia/cuda-gcc/anda.hcl
@@ -5,6 +5,5 @@ project pkg {
 	}
     labels {
         updbranch = 1
-        subrepo = "nvidia"
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(cuda-gcc): Remove from NVIDIA subrepo to use with packages that need CUDA compatible compilers (#4471)](https://github.com/terrapkg/packages/pull/4471)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)