### PR TITLE
[el10] add: LCEVCdec (#4463) (#4600)

### DIFF
--- a/anda/multimedia/lcevcdec/LCEVCdec-cstdint.patch
+++ b/anda/multimedia/lcevcdec/LCEVCdec-cstdint.patch
@@ -1,0 +1,11 @@
+diff -Naur LCEVCdec-3.3.5.old/src/api/src/buffer_manager.h LCEVCdec-3.3.5/src/api/src/buffer_manager.h
+--- LCEVCdec-3.3.5.old/src/api/src/buffer_manager.h	2025-03-22 11:46:05.946962992 +0100
++++ LCEVCdec-3.3.5/src/api/src/buffer_manager.h	2025-03-22 11:46:36.029979290 +0100
+@@ -15,6 +15,7 @@
+ #ifndef VN_API_BUFFER_MANAGER_H_
+ #define VN_API_BUFFER_MANAGER_H_
+ 
++#include <cstdint>
+ #include <functional>
+ #include <memory>
+ #include <set>

--- a/anda/multimedia/lcevcdec/LCEVCdec-docs.patch
+++ b/anda/multimedia/lcevcdec/LCEVCdec-docs.patch
@@ -1,0 +1,14 @@
+diff -Naur LCEVCdec-3.3.5.old/docs/sphinx/CMakeLists.txt LCEVCdec-3.3.5/docs/sphinx/CMakeLists.txt
+--- LCEVCdec-3.3.5.old/docs/sphinx/CMakeLists.txt	2025-03-23 16:27:09.553289475 +0100
++++ LCEVCdec-3.3.5/docs/sphinx/CMakeLists.txt	2025-03-24 08:54:32.562734384 +0100
+@@ -41,8 +41,8 @@
+     documentation ALL
+     DEPENDS doxygen
+     COMMAND
+-        ${SPHINX_EXECUTABLE} -b html -W -n -a -Dversion=${GIT_SHORT_VERSION}
++        ${SPHINX_EXECUTABLE} ${SPHINX_SOURCE} ${SPHINX_BUILD}
++        -b html -W -n -a -Dversion=${GIT_SHORT_VERSION}
+         -Drelease=${GIT_VERSION} -Dbreathe_projects.LCEVC_DEC=${DOXYGEN_OUTPUT_DIR}/xml
+-        ${SPHINX_SOURCE} ${SPHINX_BUILD}
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+     COMMENT "Generating docs with Sphinx")

--- a/anda/multimedia/lcevcdec/LCEVCdec-soversion.patch
+++ b/anda/multimedia/lcevcdec/LCEVCdec-soversion.patch
@@ -1,0 +1,22 @@
+diff -Naur LCEVCdec-3.3.5.old/src/api/CMakeLists.txt LCEVCdec-3.3.5/src/api/CMakeLists.txt
+--- LCEVCdec-3.3.5.old/src/api/CMakeLists.txt	2025-03-23 16:27:09.553851133 +0100
++++ LCEVCdec-3.3.5/src/api/CMakeLists.txt	2025-03-26 16:53:24.642189905 +0100
+@@ -57,6 +57,7 @@
+ 
+ include(GNUInstallDirs)
+ 
++set_target_properties(lcevc_dec_api PROPERTIES SOVERSION ${GIT_SHORT_VERSION} VERSION ${GIT_VERSION})
+ get_target_property(IS_APPLE_FRAMEWORK lcevc_dec_api FRAMEWORK)
+ if (IS_APPLE_FRAMEWORK)
+     install(TARGETS lcevc_dec_api DESTINATION lib)
+diff -Naur LCEVCdec-3.3.5.old/src/core/decoder/CMakeLists.txt LCEVCdec-3.3.5/src/core/decoder/CMakeLists.txt
+--- LCEVCdec-3.3.5.old/src/core/decoder/CMakeLists.txt	2025-03-23 16:27:09.556081884 +0100
++++ LCEVCdec-3.3.5/src/core/decoder/CMakeLists.txt	2025-03-26 16:53:10.698019829 +0100
+@@ -170,6 +170,7 @@
+ 
+ # -------------------------------------------------------------------------------
+ 
++set_target_properties(lcevc_dec_core PROPERTIES SOVERSION ${GIT_SHORT_VERSION} VERSION ${GIT_VERSION})
+ get_target_property(IS_APPLE_FRAMEWORK lcevc_dec_core FRAMEWORK)
+ if (IS_APPLE_FRAMEWORK)
+     install(TARGETS lcevc_dec_core DESTINATION lib)

