### PR TITLE
[el10] feat(cuda-cudnn, libcusparelt): Make update.rhai automatically track new series (#4520)

### DIFF
--- a/anda/lib/nvidia/cuda-cudnn/update.rhai
+++ b/anda/lib/nvidia/cuda-cudnn/update.rhai
@@ -1,5 +1,5 @@
-import "andax/nvidia.rhai" as nvidia;
-let series = "9.6.0";
-let url = `https://developer.download.nvidia.com/compute/cudnn/redist/redistrib_${series}.json`;
-let json = get(url).json();
+let url = "https://developer.download.nvidia.com/compute/cudnn/redist/";
+let matches = find_all("redistrib_[\\d.]+.json", get(url));
+let series = `${url}${matches[matches.len - 1][0]}`;
+let json = get(series).json();
 rpm.version(json["cudnn"]["version"]);

--- a/anda/lib/nvidia/libcusparselt/update.rhai
+++ b/anda/lib/nvidia/libcusparselt/update.rhai
@@ -1,5 +1,5 @@
-let series = "0.6.3";
-let url = `https://developer.download.nvidia.com/compute/cusparselt/redist/redistrib_${series}.json`;
-let json = get(url).json();
-
+let url = "https://developer.download.nvidia.com/compute/cusparselt/redist/";
+let matches = find_all("redistrib_[\\d.]+.json", get(url));
+let series = `${url}${matches[matches.len - 1][0]}`;
+let json = get(series).json();
 rpm.version(json["libcusparse_lt"]["version"]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(cuda-cudnn, libcusparelt): Make update.rhai automatically track new series (#4520)](https://github.com/terrapkg/packages/pull/4520)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)