### PR TITLE
[f42] fix(dkms-nvidia): Update dkms-nvidia.conf (#4789)

### DIFF
--- a/anda/system/nvidia/dkms-nvidia/dkms-nvidia.conf
+++ b/anda/system/nvidia/dkms-nvidia/dkms-nvidia.conf
@@ -5,7 +5,6 @@ AUTOINSTALL="yes"
 . /etc/nvidia/kernel.conf
 
 # Quote make to avoid DKMS replacing it with "make -j$parallel_jobs KERNELRELEASE=$kernelver"
-CLEAN="'make' -j$(nproc) -C ${MODULE_VARIANT} clean"
 MAKE[0]="'make' -j$(nproc) -C ${MODULE_VARIANT} KERNEL_UNAME=${kernelver} modules"
 
 BUILT_MODULE_NAME[0]="nvidia"

--- a/anda/system/nvidia/dkms-nvidia/dkms-nvidia.spec
+++ b/anda/system/nvidia/dkms-nvidia/dkms-nvidia.spec
@@ -5,14 +5,14 @@
 
 Name:           dkms-%{modulename}
 Version:        570.144
-Release:        1%?dist
+Release:        2%?dist
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License
 URL:            https://www.nvidia.com/object/unix.html
 Source0:        https://download.nvidia.com/XFree86/Linux-%{_arch}/%{version}/NVIDIA-Linux-%{_arch}-%{version}.run
 Source1:        %{name}.conf
-Patch0:         nvidia-kernel-ccflags-y.patch
+%dnl Patch0:         nvidia-kernel-ccflags-y.patch
 BuildRequires:  sed
 Provides:       %{modulename}-kmod = %{?epoch:%{epoch}:}%{version}
 Requires:       %{modulename}-kmod-common = %{?epoch:%{epoch}:}%{version}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(dkms-nvidia): Update dkms-nvidia.conf (#4789)](https://github.com/terrapkg/packages/pull/4789)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)