### PR TITLE
fix(egl): Bump release back up

### DIFF
--- a/anda/lib/nvidia/egl-wayland/egl-wayland.spec
+++ b/anda/lib/nvidia/egl-wayland/egl-wayland.spec
@@ -5,7 +5,7 @@
 
 Name:           egl-wayland
 Version:        1.1.19
-Release:        1%?dist
+Release:        2%?dist
 Summary:        EGLStream-based Wayland external platform
 License:        MIT
 URL:            https://github.com/NVIDIA/%{name}

--- a/anda/lib/nvidia/egl-x11/egl-x11.spec
+++ b/anda/lib/nvidia/egl-x11/egl-x11.spec
@@ -5,7 +5,7 @@
 
 Name:           egl-x11
 Version:        1.0.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA XLib and XCB EGL Platform Library
 License:        Apache-2.0
 URL:            https://github.com/NVIDIA/egl-x11


### PR DESCRIPTION
I didn't realize the update script had triggered and bumped releases back down, making the i686 package probably uninstallable. My bad chat.