### PR TITLE
[el10] chore: Bump packages on <= 41 (#4843)

### DIFF
--- a/anda/apps/discord-canary-openasar/discord-canary-openasar.spec
+++ b/anda/apps/discord-canary-openasar/discord-canary-openasar.spec
@@ -6,7 +6,7 @@
 %global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
 
 Name:           discord-canary-openasar
-Version:        0.0.665
+Version:        0.0.676
 Release:        1%?dist
 Summary:        A snappier Discord rewrite with features like further customization and theming
 License:        MIT AND https://discord.com/terms

--- a/anda/apps/discord-canary/discord-canary.spec
+++ b/anda/apps/discord-canary/discord-canary.spec
@@ -6,7 +6,7 @@
 %global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
 
 Name:           discord-canary
-Version:        0.0.665
+Version:        0.0.676
 Release:        1%?dist
 Summary:        Free Voice and Text Chat for Gamers
 URL:            discord.com

--- a/anda/desktops/lomiri-unity/lomiri-system-settings/lomiri-system-settings.spec
+++ b/anda/desktops/lomiri-unity/lomiri-system-settings/lomiri-system-settings.spec
@@ -1,5 +1,5 @@
 %global forgeurl https://gitlab.com/ubports/development/core/lomiri-system-settings
-%global commit 0c4242a1c48a46669e0fba78662df3afe560671b
+%global commit e0ea88f4f6f0f34d39112f4be455c339f11d3b3d
 %forgemeta
 
 Name:       lomiri-system-settings

--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -1,7 +1,7 @@
 %global __brp_mangle_shebangs %{nil}
 
 Name:           inputplumber
-Version:        0.55.0
+Version:        0.58.0
 Release:        1%?dist
 Summary:        Open source input router and remapper daemon for Linux
 License:        GPL-3.0-or-later

--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -1,7 +1,7 @@
 %define debug_package %nil
 
 Name:			crystal
-Version:		1.16.1
+Version:		1.16.3
 Release:		1%?dist
 Summary:		The Crystal Programming Language
 License:		Apache-2.0

--- a/anda/langs/kotlin/kotlin-native/kotlin-native.spec
+++ b/anda/langs/kotlin/kotlin-native/kotlin-native.spec
@@ -2,7 +2,7 @@
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Name:           kotlin-native
-Version:        2.1.20
+Version:        2.1.21
 Release:        1%?dist
 Summary:        LLVM backend for the Kotlin compiler
 ExclusiveArch:  x86_64

--- a/anda/langs/kotlin/kotlin/kotlin.spec
+++ b/anda/langs/kotlin/kotlin/kotlin.spec
@@ -1,7 +1,7 @@
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Name:           kotlin
-Version:        2.1.20
+Version:        2.1.21
 Release:        1%?dist
 Summary:        Statically typed programming language
 

--- a/anda/lib/tdlib/tdlib-nightly.spec
+++ b/anda/lib/tdlib/tdlib-nightly.spec
@@ -1,6 +1,6 @@
-%global commit d7831d9290d9208dd3e5d880d201cd8c8783ad69
-%global ver 1.8.47
-%global commit_date 20250430
+%global commit 1d6c95a77f156827909891f7a9715feb4ba71697
+%global ver 1.8.49
+%global commit_date 20250510
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:          tdlib-nightly


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `el10`:
 - [chore: Bump packages on <= 41 (#4843)](https://github.com/terrapkg/packages/pull/4843)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)