### PR TITLE
[f40] chore: Bump some out of sync packages on <= 42 (#4746)

### DIFF
--- a/anda/apps/komikku/komikku.spec
+++ b/anda/apps/komikku/komikku.spec
@@ -3,10 +3,10 @@
 %global gtk4_version        4.14.4
 %global libadwaita_version  1.5.1
 %global pure_protobuf_version 2.0.0
-%global raw_ver v1.75.0
+%global raw_ver v1.76.0
 
 Name:           komikku
-Version:        1.75.0
+Version:        1.76.0
 %forgemeta
 Release:        1%?dist
 Summary:        A manga reader for GNOME

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -5,7 +5,7 @@
 %global crate mise
 
 Name:           rust-mise
-Version:        2025.4.11
+Version:        2025.5.2
 Release:        1%?dist
 Summary:        Front-end to your dev env
 

--- a/anda/tools/electron/electron.spec
+++ b/anda/tools/electron/electron.spec
@@ -12,7 +12,7 @@
 %global __provides_exclude_from %{_libdir}/%{name}/.*\\.so
 
 Name:			electron
-Version:		36.0.1
+Version:		36.2.0
 Release:		1%?dist
 Summary:		Build cross platform desktop apps with web technologies
 License:		MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f40`:
 - [chore: Bump some out of sync packages on <= 42 (#4746)](https://github.com/terrapkg/packages/pull/4746)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)