### PR TITLE
[f42] fix(gstreamer1-vaapi): Properly track Bodhi (#4682)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-vaapi/anda.hcl
+++ b/anda/multimedia/gstreamer1/gstreamer1-vaapi/anda.hcl
@@ -6,5 +6,6 @@ project pkg {
   labels {
         subrepo = "extras"
         mock = 1
+        updbranch = 1
     }
 }

--- a/anda/multimedia/gstreamer1/gstreamer1-vaapi/update.rhai
+++ b/anda/multimedia/gstreamer1/gstreamer1-vaapi/update.rhai
@@ -1,4 +1,5 @@
-let release = labels.branch.to_upper();
-let ver = get(`https://bodhi.fedoraproject.org/updates/?search=gstreamer1-vaapi&status=stable&releases=${release}&rows_per_page=1&page=1`).json().updates[0].title;
-rpm.version(find(`gstreamer1-vaapi-([\d.]+)`, ver, 1));
-rpm.release(find(`gstreamer1-vaapi-[\d.]+-([\d.])`, ver, 1));
+import "andax/bump_extras.rhai" as bump;
+
+let vr = bump::bodhi_vr("gstreamer1-vaapi", bump::as_bodhi_ver(labels.branch));
+rpm.version(vr[1]);
+rpm.release(vr[2]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(gstreamer1-vaapi): Properly track Bodhi (#4682)](https://github.com/terrapkg/packages/pull/4682)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)