### PR TITLE
[f40] fix(ignis): license LGPL-2.1-or-later (#4708)

### DIFF
--- a/anda/langs/python/ignis/python-ignis.spec
+++ b/anda/langs/python/ignis/python-ignis.spec
@@ -1,9 +1,9 @@
 Name:           python-ignis
 Version:        0.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A widget framework for building desktop shells, written and configurable in Python
 
-License:        ???
+License:        LGPL-2.1-or-later
 URL:            https://linkfrg.github.io/ignis
 Source:         https://github.com/linkfrg/ignis/archive/v%{version}/ignis-%{version}.tar.gz
 Packager:       madonuko <mado@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(ignis): license LGPL-2.1-or-later (#4708)](https://github.com/terrapkg/packages/pull/4708)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)