### PR TITLE
[f41] fix(egl-x11): Bump release to 6 (#4501)

### DIFF
--- a/anda/lib/nvidia/egl-x11/egl-x11.spec
+++ b/anda/lib/nvidia/egl-x11/egl-x11.spec
@@ -5,7 +5,7 @@
 
 Name:           egl-x11
 Version:        1.0.1
-Release:        2%?dist
+Release:        6%?dist
 Summary:        NVIDIA XLib and XCB EGL Platform Library
 License:        Apache-2.0
 URL:            https://github.com/NVIDIA/egl-x11


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(egl-x11): Bump release to 6 (#4501)](https://github.com/terrapkg/packages/pull/4501)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)