### PR TITLE
[el10] fix(gstreamer1-plugins-bad): add bump function to update script (#4537)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/update.rhai
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/update.rhai
@@ -5,7 +5,9 @@ let bodhi_branch = bump::as_bodhi_ver(labels.branch);
 let pkg = "gstreamer1-plugins-bad-free";
 let branch = bump::as_bodhi_ver(labels.branch);
 
-bump::follow_bodhi_vr(rpm, "gstreamer1-plugins-bad-free", branch);
+let vr = bump::bodhi_vr("gstreamer1-plugins-bad-free", branch);
+rpm.version(vr[1]);
+rpm.release(vr[2]);
 
 let opencv_ver = bump::bodhi("opencv", bodhi_branch);
 open_file("anda/multimedia/gstreamer1/gstreamer1-plugins-bad/OPENCV_VERSION.txt", "w").write(opencv_ver);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(gstreamer1-plugins-bad): add bump function to update script (#4537)](https://github.com/terrapkg/packages/pull/4537)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)