### PR TITLE
[f41] feat(andax/nvidia.rhai): Automatically fetch new CUDA versions (#4514)

### DIFF
--- a/andax/nvidia.rhai
+++ b/andax/nvidia.rhai
@@ -2,9 +2,10 @@
 // This module is used to parse the NVIDIA website for the latest driver version
 
 fn nvidia_component_list() {
-    let series = "12.8.1";
-    let url = `https://developer.download.nvidia.com/compute/cuda/redist/redistrib_${series}.json`;
-    return get(url).json();
+    let url = "https://developer.download.nvidia.com/compute/cuda/redist/";
+    let matches = find_all("redistrib_[\\d.]+.json", get(url));
+    let series = `${url}${matches[matches.len - 1][0]}`;
+    return get(series).json();
 }
 fn nvidia_component_version(component) {
     let components = nvidia_component_list();


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(andax/nvidia.rhai): Automatically fetch new CUDA versions (#4514)](https://github.com/terrapkg/packages/pull/4514)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)