### PR TITLE
[f42] chore: Remove Zig bootstrap (#4625)

### DIFF
--- a/anda/langs/zig/zig-master.spec
+++ b/anda/langs/zig/zig-master.spec
@@ -8,7 +8,7 @@
 %endif
 %global         llvm_version 20.0.0
 %global         ver 0.15.0-dev.451+a843be44a
-%bcond bootstrap 0
+%bcond bootstrap 1
 %bcond docs      %{without bootstrap}
 %bcond test      1
 %global zig_cache_dir %{builddir}/zig-cache


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: Remove Zig bootstrap (#4625)](https://github.com/terrapkg/packages/pull/4625)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)