### PR TITLE
[f40] fix(steam): Remove broken .desktop file flags (#4567)

### DIFF
--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -184,6 +184,10 @@ install -m 644 -p %{SOURCE7} %{buildroot}%{_prefix}/lib/systemd/system.conf.d/
 install -m 644 -p %{SOURCE7} %{buildroot}%{_prefix}/lib/systemd/user.conf.d/
 install -m 775 -p %{SOURCE9} %{buildroot}%{_bindir}/steamrestart
 
+# https://github.com/ValveSoftware/steam-for-linux/issues/9940
+desktop-file-edit --remove-key=PrefersNonDefaultGPU %{buildroot}%{_datadir}/applications/%{name}.desktop
+desktop-file-edit --remove-key=X-KDE-RunOnDiscreteGpu %{buildroot}%{_datadir}/applications/%{name}.desktop
+
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%{appstream_id}.metainfo.xml

--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -5,7 +5,7 @@
 
 Name:           steam
 Version:        1.0.0.82
-Release:        7%?dist
+Release:        8%?dist
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(steam): Remove broken .desktop file flags (#4567)](https://github.com/terrapkg/packages/pull/4567)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)