### PR TITLE
[f42] fix: FFmpeg update issues (#4806)

### DIFF
--- a/anda/lib/nvidia/libnpp/anda.hcl
+++ b/anda/lib/nvidia/libnpp/anda.hcl
@@ -3,7 +3,6 @@ project pkg {
         spec = "libnpp.spec"
     }
     labels {
-	    subrepo = "nvidia"
 	    updbranch = 1
     }
 }

--- a/anda/multimedia/ffmpeg/ffmpeg.spec
+++ b/anda/multimedia/ffmpeg/ffmpeg.spec
@@ -12,7 +12,7 @@
 Summary:        A complete solution to record, convert and stream audio and video
 Name:           ffmpeg
 Version:        7.1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        LGPL-3.0-or-later
 URL:            http://%{name}.org/
 Epoch:          1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: FFmpeg update issues (#4806)](https://github.com/terrapkg/packages/pull/4806)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)