### PR TITLE
[el10] refactor: Rebase FFmpeg (#3489)

### DIFF
--- a/anda/multimedia/ffmpeg/ffmpeg-HandBrake.patch
+++ b/anda/multimedia/ffmpeg/ffmpeg-HandBrake.patch
@@ -1,0 +1,1904 @@
+diff -Naur ffmpeg-7.1.1.old/configure ffmpeg-7.1.1/configure
+--- ffmpeg-7.1.1.old/configure	2025-03-24 10:54:39.093543820 +0100
++++ ffmpeg-7.1.1/configure	2025-03-24 10:54:39.281929795 +0100
+@@ -3338,6 +3338,7 @@
+ av1_mediacodec_decoder_deps="mediacodec"
+ av1_mediacodec_encoder_deps="mediacodec"
+ av1_mediacodec_encoder_select="extract_extradata_bsf"
++av1_mf_encoder_deps="mediafoundation"
+ av1_nvenc_encoder_deps="nvenc NV_ENC_PIC_PARAMS_AV1"
+ av1_nvenc_encoder_select="atsc_a53"
+ av1_qsv_decoder_select="qsvdec"
+diff -Naur ffmpeg-7.1.1.old/libavcodec/allcodecs.c ffmpeg-7.1.1/libavcodec/allcodecs.c
+--- ffmpeg-7.1.1.old/libavcodec/allcodecs.c	2025-03-24 10:54:39.094862193 +0100
++++ ffmpeg-7.1.1/libavcodec/allcodecs.c	2025-03-24 10:54:39.282298069 +0100
+@@ -839,6 +839,7 @@
+ extern const FFCodec ff_av1_qsv_decoder;
+ extern const FFCodec ff_av1_qsv_encoder;
+ extern const FFCodec ff_av1_amf_encoder;
++extern const FFCodec ff_av1_mf_encoder;
+ extern const FFCodec ff_av1_vaapi_encoder;
+ extern const FFCodec ff_libopenh264_encoder;
+ extern const FFCodec ff_libopenh264_decoder;
+diff -Naur ffmpeg-7.1.1.old/libavcodec/amfenc_av1.c ffmpeg-7.1.1/libavcodec/amfenc_av1.c
+--- ffmpeg-7.1.1.old/libavcodec/amfenc_av1.c	2025-03-24 10:54:38.133756381 +0100
++++ ffmpeg-7.1.1/libavcodec/amfenc_av1.c	2025-03-24 10:54:39.277830845 +0100
+@@ -116,6 +116,7 @@
+     { "none",                   "no adaptive quantization",         0, AV_OPT_TYPE_CONST, {.i64 = AMF_VIDEO_ENCODER_AV1_AQ_MODE_NONE }, 0, 0, VE, .unit = "adaptive_quantisation_mode" },
+     { "caq",                    "context adaptive quantization",    0, AV_OPT_TYPE_CONST, {.i64 = AMF_VIDEO_ENCODER_AV1_AQ_MODE_CAQ }, 0, 0, VE, .unit = "adaptive_quantisation_mode" },
+ 
++    { "forced_idr",             "Force I frames to be IDR frames",  OFFSET(forced_idr),   AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
+ 
+     { "align",                  "alignment mode",                           OFFSET(align),                          AV_OPT_TYPE_INT,     {.i64 = AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE_NO_RESTRICTIONS },         AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE_64X16_ONLY, AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE_NO_RESTRICTIONS, VE, .unit = "align" },
+     { "64x16",                  "", 0, AV_OPT_TYPE_CONST, {.i64 = AMF_VIDEO_ENCODER_AV1_ALIGNMENT_MODE_64X16_ONLY               }, 0, 0, VE, .unit = "align" },
+@@ -186,6 +187,8 @@
+     AMFRate             framerate;
+     AMFSize             framesize = AMFConstructSize(avctx->width, avctx->height);
+     amf_int64           color_depth;
++    amf_int64           color_primaries;
++    amf_int64           transfer_characteristic;
+     amf_int64           color_profile;
+     enum                AVPixelFormat pix_fmt;
+ 
+@@ -238,7 +241,11 @@
+     }
+ 
+     /// Color profile
++    color_primaries = ff_amf_get_color_primaries(avctx);
++    transfer_characteristic = ff_amf_get_transfer_characteristic(avctx);
+     color_profile = ff_amf_get_color_profile(avctx);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_OUTPUT_COLOR_PRIMARIES, color_primaries);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_OUTPUT_TRANSFER_CHARACTERISTIC, transfer_characteristic);
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_OUTPUT_COLOR_PROFILE, color_profile);
+ 
+     /// Color Depth
+@@ -250,16 +257,6 @@
+     }
+ 
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_COLOR_BIT_DEPTH, color_depth);
+-    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_OUTPUT_COLOR_PROFILE, color_profile);
+-    if (color_depth == AMF_COLOR_BIT_DEPTH_8) {
+-        /// Color Transfer Characteristics (AMF matches ISO/IEC)
+-        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_OUTPUT_TRANSFER_CHARACTERISTIC, AMF_COLOR_TRANSFER_CHARACTERISTIC_BT709);
+-        /// Color Primaries (AMF matches ISO/IEC)
+-        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_OUTPUT_COLOR_PRIMARIES, AMF_COLOR_PRIMARIES_BT709);
+-    } else {
+-        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_OUTPUT_TRANSFER_CHARACTERISTIC, AMF_COLOR_TRANSFER_CHARACTERISTIC_SMPTE2084);
+-        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_AV1_OUTPUT_COLOR_PRIMARIES, AMF_COLOR_PRIMARIES_BT2020);
+-    }
+ 
+     profile_level = avctx->level;
+     if (profile_level == AV_LEVEL_UNKNOWN) {
+diff -Naur ffmpeg-7.1.1.old/libavcodec/amfenc.c ffmpeg-7.1.1/libavcodec/amfenc.c
+--- ffmpeg-7.1.1.old/libavcodec/amfenc.c	2025-03-24 10:54:38.032755166 +0100
++++ ffmpeg-7.1.1/libavcodec/amfenc.c	2025-03-24 10:54:39.279550845 +0100
+@@ -415,10 +415,6 @@
+     else
+         pix_fmt = avctx->pix_fmt;
+ 
+-    if (pix_fmt == AV_PIX_FMT_P010) {
+-        AMF_RETURN_IF_FALSE(ctx, ctx->version >= AMF_MAKE_FULL_VERSION(1, 4, 32, 0), AVERROR_UNKNOWN, "10-bit encoder is not supported by AMD GPU drivers versions lower than 23.30.\n");
+-    }
+-
+     ctx->format = amf_av_to_amf_format(pix_fmt);
+     AMF_RETURN_IF_FALSE(ctx, ctx->format != AMF_SURFACE_UNKNOWN, AVERROR(EINVAL),
+                         "Format %s is not supported\n", av_get_pix_fmt_name(pix_fmt));
+@@ -766,11 +762,50 @@
+         switch (avctx->codec->id) {
+         case AV_CODEC_ID_H264:
+             AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_INSERT_AUD, !!ctx->aud);
++            switch (frame->pict_type) {
++            case AV_PICTURE_TYPE_I:
++                if (ctx->forced_idr) {
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_INSERT_SPS, 1);
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_INSERT_PPS, 1);
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_PICTURE_TYPE_IDR);
++                } else {
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_PICTURE_TYPE_I);
++                }
++                break;
++            case AV_PICTURE_TYPE_P:
++                AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_PICTURE_TYPE_P);
++                break;
++            case AV_PICTURE_TYPE_B:
++                AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_PICTURE_TYPE_B);
++                break;
++            }
+             break;
+         case AV_CODEC_ID_HEVC:
+             AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_HEVC_INSERT_AUD, !!ctx->aud);
++            switch (frame->pict_type) {
++            case AV_PICTURE_TYPE_I:
++                if (ctx->forced_idr) {
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_HEVC_INSERT_HEADER, 1);
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_IDR);
++                } else {
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_I);
++                }
++                break;
++            case AV_PICTURE_TYPE_P:
++                AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_HEVC_FORCE_PICTURE_TYPE, AMF_VIDEO_ENCODER_HEVC_PICTURE_TYPE_P);
++                break;
++            }
++            break;
++        case AV_CODEC_ID_AV1:
++            if (frame->pict_type == AV_PICTURE_TYPE_I) {
++                if (ctx->forced_idr) {
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_AV1_FORCE_INSERT_SEQUENCE_HEADER, 1);
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_AV1_FORCE_FRAME_TYPE, AMF_VIDEO_ENCODER_AV1_FORCE_FRAME_TYPE_KEY);
++                } else {
++                    AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_AV1_FORCE_FRAME_TYPE, AMF_VIDEO_ENCODER_AV1_FORCE_FRAME_TYPE_INTRA_ONLY);
++                }
++            }
+             break;
+-        //case AV_CODEC_ID_AV1 not supported
+         default:
+             break;
+         }
+@@ -878,6 +913,115 @@
+     return ret;
+ }
+ 
++int ff_amf_get_color_primaries(AVCodecContext *avctx)
++{
++    amf_int64 color_primaries = AMF_COLOR_PRIMARIES_UNDEFINED;
++    switch (avctx->color_primaries) {
++        case AVCOL_PRI_BT709:
++            color_primaries = AMF_COLOR_PRIMARIES_BT709;
++            break;
++        case AVCOL_PRI_UNSPECIFIED:
++            color_primaries = AMF_COLOR_PRIMARIES_UNSPECIFIED;
++            break;
++        case AVCOL_PRI_RESERVED:
++            color_primaries = AMF_COLOR_PRIMARIES_RESERVED;
++            break;
++        case AVCOL_PRI_BT470M:
++            color_primaries = AMF_COLOR_PRIMARIES_BT470M;
++            break;
++        case AVCOL_PRI_BT470BG:
++            color_primaries = AMF_COLOR_PRIMARIES_BT470BG;
++            break;
++        case AVCOL_PRI_SMPTE170M:
++            color_primaries = AMF_COLOR_PRIMARIES_SMPTE170M;
++            break;
++        case AVCOL_PRI_SMPTE240M:
++            color_primaries = AMF_COLOR_PRIMARIES_SMPTE240M;
++            break;
++        case AVCOL_PRI_FILM:
++            color_primaries = AMF_COLOR_PRIMARIES_FILM;
++            break;
++        case AVCOL_PRI_BT2020:
++            color_primaries = AMF_COLOR_PRIMARIES_BT2020;
++            break;
++        case AVCOL_PRI_SMPTE428:
++            color_primaries = AMF_COLOR_PRIMARIES_SMPTE428;
++            break;
++        case AVCOL_PRI_SMPTE431:
++            color_primaries = AMF_COLOR_PRIMARIES_SMPTE431;
++            break;
++        case AVCOL_PRI_SMPTE432:
++            color_primaries = AMF_COLOR_PRIMARIES_SMPTE432;
++            break;
++        case AVCOL_PRI_EBU3213:
++            color_primaries = AMF_COLOR_PRIMARIES_JEDEC_P22;
++            break;
++    }
++    return color_primaries;
++}
++
++int ff_amf_get_transfer_characteristic(AVCodecContext *avctx)
++{
++    amf_int64 transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_UNDEFINED;
++    switch (avctx->color_trc) {
++        case AVCOL_TRC_BT709:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_BT709;
++            break;
++        case AVCOL_TRC_UNSPECIFIED:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_UNSPECIFIED;
++            break;
++        case AVCOL_TRC_RESERVED:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_RESERVED;
++            break;
++        case AVCOL_TRC_GAMMA22:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_GAMMA22;
++            break;
++        case AVCOL_TRC_GAMMA28:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_GAMMA28;
++            break;
++        case AVCOL_TRC_SMPTE170M:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_SMPTE170M;
++            break;
++        case AVCOL_TRC_SMPTE240M:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_SMPTE240M;
++            break;
++        case AVCOL_TRC_LINEAR:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_LINEAR;
++            break;
++        case AVCOL_TRC_LOG:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_LOG;
++            break;
++        case AVCOL_TRC_LOG_SQRT:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_LOG_SQRT;
++            break;
++        case AVCOL_TRC_IEC61966_2_4:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_IEC61966_2_4;
++            break;
++        case AVCOL_TRC_BT1361_ECG:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_BT1361_ECG;
++            break;
++        case AVCOL_TRC_IEC61966_2_1:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_IEC61966_2_1;
++            break;
++        case AVCOL_TRC_BT2020_10:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_BT2020_10;
++            break;
++        case AVCOL_TRC_BT2020_12:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_BT2020_12;
++            break;
++        case AVCOL_TRC_SMPTE2084:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_SMPTE2084;
++            break;
++        case AVCOL_TRC_SMPTE428:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_SMPTE428;
++            break;
++        case AVCOL_TRC_ARIB_STD_B67:
++            transfer_characteristic = AMF_COLOR_TRANSFER_CHARACTERISTIC_ARIB_STD_B67;
++            break;
++    }
++    return transfer_characteristic;
++}
++
+ int ff_amf_get_color_profile(AVCodecContext *avctx)
+ {
+     amf_int64 color_profile = AMF_VIDEO_CONVERTER_COLOR_PROFILE_UNKNOWN;
+diff -Naur ffmpeg-7.1.1.old/libavcodec/amfenc.h ffmpeg-7.1.1/libavcodec/amfenc.h
+--- ffmpeg-7.1.1.old/libavcodec/amfenc.h	2025-03-24 10:54:37.990754660 +0100
++++ ffmpeg-7.1.1/libavcodec/amfenc.h	2025-03-24 10:54:39.277763348 +0100
+@@ -114,6 +114,7 @@
+     int                 max_b_frames;
+     int                 qvbr_quality_level;
+     int                 hw_high_motion_quality_boost;
++    int                 forced_idr;
+ 
+     // HEVC - specific options
+ 
+@@ -173,6 +174,8 @@
+ */
+ extern const enum AVPixelFormat ff_amf_pix_fmts[];
+ 
++int ff_amf_get_color_primaries(AVCodecContext *avctx);
++int ff_amf_get_transfer_characteristic(AVCodecContext *avctx);
+ int ff_amf_get_color_profile(AVCodecContext *avctx);
+ 
+ /**
+diff -Naur ffmpeg-7.1.1.old/libavcodec/amfenc_h264.c ffmpeg-7.1.1/libavcodec/amfenc_h264.c
+--- ffmpeg-7.1.1.old/libavcodec/amfenc_h264.c	2025-03-24 10:54:38.175756886 +0100
++++ ffmpeg-7.1.1/libavcodec/amfenc_h264.c	2025-03-24 10:54:39.277925894 +0100
+@@ -133,6 +133,7 @@
+     { "me_half_pel",    "Enable ME Half Pixel",                 OFFSET(me_half_pel),   AV_OPT_TYPE_BOOL,  { .i64 = -1 }, -1, 1, VE },
+     { "me_quarter_pel", "Enable ME Quarter Pixel",              OFFSET(me_quarter_pel),AV_OPT_TYPE_BOOL,  { .i64 = -1 }, -1, 1, VE },
+ 
++    { "forced_idr",     "Force I frames to be IDR frames",      OFFSET(forced_idr)   , AV_OPT_TYPE_BOOL,  { .i64 = 0  }, 0, 1, VE },
+     { "aud",            "Inserts AU Delimiter NAL unit",        OFFSET(aud)          , AV_OPT_TYPE_BOOL,  { .i64 = -1 }, -1, 1, VE },
+ 
+ 
+@@ -201,6 +202,8 @@
+     AMFRate                          framerate;
+     AMFSize                          framesize = AMFConstructSize(avctx->width, avctx->height);
+     int                              deblocking_filter = (avctx->flags & AV_CODEC_FLAG_LOOP_FILTER) ? 1 : 0;
++    amf_int64                        color_primaries;
++    amf_int64                        transfer_characteristic;
+     amf_int64                        color_profile;
+     enum                             AVPixelFormat pix_fmt;
+ 
+@@ -273,7 +276,11 @@
+         AMF_ASSIGN_PROPERTY_RATIO(res, ctx->encoder, AMF_VIDEO_ENCODER_ASPECT_RATIO, ratio);
+     }
+ 
++    color_primaries = ff_amf_get_color_primaries(avctx);
++    transfer_characteristic = ff_amf_get_transfer_characteristic(avctx);
+     color_profile = ff_amf_get_color_profile(avctx);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_OUTPUT_COLOR_PRIMARIES, color_primaries);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_OUTPUT_TRANSFER_CHARACTERISTIC, transfer_characteristic);
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_OUTPUT_COLOR_PROFILE, color_profile);
+ 
+     /// Color Range (Support for older Drivers)
+@@ -287,10 +294,6 @@
+     AMF_RETURN_IF_FALSE(ctx, pix_fmt != AV_PIX_FMT_P010, AVERROR_INVALIDDATA, "10-bit input video is not supported by AMF H264 encoder\n");
+ 
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_COLOR_BIT_DEPTH, AMF_COLOR_BIT_DEPTH_8);
+-    /// Color Transfer Characteristics (AMF matches ISO/IEC)
+-    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_OUTPUT_TRANSFER_CHARACTERISTIC, (amf_int64)avctx->color_trc);
+-    /// Color Primaries (AMF matches ISO/IEC)
+-    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_OUTPUT_COLOR_PRIMARIES, (amf_int64)avctx->color_primaries);
+ 
+     // autodetect rate control method
+     if (ctx->rate_control_mode == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_UNKNOWN) {
+diff -Naur ffmpeg-7.1.1.old/libavcodec/amfenc_hevc.c ffmpeg-7.1.1/libavcodec/amfenc_hevc.c
+--- ffmpeg-7.1.1.old/libavcodec/amfenc_hevc.c	2025-03-24 10:54:37.991754672 +0100
++++ ffmpeg-7.1.1/libavcodec/amfenc_hevc.c	2025-03-24 10:54:39.278019962 +0100
+@@ -100,6 +100,7 @@
+     { "me_half_pel",    "Enable ME Half Pixel",                     OFFSET(me_half_pel),   AV_OPT_TYPE_BOOL,{ .i64 = -1 },  -1, 1, VE },
+     { "me_quarter_pel", "Enable ME Quarter Pixel ",                 OFFSET(me_quarter_pel),AV_OPT_TYPE_BOOL,{ .i64 = -1 },  -1, 1, VE },
+ 
++    { "forced_idr",     "Force I frames to be IDR frames",          OFFSET(forced_idr)    ,AV_OPT_TYPE_BOOL,{ .i64 = 0  }, 0, 1, VE },
+     { "aud",            "Inserts AU Delimiter NAL unit",            OFFSET(aud)           ,AV_OPT_TYPE_BOOL,{ .i64 = -1 }, -1, 1, VE },
+ 
+ 
+@@ -167,6 +168,8 @@
+     AMFSize             framesize = AMFConstructSize(avctx->width, avctx->height);
+     int                 deblocking_filter = (avctx->flags & AV_CODEC_FLAG_LOOP_FILTER) ? 1 : 0;
+     amf_int64           color_depth;
++    amf_int64           color_primaries;
++    amf_int64           transfer_characteristic;
+     amf_int64           color_profile;
+     enum                AVPixelFormat pix_fmt;
+ 
+@@ -241,7 +244,11 @@
+         AMF_ASSIGN_PROPERTY_RATIO(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_ASPECT_RATIO, ratio);
+     }
+ 
++    color_primaries = ff_amf_get_color_primaries(avctx);
++    transfer_characteristic = ff_amf_get_transfer_characteristic(avctx);
+     color_profile = ff_amf_get_color_profile(avctx);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_COLOR_PRIMARIES, color_primaries);
++    AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_TRANSFER_CHARACTERISTIC, transfer_characteristic);
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_COLOR_PROFILE, color_profile);
+     /// Color Range (Support for older Drivers)
+     AMF_ASSIGN_PROPERTY_BOOL(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_NOMINAL_RANGE, !!(avctx->color_range == AVCOL_RANGE_JPEG));
+@@ -253,15 +260,6 @@
+         color_depth = AMF_COLOR_BIT_DEPTH_10;
+     }
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_COLOR_BIT_DEPTH, color_depth);
+-    if (color_depth == AMF_COLOR_BIT_DEPTH_8) {
+-        /// Color Transfer Characteristics (AMF matches ISO/IEC)
+-        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_TRANSFER_CHARACTERISTIC, AMF_COLOR_TRANSFER_CHARACTERISTIC_BT709);
+-        /// Color Primaries (AMF matches ISO/IEC)
+-        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_COLOR_PRIMARIES, AMF_COLOR_PRIMARIES_BT709);
+-    } else {
+-        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_TRANSFER_CHARACTERISTIC, AMF_COLOR_TRANSFER_CHARACTERISTIC_SMPTE2084);
+-        AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_OUTPUT_COLOR_PRIMARIES, AMF_COLOR_PRIMARIES_BT2020);
+-    }
+ 
+     // Picture control properties
+     AMF_ASSIGN_PROPERTY_INT64(res, ctx->encoder, AMF_VIDEO_ENCODER_HEVC_NUM_GOPS_PER_IDR, ctx->gops_per_idr);
+diff -Naur ffmpeg-7.1.1.old/libavcodec/av1dec.c ffmpeg-7.1.1/libavcodec/av1dec.c
+--- ffmpeg-7.1.1.old/libavcodec/av1dec.c	2025-03-24 10:54:38.093755899 +0100
++++ ffmpeg-7.1.1/libavcodec/av1dec.c	2025-03-24 10:54:39.273932914 +0100
+@@ -1002,6 +1002,8 @@
+         break;
+     }
+     case ITU_T_T35_PROVIDER_CODE_DOLBY: {
++        AVBufferRef *rpu_buf;
++        AVFrameSideData *rpu;
+         int provider_oriented_code = bytestream2_get_be32(&gb);
+         if (itut_t35->itu_t_t35_country_code != ITU_T_T35_COUNTRY_CODE_US ||
+             provider_oriented_code != 0x800)
+@@ -1014,6 +1016,18 @@
+             break; // ignore
+         }
+ 
++        rpu_buf = av_buffer_alloc(itut_t35->payload_size);
++        if (rpu_buf) {
++            memcpy(rpu_buf->data, itut_t35->payload, itut_t35->payload_size);
++            rpu = av_frame_new_side_data_from_buf(frame, AV_FRAME_DATA_DOVI_RPU_BUFFER_T35, rpu_buf);
++            if (!rpu) {
++                av_buffer_unref(&rpu_buf);
++                return AVERROR(ENOMEM);
++            }
++        } else {
++            return AVERROR(ENOMEM);
++        }
++
+         ret = ff_dovi_attach_side_data(&s->dovi, frame);
+         if (ret < 0)
+             return ret;
+diff -Naur ffmpeg-7.1.1.old/libavcodec/bsf/hevc_mp4toannexb.c ffmpeg-7.1.1/libavcodec/bsf/hevc_mp4toannexb.c
+--- ffmpeg-7.1.1.old/libavcodec/bsf/hevc_mp4toannexb.c	2025-03-24 10:54:38.075755683 +0100
++++ ffmpeg-7.1.1/libavcodec/bsf/hevc_mp4toannexb.c	2025-03-24 10:54:39.273106358 +0100
+@@ -125,6 +125,7 @@
+     AVPacket *in;
+     GetByteContext gb;
+ 
++    int has_sps = 0, has_pps = 0;
+     int got_irap = 0;
+     int i, ret = 0;
+ 
+@@ -158,11 +159,14 @@
+         }
+ 
+         nalu_type = (bytestream2_peek_byte(&gb) >> 1) & 0x3f;
++        has_sps = (has_sps || nalu_type == HEVC_NAL_SPS);
++        has_pps = (has_pps || nalu_type == HEVC_NAL_PPS);
+ 
+         /* prepend extradata to IRAP frames */
+         is_irap = nalu_type >= HEVC_NAL_BLA_W_LP &&
+                   nalu_type <= HEVC_NAL_RSV_IRAP_VCL23;
+-        add_extradata = is_irap && !got_irap;
++        /* ignore the extradata if IRAP frame has sps and pps */
++        add_extradata = is_irap && !got_irap && !(has_sps && has_pps);
+         extra_size    = add_extradata * ctx->par_out->extradata_size;
+         got_irap     |= is_irap;
+ 
+diff -Naur ffmpeg-7.1.1.old/libavcodec/ccaption_dec.c ffmpeg-7.1.1/libavcodec/ccaption_dec.c
+--- ffmpeg-7.1.1.old/libavcodec/ccaption_dec.c	2025-03-24 10:54:38.169756814 +0100
++++ ffmpeg-7.1.1/libavcodec/ccaption_dec.c	2025-03-24 10:54:39.268544045 +0100
+@@ -889,12 +889,13 @@
+ 
+         if (ctx->buffer[bidx].str[0] || ctx->real_time) {
+             ff_dlog(ctx, "cdp writing data (%s)\n", ctx->buffer[bidx].str);
+-            start_time = ctx->buffer_time[0];
+-            sub->pts = start_time;
+-            end_time = ctx->buffer_time[1];
+-            if (!ctx->real_time)
++            if (!ctx->real_time) {
++                start_time = ctx->buffer_time[0];
++                sub->pts = start_time;
++                end_time = ctx->buffer_time[1];
+                 sub->end_display_time = av_rescale_q(end_time - start_time,
+                                                      AV_TIME_BASE_Q, ms_tb);
++            }
+             else
+                 sub->end_display_time = -1;
+             ret = ff_ass_add_rect2(sub, ctx->buffer[bidx].str, ctx->readorder++, 0, NULL, NULL, &nb_rect_allocated);
+diff -Naur ffmpeg-7.1.1.old/libavcodec/dvdsubdec.c ffmpeg-7.1.1/libavcodec/dvdsubdec.c
+--- ffmpeg-7.1.1.old/libavcodec/dvdsubdec.c	2025-03-24 10:54:37.975754480 +0100
++++ ffmpeg-7.1.1/libavcodec/dvdsubdec.c	2025-03-24 10:54:39.267391144 +0100
+@@ -45,6 +45,8 @@
+   int      buf_size;
+   int      forced_subs_only;
+   uint8_t  used_color[256];
++  int64_t  pts;
++  int      output_empty_rects;
+ } DVDSubContext;
+ 
+ static void yuv_a_to_rgba(const uint8_t *ycbcr, const uint8_t *alpha, uint32_t *rgba, int num_values)
+@@ -230,7 +232,10 @@
+     uint32_t size;
+     int64_t offset1, offset2;
+ 
+-    if (buf_size < 10)
++    if (buf_size < 2)
++        return AVERROR(EAGAIN);
++
++    if (buf_size == 2 && AV_RB16(buf) == 0)
+         return -1;
+ 
+     if (AV_RB16(buf) == 0) {   /* HD subpicture with 4-byte offsets */
+@@ -243,15 +248,22 @@
+         cmd_pos = 2;
+     }
+ 
++    if (big_offsets && buf_size < 6)
++        return AVERROR(EAGAIN);
++
+     size = READ_OFFSET(buf + (big_offsets ? 2 : 0));
+-    cmd_pos = READ_OFFSET(buf + cmd_pos);
+ 
+-    if (cmd_pos < 0 || cmd_pos > buf_size - 2 - offset_size) {
+-        if (cmd_pos > size) {
+-            av_log(ctx, AV_LOG_ERROR, "Discarding invalid packet\n");
+-            return 0;
+-        }
++    if (size == 0)
++        return -1;
++
++    if (buf_size < size)
+         return AVERROR(EAGAIN);
++
++    cmd_pos = READ_OFFSET(buf + cmd_pos);
++
++    if (cmd_pos < 0 || cmd_pos > size) {
++        av_log(ctx, AV_LOG_ERROR, "Discarding invalid packet\n");
++        return AVERROR_INVALIDDATA;
+     }
+ 
+     while (cmd_pos > 0 && cmd_pos < buf_size - 2 - offset_size) {
+@@ -524,10 +536,13 @@
+     int appended = 0;
+     int is_menu;
+ 
++    if (ctx->pts == AV_NOPTS_VALUE && sub->pts != AV_NOPTS_VALUE)
++        ctx->pts = sub->pts;
+     if (ctx->buf_size) {
+         int ret = append_to_cached_buf(avctx, buf, buf_size);
+         if (ret < 0) {
+             *data_size = 0;
++            ctx->pts = AV_NOPTS_VALUE;
+             return ret;
+         }
+         buf = ctx->buf;
+@@ -538,7 +553,12 @@
+     is_menu = decode_dvd_subtitles(ctx, sub, buf, buf_size);
+     if (is_menu == AVERROR(EAGAIN)) {
+         *data_size = 0;
+-        return appended ? 0 : append_to_cached_buf(avctx, buf, buf_size);
++        int ret = appended ? 0 : append_to_cached_buf(avctx, buf, buf_size);
++        if (ret < 0) {
++            ctx->pts = AV_NOPTS_VALUE;
++            return ret;
++        }
++        return buf_size;
+     }
+ 
+     if (is_menu < 0) {
+@@ -547,9 +567,10 @@
+         reset_rects(sub);
+         *data_size = 0;
+ 
++        ctx->pts = AV_NOPTS_VALUE;
+         return buf_size;
+     }
+-    if (!is_menu && find_smallest_bounding_rectangle(ctx, sub) == 0)
++    if (!is_menu && !ctx->output_empty_rects && find_smallest_bounding_rectangle(ctx, sub) == 0)
+         goto no_subtitle;
+ 
+     if (ctx->forced_subs_only && !(sub->rects[0]->flags & AV_SUBTITLE_FLAG_FORCED))
+@@ -557,6 +578,8 @@
+ 
+     ctx->buf_size = 0;
+     *data_size = 1;
++    sub->pts = ctx->pts;
++    ctx->pts = AV_NOPTS_VALUE;
+     return buf_size;
+ }
+ 
+@@ -682,6 +705,7 @@
+             av_log(avctx, AV_LOG_DEBUG, " 0x%06"PRIx32, ctx->palette[i]);
+         av_log(avctx, AV_LOG_DEBUG, "\n");
+     }
++    ctx->pts = AV_NOPTS_VALUE;
+ 
+     return 1;
+ }
+@@ -698,6 +722,7 @@
+     { "palette", "set the global palette", OFFSET(palette_str), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, SD },
+     { "ifo_palette", "obtain the global palette from .IFO file", OFFSET(ifo_str), AV_OPT_TYPE_STRING, { .str = NULL }, 0, 0, SD },
+     { "forced_subs_only", "Only show forced subtitles", OFFSET(forced_subs_only), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, SD},
++    { "output_empty_rects", "Output subtitles with empty or fully transparent rects", OFFSET(output_empty_rects), AV_OPT_TYPE_BOOL, {.i64 = 0}, 0, 1, SD},
+     { NULL }
+ };
+ static const AVClass dvdsub_class = {
+diff -Naur ffmpeg-7.1.1.old/libavcodec/libdav1d.c ffmpeg-7.1.1/libavcodec/libdav1d.c
+--- ffmpeg-7.1.1.old/libavcodec/libdav1d.c	2025-03-24 10:54:38.090755863 +0100
++++ ffmpeg-7.1.1/libavcodec/libdav1d.c	2025-03-24 10:54:39.274085311 +0100
+@@ -563,6 +563,8 @@
+             break;
+         }
+         case ITU_T_T35_PROVIDER_CODE_DOLBY: {
++            AVBufferRef *rpu_buf;
++            AVFrameSideData *rpu;
+             int provider_oriented_code = bytestream2_get_be32(&gb);
+             if (itut_t35->country_code != ITU_T_T35_COUNTRY_CODE_US ||
+                 provider_oriented_code != 0x800)
+@@ -575,6 +577,18 @@
+                 break; // ignore
+             }
+ 
++            rpu_buf = av_buffer_alloc(itut_t35->payload_size);
++            if (rpu_buf) {
++                memcpy(rpu_buf->data, itut_t35->payload, itut_t35->payload_size);
++                rpu = av_frame_new_side_data_from_buf(frame, AV_FRAME_DATA_DOVI_RPU_BUFFER_T35, rpu_buf);
++                if (!rpu) {
++                    av_buffer_unref(&rpu_buf);
++                    goto fail;
++                }
++            } else {
++                goto fail;
++            }
++
+             res = ff_dovi_attach_side_data(&dav1d->dovi, frame);
+             if (res < 0)
+                 goto fail;
+diff -Naur ffmpeg-7.1.1.old/libavcodec/mfenc.c ffmpeg-7.1.1/libavcodec/mfenc.c
+--- ffmpeg-7.1.1.old/libavcodec/mfenc.c	2025-03-24 10:54:38.125756284 +0100
++++ ffmpeg-7.1.1/libavcodec/mfenc.c	2025-03-24 10:54:39.282547759 +0100
+@@ -1315,3 +1315,4 @@
+ 
+ MF_ENCODER(VIDEO, h264,        H264, venc_opts, VFMTS, VCAPS, defaults);
+ MF_ENCODER(VIDEO, hevc,        HEVC, venc_opts, VFMTS, VCAPS, defaults);
++MF_ENCODER(VIDEO, av1,         AV1,  venc_opts, VFMTS, VCAPS, defaults);
+diff -Naur ffmpeg-7.1.1.old/libavcodec/mf_utils.c ffmpeg-7.1.1/libavcodec/mf_utils.c
+--- ffmpeg-7.1.1.old/libavcodec/mf_utils.c	2025-03-24 10:54:38.086755815 +0100
++++ ffmpeg-7.1.1/libavcodec/mf_utils.c	2025-03-24 10:54:39.282392106 +0100
+@@ -240,6 +240,7 @@
+     GUID_ENTRY(MFMediaType_Video),
+     GUID_ENTRY(MFAudioFormat_PCM),
+     GUID_ENTRY(MFAudioFormat_Float),
++    GUID_ENTRY(ff_MFVideoFormat_AV1),
+     GUID_ENTRY(MFVideoFormat_H264),
+     GUID_ENTRY(MFVideoFormat_H264_ES),
+     GUID_ENTRY(ff_MFVideoFormat_HEVC),
+@@ -507,6 +508,7 @@
+ const CLSID *ff_codec_to_mf_subtype(enum AVCodecID codec)
+ {
+     switch (codec) {
++    case AV_CODEC_ID_AV1:               return &ff_MFVideoFormat_AV1;
+     case AV_CODEC_ID_H264:              return &MFVideoFormat_H264;
+     case AV_CODEC_ID_HEVC:              return &ff_MFVideoFormat_HEVC;
+     case AV_CODEC_ID_AC3:               return &MFAudioFormat_Dolby_AC3;
+diff -Naur ffmpeg-7.1.1.old/libavcodec/mf_utils.h ffmpeg-7.1.1/libavcodec/mf_utils.h
+--- ffmpeg-7.1.1.old/libavcodec/mf_utils.h	2025-03-24 10:54:38.061755515 +0100
++++ ffmpeg-7.1.1/libavcodec/mf_utils.h	2025-03-24 10:54:39.282464482 +0100
+@@ -113,6 +113,7 @@
+ 
+ DEFINE_MEDIATYPE_GUID(ff_MFVideoFormat_HEVC, 0x43564548); // FCC('HEVC')
+ DEFINE_MEDIATYPE_GUID(ff_MFVideoFormat_HEVC_ES, 0x53564548); // FCC('HEVS')
++DEFINE_MEDIATYPE_GUID(ff_MFVideoFormat_AV1, 0x31305641); // FCC('AV01')
+ 
+ 
+ // This enum is missing from mingw-w64's codecapi.h by v7.0.0.
+diff -Naur ffmpeg-7.1.1.old/libavcodec/pgssubdec.c ffmpeg-7.1.1/libavcodec/pgssubdec.c
+--- ffmpeg-7.1.1.old/libavcodec/pgssubdec.c	2025-03-24 10:54:37.986754612 +0100
++++ ffmpeg-7.1.1/libavcodec/pgssubdec.c	2025-03-24 10:54:39.280528236 +0100
+@@ -35,9 +35,11 @@
+ #include "libavutil/opt.h"
+ 
+ #define RGBA(r,g,b,a) (((unsigned)(a) << 24) | ((r) << 16) | ((g) << 8) | (b))
+-#define MAX_EPOCH_PALETTES 8   // Max 8 allowed per PGS epoch
+-#define MAX_EPOCH_OBJECTS  64  // Max 64 allowed per PGS epoch
+-#define MAX_OBJECT_REFS    2   // Max objects per display set
++#define MAX_EPOCH_PALETTES 8    // Max 8 allowed per PGS epoch
++#define MAX_EPOCH_OBJECTS  64   // Max 64 allowed per PGS epoch
++#define MAX_OBJECT_REFS    2    // Max objects per display set
++#define MAX_OBJECT_WH      4096 // Max object width/height
++
+ 
+ enum SegmentType {
+     PALETTE_SEGMENT      = 0x14,
+@@ -48,57 +50,80 @@
+ };
+ 
+ typedef struct PGSSubObjectRef {
+-    int     id;
+-    int     window_id;
+-    uint8_t composition_flag;
+-    int     x;
+-    int     y;
+-    int     crop_x;
+-    int     crop_y;
+-    int     crop_w;
+-    int     crop_h;
++    uint16_t id;
++    uint8_t  window_id;
++    uint8_t  composition_flag;
++    uint16_t x;
++    uint16_t y;
++    uint16_t crop_x;
++    uint16_t crop_y;
++    uint16_t crop_w;
++    uint16_t crop_h;
+ } PGSSubObjectRef;
+ 
+ typedef struct PGSSubPresentation {
+-    int id_number;
+-    int palette_id;
+-    int object_count;
++    uint8_t         palette_flag;
++    uint8_t         palette_id;
++    uint8_t         object_count;
+     PGSSubObjectRef objects[MAX_OBJECT_REFS];
+-    int64_t pts;
++    int64_t         pts;
+ } PGSSubPresentation;
+ 
+ typedef struct PGSSubObject {
+-    int          id;
+-    int          w;
+-    int          h;
+-    uint8_t      *rle;
+-    unsigned int rle_buffer_size, rle_data_len;
+-    unsigned int rle_remaining_len;
++    uint16_t  id;
++    uint16_t  w;
++    uint16_t  h;
++    uint8_t   *rle;
++    uint8_t   *bitmap;
++    uint32_t  rle_buffer_size;
++    uint32_t  rle_data_len;
++    uint32_t  rle_remaining_len;
++    uint32_t  bitmap_buffer_size;
++    uint32_t  bitmap_size;
+ } PGSSubObject;
+ 
+ typedef struct PGSSubObjects {
+-    int          count;
++    uint8_t      count;
+     PGSSubObject object[MAX_EPOCH_OBJECTS];
+ } PGSSubObjects;
+ 
+ typedef struct PGSSubPalette {
+-    int         id;
+-    uint32_t    clut[256];
++    uint8_t     id;
++    uint32_t    clut[AVPALETTE_COUNT];
+ } PGSSubPalette;
+ 
+ typedef struct PGSSubPalettes {
+-    int           count;
++    uint8_t       count;
+     PGSSubPalette palette[MAX_EPOCH_PALETTES];
+ } PGSSubPalettes;
+ 
++typedef struct PGSGraphicPlane {
++   uint8_t        count;
++   uint8_t        writable;
++   AVSubtitleRect visible_rect[MAX_OBJECT_REFS];
++} PGSGraphicPlane;
++
+ typedef struct PGSSubContext {
+     AVClass *class;
+     PGSSubPresentation presentation;
+     PGSSubPalettes     palettes;
+     PGSSubObjects      objects;
++    PGSGraphicPlane    plane;
+     int forced_subs_only;
+ } PGSSubContext;
+ 
++static void clear_graphic_plane(PGSSubContext *ctx)
++{
++    int i;
++
++    for (i = 0; i < ctx->plane.count; i++) {
++       av_freep(&ctx->plane.visible_rect[i].data[0]);
++       memset(&ctx->plane.visible_rect[i], 0, sizeof(ctx->plane.visible_rect[i]));
++    }
++    ctx->plane.writable = 0;
++    ctx->plane.count = 0;
++}
++
+ static void flush_cache(AVCodecContext *avctx)
+ {
+     PGSSubContext *ctx = avctx->priv_data;
+@@ -106,8 +131,11 @@
+ 
+     for (i = 0; i < ctx->objects.count; i++) {
+         av_freep(&ctx->objects.object[i].rle);
+-        ctx->objects.object[i].rle_buffer_size  = 0;
++        ctx->objects.object[i].rle_buffer_size    = 0;
+         ctx->objects.object[i].rle_remaining_len  = 0;
++        av_freep(&ctx->objects.object[i].bitmap);
++        ctx->objects.object[i].bitmap_buffer_size = 0;
++        ctx->objects.object[i].bitmap_size        = 0;
+     }
+     ctx->objects.count = 0;
+     ctx->palettes.count = 0;
+@@ -144,6 +172,7 @@
+ 
+ static av_cold int close_decoder(AVCodecContext *avctx)
+ {
++    clear_graphic_plane((PGSSubContext *)avctx->priv_data);
+     flush_cache(avctx);
+ 
+     return 0;
+@@ -159,48 +188,51 @@
+  * @param buf pointer to the RLE data to process
+  * @param buf_size size of the RLE data to process
+  */
+-static int decode_rle(AVCodecContext *avctx, AVSubtitleRect *rect,
+-                      const uint8_t *buf, unsigned int buf_size)
++static int decode_object_rle(AVCodecContext *avctx, PGSSubObject *object)
+ {
+-    const uint8_t *rle_bitmap_end;
++    const uint8_t *rle_buf;
++    const uint8_t *rle_end;
+     int pixel_count, line_count;
++    rle_buf = object->rle;
++    rle_end = object->rle + object->rle_data_len;
+ 
+-    rle_bitmap_end = buf + buf_size;
++    object->bitmap_size = object->w * object->h;
++    av_fast_padded_malloc(&object->bitmap, &object->bitmap_buffer_size,
++                          object->bitmap_size);
+ 
+-    rect->data[0] = av_malloc_array(rect->w, rect->h);
+-
+-    if (!rect->data[0])
++    if (!object->bitmap)
+         return AVERROR(ENOMEM);
+ 
+     pixel_count = 0;
+     line_count  = 0;
+ 
+-    while (buf < rle_bitmap_end && line_count < rect->h) {
++    while (rle_buf < rle_end && line_count < object->h) {
+         uint8_t flags, color;
+         int run;
+ 
+-        color = bytestream_get_byte(&buf);
++        color = bytestream_get_byte(&rle_buf);
+         run   = 1;
+ 
+         if (color == 0x00) {
+-            flags = bytestream_get_byte(&buf);
++            flags = bytestream_get_byte(&rle_buf);
+             run   = flags & 0x3f;
+             if (flags & 0x40)
+-                run = (run << 8) + bytestream_get_byte(&buf);
+-            color = flags & 0x80 ? bytestream_get_byte(&buf) : 0;
++                run = (run << 8) + bytestream_get_byte(&rle_buf);
++            color = flags & 0x80 ? bytestream_get_byte(&rle_buf) : 0;
+         }
+ 
+-        if (run > 0 && pixel_count + run <= rect->w * rect->h) {
+-            memset(rect->data[0] + pixel_count, color, run);
++        if (run > 0 && pixel_count + run <= object->w * object->h) {
++            memset(object->bitmap + pixel_count, color, run);
+             pixel_count += run;
+         } else if (!run) {
+             /*
+              * New Line. Check if correct pixels decoded, if not display warning
+              * and adjust bitmap pointer to correct new line position.
+              */
+-            if (pixel_count % rect->w > 0) {
+-                av_log(avctx, AV_LOG_ERROR, "Decoded %d pixels, when line should be %d pixels\n",
+-                       pixel_count % rect->w, rect->w);
++            if (pixel_count % object->w > 0) {
++                av_log(avctx, AV_LOG_ERROR,
++                       "Decoded %d pixels, when object line should be %d pixels\n",
++                       pixel_count % object->w, object->w);
+                 if (avctx->err_recognition & AV_EF_EXPLODE) {
+                     return AVERROR_INVALIDDATA;
+                 }
+@@ -209,13 +241,11 @@
+         }
+     }
+ 
+-    if (pixel_count < rect->w * rect->h) {
+-        av_log(avctx, AV_LOG_ERROR, "Insufficient RLE data for subtitle\n");
++    if (pixel_count < object->w * object->h) {
++        av_log(avctx, AV_LOG_ERROR, "Insufficient RLE data for object\n");
+         return AVERROR_INVALIDDATA;
+     }
+-
+-    ff_dlog(avctx, "Pixel Count = %d, Area = %d\n", pixel_count, rect->w * rect->h);
+-
++    ff_dlog(avctx, "Pixel Count = %d, Area = %d\n", pixel_count, object->w * object->h);
+     return 0;
+ }
+ 
+@@ -237,7 +267,7 @@
+ 
+     uint8_t sequence_desc;
+     unsigned int rle_bitmap_len, width, height;
+-    int id;
++    int id, ret;
+ 
+     if (buf_size <= 4)
+         return AVERROR_INVALIDDATA;
+@@ -260,57 +290,71 @@
+     /* Read the Sequence Description to determine if start of RLE data or appended to previous RLE */
+     sequence_desc = bytestream_get_byte(&buf);
+ 
+-    if (!(sequence_desc & 0x80)) {
+-        /* Additional RLE data */
+-        if (buf_size > object->rle_remaining_len)
++    /* First in sequence object definition segment */
++    if (sequence_desc & 0x80) {
++        if (buf_size <= 7)
+             return AVERROR_INVALIDDATA;
++        buf_size -= 7;
+ 
+-        memcpy(object->rle + object->rle_data_len, buf, buf_size);
+-        object->rle_data_len += buf_size;
+-        object->rle_remaining_len -= buf_size;
+-
+-        return 0;
+-    }
+-
+-    if (buf_size <= 7)
+-        return AVERROR_INVALIDDATA;
+-    buf_size -= 7;
++        /* Decode rle bitmap length, stored size includes width/height data */
++        rle_bitmap_len = bytestream_get_be24(&buf) - 2*2;
+ 
+-    /* Decode rle bitmap length, stored size includes width/height data */
+-    rle_bitmap_len = bytestream_get_be24(&buf) - 2*2;
++        if (buf_size > rle_bitmap_len) {
++            av_log(avctx, AV_LOG_ERROR,
++                   "Buffer dimension %d larger than the expected RLE data %d\n",
++                   buf_size, rle_bitmap_len);
++            return AVERROR_INVALIDDATA;
++        }
+ 
+-    if (buf_size > rle_bitmap_len) {
+-        av_log(avctx, AV_LOG_ERROR,
+-               "Buffer dimension %d larger than the expected RLE data %d\n",
+-               buf_size, rle_bitmap_len);
+-        return AVERROR_INVALIDDATA;
+-    }
++        /* Get bitmap dimensions from data */
++        width  = bytestream_get_be16(&buf);
++        height = bytestream_get_be16(&buf);
++
++        /* Make sure the bitmap is not too large */
++        if (MAX_OBJECT_WH < width || MAX_OBJECT_WH < height || !width || !height) {
++            av_log(avctx, AV_LOG_ERROR, "Bitmap dimensions (%dx%d) invalid.\n", width, height);
++            return AVERROR_INVALIDDATA;
++        }
+ 
+-    /* Get bitmap dimensions from data */
+-    width  = bytestream_get_be16(&buf);
+-    height = bytestream_get_be16(&buf);
+-
+-    /* Make sure the bitmap is not too large */
+-    if (avctx->width < width || avctx->height < height || !width || !height) {
+-        av_log(avctx, AV_LOG_ERROR, "Bitmap dimensions (%dx%d) invalid.\n", width, height);
+-        return AVERROR_INVALIDDATA;
+-    }
++        object->rle_data_len = 0;
++        object->w = width;
++        object->h = height;
++        /* Dimensions against video are checked at decode after cropping. */
++        av_fast_padded_malloc(&object->rle, &object->rle_buffer_size, rle_bitmap_len);
+ 
+-    object->w = width;
+-    object->h = height;
++        if (!object->rle) {
++            object->rle_remaining_len = 0;
++            return AVERROR(ENOMEM);
++        }
+ 
+-    av_fast_padded_malloc(&object->rle, &object->rle_buffer_size, rle_bitmap_len);
++        memcpy(object->rle, buf, buf_size);
++        object->rle_remaining_len = rle_bitmap_len;
++    } else {
++        /* Additional RLE data */
++        if (buf_size > object->rle_remaining_len)
++            return AVERROR_INVALIDDATA;
+ 
+-    if (!object->rle) {
+-        object->rle_data_len = 0;
+-        object->rle_remaining_len = 0;
+-        return AVERROR(ENOMEM);
++        memcpy(object->rle + object->rle_data_len, buf, buf_size);
+     }
++    object->rle_data_len += buf_size;
++    object->rle_remaining_len -= buf_size;
+ 
+-    memcpy(object->rle, buf, buf_size);
+-    object->rle_data_len = buf_size;
+-    object->rle_remaining_len = rle_bitmap_len - buf_size;
+-
++    /* Last in sequence object definition (can be both first and last) */
++    if (sequence_desc & 0x40) {
++        /* Attempt decoding if data is valid */
++        if (0 == object->rle_remaining_len) {
++            ret = decode_object_rle(avctx, object);
++            if (ret < 0 && (avctx->err_recognition & AV_EF_EXPLODE || ret == AVERROR(ENOMEM))) {
++                return ret;
++            }
++        } else {
++            av_log(avctx, AV_LOG_ERROR,
++                "RLE data length %u is %u bytes shorter than expected\n",
++                object->rle_data_len, object->rle_remaining_len);
++            if (avctx->err_recognition & AV_EF_EXPLODE)
++                return AVERROR_INVALIDDATA;
++        }
++    }
+     return 0;
+ }
+ 
+@@ -318,7 +362,7 @@
+  * Parse the palette segment packet.
+  *
+  * The palette segment contains details of the palette,
+- * a maximum of 256 colors can be defined.
++ * a maximum of 256 colors (AVPALETTE_COUNT) can be defined.
+  *
+  * @param avctx contains the current codec context
+  * @param buf pointer to the packet to process
+@@ -391,13 +435,17 @@
+                                       int64_t pts)
+ {
+     PGSSubContext *ctx = avctx->priv_data;
+-    int i, state, ret;
++    int ret;
++    uint8_t i, state;
+     const uint8_t *buf_end = buf + buf_size;
+ 
+     // Video descriptor
+     int w = bytestream_get_be16(&buf);
+     int h = bytestream_get_be16(&buf);
+ 
++    // On a new display set, reset writability of the graphic plane
++    ctx->plane.writable = 0;
++
+     ctx->presentation.pts = pts;
+ 
+     ff_dlog(avctx, "Video Dimensions %dx%d\n",
+@@ -406,88 +454,121 @@
+     if (ret < 0)
+         return ret;
+ 
+-    /* Skip 1 bytes of unknown, frame rate */
+-    buf++;
++    /* Skip 3 bytes: framerate (1), presentation id number (2) */
++    buf+=3;
+ 
+-    // Composition descriptor
+-    ctx->presentation.id_number = bytestream_get_be16(&buf);
+     /*
+-     * state is a 2 bit field that defines pgs epoch boundaries
++     * State is a 2 bit field that defines pgs epoch boundaries
+      * 00 - Normal, previously defined objects and palettes are still valid
+      * 01 - Acquisition point, previous objects and palettes can be released
+      * 10 - Epoch start, previous objects and palettes can be released
+      * 11 - Epoch continue, previous objects and palettes can be released
+      *
+-     * reserved 6 bits discarded
++     * Reserved 6 bits discarded
+      */
+     state = bytestream_get_byte(&buf) >> 6;
+     if (state != 0) {
++        /* Epoch start always wipes the graphic plane. Epoch continue does only if
++         * playback is not seamless, which should not happen with a proper stream.
++         */
++        if (0b10 == state)
++            clear_graphic_plane((PGSSubContext *)avctx->priv_data);
+         flush_cache(avctx);
+     }
+ 
++    /* Reserved 7 bits discarded. */
++    ctx->presentation.palette_flag = bytestream_get_byte(&buf) & 0x80;
++    ctx->presentation.palette_id = bytestream_get_byte(&buf);
++
+     /*
+-     * skip palette_update_flag (0x80),
++     * On palette update, don't parse the compositions references,
++     * just evaluate the existing graphic plane with the new palette.
+      */
+-    buf += 1;
+-    ctx->presentation.palette_id = bytestream_get_byte(&buf);
+-    ctx->presentation.object_count = bytestream_get_byte(&buf);
+-    if (ctx->presentation.object_count > MAX_OBJECT_REFS) {
+-        av_log(avctx, AV_LOG_ERROR,
+-               "Invalid number of presentation objects %d\n",
+-               ctx->presentation.object_count);
+-        ctx->presentation.object_count = 2;
+-        if (avctx->err_recognition & AV_EF_EXPLODE) {
+-            return AVERROR_INVALIDDATA;
++    if (!ctx->presentation.palette_flag) {
++        ctx->presentation.object_count = bytestream_get_byte(&buf);
++        if (ctx->presentation.object_count > MAX_OBJECT_REFS) {
++            av_log(avctx, AV_LOG_ERROR,
++                   "Invalid number of presentation objects %d\n",
++                   ctx->presentation.object_count);
++            ctx->presentation.object_count = 2;
++            if (avctx->err_recognition & AV_EF_EXPLODE) {
++                return AVERROR_INVALIDDATA;
++            }
+         }
+-    }
+ 
++        for (i = 0; i < ctx->presentation.object_count; i++) {
++            PGSSubObjectRef *const object = &ctx->presentation.objects[i];
+ 
+-    for (i = 0; i < ctx->presentation.object_count; i++)
+-    {
+-        PGSSubObjectRef *const object = &ctx->presentation.objects[i];
+-
+-        if (buf_end - buf < 8) {
+-            av_log(avctx, AV_LOG_ERROR, "Insufficent space for object\n");
+-            ctx->presentation.object_count = i;
+-            return AVERROR_INVALIDDATA;
+-        }
+-
+-        object->id               = bytestream_get_be16(&buf);
+-        object->window_id        = bytestream_get_byte(&buf);
+-        object->composition_flag = bytestream_get_byte(&buf);
+-
+-        object->x = bytestream_get_be16(&buf);
+-        object->y = bytestream_get_be16(&buf);
+-
+-        // If cropping
+-        if (object->composition_flag & 0x80) {
+-            object->crop_x = bytestream_get_be16(&buf);
+-            object->crop_y = bytestream_get_be16(&buf);
+-            object->crop_w = bytestream_get_be16(&buf);
+-            object->crop_h = bytestream_get_be16(&buf);
+-        }
+-
+-        ff_dlog(avctx, "Subtitle Placement x=%d, y=%d\n",
+-                object->x, object->y);
+-
+-        if (object->x > avctx->width || object->y > avctx->height) {
+-            av_log(avctx, AV_LOG_ERROR, "Subtitle out of video bounds. x = %d, y = %d, video width = %d, video height = %d.\n",
+-                   object->x, object->y,
+-                    avctx->width, avctx->height);
+-            object->y = object->x = 0;
+-            if (avctx->err_recognition & AV_EF_EXPLODE) {
++            if (buf_end - buf < 8) {
++                av_log(avctx, AV_LOG_ERROR, "Insufficent space for object\n");
++                ctx->presentation.object_count = i;
+                 return AVERROR_INVALIDDATA;
+             }
++
++            object->id               = bytestream_get_be16(&buf);
++            object->window_id        = bytestream_get_byte(&buf);
++            object->composition_flag = bytestream_get_byte(&buf);
++
++            object->x = bytestream_get_be16(&buf);
++            object->y = bytestream_get_be16(&buf);
++
++            // If cropping
++            if (object->composition_flag & 0x80) {
++                object->crop_x = bytestream_get_be16(&buf);
++                object->crop_y = bytestream_get_be16(&buf);
++                object->crop_w = bytestream_get_be16(&buf);
++                object->crop_h = bytestream_get_be16(&buf);
++            }
++
++            /* Placement is checked at decode after cropping. */
++            ff_dlog(avctx, "Subtitle Placement x=%d, y=%d\n",
++                    object->x, object->y);
+         }
+     }
++    return 0;
++}
++
++/**
++ * Parse the window segment packet.
++ *
++ * The window segment instructs the decoder to redraw the graphic plane
++ * with the composition references provided in the presentation segment
++ *
++ * @param avctx contains the current codec context
++ */
++static int parse_window_segment(AVCodecContext *avctx, const uint8_t *buf,
++                                int buf_size)
++{
++    PGSSubContext *ctx = (PGSSubContext *)avctx->priv_data;
++
++    // 1 byte: number of windows defined
++    if (bytestream_get_byte(&buf) > MAX_OBJECT_REFS) {
++        av_log(avctx, AV_LOG_ERROR, "Too many windows defined.\n");
++        return AVERROR_INVALIDDATA;
++    }
+ 
++    /* TODO: mask objects with windows when transfering to the graphic plane
++     * Window Segment Structure
++     *     {
++     *       1 byte : window id,
++     *       2 bytes: X position of window,
++     *       2 bytes: Y position of window,
++     *       2 bytes: Width of window,
++     *       2 bytes: Height of window.
++     *     }
++     */
++    // Flush the graphic plane, it will be redrawn.
++    clear_graphic_plane(ctx);
++    ctx->plane.writable = 1;
++    ctx->plane.count = ctx->presentation.object_count;
+     return 0;
+ }
+ 
+ /**
+  * Parse the display segment packet.
+  *
+- * The display segment controls the updating of the display.
++ * The display segment closes the display set. The inferred data is used
++ * to decide if the display should be updated.
+  *
+  * @param avctx contains the current codec context
+  * @param data pointer to the data pertaining the subtitle to display
+@@ -500,26 +581,33 @@
+     PGSSubContext *ctx = avctx->priv_data;
+     int64_t pts;
+     PGSSubPalette *palette;
+-    int i, ret;
++    int i;
+ 
+     pts = ctx->presentation.pts != AV_NOPTS_VALUE ? ctx->presentation.pts : sub->pts;
+     memset(sub, 0, sizeof(*sub));
+     sub->pts = pts;
+     ctx->presentation.pts = AV_NOPTS_VALUE;
+-    sub->start_display_time = 0;
+     // There is no explicit end time for PGS subtitles.  The end time
+     // is defined by the start of the next sub which may contain no
+     // objects (i.e. clears the previous sub)
+     sub->end_display_time   = UINT32_MAX;
+-    sub->format             = 0;
+ 
+-    // Blank if last object_count was 0.
+-    if (!ctx->presentation.object_count)
++    // Object count is zero only on an epoch start with no WDS
++    // or the last DS with a WDS had no presentation object.
++    if (!ctx->plane.count) {
+         return 1;
+-    sub->rects = av_calloc(ctx->presentation.object_count, sizeof(*sub->rects));
+-    if (!sub->rects) {
+-        return AVERROR(ENOMEM);
+     }
++
++    if (!ctx->presentation.palette_flag && !ctx->plane.writable) {
++        // This display set does not perform a display update
++        // E.g. it only defines new objects or palettes for future usage.
++        return 0;
++    }
++
++    sub->rects = av_calloc(ctx->plane.count, sizeof(*sub->rects));
++    if (!sub->rects)
++        return AVERROR(ENOMEM);
++
+     palette = find_palette(ctx->presentation.palette_id, &ctx->palettes);
+     if (!palette) {
+         // Missing palette.  Should only happen with damaged streams.
+@@ -528,57 +616,128 @@
+         avsubtitle_free(sub);
+         return AVERROR_INVALIDDATA;
+     }
+-    for (i = 0; i < ctx->presentation.object_count; i++) {
+-        AVSubtitleRect *const rect = av_mallocz(sizeof(*rect));
+-        PGSSubObject *object;
+ 
+-        if (!rect)
+-            return AVERROR(ENOMEM);
+-        sub->rects[sub->num_rects++] = rect;
+-        rect->type = SUBTITLE_BITMAP;
++    for (i = 0; i < ctx->plane.count; i++) {
++        const PGSSubObjectRef *sub_object = &ctx->presentation.objects[i];
++        AVSubtitleRect *const gp_rect = &ctx->plane.visible_rect[i];
++        AVSubtitleRect *rect;
++        gp_rect->type = SUBTITLE_BITMAP;
++
++        // Compose the graphic plane if a window segment has been provided
++        if (ctx->plane.writable) {
++            PGSSubObject *object;
++
++            // Process bitmap
++            object = find_object(sub_object->id, &ctx->objects);
++            if (!object) {
++                // Missing object.  Should only happen with damaged streams.
++                av_log(avctx, AV_LOG_ERROR, "Invalid object id %d\n", sub_object->id);
++                if (avctx->err_recognition & AV_EF_EXPLODE)
++                    return AVERROR_INVALIDDATA;
++                // Leaves rect empty with 0 width and height.
++                continue;
++            }
++            if (sub_object->composition_flag & 0x40)
++                gp_rect->flags |= AV_SUBTITLE_FLAG_FORCED;
+ 
+-        /* Process bitmap */
+-        object = find_object(ctx->presentation.objects[i].id, &ctx->objects);
+-        if (!object) {
+-            // Missing object.  Should only happen with damaged streams.
+-            av_log(avctx, AV_LOG_ERROR, "Invalid object id %d\n",
+-                   ctx->presentation.objects[i].id);
+-            if (avctx->err_recognition & AV_EF_EXPLODE)
+-                return AVERROR_INVALIDDATA;
+-            // Leaves rect empty with 0 width and height.
+-            continue;
+-        }
+-        if (ctx->presentation.objects[i].composition_flag & 0x40)
+-            rect->flags |= AV_SUBTITLE_FLAG_FORCED;
++            gp_rect->x    = sub_object->x;
++            gp_rect->y    = sub_object->y;
+ 
+-        rect->x    = ctx->presentation.objects[i].x;
+-        rect->y    = ctx->presentation.objects[i].y;
++            if (object->rle) {
++                int out_of_picture = 0;
++                gp_rect->w = object->w;
++                gp_rect->h = object->h;
++
++                gp_rect->linesize[0] = object->w;
++
++                // Check for cropping.
++                if (sub_object->composition_flag & 0x80) {
++                    int out_of_object = 0;
++
++                    if (object->w < sub_object->crop_x + sub_object->crop_w)
++                        out_of_object = 1;
++                    if (object->h < sub_object->crop_y + sub_object->crop_h)
++                        out_of_object = 1;
++
++                    if (out_of_object) {
++                        av_log(avctx, AV_LOG_ERROR,
++                               "Subtitle cropping values are out of object. "
++                               "obj_w = %d, obj_h = %d, crop_x = %d, crop_y = %d, "
++                               "crop_w = %d, crop_h = %d.\n",
++                               object->w,
++                               object->h,
++                               sub_object->crop_x,
++                               sub_object->crop_y,
++                               sub_object->crop_w,
++                               sub_object->crop_h);
++                        if (avctx->err_recognition & AV_EF_EXPLODE)
++                            return AVERROR_INVALIDDATA;
++                    } else {
++                        // Replace subtitle dimensions with cropping ones.
++                        gp_rect->w = sub_object->crop_w;
++                        gp_rect->h = sub_object->crop_h;
++                        gp_rect->linesize[0] = sub_object->crop_w;
++                    }
++                }
+ 
+-        if (object->rle) {
+-            rect->w    = object->w;
+-            rect->h    = object->h;
++                /* Make sure the subtitle is not out of picture. */
++                if (avctx->width < gp_rect->x + gp_rect->w || !gp_rect->w)
++                    out_of_picture = 1;
++                if (avctx->height < gp_rect->y + gp_rect->h || !gp_rect->h)
++                    out_of_picture = 1;
++                if (out_of_picture) {
++                    av_log(avctx, AV_LOG_ERROR,
++                           "Subtitle out of video bounds. "
++                           "x = %d, y = %d, width = %d, height = %d.\n",
++                           gp_rect->x, gp_rect->y, gp_rect->w, gp_rect->h);
++                    if (avctx->err_recognition & AV_EF_EXPLODE)
++                        return AVERROR_INVALIDDATA;
++                    gp_rect->w = 0;
++                    gp_rect->h = 0;
++                    continue;
++                }
+ 
+-            rect->linesize[0] = object->w;
++                if (!object->bitmap_size || object->rle_remaining_len) {
++                    gp_rect->w = 0;
++                    gp_rect->h = 0;
++                    continue;
++                }
+ 
+-            if (object->rle_remaining_len) {
+-                av_log(avctx, AV_LOG_ERROR, "RLE data length %u is %u bytes shorter than expected\n",
+-                       object->rle_data_len, object->rle_remaining_len);
+-                if (avctx->err_recognition & AV_EF_EXPLODE)
+-                    return AVERROR_INVALIDDATA;
+-            }
+-            ret = decode_rle(avctx, rect, object->rle, object->rle_data_len);
+-            if (ret < 0) {
+-                if ((avctx->err_recognition & AV_EF_EXPLODE) ||
+-                    ret == AVERROR(ENOMEM)) {
+-                    return ret;
++                gp_rect->data[0] = av_malloc_array(gp_rect->w, gp_rect->h);
++                if (!gp_rect->data[0])
++                    return AVERROR(ENOMEM);
++
++                if (sub_object->composition_flag & 0x80) {
++                    /* Copy cropped bitmap. */
++                    int y;
++
++                    for (y = 0; y < sub_object->crop_h; y++) {
++                        memcpy(&gp_rect->data[0][y * sub_object->crop_w],
++                               &object->bitmap[(sub_object->crop_y + y) *
++                               object->w + sub_object->crop_x],
++                               sub_object->crop_w);
++                    }
++                }
++                else {
++                    /* copy full object */
++                    memcpy(gp_rect->data[0], object->bitmap, object->bitmap_size);
+                 }
+-                rect->w = 0;
+-                rect->h = 0;
+-                continue;
+             }
+         }
+-        /* Allocate memory for colors */
+-        rect->nb_colors = 256;
++        // Export graphic plane content with latest palette
++        rect = av_memdup(gp_rect, sizeof(*gp_rect));
++        if (!rect)
++            return AVERROR(ENOMEM);
++
++        sub->rects[sub->num_rects++] = rect;
++        if (gp_rect->data[0]) {
++            rect->data[0] = av_memdup(gp_rect->data[0], rect->w*rect->h);
++            if (!rect->data[0])
++                return AVERROR(ENOMEM);
++        }
++
++        // Allocate memory for colors
++        rect->nb_colors = AVPALETTE_COUNT;
+         rect->data[1]   = av_mallocz(AVPALETTE_SIZE);
+         if (!rect->data[1])
+             return AVERROR(ENOMEM);
+@@ -641,14 +800,7 @@
+             ret = parse_presentation_segment(avctx, buf, segment_length, sub->pts);
+             break;
+         case WINDOW_SEGMENT:
+-            /*
+-             * Window Segment Structure (No new information provided):
+-             *     2 bytes: Unknown,
+-             *     2 bytes: X position of subtitle,
+-             *     2 bytes: Y position of subtitle,
+-             *     2 bytes: Width of subtitle,
+-             *     2 bytes: Height of subtitle.
+-             */
++            ret = parse_window_segment(avctx, buf, segment_length);
+             break;
+         case DISPLAY_SEGMENT:
+             if (*got_sub_ptr) {
+diff -Naur ffmpeg-7.1.1.old/libavcodec/videotoolbox.c ffmpeg-7.1.1/libavcodec/videotoolbox.c
+--- ffmpeg-7.1.1.old/libavcodec/videotoolbox.c	2025-03-24 10:54:38.027755105 +0100
++++ ffmpeg-7.1.1/libavcodec/videotoolbox.c	2025-03-24 10:54:39.271196851 +0100
+@@ -916,6 +916,23 @@
+         break;
+     }
+ 
++#if ARCH_X86_64
++    if (avctx->codec_id == AV_CODEC_ID_H264 &&
++        avctx->sw_pix_fmt == AV_PIX_FMT_YUV420P10)
++    {
++        // 10-bit H.264 is not supported on x86_64
++        return AVERROR(ENOSYS);
++    }
++#endif
++
++    if (avctx->codec_id == AV_CODEC_ID_H264 &&
++        (avctx->level == 61 || avctx->level == 62))
++    {
++        // H.264 Level 6.1 and 6.2 can't be
++        // decoded properly
++        return AVERROR(ENOSYS);
++    }
++
+ #if defined(MAC_OS_X_VERSION_10_9) && !TARGET_OS_IPHONE && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9) && AV_HAS_BUILTIN(__builtin_available)
+     if (avctx->codec_id == AV_CODEC_ID_PRORES) {
+         if (__builtin_available(macOS 10.9, *)) {
+diff -Naur ffmpeg-7.1.1.old/libavformat/isom.h ffmpeg-7.1.1/libavformat/isom.h
+--- ffmpeg-7.1.1.old/libavformat/isom.h	2025-03-24 10:54:38.366759184 +0100
++++ ffmpeg-7.1.1/libavformat/isom.h	2025-03-24 10:54:39.261252302 +0100
+@@ -272,6 +272,9 @@
+         MOVEncryptionIndex *encryption_index;
+     } cenc;
+ 
++    int has_fallback;   // Audio fallback track
++    int fallback;
++
+     struct IAMFDemuxContext *iamf;
+ } MOVStreamContext;
+ 
+diff -Naur ffmpeg-7.1.1.old/libavformat/matroskaenc.c ffmpeg-7.1.1/libavformat/matroskaenc.c
+--- ffmpeg-7.1.1.old/libavformat/matroskaenc.c	2025-03-24 10:54:38.396759545 +0100
++++ ffmpeg-7.1.1/libavformat/matroskaenc.c	2025-03-24 10:54:39.269651231 +0100
+@@ -2933,6 +2933,16 @@
+     case AV_CODEC_ID_AAC:
+         if (side_data_size && mkv->track.bc) {
+             int output_sample_rate = 0;
++            if (par->extradata && par->extradata_size) {
++                if (par->extradata_size != side_data_size ||
++                    memcmp(par->extradata, side_data, side_data_size)) {
++                    av_log(s, AV_LOG_ERROR, "Error, AAC extradata changed mid-stream.\n");
++                    return AVERROR(EINVAL);
++                } else {
++                    // Already written
++                    break;
++                }
++            }
+             ret = get_aac_sample_rates(s, mkv, side_data, side_data_size,
+                                        &track->sample_rate, &output_sample_rate);
+             if (ret < 0)
+diff -Naur ffmpeg-7.1.1.old/libavformat/mov.c ffmpeg-7.1.1/libavformat/mov.c
+--- ffmpeg-7.1.1.old/libavformat/mov.c	2025-03-24 10:54:38.353759028 +0100
++++ ffmpeg-7.1.1/libavformat/mov.c	2025-03-24 10:54:39.261629363 +0100
+@@ -56,6 +56,7 @@
+ #include "libavcodec/mpegaudiodecheader.h"
+ #include "libavcodec/mlp_parse.h"
+ #include "avformat.h"
++#include "avlanguage.h"
+ #include "internal.h"
+ #include "avio_internal.h"
+ #include "demux.h"
+@@ -342,6 +343,73 @@
+     return 0;
+ }
+ 
++static int mov_read_3gp_udta_tag(MOVContext *c, AVIOContext *pb, MOVAtom atom)
++{
++    const char *key;
++    AVDictionary *metadata;
++    uint16_t langcode = 0;
++    char key2[32], language[4] = {0};
++    uint32_t str_size, version;
++    char *str;
++    if (atom.size < 6)
++        return AVERROR_INVALIDDATA;
++    switch (atom.type) {
++    case MKTAG( 'a','l','b','m'): key = "album"; break;
++    case MKTAG( 'a','u','t','h'): key = "author"; break;
++    case MKTAG( 'c','p','r','t'): key = "copyright"; break;
++    case MKTAG( 'd','s','c','p'): key = "comment"; break;
++    case MKTAG( 'g','n','r','e'): key = "genre"; break;
++    case MKTAG( 'p','e','r','f'): key = "artist"; break;
++    case MKTAG( 't','i','t','l'): key = "title"; break;
++    case MKTAG( 'y','r','r','c'): key = "date"; break;
++    default: return 0;
++    }
++    version = avio_rb32(pb); // version + flags
++    if (version != 0)
++        av_log(c->fc, AV_LOG_WARNING, "udta %s unknown version number: %u\n", str, version);
++    if (MKTAG( 'y','r','r','c') == atom.type) {
++        int year;
++        year = avio_rb16(pb);
++        str = av_asprintf("%d", year);
++        if (!str)
++            return AVERROR(ENOMEM);
++    } else {
++        int ret;
++        const char *tmp;
++        langcode = avio_rb16(pb);
++        ff_mov_lang_to_iso639(langcode, language);
++        tmp = ff_convert_lang_to(language, AV_LANG_ISO639_2_BIBL);
++        if (!tmp)
++           av_log(c->fc, AV_LOG_WARNING, "udta %s unknown language code: %u\n", str, langcode);
++        str_size = atom.size - 6;
++        if (str_size <= 0 || str_size >= INT_MAX/2)
++            return AVERROR_INVALIDDATA;
++        str = av_mallocz(str_size + 1);
++        if (!str)
++            return AVERROR(ENOMEM);
++        ret = ffio_read_size(pb, str, str_size);
++        if (ret < 0) {
++            av_free(str);
++            return ret;
++        }
++        str[str_size] = 0;
++    }
++    if (c->trak_index < 0) {
++        metadata = c->fc->metadata;
++        c->fc->event_flags |= AVFMT_EVENT_FLAG_METADATA_UPDATED;
++    }
++    else {
++        metadata = c->fc->streams[c->trak_index]->metadata;
++    }
++    av_dict_set(&metadata, key, str, 0);
++    if (*language && strcmp(language, "und")) {
++        snprintf(key2, sizeof(key2), "%s-%s", key, language);
++        av_dict_set(&metadata, key2, str, 0);
++    }
++    av_freep(&str);
++    return 0;
++}
++
+ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
+ {
+     char tmp_key[AV_FOURCC_MAX_STRING_SIZE] = {0};
+@@ -354,6 +422,7 @@
+     int (*parse)(MOVContext*, AVIOContext*, unsigned, const char*) = NULL;
+     int raw = 0;
+     int num = 0;
++    AVDictionary *metadata;
+ 
+     switch (atom.type) {
+     case MKTAG( '@','P','R','M'): key = "premiere_version"; raw = 1; break;
+@@ -367,15 +436,33 @@
+     case MKTAG( 'c','a','t','g'): key = "category"; break;
+     case MKTAG( 'c','p','i','l'): key = "compilation";
+         parse = mov_metadata_int8_no_padding; break;
+-    case MKTAG( 'c','p','r','t'): key = "copyright"; break;
++    case MKTAG( 'c','p','r','t'):
++        key = "copyright";
++        if (!c->itunes_metadata) {
++            int64_t pos = avio_tell(pb);
++            int ret = mov_read_3gp_udta_tag(c, pb, atom);
++            if (ret != AVERROR_INVALIDDATA)
++                return ret;
++            avio_seek(pb, pos, SEEK_SET);
++        }
++        break;
+     case MKTAG( 'd','e','s','c'): key = "description"; break;
+     case MKTAG( 'd','i','s','k'): key = "disc";
+         parse = mov_metadata_track_or_disc_number; break;
+     case MKTAG( 'e','g','i','d'): key = "episode_uid";
+         parse = mov_metadata_int8_no_padding; break;
+     case MKTAG( 'F','I','R','M'): key = "firmware"; raw = 1; break;
+-    case MKTAG( 'g','n','r','e'): key = "genre";
+-        parse = mov_metadata_gnre; break;
++    case MKTAG( 'g','n','r','e'):
++        key = "genre";
++        parse = mov_metadata_gnre;
++        if (!c->itunes_metadata) {
++            int64_t pos = avio_tell(pb);
++            int ret = mov_read_3gp_udta_tag(c, pb, atom);
++            if (ret != AVERROR_INVALIDDATA)
++                return ret;
++            avio_seek(pb, pos, SEEK_SET);
++        }
++        break;
+     case MKTAG( 'h','d','v','d'): key = "hd_video";
+         parse = mov_metadata_int8_no_padding; break;
+     case MKTAG( 'H','M','M','T'):
+@@ -386,6 +473,7 @@
+         return mov_metadata_loci(c, pb, atom.size);
+     case MKTAG( 'm','a','n','u'): key = "make"; break;
+     case MKTAG( 'm','o','d','l'): key = "model"; break;
++    case MKTAG( 'n','a','m','e'): key = "title"; raw = 1; break;
+     case MKTAG( 'p','c','s','t'): key = "podcast";
+         parse = mov_metadata_int8_no_padding; break;
+     case MKTAG( 'p','g','a','p'): key = "gapless_playback";
+@@ -445,6 +533,15 @@
+     case MKTAG(0xa9,'w','r','n'): key = "warning";   break;
+     case MKTAG(0xa9,'w','r','t'): key = "composer";  break;
+     case MKTAG(0xa9,'x','y','z'): key = "location";  break;
++    case MKTAG( 'a','l','b','m'):
++    case MKTAG( 'a','u','t','h'):
++    case MKTAG( 'd','s','c','p'):
++    case MKTAG( 'p','e','r','f'):
++    case MKTAG( 't','i','t','l'):
++    case MKTAG( 'y','r','r','c'):
++        if (!c->itunes_metadata) {
++            return mov_read_3gp_udta_tag(c, pb, atom);
++        }
+     }
+ retry:
+     if (c->itunes_metadata && atom.size > 8) {
+@@ -571,17 +668,23 @@
+             }
+             str[str_size] = 0;
+         }
+-        c->fc->event_flags |= AVFMT_EVENT_FLAG_METADATA_UPDATED;
+-        av_dict_set(&c->fc->metadata, key, str, 0);
++        if (c->trak_index < 0) {
++            metadata = c->fc->metadata;
++            c->fc->event_flags |= AVFMT_EVENT_FLAG_METADATA_UPDATED;
++            if (!strcmp(key, "encoder")) {
++                int major, minor, micro;
++                if (sscanf(str, "HandBrake %d.%d.%d", &major, &minor, &micro) == 3) {
++                    c->handbrake_version = 1000000*major + 1000*minor + micro;
++                }
++            }
++        }
++        else {
++            metadata = c->fc->streams[c->trak_index]->metadata;
++        }
++        av_dict_set(&metadata, key, str, 0);
+         if (*language && strcmp(language, "und")) {
+             snprintf(key2, sizeof(key2), "%s-%s", key, language);
+-            av_dict_set(&c->fc->metadata, key2, str, 0);
+-        }
+-        if (!strcmp(key, "encoder")) {
+-            int major, minor, micro;
+-            if (sscanf(str, "HandBrake %d.%d.%d", &major, &minor, &micro) == 3) {
+-                c->handbrake_version = 1000000*major + 1000*minor + micro;
+-            }
++            av_dict_set(&metadata, key2, str, 0);
+         }
+     }
+ 
+@@ -9081,6 +9184,23 @@
+     return ret;
+ }
+ 
++static int mov_read_fall(MOVContext *c, AVIOContext *pb, MOVAtom atom)
++{
++    AVStream *st;
++    MOVStreamContext *sc;
++
++    if (c->fc->nb_streams < 1)
++        return 0;
++    st = c->fc->streams[c->fc->nb_streams-1];
++    sc = st->priv_data;
++
++    sc->fallback = avio_rb32(pb);
++    sc->has_fallback = 1;
++
++    return 0;
++}
++
++
+ static const MOVParseTableEntry mov_default_parse_table[] = {
+ { MKTAG('A','C','L','R'), mov_read_aclr },
+ { MKTAG('A','P','R','G'), mov_read_avid },
+@@ -9183,6 +9303,7 @@
+ { MKTAG('v','p','c','C'), mov_read_vpcc },
+ { MKTAG('m','d','c','v'), mov_read_mdcv },
+ { MKTAG('c','l','l','i'), mov_read_clli },
++{ MKTAG('f','a','l','l'), mov_read_fall },
+ { MKTAG('d','v','c','C'), mov_read_dvcc_dvvc },
+ { MKTAG('d','v','v','C'), mov_read_dvcc_dvvc },
+ { MKTAG('d','v','w','C'), mov_read_dvcc_dvvc },
+@@ -10367,6 +10488,23 @@
+             err = ff_replaygain_export(st, s->metadata);
+             if (err < 0)
+                 return err;
++            if (sc->has_fallback) {
++                for (j = 0; j < s->nb_streams; j++) {
++                    if (s->streams[j]->id == sc->fallback) {
++                        AVPacketSideData *sd;
++                        int *fallback;
++                        sd = av_packet_side_data_new(&st->codecpar->coded_side_data,
++                                 &st->codecpar->nb_coded_side_data,
++                                 AV_PKT_DATA_FALLBACK_TRACK,
++                                 sizeof(int), 0);
++                        if (!sd)
++                            return AVERROR(ENOMEM);
++                        fallback = (int*)sd->data;
++                        *fallback = j;
++                        break;
++                    }
++                }
++            }
+             break;
+         case AVMEDIA_TYPE_VIDEO:
+             if (sc->display_matrix) {
+diff -Naur ffmpeg-7.1.1.old/libavformat/movenc.c ffmpeg-7.1.1/libavformat/movenc.c
+--- ffmpeg-7.1.1.old/libavformat/movenc.c	2025-03-24 10:54:38.381759365 +0100
++++ ffmpeg-7.1.1/libavformat/movenc.c	2025-03-24 10:54:39.258769917 +0100
+@@ -28,6 +28,7 @@
+ 
+ #include "movenc.h"
+ #include "avformat.h"
++#include "avlanguage.h"
+ #include "avio_internal.h"
+ #include "dovi_isom.h"
+ #include "riff.h"
+@@ -4055,6 +4056,41 @@
+     return len + 24;
+ }
+ 
++static uint16_t language_code(const char *str)
++{
++    return (((str[0] - 0x60) & 0x1F) << 10) +
++           (((str[1] - 0x60) & 0x1F) <<  5) +
++           (( str[2] - 0x60) & 0x1F);
++}
++static int mov_write_3gp_udta_tag(AVIOContext *pb, AVDictionary *metadata,
++                                  const char *tag, const char *str)
++{
++    int64_t pos = avio_tell(pb);
++    AVDictionaryEntry *t = av_dict_get(metadata, str, NULL, 0);
++    if (!t || !utf8len(t->value))
++        return 0;
++    avio_wb32(pb, 0);   /* size */
++    ffio_wfourcc(pb, tag); /* type */
++    avio_wb32(pb, 0);   /* version + flags */
++    if (!strcmp(tag, "yrrc"))
++        avio_wb16(pb, atoi(t->value));
++    else {
++        int lang = 0, len;
++        len = strlen(t->key);
++        if (t->key[len - 4] == '-') {
++            lang = ff_mov_iso639_to_lang(&t->key[len - 3], 1);
++        }
++        if (!lang)
++            lang = ff_mov_iso639_to_lang("und", 1);
++        avio_wb16(pb, lang); /* language */
++        avio_write(pb, t->value, strlen(t->value) + 1); /* UTF8 string value */
++        if (!strcmp(tag, "albm") &&
++            (t = av_dict_get(metadata, "track", NULL, 0)))
++            avio_w8(pb, atoi(t->value));
++    }
++    return update_size(pb, pos);
++}
++
+ static int mov_write_track_metadata(AVIOContext *pb, AVStream *st,
+                                     const char *tag, const char *str)
+ {
+@@ -4129,8 +4165,23 @@
+     if (ret < 0)
+         return ret;
+ 
+-    if (mov->mode & (MODE_MP4|MODE_MOV))
++    if (mov->mode & (MODE_MP4|MODE_MOV)) {
++        AVDictionaryEntry *t = NULL;
++        int und = 0;
++
+         mov_write_track_metadata(pb_buf, st, "name", "title");
++        while ((t = av_dict_get(st->metadata, "title-", t, AV_DICT_IGNORE_SUFFIX))) {
++            int len = strlen(t->key);
++            if (len == 10 &&
++                ff_convert_lang_to(&t->key[len - 3], AV_LANG_ISO639_2_BIBL)) {
++                mov_write_3gp_udta_tag(pb_buf, st->metadata, "titl", t->key);
++                if (!strcmp("und", &t->key[len - 3]))
++                    und = 1;
++            }
++        }
++        if (!und)
++            mov_write_3gp_udta_tag(pb_buf, st->metadata, "titl", "title");
++    }
+ 
+     if (mov->mode & MODE_MP4) {
+         if ((ret = mov_write_track_kinds(pb_buf, st)) < 0)
+@@ -4727,35 +4778,6 @@
+     return 0;
+ }
+ 
+-static uint16_t language_code(const char *str)
+-{
+-    return (((str[0] - 0x60) & 0x1F) << 10) +
+-           (((str[1] - 0x60) & 0x1F) <<  5) +
+-           (( str[2] - 0x60) & 0x1F);
+-}
+-
+-static int mov_write_3gp_udta_tag(AVIOContext *pb, AVFormatContext *s,
+-                                  const char *tag, const char *str)
+-{
+-    int64_t pos = avio_tell(pb);
+-    AVDictionaryEntry *t = av_dict_get(s->metadata, str, NULL, 0);
+-    if (!t || !utf8len(t->value))
+-        return 0;
+-    avio_wb32(pb, 0);   /* size */
+-    ffio_wfourcc(pb, tag); /* type */
+-    avio_wb32(pb, 0);   /* version + flags */
+-    if (!strcmp(tag, "yrrc"))
+-        avio_wb16(pb, atoi(t->value));
+-    else {
+-        avio_wb16(pb, language_code("eng")); /* language */
+-        avio_write(pb, t->value, strlen(t->value) + 1); /* UTF8 string value */
+-        if (!strcmp(tag, "albm") &&
+-            (t = av_dict_get(s->metadata, "track", NULL, 0)))
+-            avio_w8(pb, atoi(t->value));
+-    }
+-    return update_size(pb, pos);
+-}
+-
+ static int mov_write_chpl_tag(AVIOContext *pb, AVFormatContext *s)
+ {
+     int64_t pos = avio_tell(pb);
+@@ -4794,14 +4816,14 @@
+         return ret;
+ 
+     if (mov->mode & MODE_3GP) {
+-        mov_write_3gp_udta_tag(pb_buf, s, "perf", "artist");
+-        mov_write_3gp_udta_tag(pb_buf, s, "titl", "title");
+-        mov_write_3gp_udta_tag(pb_buf, s, "auth", "author");
+-        mov_write_3gp_udta_tag(pb_buf, s, "gnre", "genre");
+-        mov_write_3gp_udta_tag(pb_buf, s, "dscp", "comment");
+-        mov_write_3gp_udta_tag(pb_buf, s, "albm", "album");
+-        mov_write_3gp_udta_tag(pb_buf, s, "cprt", "copyright");
+-        mov_write_3gp_udta_tag(pb_buf, s, "yrrc", "date");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "perf", "artist");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "titl", "title");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "auth", "author");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "gnre", "genre");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "dscp", "comment");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "albm", "album");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "cprt", "copyright");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "yrrc", "date");
+         mov_write_loci_tag(s, pb_buf);
+     } else if (mov->mode == MODE_MOV && !(mov->flags & FF_MOV_FLAG_USE_MDTA)) { // the title field breaks gtkpod with mp4 and my suspicion is that stuff is not valid in mp4
+         mov_write_string_metadata(s, pb_buf, "\251ART", "artist",      0);
+diff -Naur ffmpeg-7.1.1.old/libavutil/frame.c ffmpeg-7.1.1/libavutil/frame.c
+--- ffmpeg-7.1.1.old/libavutil/frame.c	2025-03-24 10:54:38.298758366 +0100
++++ ffmpeg-7.1.1/libavutil/frame.c	2025-03-24 10:54:39.274197994 +0100
+@@ -45,6 +45,7 @@
+     [AV_FRAME_DATA_FILM_GRAIN_PARAMS]           = { "Film grain parameters" },
+     [AV_FRAME_DATA_DETECTION_BBOXES]            = { "Bounding boxes for object detection and classification" },
+     [AV_FRAME_DATA_DOVI_RPU_BUFFER]             = { "Dolby Vision RPU Data" },
++    [AV_FRAME_DATA_DOVI_RPU_BUFFER_T35]         = { "Dolby Vision RPU ITU T35 Data" },
+     [AV_FRAME_DATA_DOVI_METADATA]               = { "Dolby Vision Metadata" },
+     [AV_FRAME_DATA_LCEVC]                       = { "LCEVC NAL data" },
+     [AV_FRAME_DATA_VIEW_ID]                     = { "View ID" },
+diff -Naur ffmpeg-7.1.1.old/libavutil/frame.h ffmpeg-7.1.1/libavutil/frame.h
+--- ffmpeg-7.1.1.old/libavutil/frame.h	2025-03-24 10:54:38.287758234 +0100
++++ ffmpeg-7.1.1/libavutil/frame.h	2025-03-24 10:54:39.274296419 +0100
+@@ -201,6 +201,12 @@
+     AV_FRAME_DATA_DOVI_RPU_BUFFER,
+ 
+     /**
++     * Dolby Vision RPU ITU T35 raw data, suitable for passing to SVT-AV1
++     * or other libraries. Array of uint8_t.
++     */
++    AV_FRAME_DATA_DOVI_RPU_BUFFER_T35,
++
++    /**
+      * Parsed Dolby Vision metadata, suitable for passing to a software
+      * implementation. The payload is the AVDOVIMetadata struct defined in
+      * libavutil/dovi_meta.h.
+diff -Naur ffmpeg-7.1.1.old/libswscale/swscale_unscaled.c ffmpeg-7.1.1/libswscale/swscale_unscaled.c
+--- ffmpeg-7.1.1.old/libswscale/swscale_unscaled.c	2025-03-24 10:54:38.201757199 +0100
++++ ffmpeg-7.1.1/libswscale/swscale_unscaled.c	2025-03-24 10:54:39.272233834 +0100
+@@ -341,7 +341,7 @@
+         const uint8_t *tsrc0 = src[0];
+         for (x = c->srcW; x > 0; x--) {
+             t = *tsrc0++;
+-            output_pixel(tdstY++, t | (t << 8));
++            output_pixel(tdstY++, (t << 8));
+         }
+         src[0] += srcStride[0];
+         dstY += dstStride[0] / 2;
+@@ -352,9 +352,9 @@
+             const uint8_t *tsrc2 = src[2];
+             for (x = c->srcW / 2; x > 0; x--) {
+                 t = *tsrc1++;
+-                output_pixel(tdstUV++, t | (t << 8));
++                output_pixel(tdstUV++, (t << 8));
+                 t = *tsrc2++;
+-                output_pixel(tdstUV++, t | (t << 8));
++                output_pixel(tdstUV++, (t << 8));
+             }
+             src[1] += srcStride[1];
+             src[2] += srcStride[2];

--- a/anda/multimedia/ffmpeg/ffmpeg-chromium.patch
+++ b/anda/multimedia/ffmpeg/ffmpeg-chromium.patch
@@ -1,0 +1,30 @@
+diff -Naur ffmpeg-7.1.1.old/libavformat/avformat.h ffmpeg-7.1.1/libavformat/avformat.h
+--- ffmpeg-7.1.1.old/libavformat/avformat.h	2025-03-24 10:54:38.357759076 +0100
++++ ffmpeg-7.1.1/libavformat/avformat.h	2025-03-24 10:54:39.096586841 +0100
+@@ -1202,6 +1202,10 @@
+ 
+ struct AVCodecParserContext *av_stream_get_parser(const AVStream *s);
+ 
++// Chromium: We use the internal field first_dts vvv
++int64_t    av_stream_get_first_dts(const AVStream *st);
++// Chromium: We use the internal field first_dts ^^^
++
+ #define AV_PROGRAM_RUNNING 1
+ 
+ /**
+diff -Naur ffmpeg-7.1.1.old/libavformat/utils.c ffmpeg-7.1.1/libavformat/utils.c
+--- ffmpeg-7.1.1.old/libavformat/utils.c	2025-03-24 10:54:38.360759112 +0100
++++ ffmpeg-7.1.1/libavformat/utils.c	2025-03-24 10:54:39.097179227 +0100
+@@ -44,6 +44,13 @@
+  * various utility functions for use within FFmpeg
+  */
+ 
++// Chromium: We use the internal field first_dts vvv
++int64_t av_stream_get_first_dts(const AVStream *st)
++{
++  return cffstream(st)->first_dts;
++}
++// Chromium: We use the internal field first_dts ^^^
++
+ /* an arbitrarily chosen "sane" max packet size -- 50M */
+ #define SANE_CHUNK_SIZE (50000000)

--- a/anda/multimedia/ffmpeg/ffmpeg-nvcc.patch
+++ b/anda/multimedia/ffmpeg/ffmpeg-nvcc.patch
@@ -1,0 +1,12 @@
+diff -Naur ffmpeg-7.1.1.old/configure ffmpeg-7.1.1/configure
+--- ffmpeg-7.1.1.old/configure	2025-03-24 11:04:46.377074634 +0100
++++ ffmpeg-7.1.1/configure	2025-03-24 11:04:54.615698726 +0100
+@@ -6742,7 +6742,7 @@
+     nvccflags=$nvccflags_default
+ fi
+ 
+-nvccflags="$nvccflags -std=c++11"
++nvccflags="$nvccflags -std=c++14"
+ 
+ if enabled x86_64 || enabled ppc64 || enabled aarch64; then
+     nvccflags="$nvccflags -m64"

--- a/anda/multimedia/ffmpeg/ffmpeg-svt-vp9.patch
+++ b/anda/multimedia/ffmpeg/ffmpeg-svt-vp9.patch
@@ -1,0 +1,762 @@
+diff -Naur ffmpeg-7.1.1.old/configure ffmpeg-7.1.1/configure
+--- ffmpeg-7.1.1.old/configure	2025-03-24 10:54:38.202757211 +0100
++++ ffmpeg-7.1.1/configure	2025-03-24 10:54:38.618546808 +0100
+@@ -278,6 +278,7 @@
+   --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
+   --enable-libssh          enable SFTP protocol via libssh [no]
+   --enable-libsvtav1       enable AV1 encoding via SVT [no]
++  --enable-libsvtvp9       enable VP9 encoding via svt [no]
+   --enable-libtensorflow   enable TensorFlow as a DNN module backend
+                            for DNN based filters like sr [no]
+   --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
+@@ -1953,6 +1954,7 @@
+     libshaderc
+     libshine
+     libsmbclient
++    libsvtvp9
+     libsnappy
+     libsoxr
+     libspeex
+@@ -3575,6 +3577,7 @@
+ libvpx_vp8_encoder_deps="libvpx"
+ libvpx_vp9_decoder_deps="libvpx"
+ libvpx_vp9_encoder_deps="libvpx"
++libsvt_vp9_encoder_deps="libsvtvp9"
+ libvvenc_encoder_deps="libvvenc"
+ libwebp_encoder_deps="libwebp"
+ libwebp_anim_encoder_deps="libwebp"
+@@ -6997,6 +7000,7 @@
+ enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
+ enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
+ enabled libsvtav1         && require_pkg_config libsvtav1 "SvtAv1Enc >= 0.9.0" EbSvtAv1Enc.h svt_av1_enc_init_handle
++enabled libsvtvp9         && require_pkg_config libsvtvp9 SvtVp9Enc EbSvtVp9Enc.h       eb_vp9_svt_init_handle
+ enabled libtensorflow     && require libtensorflow tensorflow/c/c_api.h TF_Version -ltensorflow
+ enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
+ enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
+diff -Naur ffmpeg-7.1.1.old/libavcodec/allcodecs.c ffmpeg-7.1.1/libavcodec/allcodecs.c
+--- ffmpeg-7.1.1.old/libavcodec/allcodecs.c	2025-03-24 10:54:38.119756212 +0100
++++ ffmpeg-7.1.1/libavcodec/allcodecs.c	2025-03-24 10:54:38.619934060 +0100
+@@ -796,6 +796,7 @@
+ extern const FFCodec ff_libvo_amrwbenc_encoder;
+ extern const FFCodec ff_libvorbis_encoder;
+ extern const FFCodec ff_libvorbis_decoder;
++extern const FFCodec ff_libsvt_vp9_encoder;
+ extern const FFCodec ff_libvpx_vp8_encoder;
+ extern const FFCodec ff_libvpx_vp8_decoder;
+ extern FFCodec ff_libvpx_vp9_encoder;
+diff -Naur ffmpeg-7.1.1.old/libavcodec/libsvt_vp9.c ffmpeg-7.1.1/libavcodec/libsvt_vp9.c
+--- ffmpeg-7.1.1.old/libavcodec/libsvt_vp9.c	1970-01-01 01:00:00.000000000 +0100
++++ ffmpeg-7.1.1/libavcodec/libsvt_vp9.c	2025-03-24 10:54:38.620176868 +0100
+@@ -0,0 +1,701 @@
++/*
++* Scalable Video Technology for VP9 encoder library plugin
++*
++* Copyright (c) 2018 Intel Corporation
++*
++* This file is part of FFmpeg.
++*
++* FFmpeg is free software; you can redistribute it and/or
++* modify it under the terms of the GNU Lesser General Public
++* License as published by the Free Software Foundation; either
++* version 2.1 of the License, or (at your option) any later version.
++*
++* FFmpeg is distributed in the hope that it will be useful,
++* but WITHOUT ANY WARRANTY; without even the implied warranty of
++* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++* Lesser General Public License for more details.
++*
++* You should have received a copy of the GNU Lesser General Public
++* License along with this program; if not, write to the Free Software
++* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++*/
++
++#include <stdint.h>
++#include "EbSvtVp9ErrorCodes.h"
++#include "EbSvtVp9Enc.h"
++
++#include "libavutil/common.h"
++#include "libavutil/frame.h"
++#include "libavutil/mem.h"
++#include "libavutil/opt.h"
++#include "libavcodec/get_bits.h"
++
++#include "codec_internal.h"
++#include "internal.h"
++#include "encode.h"
++#include "avcodec.h"
++
++#define SUPERFRAME_INDEX_MAX_SIZE 128
++
++#define RECIVED_FRAMES_MAX_SIZE 32
++#define MAX_VP9_SUPERFRAME_SIZE 8
++
++typedef enum eos_status {
++    EOS_NOT_REACHED = 0,
++    EOS_REACHED,
++    EOS_TOTRIGGER
++}EOS_STATUS;
++
++typedef struct SvtReceivedFrameStruct {
++    // fields for AVPacket
++    AVBufferRef *buf;
++    int64_t pts;
++    int64_t dts;
++    int size;
++    int flags;
++
++    // svt fields:
++    int ready_flag; // frame or superframe in data is visible
++    int frames_count;
++    int frames_sizes[MAX_VP9_SUPERFRAME_SIZE];
++} SvtReceivedFrameStruct;
++
++typedef struct SvtContext {
++    AVClass     *class;
++
++    EbSvtVp9EncConfiguration    enc_params;
++    EbComponentType            *svt_handle;
++
++    EbBufferHeaderType         *in_buf;
++    int                         raw_size;
++
++    AVFrame *frame;
++
++    AVBufferPool* pool;
++
++    EOS_STATUS eos_flag;
++
++    // User options.
++    int enc_mode;
++    int rc_mode;
++    int tune;
++    int qp;
++
++    int target_socket;
++
++    int forced_idr;
++
++    int level;
++
++    int base_layer_switch_mode;
++
++
++    int64_t last_ready_dts;
++    SvtReceivedFrameStruct received_frames[RECIVED_FRAMES_MAX_SIZE];
++    int received_frames_size;
++} SvtContext;
++
++static int error_mapping(EbErrorType svt_ret)
++{
++    int err;
++
++    switch (svt_ret) {
++    case EB_ErrorInsufficientResources:
++        err = AVERROR(ENOMEM);
++        break;
++
++    case EB_ErrorUndefined:
++    case EB_ErrorInvalidComponent:
++    case EB_ErrorBadParameter:
++        err = AVERROR(EINVAL);
++        break;
++
++    case EB_ErrorDestroyThreadFailed:
++    case EB_ErrorSemaphoreUnresponsive:
++    case EB_ErrorDestroySemaphoreFailed:
++    case EB_ErrorCreateMutexFailed:
++    case EB_ErrorMutexUnresponsive:
++    case EB_ErrorDestroyMutexFailed:
++        err = AVERROR_EXTERNAL;
++            break;
++
++    case EB_NoErrorEmptyQueue:
++        err = AVERROR(EAGAIN);
++
++    case EB_ErrorNone:
++        err = 0;
++        break;
++
++    default:
++        err = AVERROR_UNKNOWN;
++    }
++
++    return err;
++}
++
++static void free_buffer(SvtContext *svt_enc)
++{
++    if (svt_enc->in_buf) {
++        EbSvtEncInput *in_data = (EbSvtEncInput *)svt_enc->in_buf->p_buffer;
++        av_freep(&in_data);
++        av_freep(&svt_enc->in_buf);
++    }
++    av_buffer_pool_uninit(&svt_enc->pool);
++}
++
++static int alloc_buffer(EbSvtVp9EncConfiguration *config, SvtContext *svt_enc)
++{
++    const size_t luma_size_8bit    =
++        config->source_width * config->source_height;
++    const size_t luma_size_10bit   =
++        (config->encoder_bit_depth > 8) ? luma_size_8bit : 0;
++
++    EbSvtEncInput *in_data;
++
++    svt_enc->raw_size = ((luma_size_8bit + luma_size_10bit) * 3 / 2) * MAX_VP9_SUPERFRAME_SIZE + SUPERFRAME_INDEX_MAX_SIZE;
++
++    // allocate buffer for in and out
++    svt_enc->in_buf           = av_mallocz(sizeof(*svt_enc->in_buf));
++    if (!svt_enc->in_buf)
++        goto failed;
++
++
++    svt_enc->in_buf->p_buffer = (unsigned char *)av_mallocz(sizeof(*in_data));
++    if (!svt_enc->in_buf->p_buffer)
++        goto failed;
++
++    svt_enc->in_buf->size        = sizeof(*svt_enc->in_buf);
++    svt_enc->in_buf->p_app_private  = NULL;
++
++    svt_enc->pool = av_buffer_pool_init(svt_enc->raw_size, NULL);
++    if (!svt_enc->pool)
++        goto failed;
++
++    svt_enc->received_frames_size = 0;
++    svt_enc->last_ready_dts = -1e9;
++
++    return 0;
++
++failed:
++    free_buffer(svt_enc);
++    return AVERROR(ENOMEM);
++}
++
++static int config_enc_params(EbSvtVp9EncConfiguration *param,
++                             AVCodecContext *avctx)
++{
++    SvtContext *svt_enc = avctx->priv_data;
++    int             ret;
++    int        ten_bits = 0;
++
++    param->source_width     = avctx->width;
++    param->source_height    = avctx->height;
++
++    if (avctx->pix_fmt == AV_PIX_FMT_YUV420P10LE) {
++        av_log(avctx, AV_LOG_DEBUG , "Encoder 10 bits depth input\n");
++        // Disable Compressed 10-bit format default
++        ten_bits = 1;
++    }
++
++    // Update param from options
++    param->enc_mode                 = svt_enc->enc_mode;
++    param->level                    = svt_enc->level;
++    param->rate_control_mode        = svt_enc->rc_mode;
++    param->tune                     = svt_enc->tune;
++    param->base_layer_switch_mode   = svt_enc->base_layer_switch_mode;
++    param->qp                       = svt_enc->qp;
++    param->target_socket            = svt_enc->target_socket;
++    param->target_bit_rate          = avctx->bit_rate;
++    if (avctx->gop_size > 0)
++        param->intra_period  = avctx->gop_size - 1;
++
++    if (avctx->framerate.num > 0 && avctx->framerate.den > 0) {
++        param->frame_rate_numerator     = avctx->framerate.num;
++        param->frame_rate_denominator   = avctx->framerate.den * avctx->ticks_per_frame;
++    } else {
++        param->frame_rate_numerator     = avctx->time_base.den;
++        param->frame_rate_denominator   = avctx->time_base.num * avctx->ticks_per_frame;
++    }
++
++    if (param->rate_control_mode) {
++        param->max_qp_allowed       = avctx->qmax;
++        param->min_qp_allowed       = avctx->qmin;
++    }
++
++    if (ten_bits) {
++        param->encoder_bit_depth        = 10;
++    }
++
++    ret = alloc_buffer(param, svt_enc);
++
++    return ret;
++}
++
++static void read_in_data(EbSvtVp9EncConfiguration *config,
++                         const AVFrame *frame,
++                         EbBufferHeaderType *headerPtr)
++{
++    uint8_t is16bit = config->encoder_bit_depth > 8;
++    uint64_t luma_size =
++        (uint64_t)config->source_width * config->source_height<< is16bit;
++    EbSvtEncInput *in_data = (EbSvtEncInput *)headerPtr->p_buffer;
++
++    // support yuv420p and yuv420p010
++    in_data->luma = frame->data[0];
++    in_data->cb   = frame->data[1];
++    in_data->cr   = frame->data[2];
++
++    // stride info
++    in_data->y_stride  = frame->linesize[0] >> is16bit;
++    in_data->cb_stride = frame->linesize[1] >> is16bit;
++    in_data->cr_stride = frame->linesize[2] >> is16bit;
++
++    headerPtr->n_filled_len   += luma_size * 3/2u;
++}
++
++static av_cold int eb_enc_init(AVCodecContext *avctx)
++{
++    SvtContext   *svt_enc = avctx->priv_data;
++    EbErrorType svt_ret;
++
++    svt_enc->eos_flag = EOS_NOT_REACHED;
++
++    svt_ret = eb_vp9_svt_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Error init encoder handle\n");
++        goto failed;
++    }
++
++    svt_ret = config_enc_params(&svt_enc->enc_params, avctx);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Error configure encoder parameters\n");
++        goto failed_init_handle;
++    }
++
++    svt_ret = eb_vp9_svt_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Error setting encoder parameters\n");
++        goto failed_init_handle;
++    }
++
++    svt_ret = eb_vp9_init_encoder(svt_enc->svt_handle);
++    if (svt_ret != EB_ErrorNone) {
++        av_log(avctx, AV_LOG_ERROR, "Error init encoder\n");
++        goto failed_init_handle;
++    }
++
++    svt_enc->frame = av_frame_alloc();
++    if (!svt_enc->frame)
++        return AVERROR(ENOMEM);
++
++ //   if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
++ //       EbBufferHeaderType* headerPtr;
++ //       headerPtr->size       = sizeof(headerPtr);
++ //       headerPtr->n_filled_len  = 0; /* in/out */
++ //       headerPtr->p_buffer     = av_malloc(10 * 1024 * 1024);
++ //       headerPtr->n_alloc_len   = (10 * 1024 * 1024);
++ //
++ //       if (!headerPtr->p_buffer) {
++ //           av_log(avctx, AV_LOG_ERROR,
++ //                  "Cannot allocate buffer size %d.\n", headerPtr->n_alloc_len);
++ //           svt_ret = EB_ErrorInsufficientResources;
++ //           goto failed_init_enc;
++ //       }
++ //
++ //       svt_ret = eb_svt_enc_stream_header(svt_enc->svt_handle, &headerPtr);
++ //       if (svt_ret != EB_ErrorNone) {
++ //           av_log(avctx, AV_LOG_ERROR, "Error when build stream header.\n");
++ //           av_freep(&headerPtr->p_buffer);
++ //           goto failed_init_enc;
++ //       }
++ //
++ //       avctx->extradata_size = headerPtr->n_filled_len;
++ //       avctx->extradata = av_mallocz(avctx->extradata_size + AV_INPUT_BUFFER_PADDING_SIZE);
++ //       if (!avctx->extradata) {
++ //           av_log(avctx, AV_LOG_ERROR,
++ //                  "Cannot allocate VP9 header of size %d.\n", avctx->extradata_size);
++ //           av_freep(&headerPtr->p_buffer);
++ //           svt_ret = EB_ErrorInsufficientResources;
++ //           goto failed_init_enc;
++ //       }
++ //       memcpy(avctx->extradata, headerPtr->p_buffer, avctx->extradata_size);
++ //
++ //       av_freep(&headerPtr->p_buffer);
++ //   }
++    return 0;
++
++//failed_init_enc:
++//    eb_deinit_encoder(svt_enc->svt_handle);
++failed_init_handle:
++    eb_vp9_deinit_handle(svt_enc->svt_handle);
++failed:
++    free_buffer(svt_enc);
++    return error_mapping(svt_ret);
++}
++
++static int eb_send_frame(AVCodecContext *avctx, const AVFrame *frame)
++{
++    SvtContext           *svt_enc = avctx->priv_data;
++    EbBufferHeaderType  *headerPtr = svt_enc->in_buf;
++
++    if (!frame) {
++        if (svt_enc->eos_flag == EOS_REACHED)
++            return 0;
++
++        EbBufferHeaderType headerPtrLast;
++        headerPtrLast.n_alloc_len   = 0;
++        headerPtrLast.n_filled_len  = 0;
++        headerPtrLast.n_tick_count  = 0;
++        headerPtrLast.p_app_private = NULL;
++        headerPtrLast.p_buffer      = NULL;
++        headerPtrLast.flags         = EB_BUFFERFLAG_EOS;
++
++        eb_vp9_svt_enc_send_picture(svt_enc->svt_handle, &headerPtrLast);
++        svt_enc->eos_flag = EOS_REACHED;
++        av_log(avctx, AV_LOG_DEBUG, "Finish sending frames!!!\n");
++        return 0;
++    }
++
++    read_in_data(&svt_enc->enc_params, frame, headerPtr);
++
++    headerPtr->flags         = 0;
++    headerPtr->p_app_private = NULL;
++    headerPtr->pts           = frame->pts;
++    switch (frame->pict_type) {
++    case AV_PICTURE_TYPE_I:
++        headerPtr->pic_type = svt_enc->forced_idr > 0 ? EB_IDR_PICTURE : EB_I_PICTURE;
++        break;
++    case AV_PICTURE_TYPE_P:
++        headerPtr->pic_type = EB_P_PICTURE;
++        break;
++    case AV_PICTURE_TYPE_B:
++        headerPtr->pic_type = EB_B_PICTURE;
++        break;
++    default:
++        headerPtr->pic_type = EB_INVALID_PICTURE;
++        break;
++    }
++    eb_vp9_svt_enc_send_picture(svt_enc->svt_handle, headerPtr);
++
++    return 0;
++}
++
++static int is_frame_visible(uint8_t const* ptr, int size) {
++    GetBitContext gb;
++    int ret, visible, profile;
++    if ((ret = init_get_bits8(&gb, ptr, size)) < 0) {
++        return ret;
++    }
++
++    // frame marker
++    get_bits(&gb, 2);
++    profile  = get_bits1(&gb);
++    profile |= get_bits1(&gb) << 1;
++
++    // reserved_zero
++    if (profile == 3) profile += get_bits1(&gb);  // reserved_zero
++
++    // read show_existing_frame
++    if (get_bits1(&gb)) {
++        // show_existing_frame == 1
++        visible = 1;
++    } else {
++        // show_existing_frame == 0
++        // keyframe (frame_type actually)
++        get_bits1(&gb);
++        // read show_frame
++        visible = get_bits1(&gb) ? 2 : 0;
++    }
++
++    return visible;
++}
++
++static int get_received_frame(SvtContext *svt_enc, AVPacket *pkt) {
++    SvtReceivedFrameStruct* rfs = &svt_enc->received_frames[0];
++
++    if (svt_enc->received_frames_size == 0 || !rfs->ready_flag) {
++        return AVERROR(EAGAIN);
++    }
++
++    pkt->buf = rfs->buf;
++    pkt->data = rfs->buf->data;
++    pkt->dts = rfs->dts;
++    pkt->pts = rfs->pts;
++    pkt->flags = rfs->flags;
++    pkt->size = rfs->size;
++
++    --svt_enc->received_frames_size;
++    for (int i = 0; i < svt_enc->received_frames_size; ++i) {
++        svt_enc->received_frames[i] = svt_enc->received_frames[i + 1];
++    }
++
++    return 0;
++}
++
++static int put_received_frame(AVCodecContext *avctx, uint8_t* data, int size, int keyframe, int64_t dts, int64_t pts) {
++    SvtContext  *svt_enc = avctx->priv_data;
++    SvtReceivedFrameStruct* rfs;
++
++    if (svt_enc->received_frames_size == 0 || svt_enc->received_frames[svt_enc->received_frames_size - 1].ready_flag) {
++        ++svt_enc->received_frames_size;
++        if (svt_enc->received_frames_size > RECIVED_FRAMES_MAX_SIZE) {
++            av_log(avctx, AV_LOG_ERROR, "Fail: svt_enc->received_frames_size > RECIVED_FRAMES_MAX_SIZE \n");
++            return AVERROR_BUG;
++        }
++
++        rfs = &svt_enc->received_frames[svt_enc->received_frames_size - 1];
++
++        rfs->buf = av_buffer_pool_get(svt_enc->pool);
++        if (!rfs->buf) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to allocate output packet.\n");
++            return AVERROR(ENOMEM);
++        }
++
++        rfs->size = 0;
++        rfs->flags = 0;
++        rfs->ready_flag = 0;
++        rfs->frames_count = 0;
++    } else {
++        rfs = &svt_enc->received_frames[svt_enc->received_frames_size - 1];
++    }
++
++    rfs->pts = pts;
++    rfs->dts = dts;
++    rfs->flags = (keyframe ? AV_PKT_FLAG_KEY : 0);
++
++    ++rfs->frames_count;
++    if (rfs->frames_count > MAX_VP9_SUPERFRAME_SIZE) {
++        av_log(avctx, AV_LOG_ERROR, "Fail: rfs->frames_count > MAX_VP9_SUPERFRAME_SIZE \n");
++        return AVERROR_BUG;
++    }
++
++    rfs->frames_sizes[rfs->frames_count - 1] = size;
++
++    memcpy(rfs->buf->data + rfs->size, data, size);
++    rfs->size += size;
++
++    int visible = is_frame_visible(data, size);
++    if (visible < 0) {
++        av_log(avctx, AV_LOG_ERROR, "Fail: is_frame_visible \n");
++        return visible;
++    }
++
++
++    rfs->ready_flag = visible;
++
++    if (rfs->ready_flag) {
++        if (rfs->dts <= svt_enc->last_ready_dts) {
++            rfs->dts = svt_enc->last_ready_dts + 1;
++        }
++        svt_enc->last_ready_dts = rfs->dts;
++
++    }
++
++    // add superframe_index if needed
++    if (rfs->ready_flag && rfs->frames_count > 1) {
++        // superframe_header:
++        // 110 - superframe_marker
++        // 11 = 3 = bytes_per_framesize_minus_1 - use 4-bytes size
++        // xxx = frames_in_superframe_minus_1
++        uint8_t header = 0b11011000;
++        header |= (rfs->frames_count - 1) & 0b111;
++
++        uint8_t* ptr = rfs->buf->data + rfs->size;
++
++        ptr[0] = header;
++        ++ptr;
++
++        for (int i = 0; i < rfs->frames_count; ++i) {
++            ptr[0] = (rfs->frames_sizes[i] >>  0) & 0xff;
++            ptr[1] = (rfs->frames_sizes[i] >>  8) & 0xff;
++            ptr[2] = (rfs->frames_sizes[i] >> 16) & 0xff;
++            ptr[3] = (rfs->frames_sizes[i] >> 24) & 0xff;
++
++            ptr += 4;
++        }
++
++        ptr[0] = header;
++        ++ptr;
++
++        rfs->size = ptr - rfs->buf->data;
++    }
++
++    return 0;
++}
++
++static int eb_receive_packet(AVCodecContext *avctx, AVPacket *pkt)
++{
++    SvtContext  *svt_enc = avctx->priv_data;
++    EbBufferHeaderType   *headerPtr;
++    EbErrorType          svt_ret;
++    AVBufferRef *ref;
++    int ret = 0;
++
++    if (get_received_frame(svt_enc, pkt) == 0) {
++        return 0;
++    }
++
++    if (EOS_TOTRIGGER == svt_enc->eos_flag) {
++        pkt = NULL;
++        return AVERROR_EOF;
++    }
++
++    AVFrame *frame = svt_enc->frame;
++    ret = ff_encode_get_frame(avctx, frame);
++    if (ret < 0 && ret != AVERROR_EOF) {
++        return ret;
++    }
++    if (ret == AVERROR_EOF)
++        frame = NULL;
++
++    ret = eb_send_frame(avctx, frame);
++    if (ret < 0)
++        return ret;
++    av_frame_unref(svt_enc->frame);
++
++    for (;;) {
++        svt_ret = eb_vp9_svt_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
++        if (svt_ret == EB_NoErrorEmptyQueue) {
++            return AVERROR(EAGAIN);
++        }
++
++        if (EB_BUFFERFLAG_EOS & headerPtr->flags)
++            svt_enc->eos_flag = EOS_TOTRIGGER;
++
++        ret = 0;
++
++        // ignore headerPtr->dts on purpose
++
++        if (headerPtr->flags & EB_BUFFERFLAG_SHOW_EXT) {
++            ret = put_received_frame(avctx, headerPtr->p_buffer, headerPtr->n_filled_len - 4, 0, headerPtr->pts - 3, headerPtr->pts - 3);
++            if (ret != 0) goto end;
++            ret = put_received_frame(avctx, headerPtr->p_buffer + headerPtr->n_filled_len - 4, 1, 0, headerPtr->pts - 2, headerPtr->pts - 2);
++            if (ret != 0) goto end;
++            ret = put_received_frame(avctx, headerPtr->p_buffer + headerPtr->n_filled_len - 3, 1, 0, headerPtr->pts - 1, headerPtr->pts - 1);
++            if (ret != 0) goto end;
++            ret = put_received_frame(avctx, headerPtr->p_buffer + headerPtr->n_filled_len - 2, 1, 0, headerPtr->pts + 0, headerPtr->pts + 0);
++            if (ret != 0) goto end;
++            ret = put_received_frame(avctx, headerPtr->p_buffer + headerPtr->n_filled_len - 1, 1, 0, headerPtr->pts + 1, headerPtr->pts + 1);
++            if (ret != 0) goto end;
++        } else {
++            ret = put_received_frame(avctx, headerPtr->p_buffer, headerPtr->n_filled_len, headerPtr->pic_type == EB_IDR_PICTURE, headerPtr->pts, headerPtr->pts);
++            if (ret != 0) goto end;
++        }
++
++        ret = get_received_frame(svt_enc, pkt);
++
++        end:
++            eb_vp9_svt_release_out_buffer(&headerPtr);
++
++        if (ret == AVERROR(EAGAIN)) {
++            continue;
++        }
++
++        break;
++    }
++
++
++
++    return ret;
++}
++
++static av_cold int eb_enc_close(AVCodecContext *avctx)
++{
++    SvtContext *svt_enc = avctx->priv_data;
++
++    eb_vp9_deinit_encoder(svt_enc->svt_handle);
++    eb_vp9_deinit_handle(svt_enc->svt_handle);
++
++    av_frame_free(&svt_enc->frame);
++
++    free_buffer(svt_enc);
++
++    return 0;
++}
++
++#define OFFSET(x) offsetof(SvtContext, x)
++#define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
++static const AVOption options[] = {
++    { "preset", "Encoding preset [1, 1]",
++      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = 9 }, 0, 9, VE },
++
++    { "level", "Set level (level_idc)", OFFSET(level),
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 0xff, VE, "level" },
++
++#define LEVEL(name, value) name, NULL, 0, AV_OPT_TYPE_CONST, \
++      { .i64 = value }, 0, 0, VE, "level"
++        { LEVEL("1",   10) },
++        { LEVEL("2",   20) },
++        { LEVEL("2.1", 21) },
++        { LEVEL("3",   30) },
++        { LEVEL("3.1", 31) },
++        { LEVEL("4",   40) },
++        { LEVEL("4.1", 41) },
++        { LEVEL("5",   50) },
++        { LEVEL("5.1", 51) },
++        { LEVEL("5.2", 52) },
++        { LEVEL("6",   60) },
++        { LEVEL("6.1", 61) },
++        { LEVEL("6.2", 62) },
++#undef LEVEL
++
++    { "tune", "Tune mode", OFFSET(tune),
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 2, VE , "tune"},
++        { "vq", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "tune" },
++        { "ssim", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "tune" },
++        { "vmaf", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "tune" },
++
++    { "rc", "Bit rate control mode", OFFSET(rc_mode),
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 2, VE , "rc"},
++        { "cqp", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "vbr", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "cbr", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "rc" },
++
++    { "qp", "QP value for intra frames", OFFSET(qp),
++      AV_OPT_TYPE_INT, { .i64 = 32 }, 0, 51, VE },
++
++    { "socket", "Target CPU socket to use.  -1 use all available", OFFSET(target_socket),
++      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 1, VE },
++
++    { "bl_mode", "Random Access Prediction Structure type setting", OFFSET(base_layer_switch_mode),
++      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
++
++    { "forced-idr", "If forcing keyframes, force them as IDR frames.", OFFSET(forced_idr),
++      AV_OPT_TYPE_BOOL,   { .i64 = 0 }, -1, 1, VE },
++
++    {NULL},
++};
++
++static const AVClass class = {
++    .class_name = "libsvt_vp9",
++    .item_name  = av_default_item_name,
++    .option     = options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++static const FFCodecDefault eb_enc_defaults[] = {
++    { "b",         "7M"    },
++    { "flags",     "-cgop" },
++    { "qmin",      "10"    },
++    { "qmax",      "48"    },
++    { NULL },
++};
++
++const FFCodec ff_libsvt_vp9_encoder = {
++    .p.name           = "libsvt_vp9",
++    .p.long_name      = NULL_IF_CONFIG_SMALL("SVT-VP9(Scalable Video Technology for VP9) encoder"),
++    .priv_data_size = sizeof(SvtContext),
++    .p.type           = AVMEDIA_TYPE_VIDEO,
++    .p.id             = AV_CODEC_ID_VP9,
++    .init             = eb_enc_init,
++    FF_CODEC_RECEIVE_PACKET_CB(eb_receive_packet),
++    .close            = eb_enc_close,
++    .p.capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_OTHER_THREADS,
++    .caps_internal    = FF_CODEC_CAP_NOT_INIT_THREADSAFE |
++                        FF_CODEC_CAP_AUTO_THREADS | FF_CODEC_CAP_INIT_CLEANUP,
++    .p.pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_YUV420P,
++                                                    AV_PIX_FMT_NONE },
++    .p.priv_class     = &class,
++    .defaults         = eb_enc_defaults,
++    .p.wrapper_name   = "libsvt_vp9",
++};
+diff -Naur ffmpeg-7.1.1.old/libavcodec/Makefile ffmpeg-7.1.1/libavcodec/Makefile
+--- ffmpeg-7.1.1.old/libavcodec/Makefile	2025-03-24 10:54:37.935753999 +0100
++++ ffmpeg-7.1.1/libavcodec/Makefile	2025-03-24 10:54:38.620394147 +0100
+@@ -1157,6 +1157,7 @@
+ OBJS-$(CONFIG_LIBVORBIS_DECODER)          += libvorbisdec.o
+ OBJS-$(CONFIG_LIBVORBIS_ENCODER)          += libvorbisenc.o \
+                                              vorbis_data.o
++OBJS-$(CONFIG_LIBSVT_VP9_ENCODER)         += libsvt_vp9.o
+ OBJS-$(CONFIG_LIBVPX_VP8_DECODER)         += libvpxdec.o
+ OBJS-$(CONFIG_LIBVPX_VP8_ENCODER)         += libvpxenc.o
+ OBJS-$(CONFIG_LIBVPX_VP9_DECODER)         += libvpxdec.o

--- a/anda/multimedia/ffmpeg/ffmpeg.spec
+++ b/anda/multimedia/ffmpeg/ffmpeg.spec
@@ -1,243 +1,174 @@
-# TODO: add make test to %%check section
-
-#global branch  oldabi-
-#global date    20230221
-#global commit  691d01989936d4b0681aa226aea8a19f06c04cea
-#global rel %(c=%{commit}; echo ${c:0:7})
-
-%global terrasrc_commit 60a820cdf3d0048cbffc8a83483cec768e70f909
-
-%if 0%{?fedora} >= 37 || 0%{?rhel} >= 9
-%bcond_without libavcodec_freeworld
-%else
-%bcond_with libavcodec_freeworld
-%endif
-
-%undefine _package_note_file
-
-%ifarch %{ix86} %{arm}
-# Fails due to asm issue
 %global _lto_cflags %{nil}
-%endif
 
-# Cuda and others are only available on some arches
-%global cuda_arches x86_64
+%global avcodec_soversion 61
+%global avdevice_soversion 61
+%global avfilter_soversion 10
+%global avformat_soversion 61
+%global avutil_soversion 59
+%global postproc_soversion 58
+%global swresample_soversion 5
+%global swscale_soversion 8
 
-# Disable because of gcc issue
-%global _without_lensfun  1
-# Disable due to undefined symbols in libavformat
-#global _with_dvddemuxer 1
-%ifnarch i686
-%global _with_bs2b        1
-%global _with_codec2      1
-%global _with_chromaprint 1
-%global _with_ilbc        1
-%global _with_openh264    1
-%if 0%{?fedora}
-%global _with_placebo     1
-%endif
-%global _with_rav1e       1
-%global _with_smb         1
-%global _with_snappy      1
-%global _with_svtav1      1
-%global _with_tesseract   1
-%global _with_twolame     1
-%global _with_wavpack     1
-%global _with_webp        1
-%global _with_zmq         1
-%else
-%global _without_libklvanc 1
-%global _without_libaribb24 1
-%global _without_libaribcaption 1
-%global _without_rubberband  1
-%global _without_vulkan   1
-%endif
-%ifarch x86_64
-%global _with_vpl         1
-%global _with_vapoursynth 1
-%global _with_vmaf        1
-%endif
-
-# flavor nonfree
-%if 0%{?_with_cuda:1}
-%global _with_cuvid      1
-%global _with_libnpp     1
-%endif
-
-# Disable nvenc when not relevant
-%ifnarch %{cuda_arches} aarch64
-%global _without_nvenc    1
-%endif
-
-# extras flags
-%if 0%{!?_cuda_version:1}
-%global _cuda_version 12.6
-%endif
-%global _cuda_version_rpm %(echo %{_cuda_version} | sed -e 's/\\./-/')
-%global _cuda_bindir %{_cuda_prefix}/bin
-%if 0%{?_with_cuda:1}
-%global cuda_cflags $(pkg-config --cflags cuda-%{_cuda_version})
-%global cuda_ldflags $(pkg-config --libs cuda-%{_cuda_version})
-%endif
-
-%if 0%{?_with_libnpp:1}
-%global libnpp_cflags $(pkg-config --cflags nppi-%{_cuda_version} nppc-%{_cuda_version})
-%global libnpp_ldlags $(pkg-config --libs-only-L nppi-%{_cuda_version} nppc-%{_cuda_version})
-%endif
-
-%if 0%{?_with_rpi:1}
-%global _with_omx        1
-%global _with_omx_rpi    1
-%global _with_mmal       1
-ExclusiveArch: armv7hnl
-%endif
-
-%if 0%{?_without_gpl}
-%global lesser L
-%endif
-
-%if 0%{!?_without_amr} || 0%{?_with_gmp} || 0%{?_with_smb} || 0%{?_with_vmaf}
-%global ffmpeg_license %{?lesser}GPLv3+
-%else
-%global ffmpeg_license %{?lesser}GPLv2+
-%endif
-
-Summary:        Digital VCR and streaming server
-Name:           ffmpeg%{?flavor}
-Version:        7.1
+Summary:        A complete solution to record, convert and stream audio and video
+Name:           ffmpeg
+Version:        7.1.1
 Release:        1%{?dist}
-License:        %{ffmpeg_license}
-URL:            https://ffmpeg.org/
-%if 0%{?date}
-Source0:        ffmpeg-%{?branch}%{date}.tar.bz2
-%else
-Source0:        https://ffmpeg.org/releases/ffmpeg-%{version}.tar.xz
-Source1:        https://ffmpeg.org/releases/ffmpeg-%{version}.tar.xz.asc
-Source2:        https://ffmpeg.org/ffmpeg-devel.asc
-%endif
-# We don't endorse adding this patch but fedora insists on breaking the ffmpeg ABI
-#Patch0:         https://raw.githubusercontent.com/terrapkg/pkg-ffmpeg/%terrasrc_commit/ffmpeg-chromium.patch
-Patch1:         https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/099f88b8641dfc299f3896d17d9addc5b9ae7799
-Conflicts:      %{name}-free
-Provides:       %{name}-bin = %{version}-%{release}
-Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
-%{?_with_cuda:BuildRequires: cuda-minimal-build-%{_cuda_version_rpm} cuda-drivers-devel}
-%{?_with_cuda:%{?!_with_cuda_nvcc:BuildRequires: clang}}
-%{?_with_libnpp:BuildRequires: pkgconfig(nppc-%{_cuda_version})}
-BuildRequires:  alsa-lib-devel
-BuildRequires:  AMF-devel
+License:        LGPL-3.0-or-later
+URL:            http://%{name}.org/
+Epoch:          1
+
+Source0:        http://%{name}.org/releases/%{name}-%{version}.tar.xz
+
+# https://github.com/OpenVisualCloud/SVT-VP9/tree/master/ffmpeg_plugin
+Patch0:         %{name}-svt-vp9.patch
+# https://github.com/HandBrake/HandBrake/tree/e117cfe7fca37abeec59ea4201e5d93ed7477746
+Patch2:         %{name}-HandBrake.patch
+# https://bugzilla.redhat.com/show_bug.cgi?id=2240127
+# Reference: https://crbug.com/1306560
+Patch3:         %{name}-chromium.patch
+# Fix build with recent NVCC:
+Patch4:         %{name}-nvcc.patch
+
+BuildRequires:  AMF-devel >= 1.4.28
 BuildRequires:  bzip2-devel
-%{?_with_codec2:BuildRequires: codec2-devel}
-%{?_with_faac:BuildRequires: faac-devel}
-%{?_with_fdk_aac:BuildRequires: fdk-aac-devel}
-%{?_with_flite:BuildRequires: flite-devel}
-BuildRequires:  fontconfig-devel
-BuildRequires:  freetype-devel
-BuildRequires:  fribidi-devel
-%{!?_without_frei0r:BuildRequires: frei0r-devel}
-%{?_with_gme:BuildRequires: game-music-emu-devel}
-BuildRequires:  gnupg2
-BuildRequires:  gnutls-devel
+BuildRequires:  codec2-devel
+BuildRequires:  doxygen
+BuildRequires:  frei0r-devel
+BuildRequires:  gmp-devel
 BuildRequires:  gsm-devel
-BuildRequires:  harfbuzz-devel
-%{?_with_ilbc:BuildRequires: ilbc-devel}
+BuildRequires:  ilbc-devel
 BuildRequires:  lame-devel >= 3.98.3
-%{!?_without_jack:BuildRequires: jack-audio-connection-kit-devel}
-%{!?_without_jxl:BuildRequires: libjxl-devel}
-%{!?_without_ladspa:BuildRequires: ladspa-devel}
-BuildRequires:  lcms2-devel
-%{!?_without_aom:BuildRequires:  libaom-devel}
-%{!?_without_aribb24:BuildRequires: pkgconfig(aribb24) >= 1.0.3}
-%{!?_without_dav1d:BuildRequires:  libdav1d-devel}
-%{?_with_dvddemuxer:BuildRequires:  libdvdnav-devel libdvdread-devel}
-%{!?_without_ass:BuildRequires:  libass-devel}
-%{!?_without_bluray:BuildRequires:  libbluray-devel}
-%{?_with_bs2b:BuildRequires: libbs2b-devel}
-%{?_with_caca:BuildRequires: libcaca-devel}
-%{!?_without_cdio:BuildRequires: libcdio-paranoia-devel}
-%{?_with_chromaprint:BuildRequires: libchromaprint-devel}
-%{!?_without_lensfun:BuildRequires: lensfun-devel}
-%if 0%{?_with_ieee1394}
+BuildRequires:  ladspa-devel
 BuildRequires:  libavc1394-devel
-BuildRequires:  libdc1394-devel
-BuildRequires:  libiec61883-devel
-%endif
-%{!?_without_libaribcaption:BuildRequires: pkgconfig(libaribcaption) >= 1.1.1}
-BuildRequires:  libdrm-devel
+BuildRequires:  libchromaprint-devel
 BuildRequires:  libgcrypt-devel
-%{!?_without_libklvanc:BuildRequires: libklvanc-devel}
-BuildRequires:  libGL-devel
-BuildRequires:  libmodplug-devel
-BuildRequires:  libmysofa-devel
-%if 0%{?fedora} && 0%{?fedora} > 39
-%{?_with_openh264:BuildRequires: noopenh264-devel}
-%else
-%{?_with_openh264:BuildRequires: openh264-devel}
-%endif
-BuildRequires:  libopenmpt-devel
-%{?_with_placebo:BuildRequires: libplacebo-devel >= 4.192.0}
-BuildRequires:  librsvg2-devel
-# Disable rtmp because of rfbz: 6441 & 2399
-%{?_with_rtmp:BuildRequires: librtmp-devel}
-%{?_with_smb:BuildRequires: libsmbclient-devel}
-BuildRequires:  libssh-devel
+BuildRequires:  libiec61883-devel
+BuildRequires:  libklvanc-devel
 BuildRequires:  libtheora-devel
-BuildRequires:  libv4l-devel
-%{?!_without_vaapi:BuildRequires: libva-devel >= 0.31.0}
 BuildRequires:  libvdpau-devel
-BuildRequires:  libvorbis-devel
-%{?_with_vapoursynth:BuildRequires: vapoursynth-devel}
-%{?!_without_vpx:BuildRequires: libvpx-devel >= 1.4.0}
-%{?_with_mfx:BuildRequires: pkgconfig(libmfx) >= 1.23-1}
-%ifarch %{ix86} x86_64
+BuildRequires:  libxavs-devel
+BuildRequires:  mesa-libGL-devel
 BuildRequires:  nasm
-%endif
-%{?_with_webp:BuildRequires: libwebp-devel}
-%{?_with_netcdf:BuildRequires: netcdf-devel}
-%{?_with_rpi:BuildRequires: raspberrypi-vc-devel}
-%{!?_without_nvenc:BuildRequires: nv-codec-headers}
-%{!?_without_amr:BuildRequires: opencore-amr-devel vo-amrwbenc-devel}
-%{?_with_omx:BuildRequires: libomxil-bellagio-devel}
-BuildRequires:  libxcb-devel
-BuildRequires:  libxml2-devel
-%{!?_without_lv2:BuildRequires:  lilv-devel lv2-devel}
-%{!?_without_openal:BuildRequires: openal-soft-devel}
-%if 0%{!?_without_opencl:1}
-BuildRequires:  opencl-headers ocl-icd-devel
-%{?fedora:Recommends: opencl-icd}
-%endif
-%{?_with_opencv:BuildRequires: opencv-devel}
-BuildRequires:  openjpeg2-devel
-%{!?_without_opus:BuildRequires: opus-devel >= 1.1.3}
-%{!?_without_pulse:BuildRequires: pulseaudio-libs-devel}
-BuildRequires:  perl(GD::Text)
+BuildRequires:  ocl-icd-devel
+BuildRequires:  openal-soft-devel
+BuildRequires:  opencore-amr-devel
 BuildRequires:  perl(Pod::Man)
-BuildRequires:  perl(Texinfo::Convert::HTML)
-BuildRequires:  qrencode-devel
-%{?_with_rav1e:BuildRequires: pkgconfig(rav1e)}
-%{!?_without_rubberband:BuildRequires: rubberband-devel}
-%{!?_without_tools:BuildRequires: SDL2-devel}
-%{?_with_snappy:BuildRequires: snappy-devel}
+BuildRequires:  snappy-devel
 BuildRequires:  soxr-devel
-BuildRequires:  speex-devel
-BuildRequires:  pkgconfig(srt)
-%{?_with_svtav1:BuildRequires: svt-av1-devel >= 0.9.0}
-%{?_with_tesseract:BuildRequires: tesseract-devel}
-#BuildRequires:  texi2html
+BuildRequires:  subversion
 BuildRequires:  texinfo
-%{?_with_twolame:BuildRequires: twolame-devel}
-%{?_with_vmaf:BuildRequires: libvmaf-devel >= 1.5.2}
-%{?_with_vpl:BuildRequires: pkgconfig(vpl) >= 2.6}
-%{?_with_wavpack:BuildRequires: wavpack-devel}
-%{!?_without_vidstab:BuildRequires:  vid.stab-devel}
-%{!?_without_vulkan:BuildRequires: pkgconfig(shaderc) pkgconfig(vulkan) >= 1.3.277}
-%{!?_without_x264:BuildRequires: x264-devel >= 0.0.0-0.31}
-%{!?_without_x265:BuildRequires: x265-devel}
-%{!?_without_xvid:BuildRequires: xvidcore-devel}
-%{!?_without_zimg:BuildRequires:  zimg-devel >= 2.7.0}
-BuildRequires:  zlib-devel
-%{?_with_zmq:BuildRequires: zeromq-devel}
-%{!?_without_zvbi:BuildRequires: zvbi-devel}
+BuildRequires:  twolame-devel >= 0.3.10
+BuildRequires:  vo-amrwbenc-devel
+BuildRequires:  xvidcore-devel
+BuildRequires:  xz-devel
+
+BuildRequires:  pkgconfig(alsa)
+BuildRequires:  pkgconfig(aom) >= 1.0.0
+BuildRequires:  pkgconfig(aribb24) >= 1.0.3
+BuildRequires:  pkgconfig(caca)
+BuildRequires:  pkgconfig(dav1d) >= 0.5.0
+BuildRequires:  pkgconfig(davs2) >= 1.6.0
+BuildRequires:  pkgconfig(dvdnav) >= 6.1.1
+BuildRequires:  pkgconfig(fdk-aac)
+BuildRequires:  pkgconfig(fontconfig)
+BuildRequires:  pkgconfig(freetype2)
+BuildRequires:  pkgconfig(fribidi)
+BuildRequires:  pkgconfig(harfbuzz)
+BuildRequires:  pkgconfig(jack)
+BuildRequires:  pkgconfig(kvazaar) >= 0.8.1
+BuildRequires:  pkgconfig(lc3) >= 1.1.0
+BuildRequires:  pkgconfig(lcms2) >= 2.13
+BuildRequires:  pkgconfig(lcevc_dec) >= 2.0.0
+BuildRequires:  pkgconfig(libaribcaption) >= 1.1.1
+BuildRequires:  pkgconfig(libass) >= 0.11.0
+BuildRequires:  pkgconfig(libbluray)
+BuildRequires:  pkgconfig(libbs2b)
+BuildRequires:  pkgconfig(libcdio_paranoia)
+BuildRequires:  pkgconfig(libdc1394-2)
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(libgme)
+BuildRequires:  pkgconfig(libjxl) >= 0.7.0
+#BuildRequires:  pkgconfig(lensfun) > 0.3.95
+BuildRequires:  pkgconfig(libmodplug)
+BuildRequires:  pkgconfig(libmysofa)
+BuildRequires:  pkgconfig(libopenjp2) >= 2.1.0
+BuildRequires:  pkgconfig(libopenmpt) >= 0.2.6557
+BuildRequires:  pkgconfig(libplacebo) >= 4.192.0
+BuildRequires:  pkgconfig(libpulse)
+BuildRequires:  pkgconfig(libqrencode)
+#BuildRequires:  pkgconfig(libquirc)
+BuildRequires:  pkgconfig(librabbitmq) >= 0.7.1
+BuildRequires:  pkgconfig(librist) >= 0.2.7
+BuildRequires:  pkgconfig(librtmp)
+BuildRequires:  pkgconfig(librsvg-2.0)
+BuildRequires:  pkgconfig(libssh)
+BuildRequires:  pkgconfig(libtcmalloc)
+BuildRequires:  pkgconfig(libva) >= 0.35.0
+BuildRequires:  pkgconfig(libva-drm)
+BuildRequires:  pkgconfig(libva-x11)
+BuildRequires:  pkgconfig(libv4l2)
+BuildRequires:  pkgconfig(libvvenc) >= 1.11.0
+BuildRequires:  pkgconfig(libwebp)
+BuildRequires:  pkgconfig(libwebpmux) >= 0.4.0
+BuildRequires:  pkgconfig(libxml-2.0)
+BuildRequires:  pkgconfig(libzmq) >= 4.2.1
+BuildRequires:  pkgconfig(lilv-0)
+BuildRequires:  pkgconfig(lv2)
+#BuildRequires:  pkgconfig(OpenCL)
+#BuildRequires:  pkgconfig(opencv)
+BuildRequires:  pkgconfig(openh264)
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(opus)
+BuildRequires:  pkgconfig(rav1e) >= 0.4.0
+BuildRequires:  pkgconfig(rubberband) >= 1.8.1
+BuildRequires:  pkgconfig(sdl2)
+BuildRequires:  pkgconfig(shaderc) >= 2019.1
+#BuildRequires:  pkgconfig(shine)
+BuildRequires:  pkgconfig(smbclient)
+BuildRequires:  pkgconfig(speex)
+BuildRequires:  pkgconfig(srt) >= 1.3.0
+BuildRequires:  pkgconfig(tesseract)
+BuildRequires:  pkgconfig(uavs3d) >= 1.1.41
+BuildRequires:  pkgconfig(vapoursynth-script) >= 42
+BuildRequires:  pkgconfig(vidstab) >= 0.98
+BuildRequires:  pkgconfig(vorbis)
+BuildRequires:  pkgconfig(vorbisenc)
+BuildRequires:  pkgconfig(vpx) >= 1.4.0
+BuildRequires:  pkgconfig(vulkan) >= 1.3.277
+BuildRequires:  pkgconfig(xavs2) >= 1.3.0
+BuildRequires:  pkgconfig(xcb) >= 1.4
+BuildRequires:  pkgconfig(xcb-shape)
+BuildRequires:  pkgconfig(xcb-shm)
+BuildRequires:  pkgconfig(xcb-xfixes)
+BuildRequires:  pkgconfig(xext)
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(x264)
+BuildRequires:  pkgconfig(x265)
+BuildRequires:  pkgconfig(xv)
+BuildRequires:  pkgconfig(zimg) >= 2.7.0
+BuildRequires:  pkgconfig(zlib)
+BuildRequires:  pkgconfig(zvbi-0.2) >= 0.2.28
+
+%ifarch x86_64 aarch64
+# Nvidia CUVID support and Performance Primitives based code
+BuildRequires:  cuda-cudart-devel
+BuildRequires:  cuda-nvcc
+BuildRequires:  libnpp-devel
+BuildRequires:  pkgconfig(ffnvcodec) >= 12.0.16.0
+%endif
+
+%ifarch x86_64
+BuildRequires:  pkgconfig(libmfx)
+BuildRequires:  pkgconfig(libvmaf) >= 2.0.0
+BuildRequires:  pkgconfig(SvtAv1Enc) >= 0.9.0
+BuildRequires:  pkgconfig(SvtVp9Enc)
+BuildRequires:  pkgconfig(vpl) >= 2.6
+#BuildRequires:  pkgconfig(xevd) >= 0.4.1
+#BuildRequires:  pkgconfig(xeve) >= 0.4.3
+%endif
+
+Obsoletes:      %{name}-free < %{epoch}:%{version}-%{release}
+Provides:       %{name}-free = %{epoch}:%{version}-%{release}
 
 %description
 FFmpeg is a complete and free Internet live audio and video
@@ -246,1687 +177,489 @@ VCR. It can encode in real time in many formats including MPEG1 audio
 and video, MPEG4, h263, ac3, asf, avi, real, mjpeg, and flash.
 
 %package        libs
-Summary:        Libraries for %{name}
-Conflicts:      libavcodec-free
-Conflicts:      libavfilter-free
-Conflicts:      libavformat-free
-Conflicts:      libavutil-free
-Conflicts:      libpostproc-free
-Conflicts:      libswresample-free
-Conflicts:      libswscale-free
-%{?_with_vmaf:Recommends:     vmaf-models}
-Provides: libavcodec-freeworld = %{version}-%{release}
+Summary:        Metapackage for %{name} libraries
+Requires:       libavcodec%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavdevice%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavfilter%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavformat%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavutil%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libpostproc%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswresample%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswscale%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description    libs
 FFmpeg is a complete and free Internet live audio and video
 broadcasting solution for Linux/Unix. It also includes a digital
 VCR. It can encode in real time in many formats including MPEG1 audio
 and video, MPEG4, h263, ac3, asf, avi, real, mjpeg, and flash.
-This package contains the libraries for %{name}
+This metapackage pulls in all the %{name} libraries.
 
-%package     -n libavdevice%{?flavor}
-Summary:        Special devices muxing/demuxing library
-Conflicts:      libavdevice-free
-Requires:       %{name}-libs%{_isa} = %{version}-%{release}
+%package        devel
+Summary:        Metapackage for %{name} development files
+Requires:       %{name}-libs%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       pkgconfig
 
-%description -n libavdevice%{?flavor}
+%description    devel
+FFmpeg is a complete and free Internet live audio and video broadcasting
+solution for Linux/Unix. It also includes a digital VCR. It can encode in real
+time in many formats. This package contains development files for %{name}.
+
+%package     -n libavcodec
+Summary:        FFmpeg codec library
+Obsoletes:      libavcodec-free < %{epoch}:%{version}-%{release}
+Provides:       libavcodec-free = %{epoch}:%{version}-%{release}
+
+%description -n libavcodec
+The libavcodec library provides a generic encoding/decoding framework and
+contains multiple decoders and encoders for audio, video and subtitle streams,
+and several bitstream filters.
+
+%package     -n libavcodec-devel
+Summary:        Development files for FFmpeg's codec library
+Requires:       libavcodec%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavutil-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       pkgconfig
+Obsoletes:      libavcodec-free-devel < %{epoch}:%{version}-%{release}
+Provides:       libavcodec-free-devel = %{epoch}:%{version}-%{release}
+
+%description -n libavcodec-devel
+The libavcodec library provides a generic encoding/decoding framework and
+contains multiple decoders and encoders for audio, video and subtitle streams,
+and several bitstream filters.
+
+This subpackage contains the headers for FFmpeg libavcodec.
+
+%package     -n libavdevice
+Summary:        FFMpeg devices muxing/demuxing library
+Obsoletes:      libavdevice-free < %{epoch}:%{version}-%{release}
+Provides:       libavdevice-free = %{epoch}:%{version}-%{release}
+
+%description -n libavdevice
 Libavdevice is a complementary library to libavf "libavformat". It provides
 various "special" platform-specific muxers and demuxers, e.g. for grabbing
 devices, audio capture and playback etc.
 
-%package        devel
-Summary:        Development package for %{name}
-Conflicts:      %{name}-free-devel
-Requires:       %{name}-libs%{_isa} = %{version}-%{release}
-Requires:       libavdevice%{?flavor}%{_isa} = %{version}-%{release}
+%package     -n libavdevice-devel
+Summary:        Development files for FFMpeg devices muxing/demuxing library
+Requires:       libavcodec-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavdevice%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavfilter-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavformat-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavutil-devel%{?_isa} = %{epoch}:%{version}-%{release}
 Requires:       pkgconfig
+Obsoletes:      libavdevice-free-devel < %{epoch}:%{version}-%{release}
+Provides:       libavdevice-free-devel = %{epoch}:%{version}-%{release}
 
-%description    devel
-FFmpeg is a complete and free Internet live audio and video
-broadcasting solution for Linux/Unix. It also includes a digital
-VCR. It can encode in real time in many formats including MPEG1 audio
-and video, MPEG4, h263, ac3, asf, avi, real, mjpeg, and flash.
-This package contains development files for %{name}
+%description -n libavdevice-devel
+This subpackage contains the headers for FFmpeg libavdevice.
 
-%if %{with libavcodec_freeworld}
-%package -n     libavcodec-freeworld
-Summary:        Freeworld libavcodec to complement the distro counterparts
-# Supplements doesn't work well yet - we can rely on comps for now
-#Supplements:    libavcodec-free >= %%{version}
-Conflicts: libavcodec-free < %{version}
+%package     -n libavfilter
+Summary:        FFmpeg audio and video filtering library
+Requires:       libavcodec%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavformat%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavutil%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libpostproc%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswresample%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswscale%{?_isa} = %{epoch}:%{version}-%{release}
+Obsoletes:      libavfilter-free < %{epoch}:%{version}-%{release}
+Provides:       libavfilter-free = %{epoch}:%{version}-%{release}
 
-%description -n libavcodec-freeworld
-Freeworld libavcodec to complement the distro counterparts
-%endif
+%description -n libavfilter
+The libavfilter library provides a generic audio/video filtering framework
+containing several filters, sources and sinks.
 
+%package     -n libavfilter-devel
+Summary:        Development files for FFmpeg's audio/video filter library
+Requires:       libavcodec-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavfilter%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavformat-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavutil-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libpostproc-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswresample-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswscale-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       pkgconfig
+Obsoletes:      libavfilter-free-devel < %{epoch}:%{version}-%{release}
+Provides:       libavfilter-free-devel = %{epoch}:%{version}-%{release}
 
-# Don't use the %%configure macro as this is not an autotool script
-%global ff_configure \
-./configure \\\
-    --prefix=%{_prefix} \\\
-    --bindir=%{_bindir} \\\
-    --datadir=%{_datadir}/%{name} \\\
-    --docdir=%{_docdir}/%{name} \\\
-    --incdir=%{_includedir}/%{name} \\\
-    --libdir=%{_libdir} \\\
-    --mandir=%{_mandir} \\\
-    --arch=%{_target_cpu} \\\
-    --optflags="%{optflags}" \\\
-    --extra-ldflags="%{?__global_ldflags} %{?cuda_ldflags} %{?libnpp_ldlags}" \\\
-    --extra-cflags="%{?cuda_cflags} %{?libnpp_cflags} -I%{_includedir}/rav1e" \\\
-    %{?flavor:--disable-manpages} \\\
-    %{?progs_suffix:--progs-suffix=%{progs_suffix}} \\\
-    %{?build_suffix:--build-suffix=%{build_suffix}} \\\
-    %{!?_without_amr:--enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libvo-amrwbenc --enable-version3} \\\
-    --enable-bzlib \\\
-    %{?_with_chromaprint:--enable-chromaprint} \\\
-    --enable-fontconfig \\\
-    %{!?_without_frei0r:--enable-frei0r} \\\
-    --enable-gcrypt \\\
-    %{?_with_gmp:--enable-gmp --enable-version3} \\\
-    --enable-gnutls \\\
-    %{!?_without_ladspa:--enable-ladspa} \\\
-    --enable-lcms2 \\\
-    %{!?_without_aom:--enable-libaom} \\\
-    %{!?_without_libaribb24:--enable-libaribb24} \\\
-    %{!?_without_libaribcaption:--enable-libaribcaption} \\\
-    %{!?_without_dav1d:--enable-libdav1d} \\\
-    %{!?_without_ass:--enable-libass} \\\
-    %{!?_without_bluray:--enable-libbluray} \\\
-    %{?_with_bs2b:--enable-libbs2b} \\\
-    %{?_with_caca:--enable-libcaca} \\\
-    %{?_with_codec2:--enable-libcodec2} \\\
-    %{?_with_cuda_nvcc:--enable-cuda-nvcc --enable-nonfree} \\\
-    %{?_with_cuvid:--enable-cuvid --enable-nonfree} \\\
-    %{!?_without_cdio:--enable-libcdio} \\\
-    %{?_with_ieee1394:--enable-libdc1394 --enable-libiec61883} \\\
-    --enable-libdrm \\\
-    %{?_with_dvddemuxer:--enable-libdvdnav --enable-libdvdread} \\\
-    %{?_with_faac:--enable-libfaac --enable-nonfree} \\\
-    %{?_with_fdk_aac:--enable-libfdk-aac --enable-nonfree} \\\
-    %{?_with_flite:--enable-libflite} \\\
-    %{!?_without_jack:--enable-libjack} \\\
-    %{!?_without_jxl:--enable-libjxl} \\\
-    --enable-libfreetype \\\
-    %{!?_without_fribidi:--enable-libfribidi} \\\
-    %{?_with_gme:--enable-libgme} \\\
-    --enable-libgsm \\\
-    --enable-libharfbuzz \\\
-    %{?_with_ilbc:--enable-libilbc} \\\
-    %{!?_without_lensfun:--enable-liblensfun} \\\
-    %{?_with_libnpp:--enable-libnpp --enable-nonfree} \\\
-    --enable-libmp3lame \\\
-    --enable-libmysofa \\\
-    %{?_with_netcdf:--enable-netcdf} \\\
-    %{?_with_mmal:--enable-mmal} \\\
-    %{!?_without_nvenc:--enable-nvenc} \\\
-    %{?_with_omx:--enable-omx} \\\
-    %{?_with_omx_rpi:--enable-omx-rpi} \\\
-    %{!?_without_openal:--enable-openal} \\\
-    %{!?_without_opencl:--enable-opencl} \\\
-    %{?_with_opencv:--enable-libopencv} \\\
-    %{!?_without_opengl:--enable-opengl} \\\
-    %{?_with_openh264:--enable-libopenh264} \\\
-    --enable-libopenjpeg \\\
-    --enable-libopenmpt \\\
-    %{!?_without_opus:--enable-libopus} \\\
-    %{!?_without_pulse:--enable-libpulse} \\\
-    %{?_with_placebo:--enable-libplacebo} \\\
-    --enable-librsvg \\\
-    %{?_with_rav1e:--enable-librav1e} \\\
-    %{?_with_rtmp:--enable-librtmp} \\\
-    %{!?_without_rubberband:--enable-librubberband} \\\
-    --enable-libqrencode \\\
-    %{?_with_smb:--enable-libsmbclient --enable-version3} \\\
-    %{?_with_snappy:--enable-libsnappy} \\\
-    --enable-libsoxr \\\
-    --enable-libspeex \\\
-    --enable-libsrt \\\
-    --enable-libssh \\\
-    %{?_with_svtav1:--enable-libsvtav1} \\\
-    %{?_with_tesseract:--enable-libtesseract} \\\
-    --enable-libtheora \\\
-    %{?_with_twolame:--enable-libtwolame} \\\
-    --enable-libvorbis \\\
-    --enable-libv4l2 \\\
-    %{!?_without_vidstab:--enable-libvidstab} \\\
-    %{?_with_vmaf:--enable-libvmaf --enable-version3} \\\
-    %{?_with_vapoursynth:--enable-vapoursynth} \\\
-    %{!?_without_vpx:--enable-libvpx} \\\
-    %{!?_without_vulkan:--enable-vulkan --enable-libshaderc} \\\
-    %{?_with_webp:--enable-libwebp} \\\
-    %{!?_without_x264:--enable-libx264} \\\
-    %{!?_without_x265:--enable-libx265} \\\
-    %{!?_without_xvid:--enable-libxvid} \\\
-    --enable-libxml2 \\\
-    %{!?_without_zimg:--enable-libzimg} \\\
-    %{?_with_zmq:--enable-libzmq} \\\
-    %{!?_without_zvbi:--enable-libzvbi} \\\
-    %{!?_without_lv2:--enable-lv2} \\\
-    --enable-avfilter \\\
-    --enable-libmodplug \\\
-    --enable-postproc \\\
-    --enable-pthreads \\\
-    --disable-static \\\
-    --enable-shared \\\
-    %{!?_without_gpl:--enable-gpl} \\\
-    --disable-debug \\\
-    --disable-stripping
+%description -n libavfilter-devel
+This subpackage contains the headers for FFmpeg libavfilter.
 
+%package     -n libavformat
+Summary:        FFmpeg's stream format library
+Obsoletes:      libavformat-free < %{epoch}:%{version}-%{release}
+Provides:       libavformat-free = %{epoch}:%{version}-%{release}
+
+%description -n libavformat
+The libavformat library provides a generic framework for multiplexing and
+demultiplexing (muxing and demuxing) audio, video and subtitle streams.
+It encompasses multiple muxers and demuxers for multimedia container formats.
+
+%package     -n libavformat-devel
+Summary:        Development files for FFmpeg's stream format library
+Requires:       libavcodec-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavformat%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libavutil-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswresample-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       pkgconfig
+Obsoletes:      libavformat-free-devel < %{epoch}:%{version}-%{release}
+Provides:       libavformat-free-devel = %{epoch}:%{version}-%{release}
+
+%description -n libavformat-devel
+This subpackage contains the headers for FFmpeg libavformat.
+
+%package     -n libavutil
+Summary:        FFmpeg's utility library
+Obsoletes:      libavutil-free < %{epoch}:%{version}-%{release}
+Provides:       libavutil-free = %{epoch}:%{version}-%{release}
+
+%description -n libavutil
+The libavutil library is a utility library to aid portable multimedia
+programming. It contains safe portable string functions, random
+number generators, data structures, additional mathematics functions,
+cryptography and multimedia related functionality (like enumerations
+for pixel and sample formats).
+
+%package     -n libavutil-devel
+Summary:        Development files for FFmpeg's utility library
+Requires:       libavutil%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       pkgconfig
+Obsoletes:      libavutil-free-devel < %{epoch}:%{version}-%{release}
+Provides:       libavutil-free-devel = %{epoch}:%{version}-%{release}
+
+%description -n libavutil-devel
+This subpackage contains the headers for FFmpeg libavutil.
+
+%package     -n libpostproc
+Summary:        FFmpeg post-processing library
+Obsoletes:      libpostproc-free < %{epoch}:%{version}-%{release}
+Provides:       libpostproc-free = %{epoch}:%{version}-%{release}
+
+%description -n libpostproc
+A library with video postprocessing filters, such as deblocking and
+deringing filters, noise reduction, automatic contrast and brightness
+correction, linear/cubic interpolating deinterlacing.
+
+%package     -n libpostproc-devel
+Summary:        Development files for the FFmpeg post-processing library
+Requires:       libavutil-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libpostproc%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       pkgconfig
+Obsoletes:      libpostproc-free-devel < %{epoch}:%{version}-%{release}
+Provides:       libpostproc-free-devel = %{epoch}:%{version}-%{release}
+
+%description -n libpostproc-devel
+This subpackage contains the headers for FFmpeg libpostproc.
+
+%package     -n libswresample
+Summary:        FFmpeg software resampling library
+Requires:       libavutil%{?_isa} = %{epoch}:%{version}-%{release}
+Obsoletes:      libavresemple < %{epoch}:%{version}-%{release}
+Provides:       libavresemple = %{epoch}:%{version}-%{release}
+Obsoletes:      libswresample-free < %{epoch}:%{version}-%{release}
+Provides:       libswresample-free = %{epoch}:%{version}-%{release}
+
+%description -n libswresample
+The libswresample library performs audio conversion between different
+sample rates, channel layout and channel formats.
+
+%package     -n libswresample-devel
+Summary:        Development files for the FFmpeg software resampling library
+Requires:       libavutil-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswresample%{?_isa} = %{epoch}:%{version}-%{release}
+Obsoletes:      libavresemple-devel < %{epoch}:%{version}-%{release}
+Provides:       libavresemple-devel = %{epoch}:%{version}-%{release}
+Obsoletes:      libswresample-free-devel < %{epoch}:%{version}-%{release}
+Provides:       libswresample-free-devel = %{epoch}:%{version}-%{release}
+
+%description -n libswresample-devel
+This subpackage contains the headers for FFmpeg libswresample.
+
+%package     -n libswscale
+Summary:        FFmpeg image scaling and colorspace/pixel conversion library
+Obsoletes:      libswscale-free < %{epoch}:%{version}-%{release}
+Provides:       libswscale-free = %{epoch}:%{version}-%{release}
+
+%description -n libswscale
+The libswscale library performs image scaling and colorspace and
+pixel format conversion operations.
+
+%package     -n libswscale-devel
+Summary:        Development files for FFmpeg's image scaling and colorspace library
+Requires:       libavutil-devel%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       libswscale%{?_isa} = %{epoch}:%{version}-%{release}
+Obsoletes:      libswscale-free-devel < %{epoch}:%{version}-%{release}
+Provides:       libswscale-free-devel = %{epoch}:%{version}-%{release}
+
+%description -n libswscale-devel
+This subpackage contains the headers for FFmpeg libswscale.
 
 %prep
-%if 0%{?date}
-%autosetup -p1 -n ffmpeg-%{?branch}%{date}
-echo "git-snapshot-%{?branch}%{date}-rpmfusion" > VERSION
-%else
-%{gpgverify} --keyring='%{SOURCE2}' --signature='%{SOURCE1}' --data='%{SOURCE0}'
-%autosetup -p1 -n ffmpeg-%{version}
-%endif
-# fix -O3 -g in host_cflags
-sed -i "s|check_host_cflags -O3|check_host_cflags %{optflags}|" configure
-mkdir -p _doc/examples
-cp -pr doc/examples/{*.c,Makefile,README} _doc/examples/
+%autosetup -p1
+
+# Uncomment to enable debugging while configuring
+#sed -i -e 's|#!/bin/sh|#!/bin/sh -x|g' configure
 
 %build
-%{?_with_cuda:export PATH=${PATH}:%{_cuda_bindir}}
-%{ff_configure}\
+%set_build_flags
+
+./configure \
+    --arch=%{_target_cpu} \
+    --bindir=%{_bindir} \
+    --datadir=%{_datadir}/%{name} \
+    --disable-static \
+    --disable-stripping \
+    --enable-amf \
+    --enable-avcodec \
+    --enable-avdevice \
+    --enable-avfilter \
+    --enable-avformat \
+    --enable-alsa \
+    --enable-bzlib \
+    --enable-chromaprint \
+    --enable-frei0r \
+    --enable-gcrypt \
+    --enable-gmp \
+    --enable-gpl \
+    --enable-gray \
+    --enable-iconv \
+    --enable-ladspa \
+    --enable-lcms2 \
+    --enable-libass \
+    --enable-libaom \
+    --enable-libaribb24 \
+    --enable-libaribcaption \
+    --enable-libass \
+    --enable-libbluray \
+    --enable-libbs2b \
+    --enable-libcaca \
+    --enable-libcdio \
+    --enable-libcodec2 \
+    --enable-libdav1d \
+    --enable-libdavs2 \
+    --enable-libdc1394 \
+    --enable-libdrm \
+    --enable-libdvdnav \
+    --enable-libdvdread \
+    --enable-libfdk-aac \
+    --enable-libfontconfig \
+    --enable-libfreetype \
+    --enable-libfribidi \
+    --enable-libgme \
+    --enable-libgsm \
+    --enable-libharfbuzz \
+    --enable-libiec61883 \
+    --enable-libilbc \
+    --enable-libjack \
+    --enable-libjxl \
+    --enable-libklvanc \
+    --enable-libkvazaar \
+    --enable-liblc3 \
+    --disable-liblensfun \
+    --enable-liblcevc-dec \
+    --enable-libmodplug \
+    --enable-libmp3lame \
+    --enable-libmysofa \
+    --enable-libopencore-amrnb \
+    --enable-libopencore-amrwb \
+    --disable-libopencv \
+    --enable-libopenh264 \
+    --enable-libopenjpeg \
+    --enable-libopenmpt \
+    --enable-libopus \
+    --enable-libplacebo \
+    --enable-libpulse \
+    --enable-libqrencode \
+    --disable-libquirc \
+    --enable-librabbitmq \
+    --enable-librav1e \
+    --enable-librist \
+    --enable-librsvg \
+    --enable-librtmp \
+    --enable-librubberband \
+    --enable-libshaderc \
+    --disable-libshine \
+    --enable-libsmbclient \
+    --enable-libsnappy \
+    --enable-libsoxr \
+    --enable-libspeex \
+    --enable-libsrt \
+    --enable-libssh \
+    --disable-libtensorflow \
+    --enable-libtesseract \
+    --enable-libtheora \
+    --disable-libtorch \
+    --enable-libtwolame \
+    --enable-libuavs3d \
+    --enable-libv4l2 \
+    --enable-libvidstab \
+    --enable-libvo-amrwbenc \
+    --enable-libvorbis \
+    --enable-libvpx \
+    --enable-libvvenc \
+    --enable-libwebp \
+    --enable-libx264 \
+    --enable-libx265 \
+    --enable-libxavs2 \
+    --enable-libxavs \
+    --enable-libxcb \
+    --enable-libxcb-shape \
+    --enable-libxcb-shm \
+    --enable-libxcb-xfixes \
+    --enable-libxml2 \
+    --enable-libxvid \
+    --enable-libzimg \
+    --enable-libzmq \
+    --enable-libzvbi \
+    --enable-lv2 \
+    --enable-lzma \
+    --enable-nonfree \
+    --enable-manpages \
+    --enable-openal \
+    --enable-opencl \
+    --enable-opengl \
+    --enable-openssl \
+    --enable-postproc \
+    --enable-sdl2 \
+    --enable-shared \
+    --enable-swresample \
+    --enable-swscale \
+    --enable-v4l2-m2m \
+    --enable-vaapi \
+    --enable-vapoursynth \
+    --enable-version3 \
+    --enable-vdpau \
+    --enable-vulkan \
+    --enable-xlib \
+    --enable-zlib \
+    --extra-ldflags="%{build_ldflags}" \
+    --incdir=%{_includedir} \
+    --libdir=%{_libdir} \
+    --mandir=%{_mandir} \
+    --optflags="%{build_cflags}" \
+    --prefix=%{_prefix} \
     --shlibdir=%{_libdir} \
-%if 0%{?_without_tools:1}
-    --disable-doc \
-    --disable-ffmpeg --disable-ffplay --disable-ffprobe \
+%ifarch x86_64 aarch64
+    --enable-cuda-nvcc \
+    --enable-cuvid \
+    --enable-ffnvcodec \
+    --enable-libnpp \
+    --enable-nvdec \
+    --enable-nvenc \
+    --extra-cflags="-I%{_includedir}/cuda" \
 %endif
-%ifnarch %{ix86}
-    --enable-lto \
+%ifarch x86_64
+    --enable-libsvtav1 \
+    --enable-libsvtvp9 \
+    --enable-libvmaf \
+    --enable-libvpl \
+#    --enable-libxevd \
+#    --enable-libxeve \
 %endif
-%ifarch %{ix86}
-    --cpu=%{_target_cpu} \
-%endif
-    %{?_with_mfx:--enable-libmfx} \
-    %{?_with_vpl:--enable-libvpl} \
-%ifarch %{ix86} x86_64 %{power64}
-    --enable-runtime-cpudetect \
-%endif
-%ifarch %{power64}
-%ifarch ppc64
-    --cpu=g5 \
-%endif
-%ifarch ppc64p7
-    --cpu=power7 \
-%endif
-%ifarch ppc64le
-    --cpu=power8 \
-%endif
-    --enable-pic \
-%endif
-%ifarch %{arm}
-    --disable-runtime-cpudetect --arch=arm \
-%ifarch armv6hl
-    --cpu=armv6 \
-%endif
-%ifarch armv7hl armv7hnl
-    --cpu=armv7-a \
-    --enable-vfpv3 \
-    --enable-thumb \
-%endif
-%ifarch armv7hl
-    --disable-neon \
-%endif
-%ifarch armv7hnl
-    --enable-neon \
-%endif
-%endif
-    || cat ffbuild/config.log
 
 %make_build V=1
 make documentation V=1
 make alltools V=1
 
 %install
-%make_install V=1
-%if 0%{!?flavor:1}
-rm -r %{buildroot}%{_datadir}/%{name}/examples
-%endif
-%if 0%{!?progs_suffix:1}
-install -pm755 tools/qt-faststart %{buildroot}%{_bindir}
-%endif
+%make_install
+# Let rpmbuild pick up the docs
+rm -fr %{buildroot}%{_docdir}/*
+rm -fr %{buildroot}%{_datadir}/examples
+mkdir doc/html
+mv doc/*.html doc/html
 
-%if %{with libavcodec_freeworld}
-# Install the libavcodec freeworld counterpart
-mkdir -p %{buildroot}%{_sysconfdir}/ld.so.conf.d/
-mkdir -p %{buildroot}%{_libdir}/%{name}
-echo -e "%{_libdir}/%{name}\n" > %{buildroot}%{_sysconfdir}/ld.so.conf.d/%{name}-%{_lib}.conf
-cp -pa %{buildroot}%{_libdir}/libavcodec.so.* \
- %{buildroot}%{_libdir}/%{name}
-%endif
-
-%ldconfig_scriptlets  libs
-%ldconfig_scriptlets -n libavdevice%{?flavor}
-
-%if 0%{!?_without_tools:1}
 %files
-%{_bindir}/ffmpeg%{?progs_suffix}
-%{_bindir}/ffplay%{?progs_suffix}
-%{_bindir}/ffprobe%{?progs_suffix}
-%{!?progs_suffix:%{_bindir}/qt-faststart}
-%{!?flavor:
-%{_mandir}/man1/ffmpeg*.1*
+%{_bindir}/%{name}
+%{_bindir}/ffplay
+%{_bindir}/ffprobe
+%{_mandir}/man1/%{name}*.1*
 %{_mandir}/man1/ffplay*.1*
 %{_mandir}/man1/ffprobe*.1*
-}
 %{_datadir}/%{name}
-%endif
 
 %files libs
-%doc  CREDITS README.md
-%license COPYING.*
-%{_libdir}/lib*.so.*
-%exclude %{_libdir}/libavdevice%{?build_suffix}.so.*
-%{!?flavor:%{_mandir}/man3/lib*.3.*
-%exclude %{_mandir}/man3/libavdevice.3*
-}
-
-%files -n libavdevice%{?flavor}
-%{_libdir}/libavdevice%{?build_suffix}.so.*
-%{!?flavor:%{_mandir}/man3/libavdevice.3*}
+%license COPYING.* LICENSE.md
+%doc MAINTAINERS README.md CREDITS Changelog RELEASE_NOTES
 
 %files devel
-%doc MAINTAINERS doc/APIchanges doc/*.txt
-%doc _doc/examples
-%doc %{_docdir}/%{name}/*.{css,html}
-%{_includedir}/%{name}
-%{_libdir}/pkgconfig/lib*.pc
-%{_libdir}/lib*.so
-
-%if %{with libavcodec_freeworld}
-%files -n libavcodec-freeworld
-%{_sysconfdir}/ld.so.conf.d/%{name}-%{_lib}.conf
-%{_libdir}/%{name}/libavcodec.so.*
-%endif
-
-
-%changelog
-* Wed Oct 09 2024 Leigh Scott <leigh123linux@gmail.com> - 7.0.2-4
-- Disable DVD demuxer due to undefined symbols in libavformat
-
-* Mon Oct 07 2024 Nicolas Chauvet <kwizart@gmail.com> - 7.0.2-3
-- Sync with fedora deps:
-  Enable Kernel Labs VANC processing and ARIB text/caption decoding
-
-* Fri Sep 20 2024 Leigh Scott <leigh123linux@gmail.com> - 7.0.2-2
-- Rebuild
-
-* Sun Aug 04 2024 Leigh Scott <leigh123linux@gmail.com> - 7.0.2-1
-- Update to 7.0.2
-
-* Thu Aug 01 2024 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 7.0.1-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_41_Mass_Rebuild
-
-* Fri May 31 2024 Robert-André Mauchin <zebob.m@gmail.com> - 7.0.1-2
-- Rebuild for svt-av1 2.1.0
-
-* Sun May 26 2024 Leigh Scott <leigh123linux@gmail.com> - 7.0.1-1
-- Update to 7.0.1
-
-* Fri Apr 19 2024 Leigh Scott <leigh123linux@gmail.com> - 7.0-1
-- Update to 7.0
-
-* Sat Apr 06 2024 Leigh Scott <leigh123linux@gmail.com> - 6.1.1-8
-- Rebuild for new x265 version
-
-* Fri Mar 22 2024 Sérgio Basto <sergio@serjux.com> - 6.1.1-7
-- Rebuild for jpegxl (libjxl) 0.10.2
-
-* Tue Mar 12 2024 Dominik Mierzejewski <dominik@greysector.net> - 6.1.1-6
-- Enable drawtext filter (requires libharfbuzz, rfbz#6889)
-
-* Thu Feb 01 2024 Leigh Scott <leigh123linux@gmail.com> - 6.1.1-5
-- rebuilt
-
-* Thu Feb 01 2024 Leigh Scott <leigh123linux@gmail.com> - 6.1.1-4
-- Switch to noopenh264-devel for f39+
-
-* Tue Jan 16 2024 Nicolas Chauvet <kwizart@gmail.com> - 6.1.1-3
-- Rebuilt for libavcodec-freeworld
-
-* Sun Jan 14 2024 Leigh Scott <leigh123linux@gmail.com> - 6.1.1-2
-- rebuilt
-
-* Mon Jan 01 2024 Leigh Scott <leigh123linux@gmail.com> - 6.1.1-1
-- Update to 6.1.1 release
-
-* Wed Nov 15 2023 Nicolas Chauvet <kwizart@gmail.com> - 6.1-3
-- Bump
-
-* Wed Nov 15 2023 Leigh Scott <leigh123linux@gmail.com> - 6.1-2
-- Add patch to fix fedora ffmpeg brokenABI change
-
-* Sat Nov 11 2023 Leigh Scott <leigh123linux@gmail.com> - 6.1-1
-- Update to 6.1 release
-
-* Fri Nov 10 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0.1-1
-- Update to 6.0.1 release
-
-* Sun Oct 08 2023 Dominik Mierzejewski <dominik@greysector.net> - 6.0-18
-- Backport upstream patch to fix segfault when passing non-existent filter
-  option (rfbz#6773)
-
-* Fri Sep 29 2023 Nicolas Chauvet <nchauvet@linagora.com> - 6.0-17
-- Rebuild for libplacebo
-- Backport upstream patch to fix assembly with binutils 2.41 - rathann
-
-* Fri Jul 28 2023 Nicolas Chauvet <kwizart@gmail.com> - 6.0-16
-- rebuilt
-
-* Sun Jul 16 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-15
-- rebuilt
-
-* Fri Jun 23 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-14
-- rebuilt
-
-* Fri Jun 23 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-13
-- rebuilt
-
-* Wed Jun 14 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-12
-- rebuilt
-
-* Sun May 14 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-11
-- fedora cisco repo isn't multiarch
-
-* Fri May 12 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-10
-- Enable openh264 for fedora
-
-* Mon Apr 24 2023 Nicolas Chauvet <kwizart@gmail.com> - 6.0-9
-- Add ffmpeg-bin for deps
-
-* Fri Apr 07 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-8
-- rebuilt
-
-* Fri Mar 24 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-7
-- rebuilt
-
-* Wed Mar 22 2023 Nicolas Chauvet <kwizart@gmail.com> - 6.0-6
-- Rebuilt
-
-* Sat Mar 18 2023 Todd Zullinger <tmz@pobox.com> - 6.0-5
-- verify upstream source signature
-
-* Sun Mar 12 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-4
-- Rebuild against new nvcodec-headers
-
-* Sun Mar 12 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-3
-- Enable chromaprint
-- Enable svt-av1 on all arches
-
-* Tue Feb 28 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-2
-- Disable chromaprint
-
-* Tue Feb 21 2023 Leigh Scott <leigh123linux@gmail.com> - 6.0-1
-- Update to 6.0 release
-
-* Sun Jan 08 2023 Leigh Scott <leigh123linux@gmail.com> - 5.1.2-9
-- Enable libplacebo (rfbz#6549)
-
-* Fri Dec 23 2022 Nicolas Chauvet <kwizart@gmail.com> - 5.1.2-8
-- rebuild
-
-* Mon Nov 21 2022 Nicolas Chauvet <kwizart@gmail.com> - 5.1.2-6
-- Enable libjxl
-- Enable svt-av1 on el9 x86_64
-
-* Thu Nov 17 2022 Nicolas Chauvet <kwizart@gmail.com> - 5.1.2-5
-- Rework el9 cases
-
-* Mon Oct 17 2022 Leigh Scott <leigh123linux@gmail.com> - 5.1.2-3
-- Disable rtmp because of rfbz: 6441 & 2399
-
-* Wed Sep 28 2022 Nicolas Chauvet <kwizart@gmail.com> - 5.1.2-2
-- Implement libavcodec-freeworld
-
-* Sun Sep 25 2022 Leigh Scott <leigh123linux@gmail.com> - 5.1.2-1
-- Update to 5.1.2 release
-
-* Mon Sep 05 2022 Leigh Scott <leigh123linux@gmail.com> - 5.1.1-3
-- Switch from glslang to shaderc
-
-* Sun Sep 04 2022 Leigh Scott <leigh123linux@gmail.com> - 5.1.1-2
-- move libs to a subdirectory to allow parallel installation with ffmpeg-free
-
-* Thu Sep 01 2022 Leigh Scott <leigh123linux@gmail.com> - 5.1.1-1
-- Update to 5.1.1 release
-
-* Sun Aug 07 2022 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 5.1-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_37_Mass_Rebuild and ffmpeg
-  5.1
-
-* Fri Jul 22 2022 Leigh Scott <leigh123linux@gmail.com> - 5.1-1
-- Update to 5.1 release
-
-* Mon Jul 11 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0.1-10
-- rebuilt
-
-* Thu Jun 23 2022 Robert-André Mauchin <zebob.m@gmail.com> - 5.0.1-9
-- Rebuilt for new AOM, dav1d, rav1e and svt-av1
-
-* Fri Jun 17 2022 Nicolas Chauvet <kwizart@gmail.com> - 5.0.1-8
-- Rebuilt
-
-* Sun Jun 12 2022 Sérgio Basto <sergio@serjux.com> - 5.0.1-7
-- unbootstrap
-
-* Sun Jun 12 2022 Sérgio Basto <sergio@serjux.com> - 5.0.1-6
-- Mass rebuild for x264-0.164
-- Bootstrap build without chromaprint
-
-* Fri May 27 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0.1-5
-- rebuilt
-
-* Fri May 27 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0.1-4
-- rebuilt
-
-* Fri Apr 29 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0.1-3
-- Fix zimg
-
-* Tue Apr 05 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0.1-2
-- Add conflicts
-
-* Tue Apr 05 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0.1-1
-- Update to 5.0.1 release
-
-* Sun Mar 13 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0-7
-- Rebuilt
-
-* Fri Mar 11 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0-6
-- Enable AMF support
-
-* Thu Mar 03 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0-5
-- Rebuild
-
-* Sat Feb 26 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0-4
-- Drop patch for chrome
-
-* Fri Feb 11 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0-3
-- Add patch for chrome
-
-* Fri Feb 04 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0-2
-- rebuilt
-
-* Sat Jan 15 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0-1
-- Update to 5.0 release
-
-* Tue Jan 04 2022 Leigh Scott <leigh123linux@gmail.com> - 5.0-0.1.20220104git311ea9c
-- Update to 5.0-0.1.20220104git311ea9c
-
-* Sun Dec 19 2021 Leigh Scott <leigh123linux@gmail.com> - 4.5-0.3.20211108git45dc668
-- rebuilt
-
-* Thu Dec 16 2021 Nicolas Chauvet <kwizart@gmail.com> - 4.5-0.2.20211108git45dc668
-- Rebuilt
-
-* Mon Nov 08 2021 Leigh Scott <leigh123linux@gmail.com> - 4.5-0.1.20211108git45dc668
-- Update to 4.5-0.1.20211108git45dc668
-
-* Mon Oct 25 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4.1-1
-- Update to 4.4.1 release
-
-* Mon Aug 02 2021 RPM Fusion Release Engineering <leigh123linux@gmail.com> - 4.4-7
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_35_Mass_Rebuild
-
-* Wed Jul 28 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-6
-- Enable libwebp support
-
-* Sat Jul 10 2021 Sérgio Basto <sergio@serjux.com> - 4.4-5
-- Mass rebuild for x264-0.163
-
-* Sun Jun 13 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-4
-- Rebuild for aom bump
-
-* Mon May 10 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-3
-- rebuilt
-
-* Wed Apr 14 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-2
-- Rebuild for new x265
-
-* Fri Apr 09 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-1
-- Update to 4.4 release
-
-* Thu Apr 08 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-0.8.20210408git25e794a
-- Update to 4.4-0.8.20210408git25e794a
-
-* Wed Mar 24 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-0.7.20210323git0be265e
-- rebuilt
-
-* Tue Mar 23 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-0.6.20210323git0be265e
-- Update to 4.4-0.6.20210323git0be265e
-- Switch to release/4.4 branch
-
-* Fri Mar 12 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-0.5.20210312git5136726
-- Update to 20210312git5136726
-
-* Thu Feb 18 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-0.4.20210218gitc2bf1dc
-- Update to 20210218gitc2bf1dc
-
-* Wed Feb 03 2021 RPM Fusion Release Engineering <leigh123linux@gmail.com> - 4.4-0.3.20210125gitc7016e3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_34_Mass_Rebuild
-
-* Mon Jan 25 2021 Leigh Scott <leigh123linux@gmail.com> - 4.4-0.2.20210125gitc7016e3
-- Update to 20210125gitc7016e3
-
-* Thu Dec 31 2020 Leigh Scott <leigh123linux@gmail.com> - 4.4-0.1.20201231git477dd2d
-- Update to 20201231git477dd2d
-
-* Thu Dec 24 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-15
-- Enable dash demuxer (rfbz#5876)
-- Enable lv2 support (rfbz#5863)
-
-* Mon Dec 14 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-14
-- Actually do the dav1d rebuild
-
-* Mon Dec 14 2020 Robert-André Mauchin <zebob.m@gmail.com> - 4.3.1-13
-- Rebuild for dav1d SONAME bump
-
-* Fri Nov 27 2020 Sérgio Basto <sergio@serjux.com> - 4.3.1-12
-- Mass rebuild for x264-0.161
-
-* Sat Oct 10 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-11
-- Revert last commit
-
-* Sat Oct 10 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-10
-- Add VP9 10/12 Bit support for VDPAU
-
-* Tue Aug 18 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-9
-- Disable vulkan on i686
-
-* Mon Aug 17 2020 RPM Fusion Release Engineering <leigh123linux@gmail.com> - 4.3.1-8
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
-
-* Sun Aug 16 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-7
-- Disable rav1e support as rust packaging is rawhide only
-
-* Sun Aug 09 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-6
-- Enable LTO for x86
-- Add glslang patches and bump version for build requires
-- Add upstream patches to suppress asm warnings
-
-* Mon Aug 03 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-5
-- Disable LTO for x86
-
-* Mon Aug 03 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-4
-- Add patch to fix x86_64 LTO build issue
-
-* Wed Jul 15 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-3
-- Enabled libopenmpt
-
-* Tue Jul 14 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-2
-- Enable libmysofa
-
-* Sat Jul 11 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3.1-1
-- Update to 4.3.1 release
-
-* Wed Jul 08 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-5
-- Rebuilt
-
-* Tue Jul 07 2020 Sérgio Basto <sergio@serjux.com> - 4.3-4
-- Mass rebuild for x264
-
-* Wed Jul 01 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-3
-- Rebuilt
-
-* Wed Jun 24 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-2
-- Enable vapoursynth
-
-* Mon Jun 15 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-1
-- Update to 4.3 release
-
-* Sat Jun 06 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.23.20200606git
-- Update to 20200606git
-
-* Sun May 31 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.22.20200531git
-- Update to 20200531git
-
-* Mon May 25 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.21.20200524git
-- Enable lensfun
-
-* Sun May 24 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.20.20200524git
-- Rebuild for dav1d SONAME bump
-
-* Sat May 23 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.19.20200523git
-- Update to 20200523git
-
-* Sat May 16 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.18.20200516git
-- Update to 20200516git
-
-* Fri May 08 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.17.20200508git
-- Update to 20200508git
-
-* Fri May 01 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.16.20200501git
-- Update to 20200501git
-
-* Thu Apr 23 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.15.20200423git
-- Update to 20200423git
-- Enable nvdec for aarch64
-
-* Sun Apr 19 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.14.20200419git
-- Update to 20200419git
-
-* Sun Apr 12 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.13.20200412git
-- Update to 20200412git
-
-* Wed Apr 08 2020 Nicolas Chauvet <kwizart@gmail.com> - 4.3-0.12.20200401git
-- Enable srt
-
-* Wed Apr 01 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.11.20200401git
-- Update snapshot, fixes rfbz#5537
-
-* Wed Apr 01 2020 leigh123linux <leigh123linux@googlemail.com> - 4.3-0.10.20200401git
-- Update to 20200401git
-
-* Sat Mar 21 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.9.20200321git
-- Update to 20200321git
-
-* Fri Mar 13 2020 leigh123linux <leigh123linux@googlemail.com> - 4.3-0.8.20200313git
-- Update to 20200313git
-
-* Wed Mar 11 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.7.20200305git
-- Rebuilt for i686
-
-* Mon Mar 09 2020 leigh123linux <leigh123linux@googlemail.com> - 4.3-0.6.20200305git
-- Enable rav1e support
-
-* Thu Mar 05 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.5.20200305git
-- Update to 20200305git
-
-* Tue Feb 25 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.4.20200225git
-- Update to 20200225git
-
-* Sun Feb 23 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.3.20200222git
-- Rebuild for x265
-
-* Sun Feb 23 2020 Leigh Scott <leigh123linux@gmail.com> - 4.3-0.2.20200222git
-- Enable vulkan support
-
-* Sat Feb 22 2020 Leigh Scott <leigh123linux@googlemail.com> - 4.3-0.1.20200222git
-- Update to 20200222git
-
-* Tue Feb 04 2020 RPM Fusion Release Engineering <leigh123linux@gmail.com> - 4.2.2-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
-
-* Wed Jan 01 2020 Leigh Scott <leigh123linux@gmail.com> - 4.2.2-1
-- Update to 4.2.2 release
-
-* Tue Dec 17 2019 Sérgio Monteiro Basto <sergio@serjux.com> - 4.2.1-5
-- Mass rebuild for x264
-
-* Thu Nov 28 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.2.1-4
-- Rebuilt for x265
-
-* Thu Oct 24 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.2.1-3
-- Rebuild for dav1d SONAME bump
-
-* Sat Sep 07 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.2.1-2
-- Enable libjack (rfbz #5346)
-
-* Sat Sep 07 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.2.1-1
-- Update to 4.2.1 release
-
-* Mon Aug 26 2019 Leigh Scott <leigh123linux@gmail.com> - 4.2-4
-- Rebuild for el8
-
-* Tue Aug 20 2019 Leigh Scott <leigh123linux@gmail.com> - 4.2-3
-- Rebuild for dav1d and aom SONAME bump
-- Drop XvMC support (rfbz #5328)
-
-* Fri Aug 09 2019 RPM Fusion Release Engineering <leigh123linux@gmail.com> - 4.2-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
-
-* Mon Aug 05 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.2-1
-- Update to 4.2 release
-- Enable dav1d support
-
-* Sat Jul 27 2019 Nicolas Chauvet <kwizart@gmail.com> - 4.1.4-2
-- Add patch for set_default_priority
-
-* Tue Jul 09 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.1.4-1
-- Update to 4.1.4 release
-
-* Fri Jun 28 2019 Nicolas Chauvet <kwizart@gmail.com> - 4.1.3-3
-- Rebuilt for x265
-
-* Sat Apr 06 2019 Nicolas Chauvet <kwizart@gmail.com> - 4.1.3-2
-- Backport avutil/mem: Fix invalid use of av_alloc_size - rfbz#5149
-
-* Mon Apr 01 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.1.3-1
-- Update to 4.1.3 release
-
-* Sat Mar 23 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.1.2-1
-- Update to 4.1.2 release
-
-* Tue Mar 12 2019 Sérgio Basto <sergio@serjux.com> - 4.1.1-4
-- Mass rebuild for x264
-
-* Mon Mar 04 2019 RPM Fusion Release Engineering <leigh123linux@gmail.com> - 4.1.1-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
-
-* Thu Feb 28 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.1.1-2
-- Rebuild for new x265
-
-* Sun Feb 10 2019 Leigh Scott <leigh123linux@googlemail.com> - 4.1.1-1
-- Update to 4.1.1 release
-
-* Fri Jan 25 2019 Dominik Mierzejewski <rpm@greysector.net> - 4.1-7
-- Enable libssh support by default (rfbz#5135)
-
-* Thu Jan 24 2019 Nicolas Chauvet <kwizart@gmail.com> - 4.1-6
-- Drop opencv by default
-  OpenCV 3.X has an overlinking issue - unsuitable for core libraries
-  Reported as https://github.com/opencv/opencv/issues/7001
-
-* Fri Dec 21 2018 Nicolas Chauvet <kwizart@gmail.com> - 4.1-5
-- Add omx/omx_rpi
-
-* Sun Nov 18 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.1-4
-- Rebuild for new x265
-
-* Fri Nov 09 2018 Nicolas Chauvet <kwizart@gmail.com> - 4.1-3
-- Fix for cuda enabled repo
-
-* Thu Nov 08 2018 Nicolas Chauvet <kwizart@gmail.com> - 4.1-2
-- Add support for rpi
-- Enable libvmaf for x86_64
-
-* Tue Nov 06 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.1-1
-- Update to 4.1 release
-
-* Sat Nov 03 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0.3-1
-- Update to 4.0.3 release
-
-* Thu Oct 04 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0.2-8
-- Add upstream commit to fix aom build failure
-
-* Thu Oct 04 2018 Sérgio Basto <sergio@serjux.com> - 4.0.2-7
-- Mass rebuild for x264 and/or x265
-
-* Fri Sep 14 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0.2-6
-- Change BuildRequires: aom-devel to libaom-devel
-
-* Tue Sep 11 2018 Robert-André Mauchin <zebob.m@gmail.com> - 4.0.2-5
-- Add support for libaom (rfbz#5016)
-
-* Wed Sep 05 2018 Nicolas Chauvet <kwizart@gmail.com> - 4.0.2-4
-- Add without_opus
-- Add disable opus and mfx for rhel
-- Enable nvenc for rhel
-
-* Sun Jul 29 2018 Julian Sikorski <belegdol@fedoraproject.org> - 4.0.2-3
-- Add spec fixes from rfbz #4964
-
-* Thu Jul 26 2018 RPM Fusion Release Engineering <leigh123linux@gmail.com> - 4.0.2-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
-
-* Wed Jul 18 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0.2-1
-- Update to 4.0.2 release
-
-* Fri Jul 06 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0.1-2
-- enable libzvbi by default (rfbz#4956)
-
-* Sat Jun 16 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0.1-1
-- Update to 4.0.1 release
-
-* Sat Jun 16 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0-2
-- Rebuild for new libass version
-
-* Fri Apr 20 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0-1
-- Update to 4.0 release
-
-* Thu Apr 19 2018 Leigh Scott <leigh123linux@googlemail.com> - 4.0-0.1.20180419git
-- Update to 20180419 (release/4.0 branch)
-
-* Mon Mar 05 2018 Leigh Scott <leigh123linux@googlemail.com> - 3.5-0.6.20180305git
-- Update to 20180305
-- Change build requires for nvenc
-
-* Wed Feb 28 2018 Leigh Scott <leigh123linux@googlemail.com> - 3.5-0.5.20180211git
-- Rebuilt for x265
-
-* Tue Feb 27 2018 Nicolas Chauvet <kwizart@gmail.com> - 3.5-0.4.20180211git
-- Rebuilt for x265
-
-* Sun Feb 11 2018 Leigh Scott <leigh123linux@googlemail.com> - 3.5-0.3.20180211git
-- Update to 20180211git
-
-* Fri Jan 26 2018 Leigh Scott <leigh123linux@googlemail.com> - 3.5-0.2.20180116git
-- Rebuild for new libcdio and libvpx versions
-
-* Tue Jan 16 2018 Leigh Scott <leigh123linux@googlemail.com> - 3.5-0.1.20180116git
-- Update to 20180116git
-- Remove ffserver parts from spec
-- Add requires ffmpeg-libs to libavdevice (rfbz#4768)
-
-* Mon Jan 15 2018 Nicolas Chauvet <kwizart@gmail.com> - 3.4.1-5
-- Update to libva 2.0.0
-
-* Sat Dec 30 2017 Sérgio Basto <sergio@serjux.com> - 3.4.1-4
-- Mass rebuild for x264 and x265
-
-* Sun Dec 17 2017 Nicolas Chauvet <kwizart@gmail.com> - 3.4.1-3
-- Add _cuda_version rpm macro
-
-* Mon Dec 11 2017 Nicolas Chauvet <kwizart@gmail.com> - 3.4.1-2
-- Backport patch for arm neon rfbz#4727
-
-* Mon Dec 11 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.4.1-1
-- Updated to 3.4.1
-
-* Tue Nov 28 2017 Dominik Mierzejewski <rpm@greysector.net> - 3.4-6
-- enable support for vid.stab (rfbz#4713)
-- rebuild against new libmfx (rhbz#1471768)
-
-* Wed Oct 25 2017 Dominik Mierzejewski <rpm@greysector.net> - 3.4-5
-- drop support for building on ppc (32bit)
-- explicitly support ppc64p7 and ppc64le
-- set correct CPU options on armv7hl
-- show config.log in case of configure failure
-- enable VAAPI support on all arches, it's not x86-specific anymore
-
-* Wed Oct 25 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.4-4
-- Switch from yasm to nasm
-
-* Wed Oct 25 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.4-3
-- Add SVG rasterization and KMS screengrabber support
-
-* Mon Oct 16 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.4-2
-- rebuild for x265
-
-* Sun Oct 15 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.4-1
-- Updated to 3.4
-- Remove build requires schroedinger-devel (wrapper was removed)
-
-* Thu Oct 12 2017 Dominik Mierzejewski <rpm@greysector.net> - 3.3.4-2
-- add support for OpenJPEG v2.3
-
-* Tue Sep 12 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.3.4-1
-- Updated to 3.3.4
-
-* Thu Aug 31 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.3.3-4
-- Add support for LibOpenJPEG v2.2
-
-* Thu Aug 31 2017 RPM Fusion Release Engineering <kwizart@rpmfusion.org> - 3.3.3-3
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
-
-* Thu Aug 31 2017 RPM Fusion Release Engineering <kwizart@rpmfusion.org> - 3.3.3-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
-
-* Sat Jul 29 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.3.3-1
-- Updated to 3.3.3
-
-* Wed Jun 07 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.3.2-1
-- Updated to 3.3.2
-
-* Mon May 15 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.3.1-1
-- Updated to 3.3.1
-
-* Wed Apr 19 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.3-1
-- Updated to 3.3
-- Make nvenc x86 only
-- Remove obsolete x11grab configure option
-
-* Sun Mar 19 2017 RPM Fusion Release Engineering <kwizart@rpmfusion.org> - 3.2.4-2
-- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
-
-* Sat Feb 11 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.2.4-1
-- Updated to 3.2.4
-
-* Mon Feb 06 2017 Leigh Scott <leigh123linux@googlemail.com> - 3.2.3-1
-- Updated to 3.2.3
-
-* Tue Jan 03 2017 Dominik Mierzejewski <rpm@greysector.net> - 3.2.2-3
-- rebuild for x265
-
-* Mon Jan 02 2017 Dominik Mierzejewski <rpm@greysector.net> - 3.2.2-2
-- enable optional nonfree build with cuda, cuvid, npp and fdk-aac
-  (most credit for this goes to Nicolas Chauvet)
-- allow disabling x11grab (conflicts with nonfree builds)
-- use Recommends only on Fedora (patch by Nicolas Chauvet)
-- enable AMR codecs by default (rfbz#4367, patch by Nicolas Chauvet)
-
-* Tue Dec 06 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.2.2-1
-- Updated to 3.2.2
-
-* Sat Nov 26 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.2.1-1
-- Updated to 3.2.1
-
-* Wed Nov 16 2016 Adrian Reber <adrian@lisas.de> - 3.2-3
-- Rebuild for libcdio-0.94
-
-* Tue Nov 08 2016 Sérgio Basto <sergio@serjux.com> - 3.2-2
-- Rebuild for x265-2.1
-
-* Sat Oct 29 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.2-1
-- Updated to 3.2
-- Dropped openjpeg2 patch
-- Updated BuildRequires to SDL2-devel
-- Incorporated some cleanups from RF #4243
-
-* Tue Oct 25 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.1.5-1
-- Updated to 3.1.5
-
-* Sat Oct 01 2016 Leigh Scott <leigh123linux@googlemail.com> - 3.1.4-2
-- Fix missing libxvid (rfbz#4274)
-
-* Sat Oct 01 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.1.4-1
-- Updated to 3.1.4
-
-* Thu Sep 08 2016 Nicolas Chauvet <kwizart@gmail.com> - 3.1.3-3
-- Disable OpenCV for Fedora >= 25
-
-* Sat Sep 03 2016 Dominik Mierzejewski <rpm@greysector.net> - 3.1.3-2
-- enable QSV support by default, since libmfx is in Fedora now
-- QSV is x86 only
-- put x86-specific BRs in one place
-
-* Sat Aug 27 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.1.3-1
-- Updated to 3.1.3
-
-* Thu Aug 25 2016 Leigh Scott <leigh123linux@googlemail.com> - 3.1.2-2
-- enable support for nvenc
-
-* Wed Aug 10 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.1.2-1
-- Updated to 3.1.2
-
-* Wed Jul 27 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.1.1-1
-- Updated to 3.1.1
-- Dropped included patch
-- Added $RPM_LD_FLAGS to %%configure
-- Switched to openjpeg2
-- Fixed build with openjpeg2-2.1.1 (patch by Sandro Mani)
-
-* Sat Jul 23 2016 Igor Gnatenko <ignatenko@redhat.com> - 3.0.2-5
-- Rebuild for libvpx soname bump
-
-* Sun Jul 10 2016 Dominik Mierzejewski <rpm@greysector.net> - 3.0.2-4
-- enable jack by default (rfbz#2156)
-- re-enable opencl by default (rfbz#3640 was fixed)
-- add conditional support for QSV via libmfx (rfbz#4043)
-- drop libcelt support (celt 0.11 no longer available in Fedora)
-- drop libdirac support (unsupported by FFmpeg)
-- make xvidcore support optional
-- add missing ldconfig calls for libavdevice package
-- move libavdevice manpage to its subpackage
-- move examples from main package to -devel as docs
-- add support for libiec61883 and make DV (IEEE 1394) support optional
-- enable optional support for many external libraries (rfbz#4109)
-
-* Thu Jul 07 2016 Julian Sikorski <belegdol@fedoraproject.org> - 3.0.2-3
-- Fixed build failure on rawhide due to newer opencv using a patch from upstream
-  git
-
-* Sun Jun 12 2016 Leigh Scott <leigh123linux@googlemail.com> - 3.0.2-2
-- rebuilt
-
-* Sat May 14 2016 Michael Kuhn <suraia@ikkoku.de> - 3.0.2-1
-- Update to 3.0.2.
-
-* Mon May 02 2016 Julian Sikorski <belegdol@fedoraproject.org> - 2.8.7-1
-- Updated to 2.8.7
-
-* Mon Feb 01 2016 Julian Sikorski <belegdol@fedoraproject.org> - 2.8.6-1
-- Updated to 2.8.6
-
-* Sat Jan 16 2016 Julian Sikorski <belegdol@fedoraproject.org> - 2.8.5-1
-- Updated to 2.8.5
-
-* Wed Dec 23 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.8.4-1
-- Updated to 2.8.4
-- Fixed Fraunhofer FDK AAC conditional build (RF # 3898)
-
-* Sun Nov 29 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.8.3-1
-- Updated to 2.8.3
-
-* Sat Nov 14 2015 Nicolas Chauvet <kwizart@gmail.com> - 2.8.2-1
-- Update to 2.8.2
-
-* Sat Oct 24 2015 Nicolas Chauvet <kwizart@gmail.com> - 2.8.1-1
-- Update to 2.8.1
-
-* Sat Jul 25 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.6.4-1
-- Updated to 2.6.4
-
-* Wed May 27 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.6.3-1
-- Updated to 2.6.3
-
-* Sat May 16 2015 Nicolas Chauvet <kwizart@gmail.com> - 2.6.2-3
-- Rebuilt for x265
-
-* Mon May 11 2015 Nicolas Chauvet <kwizart@gmail.com> - 2.6.2-2
-- Disable opencl by default - rfbz#3640
-- Add with condition for nvenc,fdk_aac
-
-* Tue May 05 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.6.2-1
-- Updated to 2.6.2
-
-* Tue Apr 28 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.4.9-1
-- Updated to 2.4.9
-
-* Wed Apr 15 2015 Dominik Mierzejewski <rpm@greysector.net> - 2.4.8-3
-- rebuilt for new x265
-
-* Mon Apr 13 2015 Nicolas Chauvet <kwizart@gmail.com> - 2.4.8-2
-- Fix sed for f22 where cflags contains a directory path
-
-* Mon Mar 30 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.4.8-1
-- Updated to 2.4.8
-
-* Sun Feb 15 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.4.7-1
-- Updated to 2.4.7
-
-* Sun Feb 01 2015 Dominik Mierzejewski <rpm at greysector.net> - 2.4.6-3
-- enable LADSPA support (rfbz#3134)
-
-* Sun Feb 01 2015 Dominik Mierzejewski <rpm at greysector.net> - 2.4.6-2
-- enable OpenCL support
-- BR texinfo instead of texi2html to reduce BRs by half
-- drop support for building on SPARC (no longer a Fedora Secondary Arch)
-- move libavdevice to a subpackage (rfbz#3075)
-
-* Wed Jan 14 2015 Julian Sikorski <belegdol@fedoraproject.org> - 2.4.6-1
-- Updated to 2.4.6
-
-* Sun Dec 21 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.4.5-1
-- Updated to 2.4.5
-
-* Thu Dec 18 2014 Dominik Mierzejewski <rpm at greysector.net> - 2.4.4-2
-- enable support for libx265 by default (rfbz#3421, patch by Nerijus Baliūnas)
-
-* Mon Dec 01 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.4.4-1
-- Updated to 2.4.4
-
-* Tue Nov 04 2014 Nicolas Chauvet <kwizart@gmail.com> - 2.4.3-2
-- Rebuilt for vaapi 0.36
-
-* Sun Nov 02 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.4.3-1
-- Updated to 2.4.3
-
-* Sun Oct 19 2014 Sérgio Basto <sergio@serjux.com> - 2.4.2-1
-- Update to ffmpeg-2.4.2
-
-* Fri Oct 03 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.3.4-1
-- Updated to 2.3.4
-
-* Sat Sep 27 2014 kwizart <kwizart@gmail.com> - 2.3.3-3
-- Rebuild back to ffmpeg 2.3x
-
-* Sat Sep 13 2014 Nicolas Chauvet <kwizart@gmail.com> - 2.3.3-2
-- Disable libcelt by default - rfbz#3359
-
-* Tue Sep 02 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.3.3-1
-- Updated to 2.3.3
-
-* Tue Aug 12 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.3.2-1
-- Updated to 2.3.2
-
-* Sun Aug 03 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.3.1-1
-- Updated to 2.3.1
-- README → README.md
-
-* Tue Jul 15 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.2.5-1
-- Updated to 2.2.5
-
-* Tue Jul 08 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.2.4-1
-- Updated to 2.2.4
-
-* Wed Jun 04 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.2.3-1
-- Updated to 2.2.3
-
-* Mon May 05 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.2.2-1
-- Updated to 2.2.2
-
-* Fri Apr 18 2014 Nicolas Chauvet <kwizart@gmail.com> - 2.2.1-1
-- Update to 2.2.1
-
-* Mon Mar 24 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.2-1
-- Updated to 2.2
-
-* Fri Mar 21 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.1.4-4
-- Rebuilt for libass-0.10.2
-
-* Tue Mar 18 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.1.4-3
-- Rebuilt for x264
-
-* Thu Mar 06 2014 Nicolas Chauvet <kwizart@gmail.com> - 2.1.4-2
-- Rebuilt for x264
-
-* Tue Feb 25 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.1.4-1
-- Updated to 2.1.4
-
-* Thu Jan 16 2014 Julian Sikorski <belegdol@fedoraproject.org> - 2.1.3-1
-- Updated to 2.1.3
-
-* Wed Nov 20 2013 Nicolas Chauvet <kwizart@gmail.com> - 2.1.1-1
-- Update to 2.1.1
-
-* Tue Oct 29 2013 Julian Sikorski <belegdol@fedoraproject.org> - 2.1-1
-- Updated to 2.1
-
-* Tue Oct 22 2013 Nicolas Chauvet <kwizart@gmail.com> - 2.0.2-2
-- Rebuilt for x264
-
-* Wed Oct 09 2013 Julian Sikorski <belegdol@fedoraproject.org> - 2.0.2-1
-- Updated to 2.0.2
-
-* Mon Sep 30 2013 Nicolas Chauvet <kwizart@gmail.com> - 2.0.1-3
-- Rebuilt
-
-* Tue Aug 27 2013 Nicolas Chauvet <kwizart@gmail.com> - 2.0.1-2
-- Enable avresample as noticed by Xavier Bachelot
-
-* Tue Aug 13 2013 Nicolas Chauvet <kwizart@gmail.com> - 2.0.1-1
-- Update to 2.0.1
-
-* Thu Aug 01 2013 Julian Sikorski <belegdol@fedoraproject.org> - 2.0-1
-- Updated to 2.0
-- Dropped the no longer needed bogus man dir work-around
-
-* Thu Aug 01 2013 Julian Sikorski <belegdol@fedoraproject.org> - 1.2.2-1
-- Updated to 1.2.2
-
-* Sat Jul 20 2013 Nicolas Chauvet <kwizart@gmail.com> - 1.2.1-7
-- Rebuilt for x264
-
-* Tue Jul 02 2013 Dominik Mierzejewski <rpm at greysector.net> - 1.2.1-6
-- fix building with libcdio
-
-* Mon Jul 01 2013 Dominik Mierzejewski <rpm at greysector.net> - 1.2.1-5
-- build with soxr support enabled (rfbz#2853)
-
-* Thu Jun 27 2013 Nicolas Chauvet <kwizart@gmail.com> - 1.2.1-4
-- Reverse the logic for neon on arm
-
-* Wed Jun 19 2013 Nicolas Chauvet <kwizart@gmail.com> - 1.2.1-3
-- Enable neon on armv7hnl
-- Enable thumb on all arm but armv6hl
-
-* Tue May 14 2013 Julian Sikorski <belegdol@fedoraproject.org> - 1.2.1-1
-- Updated to 1.2.1
-
-* Sun May 05 2013 Julian Sikorski <belegdol@fedoraproject.org> - 1.2-2
-- Rebuilt for x264-0.130
-
-* Mon Mar 18 2013 Julian Sikorski <belegdol@fedoraproject.org> - 1.2-1
-- Updated to 1.2
-
-* Mon Mar 18 2013 Julian Sikorski <belegdol@fedoraproject.org> - 1.1.4-1
-- Updated to 1.1.4
-
-* Sun Mar 10 2013 Nicolas Chauvet <kwizart@gmail.com> - 1.1.3-1
-- Update to 1.1.3
-
-* Sun Jan 20 2013 Nicolas Chauvet <kwizart@gmail.com> - 1.1.1-1
-- Update to 1.1.1
-- Disable libcdio with fedora 19
-
-* Mon Jan 07 2013 Julian Sikorski <belegdol@fedoraproject.org> - 1.1-1
-- Updated to 1.1
-- Added new man pages
-
-* Tue Dec 04 2012 Julian Sikorski <belegdol@fedoraproject.org> - 1.0.1-1
-- Updated to 1.0.1
-
-* Fri Nov 23 2012 Julian Sikorski <belegdol@fedoraproject.org> - 1.0-5
-- Rebuilt for x264-0.128
-
-* Sat Nov 03 2012 Julian Sikorski <belegdol@fedoraproject.org> - 1.0-4
-- Fixed -O3 -g in host_cflags
-- Made the installation verbose too
-
-* Sat Nov 03 2012 Julian Sikorski <belegdol@fedoraproject.org> - 1.0-3
-- Use Fedora %%{optflags}
-- Made the build process verbose
-
-* Thu Nov 01 2012 Nicolas Chauvet <kwizart@gmail.com> - 1.0-2
-- Add opus
-- Enable opencv frei0r by default
-- Disable librmtp - use builtin implementation rfbz#2399
-
-* Thu Oct 04 2012 Julian Sikorski <belegdol@fedoraproject.org> - 1.0-1
-- Updated to 1.0
-- Dropped obsolete Group, Buildroot, %%clean and %%defattr
-- Dropped the included patch
-
-* Wed Sep 05 2012 Nicolas Chauvet <kwizart@gmail.com> - 0.11.1-3
-- Rebuilt for x264 ABI 125
-
-* Sat Jul 21 2012 Nicolas Chauvet <kwizart@gmail.com> - 0.11.1-2
-- Backport fix rfbz#2423
-
-* Thu Jun 14 2012 Julian Sikorski <belegdol@fedoraproject.org> - 0.11.1-1
-- Updated to 0.11.1
-
-* Wed Jun 13 2012 Julian Sikorski <belegdol@fedoraproject.org> - 0.10.4-1
-- Updated to 0.10.4
-
-* Mon May 07 2012 Julian Sikorski <belegdol@fedoraproject.org> - 0.10.3-1
-- Updated to 0.10.3
-
-* Tue May 01 2012 Nicolas Chauvet <kwizart@gmail.com> - 0.10.2-3
-- Sync with ffmpeg-compat and EL
-- Add BR libmodplug-devel
-- Enable libass openal-soft
-
-* Tue Apr 10 2012 Nicolas Chauvet <kwizart@gmail.com> - 0.10.2-2
-- Explicitely disable neon unless armv7hnl
-
-* Sun Mar 18 2012 Julian Sikorski <belegdol@fedoraproject.org> - 0.10.2-1
-- Updated to 0.10.2
-
-* Mon Mar 12 2012 root - 0.10-2
-- Rebuilt for x264 ABI 0.120
-
-* Sun Feb 19 2012 Nicolas Chauvet <kwizart@gmail.com> - 0.10-1
-- Update to 0.10
-- Disable dirac by default - rfbz#1946
-- Enabled by default: libv4l2 gnutls
-- New RPM Conditionals:
-  --with crystalhd dirac jack frei0r openal opencv
-  --without celt cdio pulse
-
-* Wed Feb 01 2012 Nicolas Chauvet <kwizart@gmail.com> - 0.8.9-1
-- Update to 0.8.9
-- Add BR libass-devel
-- Rebuilt for libvpx
-
-* Mon Jan 09 2012 Nicolas Chauvet <kwizart@gmail.com> - 0.8.8-1
-- Update to 0.8.8
-
-* Wed Dec 21 2011 Nicolas Chauvet <kwizart@gmail.com> - 0.8.7-1
-- Update to 0.8.7
-
-* Fri Oct 28 2011 Nicolas Chauvet <kwizart@gmail.com> - 0.8.5-2
-- Fix for glibc bug rhbz#747377
-
-* Sun Oct 23 2011 Dominik Mierzejewski <rpm at greysector.net> - 0.8.5-1
-- update to 0.8.5
-
-* Fri Sep 23 2011 Dominik Mierzejewski <rpm at greysector.net> - 0.8.4-1
-- update to 0.8.4
-- fix FFmpeg name spelling
-
-* Mon Aug 22 2011 Dominik Mierzejewski <rpm at greysector.net> - 0.8.2-1
-- update to 0.8.2
-- enable CELT decoding via libcelt
-- support AMR WB encoding via libvo-amrwbenc (optional)
-- enable FreeType support
-
-* Thu Jul 14 2011 Nicolas Chauvet <kwizart@gmail.com> - 0.7.1-1
-- Update to 0.7.1
-
-* Fri Jul 01 2011 Nicolas Chauvet <kwizart@gmail.com> - 0.7-0.3.20110612git
-- Add XvMC in ffmpeg
-
-* Sun Jun 12 2011 Nicolas Chauvet <kwizart@gmail.com> - 0.7-0.2.20110612git
-- Update to 20110612git from oldabi branch
-
-* Sun Jun 12 2011 Nicolas Chauvet <kwizart@gmail.com> - 0.7-0.1.rc1
-- Update to 7.0-rc1
-- Remove upstreamed patch
-- Fix flv - rfbz#1743
-- New RPM build conditional --without x264.
-
-* Tue Apr 12 2011 Dominik Mierzejewski <rpm at greysector.net> - 0.6.90-0.2.rc0
-- fixed missing av_parser_parse symbol (upstream patch)
-
-* Mon Apr 04 2011 Dominik Mierzejewski <rpm at greysector.net> - 0.6.90-0.1.rc0
-- updated to 0.6.90-rc0 release
-- ensure main package is version-locked to the -libs subpackage
-
-* Sun Feb 27 2011 Dominik Mierzejewski <rpm at greysector.net> - 0.6.1-1.20110227git
-- 20110227 snapshot
-- bump version to post-0.6.1 to allow stable 0.6.1 update in older branches
-- drop --with amr->opencore_amr indirection
-- add qt-faststart tool (bug #1259)
-- build PIC objects on PPC (bug #1457)
-- provide custom version string
-- require latest x264 build
-
-* Fri Jan 21 2011 Hans de Goede <j.w.r.degoede@hhs.nl> - 0.6-5.20100704svn
-- Rebuild for new openjpeg
-
-* Wed Jul 21 2010 Nicolas Chauvet <kwizart@gmail.com> - 0.6-4.20100704svn
-- Enable libva
-- Restore compatibility --with amr
-
-* Mon Jul 05 2010 Nicolas Chauvet <kwizart@gmail.com> - 0.6-3.20100704svn
-- Fix build using --define ffmpegsuffix 'foo'
-- Disable FFmpeg binaries when built with suffix.
-
-* Sun Jul 04 2010 Dominik Mierzejewski <rpm at greysector.net> - 0.6-2.20100704svn
-- 20100703 snapshot
-- enable libvpx (WebM/VP8) support (rfbz#1250)
-- drop faad2 support (dropped upstream)
-- drop old Obsoletes:
-- enable librtmp support
-
-* Sat Jun 19 2010 Dominik Mierzejewski <rpm at greysector.net> - 0.6-1.20100619svn
-- 20100619 snapshot
-
-* Thu Apr 29 2010 Dominik Mierzejewski <rpm at greysector.net> - 0.6-0.3.20100429svn
-- 20100429 snapshot
-- dropped unnecessary imlib2-devel BR
-
-* Sat Mar 20 2010 Dominik Mierzejewski <rpm at greysector.net> - 0.6-0.2.20100320svn
-- bump for rebuild
-
-* Sat Mar 20 2010 Dominik Mierzejewski <rpm at greysector.net> - 0.6-0.1.20100320svn
-- 20100320 snapshot
-- drop upstream'd patch
-- bumped version to pre-0.6
-- added ffprobe to file list
-
-* Sat Jan 16 2010 Dominik Mierzejewski <rpm at greysector.net> - 0.5-6.20100116svn
-- 20100116 snapshot, requires recent x264
-- fix textrels on x86_64 in a different way (patch by Reimar Döffinger)
-- use -mlongcall instead of -fPIC to fix rfbz#804, it's faster
-
-* Sat Nov  7 2009 Hans de Goede <j.w.r.degoede@hhs.nl> - 0.5-5.20091026svn
-- Add -fPIC -dPIC when compiling on ppc (rf804)
-
-* Thu Oct 22 2009 Dominik Mierzejewski <rpm at greysector.net> - 0.5-4.20091026svn
-- 20091026 snapshot, requires recent x264
-- dropped support for old amr libs (not supported upstream since July)
-- don't disable yasm for generic builds
-- fixed opencore amr support
-- dropped workaround for non-standard openjpeg headers location
-- dropped separate SIMDified libs for x86 and ppc(64),
-  runtime CPU detection should be enough
-
-* Thu Oct 15 2009 kwizart <kwizart at gmail.com > - 0.5-3.svn20091007
-- Update to svn snapshot 20091007
-- Add BR dirac vdpau.
-- Use --with nonfree as a separate conditional for amr and faac.
-- Use --with gplv3 as a separate conditional for opencore-amr.
-- Don't build faac by default because it's nonfree.
-- Allow to --define 'ffmpegsuffix custom' for special SONAME.
-
-* Fri Mar 27 2009 Dominik Mierzejewski <rpm at greysector.net> - 0.5-2
-- rebuild for new faad2 and x264
-
-* Tue Mar 10 2009 Dominik Mierzejewski <rpm at greysector.net> - 0.5-1
-- 0.5 release
-- enable yasm on x86_64, fix resulting textrels
-- add missing obsoletes for ffmpeg-compat-devel (really fix bug #173)
-- disable yasm and certain asm optimizations for generic ix86 builds
-- %%{_bindir} is now usable
-- include more docs
-- specfile cleanups
-- add JPEG2000 decoding support via openjpeg
-
-* Sat Jan 31 2009 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.58.20090131
-- 20090131 snapshot
-
-* Wed Dec 17 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.57.20081217
-- 20081217 snapshot
-- fix pkgconfig files again (broken in 0.4.9-0.55.20081214)
-
-* Mon Dec 15 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.56.20081214
-- drop libdirac support for now
-
-* Sun Dec 14 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.55.20081214
-- 20081214 snapshot
-- change the lib split on x86, it doesn't work right for P3/AthlonXP
-- specfile cleanups
-- enable bzlib, dirac and speex support via external libs
-- sort BR list alphabetically
-- drop upstream'd patch
-
-* Thu Dec 11 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.54.20081202
-- fix pkgconfig file generation
-
-* Thu Dec 04 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.53.20081202
-- 20081202 snapshot
-- drop upstreamed/obsolete patches
-
-* Thu Nov 20 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.52.20080908
-- add obsoletes for -compat package (RPMFusion bug #173)
-
-* Sat Nov 01 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.51.20080908
-- reworked build system
-- build optimized versions where it makes sense
-- specfile cleanups
-- enable yasm for optimized asm routines on x86_32
-- add obsoletes for Freshrpms' libpostproc subpackage
-
-* Thu Sep 18 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.50.20080908
-- 20080908 snapshot (r25261), last before ABI change
-
-* Fri Sep 05 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.49.20080905
-- 20080905 snapshot
-- fix build --with amr
-- update snapshot.sh
-- drop liba52 support, native ac3 decoder is better in every way
-
-* Mon Aug 25 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.48.20080825
-- 20080825 snapshot
-- use CFLAGS more similar to upstream
-- enable X11 grabbing input
-- enable libavfilter
-
-* Sun Aug 03 2008 Thorsten Leemhuis <fedora [AT] leemhuis [DOT] info - 0.4.9-0.47.20080614
-- rebuild
-
-* Sat Jun 14 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.46.20080614
-- 20080614 snapshot
-- no need to conditionalize swscaler anymore
-- dropped obsolete pkgconfig patch
-- BR latest x264
-
-* Mon Mar 03 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.45.20080113
-- rebuild for new x264
-
-* Sun Jan 13 2008 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.44.20080113
-- 20080113 snapshot
-- drop unnecessary patch
-- enable libdc1394 support
-- enable swscaler
-
-* Mon Nov 12 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.43.20071111
-- ensure that we use the correct faad2 version
-
-* Sun Nov 11 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.42.20071111
-- 20071111 snapshot
-- current faad2 is good again
-
-* Thu Oct 18 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.41.20071011
-- fix BRs and Requires for faad2
-
-* Thu Oct 11 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.40.20071011
-- 20071011 snapshot
-- don't link against faad2-2.5, it makes GPL'd binary non-distributable
-- go back to normal linking instead of dlopen() of liba52
-
-* Sun Sep 23 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.39.20070923
-- 20070923 snapshot
-- use faad2 2.5
-- optional AMR support
-- dropped obsolete patch
-
-* Thu Jun 07 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.38.20070607
-- 20070607 snapshot
-- libdca BR dropped (no longer supported)
-- drop gsm.h path hack, gsm in Fedora now provides a compatibility symlink
-- remove arch hacks, ffmpeg's configure is smart enough
-- enable cmov on x86_64
-
-* Thu May 03 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.37.20070503
-- require older faad2 to prevent bugreports like #1388
-- prepare for libdc1394 support
-- enable pthreads
-- 20070503 snapshot
-
-* Thu Feb 08 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.35.20070204
-- libswscale.pc is necessary regardless of --enable-swscaler
-
-* Sun Feb  4 2007 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.34.20070204
-- 2007-02-04 snapshot, enable libtheora.
-- Make swscaler optional, disabled again by default (#1379).
-
-* Fri Jan 05 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.34.20061214
-- move vhooks to -libs
-
-* Wed Jan 03 2007 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.33.20061214
-- split -libs subpackage for multilib installs
-
-* Tue Dec 26 2006 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.32.20061214
-- new kino works with swscaler, re-enabled
-
-* Tue Dec 19 2006 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.31.20061214
-- disable swscaler, it breaks kino
-
-* Sun Dec 17 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.30.20061214
-- fix pkgconfig patch
-
-* Sat Dec 16 2006 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.29.20061214
-- liba52 change broke build on 64bit
-- resurrect lost URL changes
-
-* Fri Dec 15 2006 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.28.20061214
-- fixed build on x86
-- change liba52 file-based dependency to provides-based
-- resurrect and update pkgconfig patch
-
-* Thu Dec 14 2006 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.27.20061214
-- new snapshot URL
-- new URL
-
-* Thu Dec 14 2006 Dominik Mierzejewski <rpm at greysector.net> - 0.4.9-0.26.20061214
-- 2006-12-14 snapshot
-- added libdca support
-- enabled swscaler
-- dropped obsolete patches
-
-* Mon Oct 30 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.25.20061030
-- 2006-10-30 snapshot, fixes x86_64 build.
-- Apply a less intrusive workaround for LAME detection issues.
-
-* Sat Oct 28 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.25.20061028
-- 2006-10-28 snapshot, build with x264.
-- Clean up some pre-FC4 compat build dependency cruft.
-- Quick and dirty workarounds for ./configure's libmp3lame test and asm
-  register issues on ix86.
-
-* Fri Oct 06 2006 Thorsten Leemhuis <fedora [AT] leemhuis [DOT] info> 0.4.9-25
-- rebuilt for unwind info generation, broken in gcc-4.1.1-21
-
-* Tue Sep 26 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.24.20060817
-- Drop SELinux fcontext settings, they're supposedly fixed upstream again.
-
-* Thu Aug 17 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.23.20060817
-- 2006-08-17 snapshot.
-- Fix svn rev in "ffmpeg -version" etc.
-
-* Wed Aug  9 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.23.20060804
-- Reintroduce SELinux fcontext settings on ix86 (not needed on x86_64, ppc),
-  they're not completely taken care of upstream (#1120).
-- Split svn snapshot creator into a separate script.
-
-* Fri Aug  4 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.22.20060804
-- 2006-08-04 snapshot.
-- Drop bogus version from SDL-devel build dependency.
-- Drop no longer relevant libpostproc obsoletion.
-- Prune pre-2005 changelog entries.
-- Specfile cleanup.
-
-* Sat Jun 17 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.22.20060617
-- 2006-06-17 snapshot.
-
-* Mon Jun 12 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.22.20060612
-- 2006-06-12 snapshot, rgb.txt patch applied upstream.
-- Patch to force linking vhook modules with their dependencies, --as-needed
-  seems to drop needed things for some reason for drawtext and imlib2.
-- Revert to dlopen()'ing liba52 and add file based dependency on it, it's
-  easier this way again due to --as-needed linkage.
-
-* Wed May 17 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.22.20060517
-- 2006-05-17 snapshot.
-- Link with faad2, don't dlopen() it.
-
-* Sat May 13 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.22.20060513
-- 2006-05-13 snapshot.
-- Drop SELinux fixups, they're part of upstream policy now.
-
-* Sat Apr 15 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.22.20060407
-- SELinux file context fixups (mplayer, vdr-dxr3 etc) while waiting for #188358
-
-* Sat Apr  8 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.21.20060407
-- 2006-04-07 CVS snapshot.
-- Move *.so to -devel, hopefully nothing needs them any more.
-
-* Fri Mar 31 2006 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.21.20051228
-- Remove superfluous dependencies from pkgconfig files (#747).
-- Re-enable MMX on x86_64.
-
-* Thu Mar 09 2006 Andreas Bierfert <andreas.bierfert[AT]lowlatency.de>
-- switch to new release field
-
-* Tue Feb 28 2006 Andreas Bierfert <andreas.bierfert[AT]lowlatency.de>
-- add dist
-
-* Wed Dec 28 2005 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.lvn.0.20.20051228
-- 2005-12-28 CVS snapshot.
-- Let upstream configure take care of PIC settings (patched for ppc).
-- Own shared lib symlinks.
-
-* Fri Dec 23 2005 Ville Skyttä <ville.skytta at iki.fi> - 0.4.9-0.lvn.0.20.20050801
-- Apply upstream fix for CVE-2005-4048.
-- Patch to find rgb.txt in FC5 too.
-
-* Thu Sep 29 2005 Ville Skyttä <ville.skytta at iki.fi> - 0:0.4.9-0.lvn.0.19.20050801
-- Clean up obsolete pre-FC3 stuff (FAAC is now unconditionally enabled).
-- Drop zero Epochs.
-
-* Tue Aug 16 2005 Ville Skyttä <ville.skytta at iki.fi> - 0:0.4.9-0.lvn.0.18.20050801
-- Apply some upstream and some mine (libdir) fixes to pkgconfig files.
-- Add pkgconfig dependency to -devel.
-- Include gsm support.
-
-* Thu Aug 4 2005 David Woodhouse <dwmw2@infradead.org> - 0:0.4.9-0.lvn.0.17.20050801
-- Update to 20050801 snapshot to make xine-lib happy
-- Enable Altivec support by using --cpu=powerpc (not 'ppc')
-- Enable theora
-- Add pkgconfig files
-- Undefine various things which might be macros before redefining them
-
-* Sat Jul 23 2005 Dams <anvil[AT]livna.org> - 0:0.4.9-0.lvn.0.17.20050427
-- Added patch from Marc Deslauriers to fix wmv2 distorsion
-
-* Sun Jul 10 2005 Ville Skyttä <ville.skytta at iki.fi> - 0:0.4.9-0.lvn.0.16.20050427
-- Enable faac by default, rebuild with "--without faac" to disable.
-- Clean up obsolete pre-FC2 and other stuff.
-
-* Sun May 22 2005 Ville Skyttä <ville.skytta at iki.fi> - 0:0.4.9-0.lvn.0.15.20050427
-- PPC needs -fPIC too.
-
-* Sat May 21 2005 Thorsten Leemhuis <fedora[AT]leemhuis.info> - 0:0.4.9-0.lvn.0.14.20050427
-- disable mmx for now on x86_64 to fix build
-
-* Sat Apr 30 2005 Dams <anvil[AT]livna.org> - 0:0.4.9-0.lvn.0.13.20050427
-- Removed bogus devel requires
-- Re-added conditionnal a52dec buildreq
-
-* Fri Apr 29 2005 Ville Skyttä <ville.skytta at iki.fi> - 0:0.4.9-0.lvn.0.12.20050427
-- Link avcodec with a52 when building with a52bin, remove unnecessary
-  hardcoded liba52.so.0 dependency.
-
-* Fri Apr 29 2005 Dams <anvil[AT]livna.org> - 0:0.4.9-0.lvn.0.11.20050427
-- Fixed devel package deps
-
-* Fri Apr 29 2005 Dams <anvil[AT]livna.org> - 0:0.4.9-0.lvn.0.10.20050427
-- texi2html replaces tetex as build dependency (FC4 compliance)
-- re-added man pages
-
-* Thu Apr 28 2005 Dams <anvil[AT]livna.org> - 0:0.4.9-0.lvn.0.9.20050427
-- Patch from Enrico to fix build on gcc4
-- Missing BuildReq a52dec-devel when a52bin is defined
-- Patch to fix a52 build
-
-* Wed Apr 27 2005 Dams <anvil[AT]livna.org> - 0:0.4.9-0.lvn.0.8.20050427
-- Updated tarball to cvs 20050427 snapshot
-- Enabled libogg, xvid, a52bin
-- Dropped Patch[0-3]
+%doc doc/APIchanges doc/*.txt
+%doc doc/html doc/examples
+
+%files -n libavcodec
+%license COPYING.GPLv2 LICENSE.md
+%{_libdir}/libavcodec.so.%{avcodec_soversion}*
+
+%files -n libavcodec-devel
+%{_includedir}/libavcodec
+%{_libdir}/pkgconfig/libavcodec.pc
+%{_libdir}/libavcodec.so
+%{_mandir}/man3/libavcodec.3*
+
+%files -n libavdevice
+%license COPYING.GPLv2 LICENSE.md
+%{_libdir}/libavdevice.so.%{avdevice_soversion}*
+
+%files -n libavdevice-devel
+%{_includedir}/libavdevice
+%{_libdir}/pkgconfig/libavdevice.pc
+%{_libdir}/libavdevice.so
+%{_mandir}/man3/libavdevice.3*
+
+%files -n libavfilter
+%license COPYING.GPLv2 LICENSE.md
+%{_libdir}/libavfilter.so.%{avfilter_soversion}*
+
+%files -n libavfilter-devel
+%{_includedir}/libavfilter
+%{_libdir}/pkgconfig/libavfilter.pc
+%{_libdir}/libavfilter.so
+%{_mandir}/man3/libavfilter.3*
+
+%files -n libavformat
+%license COPYING.GPLv2 LICENSE.md
+%{_libdir}/libavformat.so.%{avformat_soversion}*
+
+%files -n libavformat-devel
+%{_includedir}/libavformat
+%{_libdir}/pkgconfig/libavformat.pc
+%{_libdir}/libavformat.so
+%{_mandir}/man3/libavformat.3*
+
+%files -n libavutil
+%license COPYING.GPLv2 LICENSE.md
+%{_libdir}/libavutil.so.%{avutil_soversion}*
+
+%files -n libavutil-devel
+%{_includedir}/libavutil
+%{_libdir}/pkgconfig/libavutil.pc
+%{_libdir}/libavutil.so
+%{_mandir}/man3/libavutil.3*
+
+%files -n libpostproc
+%license COPYING.GPLv2 LICENSE.md
+%{_libdir}/libpostproc.so.%{postproc_soversion}*
+
+%files -n libpostproc-devel
+%{_includedir}/libpostproc
+%{_libdir}/pkgconfig/libpostproc.pc
+%{_libdir}/libpostproc.so
+
+%files -n libswresample
+%license COPYING.GPLv2 LICENSE.md
+%{_libdir}/libswresample.so.%{swresample_soversion}*
+
+%files -n libswresample-devel
+%{_includedir}/libswresample
+%{_libdir}/pkgconfig/libswresample.pc
+%{_libdir}/libswresample.so
+%{_mandir}/man3/libswresample.3*
+
+%files -n libswscale
+%license COPYING.GPLv2 LICENSE.md
+%{_libdir}/libswscale.so.%{swscale_soversion}*
+
+%files -n libswscale-devel
+%{_includedir}/libswscale
+%{_libdir}/pkgconfig/libswscale.pc
+%{_libdir}/libswscale.so
+%{_mandir}/man3/libswscale.3*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [refactor: Rebase FFmpeg (#3489)](https://github.com/terrapkg/packages/pull/3489)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)