### PR TITLE
[el10] fix(vvenc): Pull in upstreamed patches for i386 builds, re-enable X86 SIMD (#4838)

### DIFF
--- a/anda/multimedia/vvenc/vvenc.spec
+++ b/anda/multimedia/vvenc/vvenc.spec
@@ -2,7 +2,7 @@
 
 Name:           vvenc
 Version:        1.13.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        VVenC, the Fraunhofer Versatile Video Encoder
 License:        BSD-3-Clause
 URL:            https://github.com/fraunhoferhhi/%{name}
@@ -11,6 +11,7 @@ Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Fixes for i386/ARM32 builds
 Patch0:         %{url}/commit/ebce395254d9d7be7dc00cec7b49c7ed1d9eebec.patch
 Patch1:         %{url}/commit/bfd55ee783bfe30fc73f6f314b066b84bb1e5b60.patch
+Patch2:         %{url}/commit/982fcaac22488415899ae6c6ef7977a728a88e94.patch
 
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
@@ -50,10 +51,7 @@ developing applications that use %{name}.
 %build
 %cmake \
     -DCMAKE_SKIP_INSTALL_RPATH=OFF \
-    -DVVENC_INSTALL_FULLFEATURE_APP=ON \
-%ifarch %ix86
-    -DVVENC_ENABLE_X86_SIMD=FALSE
-%endif
+    -DVVENC_INSTALL_FULLFEATURE_APP=ON
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(vvenc): Pull in upstreamed patches for i386 builds, re-enable X86 SIMD (#4838)](https://github.com/terrapkg/packages/pull/4838)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)