### PR TITLE
chore: Update spec to automatically handle Dracut, following Negativo

### DIFF
--- a/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
+++ b/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
@@ -69,6 +69,9 @@ fi ||:
 %triggerin -- nvidia-kmod
 dracut --regenerate-all --force
 
+%triggerin -- nvidia-open-kmod
+dracut --regenerate-all --force
+
 %files
 %doc MODULE_VARIANT.txt
 %{_modprobedir}/nvidia.conf

--- a/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
+++ b/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
@@ -25,6 +25,7 @@ Source21:       60-nvidia.rules
 # UDev rule location (_udevrulesdir) and systemd macros:
 BuildRequires:  systemd-rpm-macros
 
+Requires:       dracut
 Requires:       nvidia-modprobe
 Requires:       (nvidia-open-kmod = %{?epoch:%{epoch}:}%{version} or nvidia-kmod = %{?epoch:%{epoch}:}%{version})
 Provides:       nvidia-kmod-common = %{?epoch:%{epoch}:}%{version}
@@ -66,10 +67,7 @@ if [ "$1" -eq "2" ] && [ -x %{_bindir}/nvidia-boot-update ]; then
 
 fi ||:
 
-%triggerin -- nvidia-kmod
-dracut --regenerate-all --force
-
-%triggerin -- nvidia-open-kmod
+%triggerin -- nvidia-kmod,nvidia-open-kmod
 dracut --regenerate-all --force
 
 %files

--- a/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
+++ b/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
@@ -8,7 +8,7 @@
 
 Name:           nvidia-kmod-common
 Version:        570.144
-Release:        3%?dist
+Release:        4%?dist
 Summary:        Common file for NVIDIA's proprietary driver kernel modules
 Epoch:          3
 License:        NVIDIA License
@@ -65,6 +65,9 @@ if [ "$1" -eq "2" ] && [ -x %{_bindir}/nvidia-boot-update ]; then
   %{_bindir}/nvidia-boot-update preun
 
 fi ||:
+
+%triggerin -- nvidia-kmod
+dracut --regenerate-all --force
 
 %files
 %doc MODULE_VARIANT.txt


### PR DESCRIPTION
Is `Requires(triggerin)` a thing? /hj