### PR TITLE
[el10] fix(lightly-qt5): Import andax/bump_extras.rhai for update.rhai (#4535)

### DIFF
--- a/anda/themes/lightly-qt5/update.rhai
+++ b/anda/themes/lightly-qt5/update.rhai
@@ -1,3 +1,5 @@
+import "andax/bump_extras.rhai" as bump;
+
 fn main(labels) {
     let branch = bump::as_bodhi_ver(labels.branch);
     let url = `https://bodhi.fedoraproject.org/updates/?search=qt5-5.&status=stable&releases=${branch}&rows_per_page=1&page=1`;


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(lightly-qt5): Import andax/bump_extras.rhai for update.rhai (#4535)](https://github.com/terrapkg/packages/pull/4535)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)