### PR TITLE
[f41] chore: Move NVIDIA tools to NVIDIA repo (#4605)

### DIFF
--- a/anda/tools/cuda-gcc/anda.hcl
+++ b/anda/tools/cuda-gcc/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
 	}
     labels {
         updbranch = 1
+        subrepo = "nvidia"
     }
 }

--- a/anda/tools/cuda-nvcc/anda.hcl
+++ b/anda/tools/cuda-nvcc/anda.hcl
@@ -4,5 +4,6 @@ project "pkg" {
     }
     labels {
         upbranch = 1
+        subrepo = "nvidia"
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore: Move NVIDIA tools to NVIDIA repo (#4605)](https://github.com/terrapkg/packages/pull/4605)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)