### PR TITLE
[el10] Add: GStreamer VA-API (#3276)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-vaapi/anda.hcl
+++ b/anda/multimedia/gstreamer1/gstreamer1-vaapi/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+  arches = ["x86_64", "aarch64", "i386"]
+  rpm {
+    spec = "gstreamer1-vaapi.spec"
+  }
+  labels {
+        subrepo = "extras"
+        mock = 1
+    }
+}

--- a/anda/multimedia/gstreamer1/gstreamer1-vaapi/gstreamer1-vaapi.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-vaapi/gstreamer1-vaapi.spec
@@ -1,0 +1,76 @@
+Name:           gstreamer1-plugin-vaapi
+Version:        1.26.0
+Release:        1%{?dist}
+Epoch:          1
+Summary:        GStreamer VA-API integration
+License:        LGPLv2+
+URL:            https://gstreamer.freedesktop.org/modules/gstreamer-vaapi.html
+
+Source0:        https://gstreamer.freedesktop.org/src/gstreamer-vaapi/gstreamer-vaapi-%{version}.tar.xz
+
+BuildRequires:  gcc
+BuildRequires:  glib2-devel >= 2.44
+BuildRequires:  gstreamer1-devel >= %{version}
+BuildRequires:  gstreamer1-plugins-base-devel >= %{version}
+BuildRequires:  gstreamer1-plugins-bad-devel >= %{version}
+BuildRequires:  libvpx-devel
+BuildRequires:  meson >= 0.48.0
+BuildRequires:  pkgconfig(egl)
+BuildRequires:  pkgconfig(gl)
+BuildRequires:  pkgconfig(glesv2)
+#BuildRequires:  pkgconfig(glesv3)
+BuildRequires:  pkgconfig(gtk+-3.0)
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(libudev)
+BuildRequires:  pkgconfig(libva) >= 0.39.0
+BuildRequires:  pkgconfig(libva-x11) >= 0.31.0
+BuildRequires:  pkgconfig(libva-drm) >= 0.33.0
+BuildRequires:  pkgconfig(libva-wayland) >= 0.33.0
+BuildRequires:  pkgconfig(wayland-client) >= 1.11.0
+BuildRequires:  pkgconfig(wayland-cursor) >= 1.11.0
+BuildRequires:  pkgconfig(wayland-egl)
+BuildRequires:  pkgconfig(wayland-protocols) >= 1.11.0
+BuildRequires:  pkgconfig(wayland-scanner) >= 1.11.0
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xrandr)
+BuildRequires:  pkgconfig(xrender)
+
+Obsoletes:      gstreamer1-vaapi < 1:1.20.3-2
+Provides:       gstreamer1-vaapi = 1:%{version}-%{release}
+Provides:       gstreamer1-vaapi%{?_isa} = 1:%{version}-%{release}
+
+%description
+GStreamer is a streaming media framework, based on graphs of elements which
+operate on media data.
+
+VA-API-based decoder, encoder, postprocessing and video sink elements for
+GStreamer.
+
+%prep
+%autosetup -n gstreamer-vaapi-%{version}
+
+%build
+%meson \
+  -D doc=disabled \
+  -D drm=enabled \
+  -D egl=enabled \
+  -D encoders=enabled \
+  -D glx=enabled \
+  -D wayland=enabled \
+  -D x11=enabled
+
+%meson_build
+
+%install
+%meson_install
+find %{buildroot} -name "*.la" -delete
+
+%ldconfig_scriptlets
+
+%files
+%license COPYING.LIB
+%doc AUTHORS NEWS README
+%{_libdir}/gstreamer-1.0/*.so
+
+%changelog
+%autochangelog

--- a/anda/multimedia/gstreamer1/gstreamer1-vaapi/update.rhai
+++ b/anda/multimedia/gstreamer1/gstreamer1-vaapi/update.rhai
@@ -1,0 +1,4 @@
+let release = labels.branch.to_upper();
+let ver = get(`https://bodhi.fedoraproject.org/updates/?search=gstreamer1-vaapi&status=stable&releases=${release}&rows_per_page=1&page=1`).json().updates[0].title;
+rpm.version(find(`gstreamer1-vaapi-([\d.]+)`, ver, 1));
+rpm.release(find(`gstreamer1-vaapi-[\d.]+-([\d.])`, ver, 1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Add: GStreamer VA-API (#3276)](https://github.com/terrapkg/packages/pull/3276)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)