### PR TITLE
[f42] fix?(gstreamer1-plugins-ugly): Self obsolete to obsolete Fusion (#4715)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/gstreamer1-plugins-ugly.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/gstreamer1-plugins-ugly.spec
@@ -29,6 +29,7 @@ BuildRequires:  pkgconfig(x264) >= 0.120
 Obsoletes:      %{name}-free < %{?epoch}:%{version}-%{release}
 Provides:       %{name}-free = %{?epoch}:%{version}-%{release}
 Provides:       %{name}-free%{?_isa} = %{?epoch}:%{version}-%{release}
+Obsoletes:      %{name} < %{?epoch}:%{version}-%{release}
 
 %description
 This module contains a set of plugins that have good quality and are well tested, but can be questionable to distribute due to patents.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix?(gstreamer1-plugins-ugly): Self obsolete to obsolete Fusion (#4715)](https://github.com/terrapkg/packages/pull/4715)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)