### PR TITLE
chore(sphinxcontrib-moderncmakedomain): Add explicit build dep on pyproject-rpm-macros

### DIFF
--- a/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
+++ b/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
@@ -10,6 +10,7 @@ Summary:        Sphinx domain for modern CMake
 License:        BSD-3-Clause
 URL:            https://github.com/scikit-build/moderncmakedomain
 Source0:        %{pypi_source}
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(hatchling)
 BuildRequires:  python3dist(nox)

--- a/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
+++ b/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
@@ -13,7 +13,9 @@ Source0:        %{pypi_source}
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(hatchling)
+%if 0%{?fedora}
 BuildRequires:  python3dist(nox)
+%endif
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
@@ -44,7 +46,11 @@ Modern CMake domain entries, originally from Kitware.
 %pyproject_install
 
 %check
+%if 0%{?rhel}
+%pytest tests/*.py
+%else
 nox -s tests
+%endif
 
 %files -n python3-%{real_name}
 %doc     PKG-INFO


### PR DESCRIPTION
Really only needed for EL10 but wanted all specs to be the same so there'd be no conflicts.