### PR TITLE
[f41] [frawhide] fix(mesa): remove duplicated vulkan_drivers (#4637)

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -68,7 +68,6 @@
 %endif
 
 %global vulkan_drivers swrast,virtio%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan}%{?with_nvk:,nouveau}
-%global vulkan_drivers swrast%{?base_vulkan}%{?intel_platform_vulkan}%{?extra_platform_vulkan}%{?with_nvk:,nouveau}
 Name:           %{srcname}
 Summary:        Mesa graphics libraries
 # Make the dep solver always prefer our Mesa over the distro's
@@ -682,8 +681,8 @@ popd
 %files vulkan-drivers
 %{_libdir}/libvulkan_lvp.so
 %{_datadir}/vulkan/icd.d/lvp_icd.*.json
-%dnl %{_libdir}/libvulkan_virtio.so
-%dnl %{_datadir}/vulkan/icd.d/virtio_icd.*.json
+%{_libdir}/libvulkan_virtio.so
+%{_datadir}/vulkan/icd.d/virtio_icd.*.json
 %{_libdir}/libVkLayer_MESA_device_select.so
 %{_datadir}/vulkan/implicit_layer.d/VkLayer_MESA_device_select.json
 %if 0%{?with_vulkan_hw}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [[frawhide] fix(mesa): remove duplicated vulkan_drivers (#4637)](https://github.com/terrapkg/packages/pull/4637)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)