### PR TITLE
fix(lightly-qt5): Import andax/bump_extras.rhai for update.rhai

### DIFF
--- a/anda/themes/lightly-qt5/update.rhai
+++ b/anda/themes/lightly-qt5/update.rhai
@@ -1,3 +1,5 @@
+import "andax/bump_extras.rhai" as bump;
+
 fn main(labels) {
     let branch = bump::as_bodhi_ver(labels.branch);
     let url = `https://bodhi.fedoraproject.org/updates/?search=qt5-5.&status=stable&releases=${branch}&rows_per_page=1&page=1`;


### PR DESCRIPTION
Is this what it should print? 
![image](https://github.com/user-attachments/assets/c60375e1-8ebe-4359-9cbf-618ec9c654e1)
