### PR TITLE
[f42] add: steam_notif_daemon (#4815)

### DIFF
--- a/anda/games/steam-notif-daemon/anda.hcl
+++ b/anda/games/steam-notif-daemon/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "steam-notif-daemon.spec"
+    }
+}

--- a/anda/games/steam-notif-daemon/steam-notif-daemon.spec
+++ b/anda/games/steam-notif-daemon/steam-notif-daemon.spec
@@ -1,0 +1,30 @@
+Name:			steam-notif-daemon
+Version:		1.0.1
+Release:		1%?dist
+Summary:		Steam notification daemon
+License:		MIT
+URL:			https://github.com/Jovian-Experiments/steam_notif_daemon
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+Packager:		madonuko <mado@fyralabs.com>
+Provides:		steam_notif_daemon = %version-%release
+BuildRequires:	meson gcc
+BuildRequires:	pkgconfig(libsystemd)
+BuildRequires:	pkgconfig(libcurl)
+
+%description
+%summary.
+
+%prep
+%autosetup -n steam_notif_daemon-%version
+
+%build
+%meson -Dsd-bus-provider=libsystemd
+%meson_build
+
+%install
+%meson_install
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/steam_notif_daemon

--- a/anda/games/steam-notif-daemon/update.rhai
+++ b/anda/games/steam-notif-daemon/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("Jovian-Experiments/steam_notif_daemon"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: steam_notif_daemon (#4815)](https://github.com/terrapkg/packages/pull/4815)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)