### PR TITLE
[el10] chore: Bump yt-dlp (#4578)

### DIFF
--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,7 +2,7 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2025.04.29.164609
+Version:        2025.04.30.230140
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f40` to `el10`:
 - [chore: Bump yt-dlp (#4578)](https://github.com/terrapkg/packages/pull/4578)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)