### PR TITLE
[el10] fix(minecraft): allow other kwallets (#4672)

### DIFF
--- a/anda/games/minecraft-java/minecraft-java.spec
+++ b/anda/games/minecraft-java/minecraft-java.spec
@@ -17,7 +17,7 @@ ExclusiveArch:	x86_64
 Requires:	java >= 1.8.0
 Requires:       gtk3
 Requires:       libgpg-error
-Requires:       (gnome-keyring or kwallet)
+Requires:       (gnome-keyring or kf6-kwallet or kf5-kwallet or kwallet)
 
 %description
 The official Linux release of the launcher for Minecraft, a game about placing blocks and going on adventures.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(minecraft): allow other kwallets (#4672)](https://github.com/terrapkg/packages/pull/4672)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)