### PR TITLE
[f42] chore: Update Python packages to the modern RPM Python build system (#4816)

### DIFF
--- a/anda/desktops/lomiri-unity/lomiri-ui-toolkit/lomiri-ui-toolkit.spec
+++ b/anda/desktops/lomiri-unity/lomiri-ui-toolkit/lomiri-ui-toolkit.spec
@@ -4,7 +4,7 @@
 
 Name:           lomiri-ui-toolkit
 Version:        1.3.5110
-Release:        1%?dist
+Release:        2%?dist
 Summary:        QML components to ease the creation of beautiful applications in QML for Lomiri
 
 License:        LGPL-3.0
@@ -34,6 +34,7 @@ BuildRequires: python3-devel
 BuildRequires: python3-rpm-macros
 BuildRequires: qt5-qtsvg-devel
 BuildRequires: fdupes
+BuildRequires: python3dist(pip)
 BuildRequires: python3dist(setuptools)
 Requires:      qt5-qtgraphicaleffects
 Requires:      qt5-qtfeedback
@@ -84,7 +85,7 @@ Examples for Lomiri-ui-toolkit.
 %build
 %{qmake_qt5} 'CONFIG+=ubuntu-uitk-compat' 'CONFIG+=test'
 pushd tests/autopilot
-%py3_build
+%pyproject_wheel
 popd
 %make_build
 
@@ -96,8 +97,8 @@ rm -rf %{buildroot}%{_qt5_qmldir}/Extinct
 %fdupes %buildroot%_libdir/qt5/examples/%name/examples/
 
 pushd tests/autopilot
-%py3_install
-mv lomiriuitoolkit/{tests,_custom_proxy_objects} %{buildroot}%{python3_sitelib}/lomiriuitoolkit/
+%pyproject_install
+mv lomiriuitoolkit/{tests,_custom_proxy_objects} -t %{buildroot}%{python3_sitelib}/lomiriuitoolkit/
 popd
 
 %find_lang %{name}
@@ -143,11 +144,10 @@ popd
 %doc README.md
 %dir %{python3_sitelib}/lomiriuitoolkit
 %{python3_sitelib}/lomiriuitoolkit/*.py
-%dir %{python3_sitelib}/lomiriuitoolkit-%{version}-py%{python3_version}.egg-info
-%{python3_sitelib}/lomiriuitoolkit-%{version}-py%{python3_version}.egg-info/*
 %{python3_sitelib}/lomiriuitoolkit/_custom_proxy_objects/
 %{python3_sitelib}/lomiriuitoolkit/__pycache__/
 %{python3_sitelib}/lomiriuitoolkit/tests/
+%{python3_sitelib}/lomiriuitoolkit-%{version}.dist-info/
 
 %files doc
 %license COPYING.CC-BY-SA-3.0

--- a/anda/devs/shibuya/python-shibuya.spec
+++ b/anda/devs/shibuya/python-shibuya.spec
@@ -1,11 +1,12 @@
 %global pypi_name shibuya
 %global _description %{expand:
 A responsive, good looking with modern design documentation theme for Sphinx, with great supports for many sphinx extensions.}
+# I would love to enable the docs but Fedora has stopped maintaining their jupyter-sphinx package with 42 and it is required to build them
 %bcond docs 0
 
 Name:           python-%{pypi_name}
 Version:        2025.4.25
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A clean, responsive, and customizable Sphinx documentation theme with light/dark mode
 License:        BSD-3-Clause
 URL:            https://shibuya.lepture.com
@@ -15,11 +16,17 @@ Source0:        https://github.com/lepture/shibuya/archive/refs/tags/%{version}.
 Source0:        %{pypi_source}
 %endif
 BuildRequires:  python3-devel
+BuildRequires:  python3-rpm-macros
 BuildRequires:  python3dist(babel)
+BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(sphinx)
 %if %{with docs}
+BuildRequires:  python3dist(jupyter-sphinx)
+BuildRequires:  python3dist(myst-parser)
 BuildRequires:  python3dist(shibuya)
+BuildRequires:  python3dist(sphinx-copybutton)
+BuildRequires:  python3dist(sphinx-design)
 %endif
 BuildArch:      noarch
 Packager:       Gilver E. <rockgrub@disroot.org>
@@ -68,23 +75,31 @@ This package contains the official docs for Shibuya.
 rm -rf %{pypi_name}.egg-info
 
 %build
-%py3_build
+%pyproject_wheel
 
 %if %{with docs}
-PYTHONPATH=${PWD} sphinx-build docs build/_html -b dirhtml -a
+sphinx-build docs build/_html -b dirhtml -a
+pybabel extract -F babel.cfg src/shibuya/theme -o src/shibuya/locale/sphinx.pot
+for l in de en es fr ja ko pt pt_BR zh zh_TW; do
+pybabel init -D sphinx -i src/shibuya/locale/sphinx.pot -d src/shibuya/locale -l $l
+pybabel update -D sphinx -i src/shibuya/locale/sphinx.pot -d src/shibuya/locale -l $l
+pybabel compile -D sphinx -d src/shibuya/locale
+done
 %endif
 
 %install
-%py3_install
+%pyproject_install
 
 %files -n python3-%{pypi_name}
 %license LICENSE
 %doc README.md
 %{python3_sitelib}/%{pypi_name}
-%{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
 
 %if %{with docs}
 %files -n python3-%{pypi_name}-doc
+%doc build/_html/*
+%doc src/shibuya/locale/{de,en,es,fr,ja,ko,pt,pt_BR,zh,zh_TW}
 %endif
 
 %changelog

--- a/anda/langs/python/pillow-heif/python3-pillow-heif.spec
+++ b/anda/langs/python/pillow-heif/python3-pillow-heif.spec
@@ -7,7 +7,7 @@
 
 Name:           python-%{srcname}
 Version:        0.22.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Python library for working with HEIF images and plugin for Pillow
 
 License:        BSD-3-Clause
@@ -22,6 +22,7 @@ BuildRequires:  python%{python3_pkgversion}-devel
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-pillow-devel
 BuildRequires:  libheif-devel
+BuildRequires:  python%{python3_pkgversion}dist(pip)
 %if %{with doc}
 BuildRequires:  make
 BuildRequires:  python%{python3_pkgversion}-sphinx
@@ -72,7 +73,7 @@ Documentation for %{srcname}.
 
 %build
 # Native build
-%py3_build
+%pyproject_wheel
 
 # Doc build
 %if %{with doc}
@@ -83,7 +84,7 @@ rm -f docs/_build_py3/html/.buildinfo
 
 %install
 # Native build
-%py3_install
+%pyproject_install
 
 %check
 # Check Python 3 modules
@@ -97,7 +98,7 @@ popd
 %doc README.md CHANGELOG.md
 %license LICENSE.txt
 %{python3_sitearch}/pillow_heif/
-%{python3_sitearch}/pillow_heif-%{version}-py%{python3_version}.egg-info/
+%{python3_sitearch}/pillow_heif-%{version}.dist-info/
 %{python3_sitearch}/_pillow_heif.*.so
 
 %files -n python%{python3_pkgversion}-%{srcname}-devel

--- a/anda/langs/python/protobuf/python3-protobuf.spec
+++ b/anda/langs/python/protobuf/python3-protobuf.spec
@@ -2,7 +2,7 @@
 %global pypi_name protobuf
 
 Name:           python-%{pypi_name}
-Version:        6.30.1
+Version:        6.30.2
 Release:        2%?dist
 Summary:        Protocol Buffers
 
@@ -11,6 +11,7 @@ URL:            https://developers.google.com/protocol-buffers/
 Source0:        %{pypi_source}
 
 BuildRequires:  python3-devel gcc
+BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
 %description
@@ -30,15 +31,15 @@ Protocol Buffers are Google's data interchange format
 rm -rf %{pypi_name}.egg-info
 
 %build
-%py3_build
+%pyproject_wheel
 
 %install
-%py3_install
+%pyproject_install
 
 %files -n python3-%{pypi_name}
 %doc README.md
-%{python3_sitearch}/google
-%{python3_sitearch}/%{pypi_name}-%{version}-py%{python3_version}.egg-info
+%{python3_sitearch}/google/
+%{python3_sitearch}/protobuf-%{version}.dist-info/
 
 %changelog
 * Sun Feb 19 2023 windowsboy111 <wboy111@outlook.com> - 4.22.0-1

--- a/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
+++ b/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
@@ -5,13 +5,14 @@
 
 Name:           python-%{real_name}
 Version:        3.29.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Sphinx domain for modern CMake
 License:        BSD-3-Clause
 URL:            https://github.com/scikit-build/moderncmakedomain
 Source0:        %{pypi_source}
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(hatchling)
+BuildRequires:  python3dist(nox)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
@@ -22,13 +23,14 @@ Packager:       Gilver E. <rockgrub@disroot.org>
 %description
 Modern CMake domain entries, originally from Kitware.
 
-%package -n     python3-%{pypi_name}
+%package -n     python3-%{real_name}
 Summary:        %{summary}
 Requires:       python3dist(hatchling)
 Requires:       python3dist(sphinx)
-%{?python_provide:%python_provide python3-%{pypi_name}}
+Obsoletes:      python3-%{pypi_name} < 3.29.0-2
+%{?python_provide:%python_provide python3-%{real_name}}
 
-%description -n python3-%{pypi_name}
+%description -n python3-%{real_name}
 Modern CMake domain entries, originally from Kitware.
 
 %prep
@@ -41,9 +43,9 @@ Modern CMake domain entries, originally from Kitware.
 %pyproject_install
 
 %check
-%pytest tests/*.py
+nox -s tests
 
-%files -n python3-%{pypi_name}
+%files -n python3-%{real_name}
 %doc     PKG-INFO
 %doc     README.md
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: Update Python packages to the modern RPM Python build system (#4816)](https://github.com/terrapkg/packages/pull/4816)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)