### PR TITLE
[el10] fix: Bump LCEVCdec on &lt;&#x3D; 42 (#4758)

### DIFF
--- a/anda/multimedia/lcevcdec/LCEVCdec.spec
+++ b/anda/multimedia/lcevcdec/LCEVCdec.spec
@@ -16,7 +16,7 @@
 %bcond docs 0
 
 Name:           LCEVCdec
-Version:        3.3.5
+Version:        3.3.7
 Release:        1%{?dist}
 Summary:        MPEG-5 LCEVC Decoder
 License:        BSD-3-Clause-Clear


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [fix: Bump LCEVCdec on &lt;&#x3D; 42 (#4758)](https://github.com/terrapkg/packages/pull/4758)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)