### PR TITLE
[el10] fix(lightly-qt6): Import andax/bump_extras.rhai for update.rhai (#4557)

### DIFF
--- a/anda/themes/lightly-qt6/update.rhai
+++ b/anda/themes/lightly-qt6/update.rhai
@@ -1,3 +1,5 @@
+import "andax/bump_extras.rhai" as bump;
+
 fn main() {
     let branch = bump::as_bodhi_ver(labels.branch);
     let url = `https://bodhi.fedoraproject.org/updates/?search=qt6-6.&status=stable&releases=${branch}&rows_per_page=1&page=1`;


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(lightly-qt6): Import andax/bump_extras.rhai for update.rhai (#4557)](https://github.com/terrapkg/packages/pull/4557)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)