### PR TITLE
[f41] fix(cuda-nvcc): Missing D in updbranch (#4610)

### DIFF
--- a/anda/tools/cuda-nvcc/anda.hcl
+++ b/anda/tools/cuda-nvcc/anda.hcl
@@ -3,7 +3,7 @@ project "pkg" {
         spec = "cuda-nvcc.spec"
     }
     labels {
-        upbranch = 1
+        updbranch = 1
         subrepo = "nvidia"
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(cuda-nvcc): Missing D in updbranch (#4610)](https://github.com/terrapkg/packages/pull/4610)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)