### PR TITLE
[f40] chore: Bump yt-dlp on <= 41 (#4507)

### DIFF
--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,7 +2,7 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2025.04.17.233446
+Version:        2025.04.28.224217
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `f40`:
 - [chore: Bump yt-dlp on <= 41 (#4507)](https://github.com/terrapkg/packages/pull/4507)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)