### PR TITLE
chore(modern-colorthief): pyproject-rpm-macros build dep

### DIFF
--- a/anda/tools/modern-colorthief/modern-colorthief.spec
+++ b/anda/tools/modern-colorthief/modern-colorthief.spec
@@ -17,6 +17,7 @@ BuildRequires: cargo-rpm-macros
 BuildRequires: maturin
 BuildRequires: mold
 BuildRequires: python3-devel
+BuildRequires: pyproject-rpm-macros
 BuildRequires: python3dist(pip)
 BuildRequires: python3dist(setuptools)
 %if %{with docs}


### PR DESCRIPTION
I forgot EL10 is different and doesn't automatically pull this as a dep of the other Python build packages.

Partner to a PR I am going to do for <= 42 to re-enable the tests so this backports cleanly once this package is merged on all branches.

Already fixed on EL10 itself, this is normalizing specs across all branches.