### PR TITLE
fix(ruffle-nightly): Use %cargo_build instead of %cargo_install

### DIFF
--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -50,7 +50,7 @@ install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.svg %buildroot%_iconsdir/
 install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.desktop %buildroot%_datadir/applications/rs.ruffle.Ruffle.desktop
 install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml %buildroot%_metainfodir/rs.ruffle.Ruffle.metainfo.xml
 
-%cargo_license_online > LICENSE.dependencies
+%{cargo_license_online} > LICENSE.dependencies
 
 %changelog
 * Mon Jul 29 2024 madonuko <mado@fyralabs.com>

--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -1,4 +1,4 @@
-%global ver 2025-05-03
+%global ver 2025-05-01
 %global goodver %(echo %ver | sed 's/-//g')
 %global __brp_mangle_shebangs %{nil}
 %bcond_without mold
@@ -9,7 +9,7 @@ language. Ruffle targets both the desktop and the web using WebAssembly.}
 
 Name:           ruffle-nightly
 Version:        %goodver
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A Flash Player emulator written in Rust
 License:        Apache-2.0 OR MIT
 URL:            https://ruffle.rs/
@@ -32,7 +32,7 @@ Packager:       madonuko <mado@fyralabs.com>
 %doc README.md
 %license LICENSE.md
 %license LICENSE.dependencies
-%_bindir/ruffle_desktop
+%_bindir/ruffle
 %_datadir/applications/rs.ruffle.Ruffle.desktop
 %_iconsdir/hicolor/scalable/apps/rs.ruffle.Ruffle.svg
 %_metainfodir/rs.ruffle.Ruffle.metainfo.xml
@@ -40,21 +40,18 @@ Packager:       madonuko <mado@fyralabs.com>
 %prep
 %autosetup -n ruffle-nightly-%ver -p1
 %cargo_prep_online
-desktop-file-edit --set-key=Exec --set-value="ruffle_desktop %u" desktop/packages/linux/rs.ruffle.Ruffle.desktop
-cat desktop/packages/linux/rs.ruffle.Ruffle.desktop
 
 %build
-%{cargo_license_online} > LICENSE.dependencies
+cd desktop
+%cargo_build
 
 %install
-cd desktop
-%cargo_install
-install -Dm644 packages/linux/rs.ruffle.Ruffle.svg %buildroot%_iconsdir/hicolor/scalable/apps/rs.ruffle.Ruffle.svg
-install -Dm644 packages/linux/rs.ruffle.Ruffle.desktop %buildroot%_datadir/applications/rs.ruffle.Ruffle.desktop
-install -Dm644 packages/linux/rs.ruffle.Ruffle.metainfo.xml %buildroot%_metainfodir/rs.ruffle.Ruffle.metainfo.xml
+install -Dm755 target/rpm/ruffle_desktop %buildroot%_bindir/ruffle
+install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.svg %buildroot%_iconsdir/hicolor/scalable/apps/rs.ruffle.Ruffle.svg
+install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.desktop %buildroot%_datadir/applications/rs.ruffle.Ruffle.desktop
+install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml %buildroot%_metainfodir/rs.ruffle.Ruffle.metainfo.xml
 
-%check
-desktop-file-validate %buildroot%_datadir/applications/rs.ruffle.Ruffle.desktop
+%cargo_license_online > LICENSE.dependencies
 
 %changelog
 * Mon Jul 29 2024 madonuko <mado@fyralabs.com>

--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -1,4 +1,4 @@
-%global ver 2025-05-01
+%global ver 2025-05-03
 %global goodver %(echo %ver | sed 's/-//g')
 %global __brp_mangle_shebangs %{nil}
 %bcond_without mold
@@ -9,7 +9,7 @@ language. Ruffle targets both the desktop and the web using WebAssembly.}
 
 Name:           ruffle-nightly
 Version:        %goodver
-Release:        2%?dist
+Release:        1%?dist
 Summary:        A Flash Player emulator written in Rust
 License:        Apache-2.0 OR MIT
 URL:            https://ruffle.rs/
@@ -17,7 +17,6 @@ Source0:        https://github.com/ruffle-rs/ruffle/archive/refs/tags/nightly-%v
 Provides:       ruffle
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros mold
-BuildRequires:  desktop-file-utils
 BuildRequires:  gcc-c++ cmake java
 BuildRequires:  java-latest-openjdk-headless
 BuildRequires:  pkgconfig(alsa)


### PR DESCRIPTION
`%cargo_install` is broken.

Also with this no more `.desktop` file pain?