### PR TITLE
[el10] fix(libva-nvidia-driver): Ifcond for ix86 (#4757)

### DIFF
--- a/anda/system/nvidia/libva-nvidia-driver/anda.hcl
+++ b/anda/system/nvidia/libva-nvidia-driver/anda.hcl
@@ -6,5 +6,6 @@ project "pkg" {
     labels = {
         subrepo = "nvidia"
         mock = 1
+        nightly = 1
     }
 }

--- a/anda/system/nvidia/libva-nvidia-driver/libva-nvidia-driver.spec
+++ b/anda/system/nvidia/libva-nvidia-driver/libva-nvidia-driver.spec
@@ -4,6 +4,10 @@
 
 %global upstream_name nvidia-vaapi-driver
 
+%ifarch %ix86
+%global build_cflags %{__build_flags_lang_c} %{?_distro_extra_cflags} -Wno-error=format=
+%endif
+
 Name:           libva-nvidia-driver
 Epoch:          1
 Version:        0.0.13%{!?tag:^%{date}git%{shortcommit0}}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(libva-nvidia-driver): Ifcond for ix86 (#4757)](https://github.com/terrapkg/packages/pull/4757)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)