### PR TITLE
fix?(cuda): Add updbranch label to all CUDA packages

### DIFF
--- a/anda/lib/nvidia/cuda-cccl/anda.hcl
+++ b/anda/lib/nvidia/cuda-cccl/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-cudart/anda.hcl
+++ b/anda/lib/nvidia/cuda-cudart/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-cudnn/anda.hcl
+++ b/anda/lib/nvidia/cuda-cudnn/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-cuobjdump/anda.hcl
+++ b/anda/lib/nvidia/cuda-cuobjdump/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-cupti/anda.hcl
+++ b/anda/lib/nvidia/cuda-cupti/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-cuxxfilt/anda.hcl
+++ b/anda/lib/nvidia/cuda-cuxxfilt/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-gdb/anda.hcl
+++ b/anda/lib/nvidia/cuda-gdb/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-nvdisasm/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvdisasm/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-nvml/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvml/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-nvprof/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvprof/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-nvprune/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvprune/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-nvrtc/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvrtc/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-nvtx/anda.hcl
+++ b/anda/lib/nvidia/cuda-nvtx/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-profiler/anda.hcl
+++ b/anda/lib/nvidia/cuda-profiler/anda.hcl
@@ -6,5 +6,6 @@ project pkg {
     labels {
         mock = 1
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-sandbox/anda.hcl
+++ b/anda/lib/nvidia/cuda-sandbox/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda-sanitizer/anda.hcl
+++ b/anda/lib/nvidia/cuda-sanitizer/anda.hcl
@@ -6,5 +6,6 @@ project pkg {
     labels {
         mock = 1
         subrepo = "nvidia"
+        updbranch = 1
     }
 }

--- a/anda/lib/nvidia/cuda/anda.hcl
+++ b/anda/lib/nvidia/cuda/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 	   subrepo = "nvidia"
+	   updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libcublas/anda.hcl
+++ b/anda/lib/nvidia/libcublas/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libcudla/anda.hcl
+++ b/anda/lib/nvidia/libcudla/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libcufft/anda.hcl
+++ b/anda/lib/nvidia/libcufft/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libcurand/anda.hcl
+++ b/anda/lib/nvidia/libcurand/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libcusparse/anda.hcl
+++ b/anda/lib/nvidia/libcusparse/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libcusparselt/anda.hcl
+++ b/anda/lib/nvidia/libcusparselt/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libnpp/anda.hcl
+++ b/anda/lib/nvidia/libnpp/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libnvfatbin/anda.hcl
+++ b/anda/lib/nvidia/libnvfatbin/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/lib/nvidia/libnvjpeg/anda.hcl
+++ b/anda/lib/nvidia/libnvjpeg/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
     }
     labels {
 	    subrepo = "nvidia"
+	    updbranch = 1
     }
 }

--- a/anda/tools/cuda-nvcc/anda.hcl
+++ b/anda/tools/cuda-nvcc/anda.hcl
@@ -2,4 +2,7 @@ project "pkg" {
     rpm {
         spec = "cuda-nvcc.spec"
     }
+    labels {
+        upbranch = 1
+    }
 }


### PR DESCRIPTION
Will probably need to manually backport due to `cuda-sandbox` being unstaged in the backport branches because it was part of the CUDA mass update.