### PR TITLE
[f40] chore(sphinxcontrib-moderncmakedomain): Add explicit build dep on pyproject-rpm-macros (#4829)

### DIFF
--- a/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
+++ b/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
@@ -10,9 +10,12 @@ Summary:        Sphinx domain for modern CMake
 License:        BSD-3-Clause
 URL:            https://github.com/scikit-build/moderncmakedomain
 Source0:        %{pypi_source}
+BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(hatchling)
+%if 0%{?fedora}
 BuildRequires:  python3dist(nox)
+%endif
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
@@ -43,7 +46,11 @@ Modern CMake domain entries, originally from Kitware.
 %pyproject_install
 
 %check
+%if 0%{?rhel}
+%pytest tests/*.py
+%else
 nox -s tests
+%endif
 
 %files -n python3-%{real_name}
 %doc     PKG-INFO


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [chore(sphinxcontrib-moderncmakedomain): Add explicit build dep on pyproject-rpm-macros (#4829)](https://github.com/terrapkg/packages/pull/4829)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)