### PR TITLE
[f41] fix(readymade-git): lock cargo dependencies (#4733)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -42,9 +42,10 @@ ls -l
 %cargo_prep_online
 
 %build
+%{cargo_build} --locked
 
 %install
-%cargo_install
+install -Dm755 target/rpm/readymade -t %buildroot%_bindir
 ./install.sh %buildroot
 ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_datadir}/applications/liveinst.desktop
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(readymade-git): lock cargo dependencies (#4733)](https://github.com/terrapkg/packages/pull/4733)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)