### PR TITLE
chore: Move NVIDIA tools to NVIDIA repo

### DIFF
--- a/anda/tools/cuda-gcc/anda.hcl
+++ b/anda/tools/cuda-gcc/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
 	}
     labels {
         updbranch = 1
+        subrepo = "nvidia"
     }
 }

--- a/anda/tools/cuda-nvcc/anda.hcl
+++ b/anda/tools/cuda-nvcc/anda.hcl
@@ -4,5 +4,6 @@ project "pkg" {
     }
     labels {
         upbranch = 1
+        subrepo = "nvidia"
     }
 }


### PR DESCRIPTION
Moved these because other stuff sometimes needed them to build but I suppose we can just enable the NVIDIA repo in those cases like here: #4601