### PR TITLE
[f41] fix: nv-codec-headers update.rhai (#4577)

### DIFF
--- a/anda/lib/nvidia/nv-codec-headers/update.rhai
+++ b/anda/lib/nvidia/nv-codec-headers/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh("FFmpeg/nv-codec-headers"));
+let v = gh("FFmpeg/nv-codec-headers");
+v.crop(1);
+rpm.version(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: nv-codec-headers update.rhai (#4577)](https://github.com/terrapkg/packages/pull/4577)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)