### PR TITLE
[f42] fix(egl): Bump release back up (#4490)

### DIFF
--- a/anda/lib/nvidia/egl-wayland/egl-wayland.spec
+++ b/anda/lib/nvidia/egl-wayland/egl-wayland.spec
@@ -5,7 +5,7 @@
 
 Name:           egl-wayland
 Version:        1.1.19
-Release:        1%?dist
+Release:        2%?dist
 Summary:        EGLStream-based Wayland external platform
 License:        MIT
 URL:            https://github.com/NVIDIA/%{name}

--- a/anda/lib/nvidia/egl-x11/egl-x11.spec
+++ b/anda/lib/nvidia/egl-x11/egl-x11.spec
@@ -5,7 +5,7 @@
 
 Name:           egl-x11
 Version:        1.0.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA XLib and XCB EGL Platform Library
 License:        Apache-2.0
 URL:            https://github.com/NVIDIA/egl-x11


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(egl): Bump release back up (#4490)](https://github.com/terrapkg/packages/pull/4490)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)