### PR TITLE
[f40] bump: preview (#4492)

### DIFF
--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -1,6 +1,6 @@
 %bcond_with check
 
-%global ver 0.183.7-pre
+%global ver 0.184.5-pre
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `f40`:
 - [bump: preview (#4492)](https://github.com/terrapkg/packages/pull/4492)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)