### PR TITLE
[f41] chore (andax/nvidia.rhai): Bump CUDA component version (#4503)

### DIFF
--- a/andax/nvidia.rhai
+++ b/andax/nvidia.rhai
@@ -2,7 +2,7 @@
 // This module is used to parse the NVIDIA website for the latest driver version
 
 fn nvidia_component_list() {
-    let series = "12.6.3";
+    let series = "12.8.1";
     let url = `https://developer.download.nvidia.com/compute/cuda/redist/redistrib_${series}.json`;
     return get(url).json();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore (andax/nvidia.rhai): Bump CUDA component version (#4503)](https://github.com/terrapkg/packages/pull/4503)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)