### PR TITLE
chore: Bump release of mesa-compat so it is higher than terra-mesa

### DIFF
--- a/anda/lib/mesa-compat/mesa-compat.spec
+++ b/anda/lib/mesa-compat/mesa-compat.spec
@@ -5,7 +5,7 @@
 Name:           %{origname}-compat
 Summary:        Mesa graphics libraries - legacy compatibility libraries
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        1%{?dist}
+Release:        3%{?dist}
 Epoch:          1
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org


### PR DESCRIPTION
I noticed a funny with `terra-mesa` packages getting pulled while building WINE.