### PR TITLE
[f42] chore: Mass CUDA update (#4546)

### DIFF
--- a/anda/lib/nvidia/cuda-cccl/cuda-cccl.spec
+++ b/anda/lib/nvidia/cuda-cccl/cuda-cccl.spec
@@ -1,12 +1,12 @@
 %global real_name cuda_cccl
 
 %global debug_package %{nil}
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CXX Core Compute Libraries
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit

--- a/anda/lib/nvidia/cuda-cudart/cuda-cudart.spec
+++ b/anda/lib/nvidia/cuda-cudart/cuda-cudart.spec
@@ -9,7 +9,7 @@
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA Runtime API library
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -19,7 +19,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{real
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{real_name}/linux-sbsa/%{real_name}-linux-sbsa-%{version}-archive.tar.xz
 Source3:        cudart.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -66,8 +65,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/cuda-cudnn/cuda-cudnn.spec
+++ b/anda/lib/nvidia/cuda-cudnn/cuda-cudnn.spec
@@ -6,7 +6,7 @@
 
 Name:           cuda-cudnn
 Version:        9.8.0.87
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        NVIDIA CUDA Deep Neural Network library (cuDNN)
 License:        NVIDIA Software Development Kit
@@ -58,8 +58,6 @@ chmod 644 %{buildroot}%{_libdir}/*.a
 mkdir -p %{buildroot}%{_includedir}
 cp -a include/* %{buildroot}%{_includedir}/
 chmod 644 %{buildroot}%{_includedir}/*
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/cuda-cuobjdump/cuda-cuobjdump.spec
+++ b/anda/lib/nvidia/cuda-cuobjdump/cuda-cuobjdump.spec
@@ -4,12 +4,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Utility to extract information from CUDA binary files
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit

--- a/anda/lib/nvidia/cuda-cupti/cuda-cupti.spec
+++ b/anda/lib/nvidia/cuda-cupti/cuda-cupti.spec
@@ -9,7 +9,7 @@
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA CUDA Profiling Tools Interface (CUPTI) library
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -50,8 +50,6 @@ This package contains static libraries for NVIDIA CUDA Profiling Tools Interface
 %ifarch aarch64
 %setup -q -T -b 1 -n %{real_name}-linux-sbsa-%{version}-archive
 %endif
-
-%{?ldconfig_scriptlets}
 
 %install
 mkdir -p %{buildroot}%{_includedir}

--- a/anda/lib/nvidia/cuda-cuxxfilt/cuda-cuxxfilt.spec
+++ b/anda/lib/nvidia/cuda-cuxxfilt/cuda-cuxxfilt.spec
@@ -4,12 +4,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA cuxxfilt (demangler)
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -22,7 +22,7 @@ Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{real
 CUDA cuxxfilt (demangler).
 
 %package devel
-Summary:        CUDA cuxxfilt (demangler) development files
+Summary:        CUDA cuxxfilt (demangler)
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description devel

--- a/anda/lib/nvidia/cuda-gdb/cuda-gdb.spec
+++ b/anda/lib/nvidia/cuda-gdb/cuda-gdb.spec
@@ -3,13 +3,13 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
-Summary:        CUDA GDB tool for debugging CUDA applications
+Release:        2%?dist
+Summary:        CUDA GDB
 License:        GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL
 URL:            https://developer.nvidia.com/cuda-toolkit
 ExclusiveArch:  x86_64 aarch64

--- a/anda/lib/nvidia/cuda-nvdisasm/cuda-nvdisasm.spec
+++ b/anda/lib/nvidia/cuda-nvdisasm/cuda-nvdisasm.spec
@@ -4,12 +4,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Utility to extract information from CUDA binary files
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -19,7 +19,7 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{real
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{real_name}/linux-sbsa/%{real_name}-linux-sbsa-%{version}-archive.tar.xz
 
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
- 
+
 %description
 nvdisasm extracts information from standalone cubin files and presents them in
 human readable format. The output of nvdisasm includes CUDA assembly code for

--- a/anda/lib/nvidia/cuda-nvml/cuda-nvml.spec
+++ b/anda/lib/nvidia/cuda-nvml/cuda-nvml.spec
@@ -4,12 +4,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           cuda-nvml
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA Management library (NVML)
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -19,7 +19,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{real
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{real_name}/linux-sbsa/%{real_name}-linux-sbsa-%{version}-archive.tar.xz
 Source3:        nvidia-ml.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -65,8 +64,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files devel
 %license LICENSE

--- a/anda/lib/nvidia/cuda-nvprof/cuda-nvprof.spec
+++ b/anda/lib/nvidia/cuda-nvprof/cuda-nvprof.spec
@@ -4,12 +4,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA command line profiling tool
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -19,7 +19,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{real
 Source3:        accinj%{__isa_bits}.pc
 Source4:        cuinj%{__isa_bits}.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -61,8 +60,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/cuda-nvprune/cuda-nvprune.spec
+++ b/anda/lib/nvidia/cuda-nvprune/cuda-nvprune.spec
@@ -4,13 +4,13 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
-Summary:        CUDA tool to prune host object files and libraries
+Release:        2%?dist
+Summary:        CUDA nvprune
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
 ExclusiveArch:  x86_64 aarch64

--- a/anda/lib/nvidia/cuda-nvrtc/cuda-nvrtc.spec
+++ b/anda/lib/nvidia/cuda-nvrtc/cuda-nvrtc.spec
@@ -4,12 +4,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.93
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA runtime compilation library (NVRTC)
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -19,7 +19,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{real
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{real_name}/linux-sbsa/%{real_name}-linux-sbsa-%{version}-archive.tar.xz
 Source3:        nvrtc.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -72,22 +71,31 @@ sed -i \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
 
-%{?ldconfig_scriptlets}
-
 %files
 %license LICENSE
+%ifarch x86_64
+%{_libdir}/libnvrtc-builtins.alt.so.*
+%{_libdir}/libnvrtc.alt.so.*
+%endif
 %{_libdir}/libnvrtc-builtins.so.*
 %{_libdir}/libnvrtc.so.*
 
 %files devel
 %{_includedir}/nvrtc.h
+%ifarch x86_64
+%{_libdir}/libnvrtc-builtins.alt.so
+%{_libdir}/libnvrtc.alt.so
+%endif
 %{_libdir}/libnvrtc-builtins.so
 %{_libdir}/libnvrtc.so
 %{_libdir}/pkgconfig/nvrtc.pc
 
 %files static
+%ifarch x86_64
+%{_libdir}/libnvrtc-builtins_static.alt.a
+%{_libdir}/libnvrtc_static.alt.a
+%endif
 %{_libdir}/libnvrtc-builtins_static.a
-%{_libdir}/libnvrtc.so
 %{_libdir}/libnvrtc_static.a
 
 %changelog

--- a/anda/lib/nvidia/cuda-nvtx/cuda-nvtx.spec
+++ b/anda/lib/nvidia/cuda-nvtx/cuda-nvtx.spec
@@ -4,12 +4,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA Tools Extension (NVTX) library
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -19,7 +19,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{real
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{real_name}/linux-sbsa/%{real_name}-linux-sbsa-%{version}-archive.tar.xz
 Source3:        nvToolsExt.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -60,8 +59,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/cuda-profiler/cuda-profiler.spec
+++ b/anda/lib/nvidia/cuda-profiler/cuda-profiler.spec
@@ -6,7 +6,7 @@
 Name:           cuda-profiler
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA Profiler API
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit

--- a/anda/lib/nvidia/cuda-sandbox/cuda-sandbox.spec
+++ b/anda/lib/nvidia/cuda-sandbox/cuda-sandbox.spec
@@ -1,0 +1,53 @@
+%global real_name cuda_sandbox_dev
+
+%global debug_package %{nil}
+%global __strip /bin/true
+%global _missing_build_ids_terminate_build 0
+%global _build_id_links none
+%global major_package_version 12-8
+
+Name:           cuda-sandbox
+Epoch:          1
+Version:        12.8.55
+Release:        1%{?dist}
+Summary:        CUDA nvsandboxutils
+License:        CUDA Toolkit
+URL:            https://developer.nvidia.com/cuda-toolkit
+ExclusiveArch:  x86_64
+
+Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{real_name}/linux-x86_64/%{real_name}-linux-x86_64-%{version}-archive.tar.xz
+
+Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
+
+%description
+A C-based API for monitoring and managing various states of the NVIDIA GPU
+devices. It provides a direct access to the queries and commands exposed via
+nvidia-smi. The runtime version of NVML ships with the NVIDIA display driver.
+
+Each new version of NVML is backwards compatible and is intended to be a
+platform for building 3rd party applications.
+
+%package devel
+Summary:        Development files for the CUDA nvsandboxutils library
+Conflicts:      %{name}-devel-%{major_package_version} < %{?epoch:%{epoch}:}%{version}
+
+%description devel
+This package provides development files for the CUDA nvsandboxutils library.
+
+%prep
+%setup -q -n %{real_name}-linux-x86_64-%{version}-archive
+
+%install
+mkdir -p %{buildroot}%{_includedir}
+
+cp -fr include/* %{buildroot}%{_includedir}/
+install -p -m 0644 -D %{_lib}/stubs/libnvidia-sandboxutils_loader.a %{buildroot}%{_libdir}/libnvidia-sandboxutils_loader.a
+
+%files devel
+%license LICENSE
+%{_includedir}/nvsandboxutils_loader.h
+%{_includedir}/nvsandboxutils.h
+%{_libdir}/libnvidia-sandboxutils_loader.a
+
+%changelog
+%autochangelog

--- a/anda/lib/nvidia/cuda-sandbox/update.rhai
+++ b/anda/lib/nvidia/cuda-sandbox/update.rhai
@@ -1,0 +1,3 @@
+import "andax/nvidia.rhai" as nvidia;
+
+rpm.version(nvidia::nvidia_component_version("cuda_sandbox_dev"));

--- a/anda/lib/nvidia/cuda-sanitizer/cuda-sanitizer.spec
+++ b/anda/lib/nvidia/cuda-sanitizer/cuda-sanitizer.spec
@@ -4,12 +4,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           cuda-sanitizer
 Epoch:          1
 Version:        12.8.93
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA Compute Sanitizer API
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -20,7 +20,6 @@ Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{real
 
 BuildRequires:  chrpath
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -60,8 +59,6 @@ cp -fr compute-sanitizer/x86/Tree* %{buildroot}%{_bindir}/
 cp -fr compute-sanitizer/lib* %{buildroot}%{_libdir}/
 cp -fr compute-sanitizer/Tree* compute-sanitizer/compute-sanitizer %{buildroot}%{_bindir}/
 %endif
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/cuda/cuda.spec
+++ b/anda/lib/nvidia/cuda/cuda.spec
@@ -1,9 +1,9 @@
 %global debug_package %{nil}
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           cuda
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA Compute Unified Device Architecture Toolkit
 Epoch:          1
 License:        CUDA Toolkit
@@ -91,6 +91,7 @@ Requires:       %{name}-nvrtc-devel%{?_isa}
 Requires:       %{name}-nvtx-devel%{?_isa}
 Requires:       %{name}-cuobjdump%{?_isa}
 Requires:       %{name}-cuxxfilt-devel%{?_isa}
+Requires:       %{name}-sandbox-devel%{?_isa}
 Requires:       libcublas-devel%{?_isa}
 Requires:       libcufft-devel%{?_isa}
 Requires:       libcufile-devel%{?_isa}

--- a/anda/lib/nvidia/libcublas/libcublas.spec
+++ b/anda/lib/nvidia/libcublas/libcublas.spec
@@ -2,12 +2,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           libcublas
 Epoch:          1
 Version:        12.8.4.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA CUDA Basic Linear Algebra Subroutines (cuBLAS) libraries
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -18,7 +18,6 @@ Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{name
 Source3:        cublas.pc
 Source4:        cublasLt.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -67,8 +66,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/libcudla/libcudla.spec
+++ b/anda/lib/nvidia/libcudla/libcudla.spec
@@ -2,13 +2,13 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           libcudla
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
-Summary:        NVIDIA CUDA Deep Learning Accelerator (DLA) engines (Jetson Xavier and Orin)
+Release:        2%?dist
+Summary:        NVIDIA CUDA Deep Learning Accelerator (DLA) engines (Jetson Xavier + Orin)
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
 ExclusiveArch:  aarch64
@@ -17,7 +17,8 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{name
 Source1:        cudla.pc
 
 %description
-Low-level driver for the Deep Learning Accelerator (DLA) engine for Jetson Xavier and Orin boards.
+Low-level driver for the Deep Learning Accelerator (DLA) engine for Jetson
+Xavier + Orin boards.
 
 %package devel
 Summary:        Development files for CUDA Deep Learning Accelerator (DLA) engines
@@ -25,7 +26,8 @@ Requires:       %{name}%{_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 Conflicts:      %{name}-devel-%{major_package_version} < %{?epoch:%{epoch}:}%{version}
 
 %description devel
-This package provides development files for the CUDA Deep Learning Accelerator (DLA) engines.
+This package provides development files for the CUDA Deep Learning Accelerator
+(DLA) engines.
 
 %prep
 %autosetup -n %{name}-linux-aarch64-%{version}-archive

--- a/anda/lib/nvidia/libcufft/libcufft.spec
+++ b/anda/lib/nvidia/libcufft/libcufft.spec
@@ -2,12 +2,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           libcufft
 Epoch:          2
 Version:        11.3.3.83
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA CUDA Fast Fourier Transform library (cuFFT) libraries
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -18,7 +18,6 @@ Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{name
 Source3:        cufft.pc
 Source4:        cufftw.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 # Drop in 11.7:
 Provides:       cuda-cufft = %{?epoch:%{epoch}:}%{version}-%{release}
@@ -77,8 +76,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/libcurand/libcurand.spec
+++ b/anda/lib/nvidia/libcurand/libcurand.spec
@@ -2,12 +2,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           libcurand
 Epoch:          2
 Version:        10.3.9.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA CUDA Random Number Generation library (cuRAND)
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -17,7 +17,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{name
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{name}/linux-sbsa/%{name}-linux-sbsa-%{version}-archive.tar.xz
 Source3:        curand.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -67,8 +66,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/libcusparse/libcusparse.spec
+++ b/anda/lib/nvidia/libcusparse/libcusparse.spec
@@ -2,12 +2,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           libcusparse
 Epoch:          1
 Version:        12.5.8.93
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA CUDA Sparse Matrix library (cuSPARSE) library
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -17,7 +17,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{name
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{name}/linux-sbsa/%{name}-linux-sbsa-%{version}-archive.tar.xz
 Source3:        cusparse.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -67,8 +66,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/libcusparselt/libcusparselt.spec
+++ b/anda/lib/nvidia/libcusparselt/libcusparselt.spec
@@ -5,7 +5,7 @@
 
 Name:           libcusparselt
 Version:        0.7.1.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA Library for Sparse Matrix-Matrix Multiplication
 License:        NVIDIA License
 URL:            https://docs.nvidia.com/cuda/cusparselt/index.html
@@ -61,8 +61,6 @@ install -p -m0644 lib/libcusparseLt_static.a %{buildroot}%{_libdir}/
 
 mkdir -p %{buildroot}%{_includedir}/
 install -p -m0644 include/cusparseLt.h %{buildroot}%{_includedir}/
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/libnpp/libnpp.spec
+++ b/anda/lib/nvidia/libnpp/libnpp.spec
@@ -2,12 +2,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           libnpp
 Epoch:          1
 Version:        12.3.3.100
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA Performance Primitives libraries
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -30,7 +30,6 @@ Source20:       nppisu.pc
 Source21:       nppitc.pc
 Source22:       npps.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -84,8 +83,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE
@@ -148,5 +145,6 @@ sed -i \
 %{_libdir}/libnppisu_static.a
 %{_libdir}/libnppitc_static.a
 %{_libdir}/libnpps_static.a
+
 %changelog
 %autochangelog

--- a/anda/lib/nvidia/libnvfatbin/libnvfatbin.spec
+++ b/anda/lib/nvidia/libnvfatbin/libnvfatbin.spec
@@ -2,12 +2,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           libnvfatbin
 Epoch:          1
 Version:        12.8.90
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA Fatbin Creator API
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -17,7 +17,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{name
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{name}/linux-sbsa/%{name}-linux-sbsa-%{version}-archive.tar.xz
 Source3:        nvfatbin.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -72,8 +71,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE

--- a/anda/lib/nvidia/libnvjpeg/libnvjpeg.spec
+++ b/anda/lib/nvidia/libnvjpeg/libnvjpeg.spec
@@ -2,12 +2,12 @@
 %global __strip /bin/true
 %global _missing_build_ids_terminate_build 0
 %global _build_id_links none
-%global major_package_version 12-6
+%global major_package_version 12-8
 
 Name:           libnvjpeg
 Epoch:          1
 Version:        12.3.5.92
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA NVIDIA JPEG decoder (nvJPEG)
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
@@ -17,7 +17,6 @@ Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{name
 Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{name}/linux-sbsa/%{name}-linux-sbsa-%{version}-archive.tar.xz
 Source3:        nvjpeg.pc
 
-Requires(post): ldconfig
 Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
@@ -67,8 +66,6 @@ sed -i \
     -e 's|LIBDIR|%{_libdir}|g' \
     -e 's|INCLUDE_DIR|%{_includedir}|g' \
     %{buildroot}/%{_libdir}/pkgconfig/*.pc
-
-%{?ldconfig_scriptlets}
 
 %files
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: Mass CUDA update (#4546)](https://github.com/terrapkg/packages/pull/4546)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)