### PR TITLE
[f42] fix(vvenc): Add upstreamed patches, disable x86 SIMD for now (#4770)

### DIFF
--- a/anda/multimedia/vvenc/vvenc.spec
+++ b/anda/multimedia/vvenc/vvenc.spec
@@ -2,12 +2,15 @@
 
 Name:           vvenc
 Version:        1.13.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        VVenC, the Fraunhofer Versatile Video Encoder
 License:        BSD-3-Clause
 URL:            https://github.com/fraunhoferhhi/%{name}
 
 Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+# Fixes for i386/ARM32 builds
+Patch0:         %{url}/commit/ebce395254d9d7be7dc00cec7b49c7ed1d9eebec.patch
+Patch1:         %{url}/commit/bfd55ee783bfe30fc73f6f314b066b84bb1e5b60.patch
 
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
@@ -45,12 +48,12 @@ developing applications that use %{name}.
 %autosetup -p1
 
 %build
-%ifarch %ix86
-export LDFLAGS="%{optflags} -Wl,--unresolved-symbols=ignore-all"
-%endif
 %cmake \
     -DCMAKE_SKIP_INSTALL_RPATH=OFF \
-    -DVVENC_INSTALL_FULLFEATURE_APP=ON
+    -DVVENC_INSTALL_FULLFEATURE_APP=ON \
+%ifarch %ix86
+    -DVVENC_ENABLE_X86_SIMD=FALSE
+%endif
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(vvenc): Add upstreamed patches, disable x86 SIMD for now (#4770)](https://github.com/terrapkg/packages/pull/4770)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)