### PR TITLE
fix: make it so readymade package doesnt conflict w/ downstream packages

### DIFF
--- a/anda/system/readymade/nightly/readymade-nightly.spec
+++ b/anda/system/readymade/nightly/readymade-nightly.spec
@@ -4,7 +4,7 @@
 
 Name:           readymade-nightly
 Version:        %commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Install ready-made distribution images!
 License:        GPL-3.0-or-later
 URL:            https://github.com/FyraLabs/readymade

--- a/anda/system/readymade/nightly/readymade-nightly.spec
+++ b/anda/system/readymade/nightly/readymade-nightly.spec
@@ -57,6 +57,6 @@ ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_da
 %_datadir/polkit-1/actions/com.fyralabs.pkexec.readymade.policy
 %_datadir/applications/com.fyralabs.Readymade.desktop
 %_datadir/applications/liveinst.desktop
-%_datadir/readymade
+%ghost %_datadir/readymade
 %_datadir/icons/hicolor/scalable/apps/com.fyralabs.Readymade.svg
 

--- a/anda/system/readymade/stable/readymade.spec
+++ b/anda/system/readymade/stable/readymade.spec
@@ -1,6 +1,6 @@
 Name:           readymade
 Version:        0.12.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Install ready-made distribution images!
 License:        GPL-3.0-or-later
 URL:            https://github.com/FyraLabs/readymade

--- a/anda/system/readymade/stable/readymade.spec
+++ b/anda/system/readymade/stable/readymade.spec
@@ -50,6 +50,6 @@ ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_da
 %_datadir/polkit-1/actions/com.fyralabs.pkexec.readymade.policy
 %_datadir/applications/com.fyralabs.Readymade.desktop
 %_datadir/applications/liveinst.desktop
-%_datadir/readymade
+%ghost %_datadir/readymade
 %_datadir/icons/hicolor/scalable/apps/com.fyralabs.Readymade.svg
 


### PR DESCRIPTION
This just removes `/usr/share/readymade` from the spec entirely. Theres probably a better way to do this tho
