### PR TITLE
[f40] fix(lightly-qt6): Update script and build (#4673)

### DIFF
--- a/anda/themes/lightly-qt6/lightly-qt6.spec
+++ b/anda/themes/lightly-qt6/lightly-qt6.spec
@@ -2,6 +2,7 @@
 %global _style lightly
 %global dev boehs
 %global _qt_major_version 6
+%global _qt_old_major 5
  
 %global forgeurl https://github.com/%{dev}/%{style}
 %global commit 00ca23447844114d41bfc0d37cf8823202c082e8
@@ -49,7 +50,10 @@ BuildRequires:  cmake(KF%{_qt_major_version}Kirigami2)
 BuildRequires:  cmake(KF%{_qt_major_version}Notifications)
 BuildRequires:  cmake(KF%{_qt_major_version}Package)
 BuildRequires:  cmake(KF%{_qt_major_version}WindowSystem)
- 
+
+BuildRequires:  cmake(Qt%{_qt_old_major}Core)
+BuildRequires:  cmake(Qt%{_qt_old_major}Gui)
+
 BuildRequires:  cmake(KDecoration2)
 BuildRequires:  cmake(KWayland)
 BuildRequires:  cmake(Plasma)
@@ -71,7 +75,12 @@ Lightly is a fork of breeze theme style that aims to be visually modern and mini
 %forgeautosetup -p1
  
 %build
-%cmake_kf6 -DQT_MAJOR_VERSION=%{_qt_major_version}
+%cmake_kf6 \
+   -DQT_MAJOR_VERSION=%{_qt_major_version} \
+   -DCMAKE_INSTALL_PREFIX=%{_prefix} \
+   -DCMAKE_BUILD_TYPE=Release \
+   -DBUILD_TESTING=OFF \
+   -DKDE_INSTALL_USE_QT_SYS_PATHS=ON 
 %cmake_build
  
 %install

--- a/anda/themes/lightly-qt6/update.rhai
+++ b/anda/themes/lightly-qt6/update.rhai
@@ -1,6 +1,6 @@
 import "andax/bump_extras.rhai" as bump;
 
-fn main() {
+fn main(labels) {
     let branch = bump::as_bodhi_ver(labels.branch);
     let url = `https://bodhi.fedoraproject.org/updates/?search=qt6-6.&status=stable&releases=${branch}&rows_per_page=1&page=1`;
     for entry in get(url).json().updates[0].title.split(' ') {
@@ -11,4 +11,4 @@ fn main() {
     }
 }
 
-open_file("anda/themes/lightly-qt6/VER6.txt").write(`${main()}`); // will trig rebuild when changed
+open_file("anda/themes/lightly-qt6/VER6.txt").write(`${main(labels)}`); // will trig rebuild when changed


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(lightly-qt6): Update script and build (#4673)](https://github.com/terrapkg/packages/pull/4673)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)