### PR TITLE
[f40] fix(nekoray): update.rhai (#4529)

### DIFF
--- a/anda/apps/nekoray/update.rhai
+++ b/anda/apps/nekoray/update.rhai
@@ -1,3 +1,3 @@
 rpm.version(find(`([\d.]+)-\d+-\d+-\d+`, gh_rawfile("Mahdi-zarei/nekoray", "dev", "nekoray_version.txt"), 1));
 
-open_file("anda/apps/nekoray/Sagernet.SingBox.Version.txt", "w").write(gh('sagernet/sing-box'));
+open_file("anda/apps/nekoray/Sagernet.SingBox.Version.txt", "w").write(gh("sagernet/sing-box"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(nekoray): update.rhai (#4529)](https://github.com/terrapkg/packages/pull/4529)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)