--- a/anda/multimedia/lcevcdec/LCEVCdec.spec
+++ b/anda/multimedia/lcevcdec/LCEVCdec.spec
@@ -1,0 +1,173 @@
+# This information is required if not building from a GIT checkout.
+# See cmake/modules/VNovaSetup.cmake:
+%global gitlonghash bf7e0d91c969502e90a925942510a1ca8088afec
+%global gitdate 20250320
+%global githash %(c=%{gitlonghash}; echo ${c:0:7})
+%global gitbranch main
+
+# Tests require network, as described in src/func_tests/README.md, and each test type
+# (Qualcomm dev kit, Ubuntu, etc.) requires the download of a few gigabytes of videos
+# from https://lcevcdec.nbg1.your-objectstorage.com. The videos used for testing
+# are described in the "Content attribution" paragraph of the README.md file.
+# So disable tests by default:
+%bcond python_tests 0
+
+# python3-sphinxcontrib-plantuml currently missing from Fedora:
+%bcond docs 0
+
+Name:           LCEVCdec
+Version:        3.3.5
+Release:        1%{?dist}
+Summary:        MPEG-5 LCEVC Decoder
+License:        BSD-3-Clause-Clear
+URL:            https://docs.v-nova.com/v-nova/lcevc/lcevc-sdk-overview
+
+Source0:        https://github.com/v-novaltd/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Patch0:         %{name}-cstdint.patch
+Patch1:         %{name}-docs.patch
+Patch2:         %{name}-soversion.patch
+
+BuildRequires:  cmake
+BuildRequires:  cmake(CLI11)
+BuildRequires:  cmake(fmt)
+BuildRequires:  cmake(nlohmann_json)
+BuildRequires:  cmake(range-v3)
+BuildRequires:  gcc-c++
+BuildRequires:  git
+BuildRequires:  pkgconfig(libavcodec)
+BuildRequires:  pkgconfig(libavdevice)
+BuildRequires:  pkgconfig(libxxhash)
+BuildRequires:  pkgconfig(gtest)
+
+%if %{with docs}
+BuildRequires:  doxygen
+BuildRequires:  sphinx
+BuildRequires:  plantuml
+BuildRequires:  python3-breathe
+BuildRequires:  python3-sphinx
+BuildRequires:  python3-sphinx_rtd_theme
+BuildRequires:  python3-sphinxcontrib-plantuml
+%endif
+
+%if %{with tests}
+BuildRequires:  python3
+BuildRequires:  python3-GitPython
+BuildRequires:  python3-numpy
+BuildRequires:  python3-requests
+%endif
+
+%description
+Low Complexity Enhancement Video Codec Decoder (LCEVCdec) is the primary MPEG-5
+Part 2 decoder SDK repository maintained by V-Nova.
+
+Features:
+ - Decode LCEVC compliant bitstreams
+ - Support for a range of formats including YUV, NV12 and RGBA
+ - Support for a range of colour formats including BT709 and BT2020
+ - Support for HDR and 10-bit streams
+ - Support for ABR ladders
+ - CPU pixel processing stage
+ - Extensive API
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       plutovg-devel%{?_isa}       
+
+%description    devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+%package        static
+Summary:        Static libraries for %{name}
+Requires:       %{name}-devel%{?_isa} = %{version}-%{release}
+
+%description    static
+Static library files for %{name}.
+
+%package        samples
+Summary:        Sample programs for %{name}
+
+%description    samples
+Sample programs that use %{name}.
+
+%prep
+%autosetup -p1
+
+# This information is required if not building from a GIT checkout.
+# See cmake/modules/VNovaSetup.cmake:
+echo -n %{gitlonghash} > .gitlonghash
+echo -n %{gitdate} | date +%Y-%m-%d > .gitdate
+echo -n %{githash} > .githash
+echo -n %{gitbranch} > .gitbranch
+echo -n %{version} > .gitversion
+echo -n %(echo %version | cut -d. -f1) > .gitshortversion
+
+%if %{with tests}
+# Adjust configuration file for tests:
+sed -i \
+    -e 's/BIN_DIR = build/BIN_DIR = %{_vpath_builddir}/g' \
+    src/func_tests/config.ini
+%endif
+
+%build
+%cmake \
+  -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DVN_SDK_EXECUTABLES=ON \
+  -DVN_SDK_UNIT_TESTS=ON \
+  -DVN_SDK_API_LAYER=ON \
+  -DVN_SDK_JSON_CONFIG=ON \
+%if %{with docs}
+  -DVN_SDK_DOCS=ON
+%else
+  -DVN_SDK_DOCS=OFF
+%endif
+
+%cmake_build
+
+%install
+%cmake_install
+%ifnarch %ix86
+mv %{buildroot}%{_prefix}/lib/*.a %{buildroot}%{_libdir}/
+rm -fr %{buildroot}%{_prefix}/lib
+%endif
+
+# Let RPM pick up docs in the files section
+rm -fr %{buildroot}%{_docdir}
+
+%if %{with tests}
+%check
+python3 src/func_tests/run_tests.py
+%endif
+
+%files
+%license LICENSE.md COPYING
+%doc README.md
+%{_libdir}/liblcevc_dec_api.so.3
+%{_libdir}/liblcevc_dec_api.so.%{version}
+%{_libdir}/liblcevc_dec_core.so.3
+%{_libdir}/liblcevc_dec_core.so.%{version}
+
+%files devel
+%{_includedir}/LCEVC
+%{_libdir}/liblcevc_dec_api.so
+%{_libdir}/liblcevc_dec_core.so
+%{_libdir}/pkgconfig/lcevc_dec.pc
+
+%files static
+%{_libdir}/liblcevc_dec_api_utility.a
+%{_libdir}/liblcevc_dec_core_sequencing.a
+%{_libdir}/liblcevc_dec_unit_test_utilities.a
+%{_libdir}/liblcevc_dec_utility.a
+
+%files samples
+%{_bindir}/lcevc_dec_sample
+%{_bindir}/lcevc_dec_test_harness
+%{_bindir}/lcevc_dec_test_unit
+%{_bindir}/lcevc_dec_utility_test_unit
+%{_bindir}/lcevc_core_test_unit
+%{_bindir}/lcevc_core_sequencing_test_unit
+
+%changelog
+%autochangelog

--- a/anda/multimedia/lcevcdec/anda.hcl
+++ b/anda/multimedia/lcevcdec/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+    arches = ["x86_64", "aarch64", "i386"]
+    rpm {
+        spec = "LCEVCdec.spec"
+    }
+    labels {
+        mock = 1
+   }
+}

--- a/anda/multimedia/lcevcdec/update.rhai
+++ b/anda/multimedia/lcevcdec/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("v-novaltd/LCEVCdec"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [add: LCEVCdec (#4463) (#4600)](https://github.com/terrapkg/packages/pull/4600)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)