### PR TITLE
[f41] fix(ruffle-nightly): Use %cargo_build instead of %cargo_install (#4628)

### DIFF
--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -17,7 +17,6 @@ Source0:        https://github.com/ruffle-rs/ruffle/archive/refs/tags/nightly-%v
 Provides:       ruffle
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros mold
-BuildRequires:  desktop-file-utils
 BuildRequires:  gcc-c++ cmake java
 BuildRequires:  java-latest-openjdk-headless
 BuildRequires:  pkgconfig(alsa)
@@ -32,7 +31,7 @@ Packager:       madonuko <mado@fyralabs.com>
 %doc README.md
 %license LICENSE.md
 %license LICENSE.dependencies
-%_bindir/ruffle_desktop
+%_bindir/ruffle
 %_datadir/applications/rs.ruffle.Ruffle.desktop
 %_iconsdir/hicolor/scalable/apps/rs.ruffle.Ruffle.svg
 %_metainfodir/rs.ruffle.Ruffle.metainfo.xml
@@ -40,21 +39,18 @@ Packager:       madonuko <mado@fyralabs.com>
 %prep
 %autosetup -n ruffle-nightly-%ver -p1
 %cargo_prep_online
-desktop-file-edit --set-key=Exec --set-value="ruffle_desktop %u" desktop/packages/linux/rs.ruffle.Ruffle.desktop
-cat desktop/packages/linux/rs.ruffle.Ruffle.desktop
 
 %build
-%{cargo_license_online} > LICENSE.dependencies
+cd desktop
+%cargo_build
 
 %install
-cd desktop
-%cargo_install
-install -Dm644 packages/linux/rs.ruffle.Ruffle.svg %buildroot%_iconsdir/hicolor/scalable/apps/rs.ruffle.Ruffle.svg
-install -Dm644 packages/linux/rs.ruffle.Ruffle.desktop %buildroot%_datadir/applications/rs.ruffle.Ruffle.desktop
-install -Dm644 packages/linux/rs.ruffle.Ruffle.metainfo.xml %buildroot%_metainfodir/rs.ruffle.Ruffle.metainfo.xml
+install -Dm755 target/rpm/ruffle_desktop %buildroot%_bindir/ruffle
+install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.svg %buildroot%_iconsdir/hicolor/scalable/apps/rs.ruffle.Ruffle.svg
+install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.desktop %buildroot%_datadir/applications/rs.ruffle.Ruffle.desktop
+install -Dm644 desktop/packages/linux/rs.ruffle.Ruffle.metainfo.xml %buildroot%_metainfodir/rs.ruffle.Ruffle.metainfo.xml
 
-%check
-desktop-file-validate %buildroot%_datadir/applications/rs.ruffle.Ruffle.desktop
+%{cargo_license_online} > LICENSE.dependencies
 
 %changelog
 * Mon Jul 29 2024 madonuko <mado@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(ruffle-nightly): Use %cargo_build instead of %cargo_install (#4628)](https://github.com/terrapkg/packages/pull/4628)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)