### PR TITLE
[frawhide] lib/mesa: import doom patches from steamos (#4773)

### DIFF
--- a/anda/lib/mesa/doom-dta.patch
+++ b/anda/lib/mesa/doom-dta.patch
@@ -1,0 +1,30 @@
+From 80ac865565c8b2cbdf9cca953a234cb630549802 Mon Sep 17 00:00:00 2001
+From: Atapi <34801996+Sterophonick@users.noreply.github.com>
+Date: Sat, 10 May 2025 20:07:43 -0600
+Subject: [PATCH] util: import doom changes from SteamOS
+
+---
+ src/util/00-radv-defaults.conf | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
+index aef8b9006cd..3bb0f3451a4 100644
+--- a/src/util/00-radv-defaults.conf
++++ b/src/util/00-radv-defaults.conf
+@@ -123,6 +123,13 @@ Application bugs worked around in this file:
+             <option name="radv_invariant_geom" value="true" />
+         </application>
+ 
++        <application name="DOOM: The Dark Ages" application_name_match="DOOMTheDarkAges">
++            <option name="radv_force_64k_sparse_alignment" value="true" />
++            <option name="radv_zero_vram" value="true" />
++            <option name="radv_legacy_sparse_binding" value="true" />
++            <option name="radv_disable_dcc_stores" value="true" />
++        </application>
++
+         <application name="Wolfenstein II" application_name_match="Wolfenstein II The New Colossus">
+             <option name="radv_disable_dcc" value="true" />
+         </application>
+-- 
+2.49.0
+

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -90,6 +90,9 @@ Source1:        Mesa-MLAA-License-Clarification-Email.txt
 # https://github.com/bazzite-org/mesa
 Patch20:        bazzite.patch
 
+# temporary: DOOM: The Dark Ages patches from SteamOS
+Patch21:        doom-dta.patch
+
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc
 BuildRequires:  gcc-c++


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [lib/mesa: import doom patches from steamos (#4773)](https://github.com/terrapkg/packages/pull/4773)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)