### PR TITLE
[f41] fix(rnote): rustflags_debuginfo 1 (#4545)

### DIFF
--- a/anda/langs/rust/rnote/rnote.spec
+++ b/anda/langs/rust/rnote/rnote.spec
@@ -1,4 +1,5 @@
 %global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
+%global rustflags_debuginfo 1
 
 Name:           rnote
 Version:        0.12.0
@@ -36,8 +37,9 @@ import/export, an infinite canvas and an adaptive UI for big and small screens.
 %files
 %doc README.md
 %license LICENSE
-
+%_bindir/rnote-cli
 %_bindir/rnote
+%_datadir/thumbnailers/rnote.thumbnailer
 %_datadir/applications/com.github.flxzt.rnote.desktop
 %_datadir/glib-2.0/schemas/com.github.flxzt.rnote.gschema.xml
 %_datadir/icons/hicolor/scalable/apps/com.github.flxzt.rnote.svg


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(rnote): rustflags_debuginfo 1 (#4545)](https://github.com/terrapkg/packages/pull/4545)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)