### PR TITLE
[el10] chore: Bump vvenc, add update script (#4765)

### DIFF
--- a/anda/multimedia/vvenc/update.rhai
+++ b/anda/multimedia/vvenc/update.rhai
@@ -1,0 +1,4 @@
+let v = gh_tag("fraunhoferhhi/vvenc");
+if `[\d.]+-rc\d+`.find_all(v).len == 0 {
+  rpm.version(v);
+}

--- a/anda/multimedia/vvenc/vvenc.spec
+++ b/anda/multimedia/vvenc/vvenc.spec
@@ -1,5 +1,7 @@
+%global build_cxxflags %{__build_flags_lang_cxx} %{?_distro_extra_cxxflags} -Wno-error=maybe-uninitialized -Wno-error=uninitialized
+
 Name:           vvenc
-Version:        1.12.1
+Version:        1.13.1
 Release:        1%{?dist}
 Summary:        VVenC, the Fraunhofer Versatile Video Encoder
 License:        BSD-3-Clause
@@ -9,6 +11,9 @@ Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
+
+# Define this after the version is defined
+%global vvenc_majorminor %(v=%{version}; echo ${v:0:4})
 
 %description
 VVenC, the Fraunhofer Versatile Video Encoder, is a fast and efficient software
@@ -40,7 +45,9 @@ developing applications that use %{name}.
 %autosetup -p1
 
 %build
-export CXXFLAGS="%{optflags} -Wno-error=maybe-uninitialized -Wno-error=uninitialized"
+%ifarch %ix86
+export LDFLAGS="%{optflags} -Wl,--unresolved-symbols=ignore-all"
+%endif
 %cmake \
     -DCMAKE_SKIP_INSTALL_RPATH=OFF \
     -DVVENC_INSTALL_FULLFEATURE_APP=ON
@@ -56,7 +63,7 @@ export CXXFLAGS="%{optflags} -Wno-error=maybe-uninitialized -Wno-error=uninitial
 %files libs
 %license LICENSE.txt
 %doc README.md changelog.txt
-%{_libdir}/lib%{name}.so.1.12
+%{_libdir}/lib%{name}.so.%{vvenc_majorminor}
 %{_libdir}/lib%{name}.so.%{version}
 
 %files devel
@@ -66,8 +73,4 @@ export CXXFLAGS="%{optflags} -Wno-error=maybe-uninitialized -Wno-error=uninitial
 %{_libdir}/pkgconfig/lib%{name}.pc
 
 %changelog
-* Mon Nov 11 2024 Simone Caronni <negativo17@gmail.com> - 1.12.1-1
-- Update to 1.12.1.
-
-* Mon Aug 19 2024 Simone Caronni <negativo17@gmail.com> - 1.12.0-1
-- First build.
+%autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: Bump vvenc, add update script (#4765)](https://github.com/terrapkg/packages/pull/4765)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)