### PR TITLE
[f41] chore: Move nvidia-patch to NVIDIA subrepo (#4722)

### DIFF
--- a/anda/system/nvidia-patch/anda.hcl
+++ b/anda/system/nvidia-patch/anda.hcl
@@ -4,5 +4,6 @@ project "pkg" {
     }
    	labels {
 		nightly = "1"
+                subrepo = "nvidia"
 	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore: Move nvidia-patch to NVIDIA subrepo (#4722)](https://github.com/terrapkg/packages/pull/4722)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)