### PR TITLE
Switch EL10 mock configs to non-dev

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -69,7 +69,7 @@ jobs:
           dnf builddep -y ${dir}/*.spec
 
       - name: Build with Andaman
-        run: anda build ${{ matrix.pkg.pkg }} -c terra-el${{ matrix.version }}-dev-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
+        run: anda build ${{ matrix.pkg.pkg }} -c terra-el${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
 
       - name: Generating artifact name
         id: art

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -48,14 +48,14 @@ jobs:
         run: anda build anda/terra/release/pkg --rpm-builder=rpmbuild
 
       - name: Build Subatomic
-        run: anda build -c terra-el${{ matrix.version }}-dev-${{ matrix.arch }}.cfg anda/tools/buildsys/subatomic/pkg --rpm-builder=rpmbuild
+        run: anda build -c terra-el${{ matrix.version }}-${{ matrix.arch }}.cfg anda/tools/buildsys/subatomic/pkg --rpm-builder=rpmbuild
       - name: Install Subatomic and anda-srpm-macros
         run: dnf install -y ./anda-build/rpm/rpms/{subatomic,anda-srpm-macros}-*.rpm
 
       - name: Install Build Dependencies for Andaman
         run: dnf builddep -y anda/tools/buildsys/anda/*.spec
       - name: Build Andaman
-        run: anda build -c terra-el${{ matrix.version }}-dev-${{ matrix.arch }} anda/tools/buildsys/anda/pkg --rpm-builder=rpmbuild
+        run: anda build -c terra-el${{ matrix.version }}-${{ matrix.arch }} anda/tools/buildsys/anda/pkg --rpm-builder=rpmbuild
 
       - name: Upload packages to subatomic
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build with Andaman
-        run: anda build -c terra-el${{ matrix.version }}-dev-${{ matrix.arch }} anda/${{ matrix.pkg }}pkg
+        run: anda build -c terra-el${{ matrix.version }}-${{ matrix.arch }} anda/${{ matrix.pkg }}pkg
 
       - name: Generating artifact name
         id: art

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -41,7 +41,7 @@ jobs:
           dnf builddep -y ${dir}/*.spec
 
       - name: Build with Andaman
-        run: anda build ${{ matrix.pkg.pkg }} -c terra-el${{ matrix.version }}-dev-${{ matrix.pkg.arch }} ${{ contains(matrix.pkg.labels, 'mock') && '' || '-rrpmbuild' }}
+        run: anda build ${{ matrix.pkg.pkg }} -c terra-el${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ contains(matrix.pkg.labels, 'mock') && '' || '-rrpmbuild' }}
 
       - name: Generating artifact name
         id: art

--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -33,7 +33,7 @@ cp -v *.cfg %{buildroot}%{_sysconfdir}/mock/
 
 %files
 %config %{_sysconfdir}/mock/templates/terra.tpl
-%config %{_sysconfdir}/mock/templates/terra-el-dev.tpl
+%config %{_sysconfdir}/mock/templates/terra-el.tpl
 %config %{_sysconfdir}/mock/terra-*-x86_64.cfg
 %config %{_sysconfdir}/mock/terra-*-aarch64.cfg
 %config %{_sysconfdir}/mock/terra-*-i386.cfg

--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,6 +1,6 @@
 Name:           terra-mock-configs
 Version:        1.4.3
-Release:        2%?dist
+Release:        1%?dist
 Epoch:          1
 Summary:        Mock configs for Terra repos
 
@@ -27,13 +27,13 @@ Obsoletes: anda-mock-configs < 3-2%{?dist}
 mkdir -p %{buildroot}%{_sysusersdir}
 mkdir -p %{buildroot}%{_sysconfdir}/mock/templates
 
-# not copying terra-el-dev.tpl as we aren't using dev
-cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el.tpl
+# not copying terra-el.tpl as it might be a duplicate
+cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el-dev.tpl
 cp -v *.cfg %{buildroot}%{_sysconfdir}/mock/
 
 %files
 %config %{_sysconfdir}/mock/templates/terra.tpl
-%config %{_sysconfdir}/mock/templates/terra-el.tpl
+%config %{_sysconfdir}/mock/templates/terra-el-dev.tpl
 %config %{_sysconfdir}/mock/terra-*-x86_64.cfg
 %config %{_sysconfdir}/mock/terra-*-aarch64.cfg
 %config %{_sysconfdir}/mock/terra-*-i386.cfg

--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,6 +1,6 @@
 Name:           terra-mock-configs
 Version:        1.4.3
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        Mock configs for Terra repos
 
@@ -27,8 +27,8 @@ Obsoletes: anda-mock-configs < 3-2%{?dist}
 mkdir -p %{buildroot}%{_sysusersdir}
 mkdir -p %{buildroot}%{_sysconfdir}/mock/templates
 
-# not copying terra-el.tpl as that might be a duplicate
-cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el-dev.tpl
+# not copying terra-el-dev.tpl as we aren't using dev
+cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el.tpl
 cp -v *.cfg %{buildroot}%{_sysconfdir}/mock/
 
 %files

--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -27,7 +27,7 @@ Obsoletes: anda-mock-configs < 3-2%{?dist}
 mkdir -p %{buildroot}%{_sysusersdir}
 mkdir -p %{buildroot}%{_sysconfdir}/mock/templates
 
-# not copying terra-el.tpl as it might be a duplicate
+# not copying terra-el.tpl as that might be a duplicate
 cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el-dev.tpl
 cp -v *.cfg %{buildroot}%{_sysconfdir}/mock/
 


### PR DESCRIPTION
Don't merge this yet! This is part of a project to transition Terra EL10 over to Red Hat's UBI once RHEL10 is released. Merge this with https://github.com/terrapkg/mock-configs/pull/10 and https://github.com/terrapkg/builder/pull/7.