### PR TITLE
fix(zig-master): Normalize version

### DIFF
--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -38,7 +38,7 @@
 }
 
 Name:           zig-master
-Version:        %(echo %{ver} | sed 's/-/~/g')
+Version:        0.15.0~dev.464+dffd18f13
 Release:        1%?dist
 Summary:        Master builds of the Zig language
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1


### PR DESCRIPTION
I didn't bump the version itself to hopefully avoid backport conflicts.