### PR TITLE
chore(.github/workflows/sync.yaml): Update to latest Action version

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,7 +23,7 @@ jobs:
           git config --global commit.gpgsign true
 
       - name: Backport Action
-        uses: sorenlouv/backport-github-action@v9.3.0
+        uses: sorenlouv/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.RABONEKO_BACKPORT_GITHUB_TOKEN }}
           auto_backport_label_prefix: sync-


### PR DESCRIPTION
Honestly I'm kinda just hoping some of the bugfixes make this thing work better.

I will revert if any issues arise.

I may have to manually backport this since the backport token seems to either not have the workflow scope or GitHub is broken again (I have actions fail in my own repos despite using my own token in them which absolutely has the workflow scope LOL).