### PR TITLE
[f42] fix?(gstreamer1-plugins-bad): Fully obsolete freeworld (#4665)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/gstreamer1-plugins-bad.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/gstreamer1-plugins-bad.spec
@@ -44,8 +44,7 @@ Provides:       %{name}-free-libs%{?_isa} = %{?epoch}:%{version}-%{release}
 Obsoletes:      gstreamer1-plugin-vaapi < %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-plugin-vaapi = %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-plugin-vaapi%{?_isa} = %{?epoch}:%{version}-%{release}
-Obsoletes:      %{name}-freeworld < %{?epoch}:%{version}-%{release}
-Provides:       %{name}-freeworld = %{?epoch}:%{version}-%{release}
+Obsoletes:      %{name}-freeworld <= %{?epoch}:%{version}-%{release}
 
 BuildRequires:  gcc-c++
 BuildRequires:  meson >= 0.62


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix?(gstreamer1-plugins-bad): Fully obsolete freeworld (#4665)](https://github.com/terrapkg/packages/pull/4665)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)