### PR TITLE
[f40] chore(protobuf): Bump on &lt;&#x3D; 41 (#4830)

### DIFF
--- a/anda/langs/python/protobuf/python3-protobuf.spec
+++ b/anda/langs/python/protobuf/python3-protobuf.spec
@@ -2,7 +2,7 @@
 %global pypi_name protobuf
 
 Name:           python-%{pypi_name}
-Version:        6.30.1
+Version:        6.30.2
 Release:        2%?dist
 Summary:        Protocol Buffers
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `f40`:
 - [chore(protobuf): Bump on &lt;&#x3D; 41 (#4830)](https://github.com/terrapkg/packages/pull/4830)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)