### PR TITLE
[f41] add: Modern Colorthief (#4821)

### DIFF
--- a/anda/tools/modern-colorthief/anda.hcl
+++ b/anda/tools/modern-colorthief/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "modern-colorthief.spec"
+	}
+}

--- a/anda/tools/modern-colorthief/modern-colorthief.spec
+++ b/anda/tools/modern-colorthief/modern-colorthief.spec
@@ -1,0 +1,108 @@
+%global pypi_name modern_colorthief
+%bcond docs 0
+%bcond test 1
+
+# The srcrpm is not prefixed with Python because the source is mostly Rust
+Name:          modern-colorthief
+Version:       0.1.7
+Release:       1%{?dist}
+Summary:       ColorThief reimagined
+SourceLicense: MIT
+License:       (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
+URL:           https://modern-colorthief.readthedocs.io
+Source0:       %{pypi_source}
+BuildRequires: anda-srpm-macros
+BuildRequires: cargo
+BuildRequires: cargo-rpm-macros
+BuildRequires: maturin
+BuildRequires: mold
+BuildRequires: python3-devel
+BuildRequires: python3dist(pip)
+BuildRequires: python3dist(setuptools)
+%if %{with docs}
+BuildRequires: python3dist(modern-colorthief)
+BuildRequires: python3dist(myst-parser)
+BuildRequires: python3dist(shibuya)
+BuildRequires: python3dist(sphinx)
+%endif
+%if %{with test}
+%if 0%{?fedora} <= 42 
+BuildRequires: poetry
+# Colorthief does not exist on Rawhide?
+BuildRequires: python3dist(colorthief)
+BuildRequires: python3dist(poetry)
+%endif
+BuildRequires: python3dist(fast-colorthief)
+BuildRequires: python3dist(pytest)
+%endif
+
+%description
+Colorthief but with modern code.
+
+%package -n      python3-%{name}
+Summary:         %{summary}
+License:         MIT
+
+%description -n python3-%{name}
+Colorthief but with modern code.
+
+%if %{with docs}
+%package -n      python3-%{name}-doc
+Summary:         Doc files for Modern Colorthief
+License:         MIT
+BuildArch:       noarch
+
+%description -n python3-%{name}-doc
+Documentation for Modern Colorthief.
+%endif
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+%cargo_prep_online
+
+%build
+%pyproject_wheel
+
+%if %{with docs}
+# Generates the docs in all languages Sphinx can translate most or all of the docs for this project in
+for l in ca cs cy da de el en es et eu fa fr he hi hi_IN hr hu id it ja ko lt lv nb_NO nl pl pt pt_BR pt_PT ro ru sk sq sv tr zh_CN zh_TW; do
+sphinx-build docs html/$l -D language=$l
+# Remove the sphinx-build leftovers
+rm -rf html/$l/.{doctrees,buildinfo}
+done
+%endif
+
+%install
+%pyproject_install
+
+%{cargo_license_online} > LICENSE.dependencies
+
+%if %{with test}
+%check
+%pytest tests/*.py
+# Poetry Pytests will fail on Rawhide due to original Colorthief being missing
+%if 0%{?fedora} <= 42
+# This is in the wrong spot in pyproject.toml and Poetry hates it
+# May seem like defeating the purpose of testing but the other tests can be useful
+sed -iE 's/python = ">=3.9,<3.14"//' pyproject.toml
+poetry run pytest
+%endif
+%endif
+
+%files -n python3-%{name}
+%doc DIFFERENCES.md
+%doc PKG-INFO
+%doc README.md
+%license LICENSE
+%license LICENSE.dependencies
+%{python3_sitearch}/%{pypi_name}
+%{python3_sitearch}/%{pypi_name}-%{version}.dist-info
+
+%if %{with docs}
+%files -n python3-%{name}-doc
+%doc html/*
+%endif
+
+%changelog
+* Tue May 13 2025 Gilver E. <rockgrub@disroot.org> - 0.1.7-1
+- Initial package

--- a/anda/tools/modern-colorthief/modern-colorthief.spec
+++ b/anda/tools/modern-colorthief/modern-colorthief.spec
@@ -1,6 +1,6 @@
 %global pypi_name modern_colorthief
 %bcond docs 0
-%bcond test 1
+%bcond test 0
 
 # The srcrpm is not prefixed with Python because the source is mostly Rust
 Name:          modern-colorthief

--- a/anda/tools/modern-colorthief/update.rhai
+++ b/anda/tools/modern-colorthief/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("modern-colorthief"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: Modern Colorthief (#4821)](https://github.com/terrapkg/packages/pull/4821)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)