### PR TITLE
[frawhide] fix(mesa): remove duplicated vulkan_drivers

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -68,7 +68,6 @@
 %endif
 
 %global vulkan_drivers swrast,virtio%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan}%{?with_nvk:,nouveau}
-%global vulkan_drivers swrast%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan}%{?with_nvk:,nouveau}
 Name:           %{srcname}
 Summary:        Mesa graphics libraries
 # Make the dep solver always prefer our Mesa over the distro's
@@ -682,8 +681,8 @@ popd
 %files vulkan-drivers
 %{_libdir}/libvulkan_lvp.so
 %{_datadir}/vulkan/icd.d/lvp_icd.*.json
-%dnl %{_libdir}/libvulkan_virtio.so
-%dnl %{_datadir}/vulkan/icd.d/virtio_icd.*.json
+%{_libdir}/libvulkan_virtio.so
+%{_datadir}/vulkan/icd.d/virtio_icd.*.json
 %{_libdir}/libVkLayer_MESA_device_select.so
 %{_datadir}/vulkan/implicit_layer.d/VkLayer_MESA_device_select.json
 %if 0%{?with_vulkan_hw}


### PR DESCRIPTION
This extra line accidentally removes the virtio vulkan driver from the final mesa-vulkan-drivers package, as documented in the following bazzite issue:

fixes: ublue-os/bazzite #2472