### PR TITLE
[frawhide] chore: Add more patches for DOOM: The Dark Ages & Proton GE/Wine Wayland (#4878)

### DIFF
--- a/anda/lib/mesa/bazzite.patch
+++ b/anda/lib/mesa/bazzite.patch
@@ -1,7 +1,7 @@
 From aac6b04f39717f7363071f5500a89bb33e01cb33 Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Sat, 15 Mar 2025 16:39:08 +0100
-Subject: [PATCH 1/9] [BEGIN] SteamOS Changes
+Subject: [PATCH 01/12] [BEGIN] SteamOS Changes
 
 -- 
 2.49.0
@@ -10,7 +10,7 @@ Subject: [PATCH 1/9] [BEGIN] SteamOS Changes
 From 9fc35e8c53fe7e6c84b7da9ddff3d528f22ea4a9 Mon Sep 17 00:00:00 2001
 From: Bas Nieuwenhuizen <bas@basnieuwenhuizen.nl>
 Date: Fri, 14 Jan 2022 15:58:45 +0100
-Subject: [PATCH 2/9] STEAMOS: radv: min image count override for FH5
+Subject: [PATCH 02/12] STEAMOS: radv: min image count override for FH5
 
 Otherwise in combination with the vblank time reservation in
 gamescope the game could get stuck in low power states.
@@ -39,8 +39,8 @@ index aef8b9006cd..2a6b0ec84a4 100644
 From 09299a2cf516078ce9ed9786a49ea6f957ac6527 Mon Sep 17 00:00:00 2001
 From: Samuel Pitoiset <samuel.pitoiset@gmail.com>
 Date: Thu, 22 Feb 2024 22:32:45 +0100
-Subject: [PATCH 3/9] STEAMOS: Dynamic swapchain override for gamescope limiter
- for DRI3 only
+Subject: [PATCH 03/12] STEAMOS: Dynamic swapchain override for gamescope
+ limiter for DRI3 only
 
 The original patch (from Bas) contained WSI VK support too but it's
 been removed because the Gamescope WSI layer already handles that.
@@ -143,59 +143,28 @@ index 4da19d73090..819a0e548fc 100644
 2.49.0
 
 
-From d89154279b50afa429848b84624530f9e8771853 Mon Sep 17 00:00:00 2001
-From: Kyle Gospodnetich <me@kylegospodneti.ch>
-Date: Sun, 11 May 2025 13:30:57 -0700
-Subject: [PATCH 4/9] STEAMOS: Fixes for DOOM: The Dark Ages
-
----
- src/util/00-radv-defaults.conf | 7 +++++++
- 1 file changed, 7 insertions(+)
-
-diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
-index 2a6b0ec84a4..b28d9215b59 100644
---- a/src/util/00-radv-defaults.conf
-+++ b/src/util/00-radv-defaults.conf
-@@ -123,6 +123,13 @@ Application bugs worked around in this file:
-             <option name="radv_invariant_geom" value="true" />
-         </application>
- 
-+        <application name="DOOM: The Dark Ages" application_name_match="DOOMTheDarkAges">
-+            <option name="radv_force_64k_sparse_alignment" value="true" />
-+            <option name="radv_zero_vram" value="true" />
-+            <option name="radv_legacy_sparse_binding" value="true" />
-+            <option name="radv_disable_dcc_stores" value="true" />
-+        </application>
-+
-         <application name="Wolfenstein II" application_name_match="Wolfenstein II The New Colossus">
-             <option name="radv_disable_dcc" value="true" />
-         </application>
--- 
-2.49.0
-
-
-From 614a06238ee1219c1dd2bbcb5cca6b3ab4bc574c Mon Sep 17 00:00:00 2001
+From 379efbce79f2ca73d34ec48b10e28942be3ed1be Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Sat, 15 Mar 2025 16:39:25 +0100
-Subject: [PATCH 5/9] [BEGIN] SteamOS Backports
+Subject: [PATCH 04/12] [BEGIN] SteamOS Backports
 
 -- 
 2.49.0
 
 
-From 5177e8134f047f38d2fe1e0f3608323d02db3cc2 Mon Sep 17 00:00:00 2001
+From a4ac8f2bcd23eb4194adfe41117d4e168ffc6ddd Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Sat, 15 Mar 2025 16:39:33 +0100
-Subject: [PATCH 6/9] [BEGIN] Our Mesa backports
+Subject: [PATCH 05/12] [BEGIN] Our Mesa backports
 
 -- 
 2.49.0
 
 
-From 045d4757aaf29dcb8ed4d81f575e331a017317ed Mon Sep 17 00:00:00 2001
+From 7286b058c851688929bd145116c61872d06d81c8 Mon Sep 17 00:00:00 2001
 From: Maarten Lankhorst <maarten.lankhorst@intel.com>
 Date: Mon, 17 Feb 2025 14:55:29 -0800
-Subject: [PATCH 7/9] anv: Mark images with format modifiers set as scanout.
+Subject: [PATCH 06/12] anv: Mark images with format modifiers set as scanout.
 
 We currently use the presence of struct WSI_IMAGE_CREATE_INFO_MESA.scanout to mark the BO as scanout,
 but this only handles the linear case, and fails when drm format modifiers are used.
@@ -230,10 +199,10 @@ index 0fb86e9d846..de37994d324 100644
 2.49.0
 
 
-From d08d3f395ecfa666763f7a8dac0543c52325294c Mon Sep 17 00:00:00 2001
+From 643137e1f57b1c89451a77edec40565e6084e2e1 Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Mon, 24 Mar 2025 19:50:51 +0100
-Subject: [PATCH 8/9] Revert "winsys/amdgpu: use VM_ALWAYS_VALID for all VRAM
+Subject: [PATCH 07/12] Revert "winsys/amdgpu: use VM_ALWAYS_VALID for all VRAM
  and GTT allocations"
 
 This reverts commit 8c91624614c1f939974fe0d2d1a3baf83335cecb.
@@ -263,11 +232,652 @@ index dfefc468bca..cc0719a1898 100644
 2.49.0
 
 
-From 54cf223f100a114680f51f43f5dfc632eeeefb3b Mon Sep 17 00:00:00 2001
+From e38d54fb349d78b10ca5000add7cd97bf921323a Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Wed, 7 May 2025 18:50:48 +0200
-Subject: [PATCH 9/9] [BEGIN] Intel DX12 fix
+Subject: [PATCH 08/12] [BEGIN] Intel DX12 fix
 
+-- 
+2.49.0
+
+
+From cb2c3290e03518f90e13e83f68edea63c9c6c0cf Mon Sep 17 00:00:00 2001
+From: Kyle Gospodnetich <me@kylegospodneti.ch>
+Date: Sun, 18 May 2025 09:40:01 -0700
+Subject: [PATCH 09/12] [BEGIN] Proton-GE Patches
+
+-- 
+2.49.0
+
+
+From 24d4a18ec695dbdc4fba33eee941dcca49a9a106 Mon Sep 17 00:00:00 2001
+From: Kyle Gospodnetich <me@kylegospodneti.ch>
+Date: Sun, 18 May 2025 09:41:21 -0700
+Subject: [PATCH 10/12] radv,driconf: Add radv_force_64k_sparse_alignment
+ config
+
+---
+ src/amd/vulkan/radv_buffer.c   | 6 +++++-
+ src/amd/vulkan/radv_instance.c | 3 +++
+ src/amd/vulkan/radv_instance.h | 1 +
+ src/util/00-radv-defaults.conf | 7 +++++++
+ src/util/driconf.h             | 3 +++
+ 5 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/src/amd/vulkan/radv_buffer.c b/src/amd/vulkan/radv_buffer.c
+index 88111750517..8ef575f8246 100644
+--- a/src/amd/vulkan/radv_buffer.c
++++ b/src/amd/vulkan/radv_buffer.c
+@@ -167,6 +167,7 @@ radv_get_buffer_memory_requirements(struct radv_device *device, VkDeviceSize siz
+                                     VkBufferUsageFlags2 usage, VkMemoryRequirements2 *pMemoryRequirements)
+ {
+    const struct radv_physical_device *pdev = radv_device_physical(device);
++   const struct radv_instance *instance = radv_physical_device_instance(pdev);
+ 
+    pMemoryRequirements->memoryRequirements.memoryTypeBits =
+       ((1u << pdev->memory_properties.memoryTypeCount) - 1u) & ~pdev->memory_types_32bit;
+@@ -179,7 +180,10 @@ radv_get_buffer_memory_requirements(struct radv_device *device, VkDeviceSize siz
+       pMemoryRequirements->memoryRequirements.memoryTypeBits = pdev->memory_types_32bit;
+ 
+    if (flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
+-      pMemoryRequirements->memoryRequirements.alignment = 4096;
++      if (instance->drirc.force_64k_sparse_alignment)
++         pMemoryRequirements->memoryRequirements.alignment = 65536;
++      else
++         pMemoryRequirements->memoryRequirements.alignment = 4096;
+    } else {
+       if (usage & VK_BUFFER_USAGE_2_PREPROCESS_BUFFER_BIT_EXT)
+          pMemoryRequirements->memoryRequirements.alignment = radv_dgc_get_buffer_alignment(device);
+diff --git a/src/amd/vulkan/radv_instance.c b/src/amd/vulkan/radv_instance.c
+index 7aebf073dfd..15a3f710502 100644
+--- a/src/amd/vulkan/radv_instance.c
++++ b/src/amd/vulkan/radv_instance.c
+@@ -194,6 +194,7 @@ static const driOptionDescription radv_dri_options[] = {
+       DRI_CONF_RADV_APP_LAYER()
+       DRI_CONF_RADV_EMULATE_RT(false)
+       DRI_CONF_RADV_ENABLE_FLOAT16_GFX8(false)
++      DRI_CONF_RADV_FORCE_64K_SPARSE_ALIGNMENT(false)
+    DRI_CONF_SECTION_END
+ };
+ // clang-format on
+@@ -298,6 +299,8 @@ radv_init_dri_options(struct radv_instance *instance)
+    instance->drirc.emulate_rt = driQueryOptionb(&instance->drirc.options, "radv_emulate_rt");
+ 
+    instance->drirc.expose_float16_gfx8 = driQueryOptionb(&instance->drirc.options, "radv_enable_float16_gfx8");
++
++   instance->drirc.force_64k_sparse_alignment = driQueryOptionb(&instance->drirc.options, "radv_force_64k_sparse_alignment");
+ }
+ 
+ static const struct vk_instance_extension_table radv_instance_extensions_supported = {
+diff --git a/src/amd/vulkan/radv_instance.h b/src/amd/vulkan/radv_instance.h
+index d0f23404285..81c4921222e 100644
+--- a/src/amd/vulkan/radv_instance.h
++++ b/src/amd/vulkan/radv_instance.h
+@@ -74,6 +74,7 @@ struct radv_instance {
+       bool lower_terminate_to_discard;
+       bool emulate_rt;
+       bool expose_float16_gfx8;
++      bool force_64k_sparse_alignment;
+       char *app_layer;
+       uint8_t override_graphics_shader_version;
+       uint8_t override_compute_shader_version;
+diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
+index 2a6b0ec84a4..595a435802f 100644
+--- a/src/util/00-radv-defaults.conf
++++ b/src/util/00-radv-defaults.conf
+@@ -123,6 +123,13 @@ Application bugs worked around in this file:
+             <option name="radv_invariant_geom" value="true" />
+         </application>
+ 
++        <application name="DOOM: The Dark Ages" application_name_match="DOOMTheDarkAges">
++            <option name="radv_force_64k_sparse_alignment" value="true" />
++            <option name="radv_zero_vram" value="true" />
++            <option name="radv_disable_dedicated_sparse_queue" value="true" />
++            <option name="radv_disable_dcc_stores" value="true" />
++        </application>
++
+         <application name="Wolfenstein II" application_name_match="Wolfenstein II The New Colossus">
+             <option name="radv_disable_dcc" value="true" />
+         </application>
+diff --git a/src/util/driconf.h b/src/util/driconf.h
+index 5b0481912c8..26f7ca0b551 100644
+--- a/src/util/driconf.h
++++ b/src/util/driconf.h
+@@ -834,6 +834,9 @@
+    DRI_CONF_OPT_B(radv_enable_float16_gfx8, def, \
+                   "Expose float16 on GFX8, where it's supported but usually not beneficial.")
+ 
++#define DRI_CONF_RADV_FORCE_64K_SPARSE_ALIGNMENT(def) \
++   DRI_CONF_OPT_B(radv_force_64k_sparse_alignment, def, \
++                  "Force the alignment of sparse buffers to 64KiB")
+ /**
+  * \brief ANV specific configuration options
+  */
+-- 
+2.49.0
+
+
+From 06e57ae464ad6a373808a132e096d6a7bc137dfb Mon Sep 17 00:00:00 2001
+From: Kyle Gospodnetich <me@kylegospodneti.ch>
+Date: Sun, 18 May 2025 09:42:23 -0700
+Subject: [PATCH 11/12] radv: min image count patch for Wine Wayland/Path of
+ Exile 2 Credit to Glorious Eggroll.
+
+---
+ src/amd/vulkan/radv_instance.c       |  2 +-
+ src/asahi/vulkan/hk_instance.c       |  2 +-
+ src/freedreno/vulkan/tu_device.cc    |  2 +-
+ src/intel/vulkan/anv_instance.c      |  2 +-
+ src/intel/vulkan_hasvk/anv_device.c  |  2 +-
+ src/nouveau/vulkan/nvk_instance.c    |  2 +-
+ src/panfrost/vulkan/panvk_instance.c |  2 +-
+ src/util/00-mesa-defaults.conf       | 10 ++++++----
+ src/util/driconf.h                   |  4 ++--
+ src/virtio/vulkan/vn_instance.c      |  2 +-
+ src/vulkan/wsi/wsi_common.c          |  2 +-
+ src/vulkan/wsi/wsi_common.h          |  4 ++++
+ src/vulkan/wsi/wsi_common_private.h  |  3 ++-
+ src/vulkan/wsi/wsi_common_wayland.c  | 21 +++++++++++++++++----
+ src/vulkan/wsi/wsi_common_x11.c      |  4 ++--
+ 15 files changed, 42 insertions(+), 22 deletions(-)
+
+diff --git a/src/amd/vulkan/radv_instance.c b/src/amd/vulkan/radv_instance.c
+index 15a3f710502..a6af9d67db0 100644
+--- a/src/amd/vulkan/radv_instance.c
++++ b/src/amd/vulkan/radv_instance.c
+@@ -148,7 +148,7 @@ static const struct debug_control trace_options[] = {
+ static const driOptionDescription radv_dri_options[] = {
+    DRI_CONF_SECTION_PERFORMANCE
+       DRI_CONF_ADAPTIVE_SYNC(true)
+-      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
++      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
+       DRI_CONF_VK_KHR_PRESENT_WAIT(false)
+diff --git a/src/asahi/vulkan/hk_instance.c b/src/asahi/vulkan/hk_instance.c
+index 4be7a763da7..f1171053e0b 100644
+--- a/src/asahi/vulkan/hk_instance.c
++++ b/src/asahi/vulkan/hk_instance.c
+@@ -80,7 +80,7 @@ hk_EnumerateInstanceExtensionProperties(const char *pLayerName,
+ static const driOptionDescription hk_dri_options[] = {
+    DRI_CONF_SECTION_PERFORMANCE
+       DRI_CONF_ADAPTIVE_SYNC(true)
+-      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
++      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
+       DRI_CONF_VK_KHR_PRESENT_WAIT(false)
+diff --git a/src/freedreno/vulkan/tu_device.cc b/src/freedreno/vulkan/tu_device.cc
+index 50b9b322ad4..8d7ab456a87 100644
+--- a/src/freedreno/vulkan/tu_device.cc
++++ b/src/freedreno/vulkan/tu_device.cc
+@@ -1623,7 +1623,7 @@ tu_destroy_physical_device(struct vk_physical_device *device)
+ 
+ static const driOptionDescription tu_dri_options[] = {
+    DRI_CONF_SECTION_PERFORMANCE
+-      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
++      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_KHR_PRESENT_WAIT(false)
+       DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
+diff --git a/src/intel/vulkan/anv_instance.c b/src/intel/vulkan/anv_instance.c
+index d478c2d52cd..e4ee0aa51ca 100644
+--- a/src/intel/vulkan/anv_instance.c
++++ b/src/intel/vulkan/anv_instance.c
+@@ -10,7 +10,7 @@
+ static const driOptionDescription anv_dri_options[] = {
+    DRI_CONF_SECTION_PERFORMANCE
+       DRI_CONF_ADAPTIVE_SYNC(true)
+-      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
++      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_KHR_PRESENT_WAIT(false)
+       DRI_CONF_VK_XWAYLAND_WAIT_READY(false)
+diff --git a/src/intel/vulkan_hasvk/anv_device.c b/src/intel/vulkan_hasvk/anv_device.c
+index fd4f4c73a33..3cba9ac23ef 100644
+--- a/src/intel/vulkan_hasvk/anv_device.c
++++ b/src/intel/vulkan_hasvk/anv_device.c
+@@ -65,7 +65,7 @@
+ static const driOptionDescription anv_dri_options[] = {
+    DRI_CONF_SECTION_PERFORMANCE
+       DRI_CONF_ADAPTIVE_SYNC(true)
+-      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
++      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_KHR_PRESENT_WAIT(false)
+       DRI_CONF_VK_XWAYLAND_WAIT_READY(true)
+diff --git a/src/nouveau/vulkan/nvk_instance.c b/src/nouveau/vulkan/nvk_instance.c
+index 8c7d9050063..3966dab52c5 100644
+--- a/src/nouveau/vulkan/nvk_instance.c
++++ b/src/nouveau/vulkan/nvk_instance.c
+@@ -103,7 +103,7 @@ nvk_init_debug_flags(struct nvk_instance *instance)
+ static const driOptionDescription nvk_dri_options[] = {
+    DRI_CONF_SECTION_PERFORMANCE
+       DRI_CONF_ADAPTIVE_SYNC(true)
+-      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
++      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
+       DRI_CONF_VK_KHR_PRESENT_WAIT(false)
+diff --git a/src/panfrost/vulkan/panvk_instance.c b/src/panfrost/vulkan/panvk_instance.c
+index a87abdd4c7c..836f91bad40 100644
+--- a/src/panfrost/vulkan/panvk_instance.c
++++ b/src/panfrost/vulkan/panvk_instance.c
+@@ -151,7 +151,7 @@ panvk_kmod_free(const struct pan_kmod_allocator *allocator, void *data)
+ static const driOptionDescription panvk_dri_options[] = {
+    DRI_CONF_SECTION_PERFORMANCE
+       DRI_CONF_ADAPTIVE_SYNC(true)
+-      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
++      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
+       DRI_CONF_VK_KHR_PRESENT_WAIT(false)
+diff --git a/src/util/00-mesa-defaults.conf b/src/util/00-mesa-defaults.conf
+index 082add17d58..31e8b277bd7 100644
+--- a/src/util/00-mesa-defaults.conf
++++ b/src/util/00-mesa-defaults.conf
+@@ -616,24 +616,24 @@ TODO: document the other workarounds.
+ 
+         <application name="gfxbench" executable="testfw_app">
+             <option name="mesa_glthread_app_profile" value="0" />
+-            <option name="vk_x11_override_min_image_count" value="2" />
++            <option name="vk_override_min_image_count" value="2" />
+             <option name="vk_wsi_force_bgra8_unorm_first" value="true" />
+         </application>
+ 
+         <application name="Rainbow Six Siege (Vulkan)" executable="RainbowSix_Vulkan.exe">
+-            <option name="vk_x11_override_min_image_count" value="2" />
++            <option name="vk_override_min_image_count" value="2" />
+             <option name="vk_x11_strict_image_count" value="true" />
+         </application>
+ 
+         <application name="Rainbow Six Extraction (Wine)" executable="R6-Extraction.exe">
+-            <option name="vk_x11_override_min_image_count" value="2" />
++            <option name="vk_override_min_image_count" value="2" />
+             <option name="vk_x11_strict_image_count" value="true" />
+         </application>
+ 
+         <!-- Workaround for Hades: Vulkan backend of the game is not starting
+              if the implementation returns more than 3 swapchain images. -->
+         <application name="Hades" executable="Hades.exe">
+-            <option name="vk_x11_override_min_image_count" value="3" />
++            <option name="vk_override_min_image_count" value="3" />
+             <option name="vk_x11_strict_image_count" value="true" />
+         </application>
+ 
+@@ -694,10 +694,12 @@ TODO: document the other workarounds.
+ 
+         <application name="Path of Exile" executable="PathOfExile_x64Steam.exe">
+             <option name="vk_zero_vram" value="true" />
++            <option name="vk_override_min_image_count" value="3" />
+         </application>
+ 
+         <application name="Path of Exile" executable="PathOfExileSteam.exe">
+             <option name="vk_zero_vram" value="true" />
++            <option name="vk_override_min_image_count" value="3" />
+         </application>
+ 
+         <application name="X4 Foundations" executable="X4.exe">
+diff --git a/src/util/driconf.h b/src/util/driconf.h
+index 26f7ca0b551..5ced93ddede 100644
+--- a/src/util/driconf.h
++++ b/src/util/driconf.h
+@@ -445,8 +445,8 @@
+    DRI_CONF_OPT_B(vk_wsi_force_swapchain_to_current_extent, def, \
+                   "Force VkSwapchainCreateInfoKHR::imageExtent to be VkSurfaceCapabilities2KHR::currentExtent")
+ 
+-#define DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(def) \
+-   DRI_CONF_OPT_I(vk_x11_override_min_image_count, def, 0, 999, \
++#define DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(def) \
++   DRI_CONF_OPT_I(vk_override_min_image_count, def, 0, 999, \
+                   "Override the VkSurfaceCapabilitiesKHR::minImageCount (0 = no override)")
+ 
+ #define DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(def) \
+diff --git a/src/virtio/vulkan/vn_instance.c b/src/virtio/vulkan/vn_instance.c
+index a843b463e84..4de75ceb8af 100644
+--- a/src/virtio/vulkan/vn_instance.c
++++ b/src/virtio/vulkan/vn_instance.c
+@@ -70,8 +70,8 @@ static const struct vk_instance_extension_table
+ static const driOptionDescription vn_dri_options[] = {
+    /* clang-format off */
+    DRI_CONF_SECTION_PERFORMANCE
++      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
+-      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
+       DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_XWAYLAND_WAIT_READY(true)
+       DRI_CONF_VENUS_IMPLICIT_FENCING(false)
+diff --git a/src/vulkan/wsi/wsi_common.c b/src/vulkan/wsi/wsi_common.c
+index 05a247181cf..b0fb88bf2d6 100644
+--- a/src/vulkan/wsi/wsi_common.c
++++ b/src/vulkan/wsi/wsi_common.c
+@@ -219,7 +219,7 @@ wsi_device_init(struct wsi_device *wsi,
+ #endif
+ 
+ #ifdef VK_USE_PLATFORM_WAYLAND_KHR
+-   result = wsi_wl_init_wsi(wsi, alloc, pdevice);
++   result = wsi_wl_init_wsi(wsi, alloc, pdevice, dri_options);
+    if (result != VK_SUCCESS)
+       goto fail;
+ #endif
+diff --git a/src/vulkan/wsi/wsi_common.h b/src/vulkan/wsi/wsi_common.h
+index 08c1438cb1f..f12f57e70e0 100644
+--- a/src/vulkan/wsi/wsi_common.h
++++ b/src/vulkan/wsi/wsi_common.h
+@@ -209,6 +209,10 @@ struct wsi_device {
+    struct {
+       /* Don't use the commit-timing protocol for pacing */
+       bool disable_timestamps;
++
++      /* Override the minimum number of images on the swapchain.
++       * 0 = no override */
++      double override_minImageCount;
+    } wayland;
+ 
+    /*
+diff --git a/src/vulkan/wsi/wsi_common_private.h b/src/vulkan/wsi/wsi_common_private.h
+index 51bfa77d4b2..593743c8b0e 100644
+--- a/src/vulkan/wsi/wsi_common_private.h
++++ b/src/vulkan/wsi/wsi_common_private.h
+@@ -413,7 +413,8 @@ void wsi_x11_finish_wsi(struct wsi_device *wsi_device,
+                         const VkAllocationCallbacks *alloc);
+ VkResult wsi_wl_init_wsi(struct wsi_device *wsi_device,
+                          const VkAllocationCallbacks *alloc,
+-                         VkPhysicalDevice physical_device);
++                         VkPhysicalDevice physical_device,
++                         const struct driOptionCache *dri_options);
+ void wsi_wl_finish_wsi(struct wsi_device *wsi_device,
+                        const VkAllocationCallbacks *alloc);
+ VkResult wsi_win32_init_wsi(struct wsi_device *wsi_device,
+diff --git a/src/vulkan/wsi/wsi_common_wayland.c b/src/vulkan/wsi/wsi_common_wayland.c
+index 6be46f49d14..1f1adf4ddf9 100644
+--- a/src/vulkan/wsi/wsi_common_wayland.c
++++ b/src/vulkan/wsi/wsi_common_wayland.c
+@@ -58,6 +58,7 @@
+ #include <util/u_dynarray.h>
+ #include <util/anon_file.h>
+ #include <util/os_time.h>
++#include <util/xmlconfig.h>
+ 
+ #include <loader/loader_wayland_helper.h>
+ 
+@@ -1683,9 +1684,12 @@ wsi_wl_surface_get_support(VkIcdSurfaceBase *surface,
+ #define WSI_WL_DEFAULT_NUM_IMAGES 3
+ 
+ static uint32_t
+-wsi_wl_surface_get_min_image_count(struct wsi_wl_display *display,
++wsi_wl_surface_get_min_image_count(struct wsi_device *wsi_device, struct wsi_wl_display *display,
+                                    const VkSurfacePresentModeEXT *present_mode)
+ {
++   if (wsi_device->wayland.override_minImageCount)
++      return wsi_device->wayland.override_minImageCount;
++
+    if (present_mode) {
+       return present_mode->presentMode == VK_PRESENT_MODE_MAILBOX_KHR ?
+              WSI_WL_BUMPED_NUM_IMAGES : WSI_WL_DEFAULT_NUM_IMAGES;
+@@ -1734,7 +1738,7 @@ wsi_wl_surface_get_capabilities(VkIcdSurfaceBase *icd_surface,
+       display = &temp_display;
+    }
+ 
+-   caps->minImageCount = wsi_wl_surface_get_min_image_count(display, present_mode);
++   caps->minImageCount = wsi_wl_surface_get_min_image_count(wsi_device, display, present_mode);
+ 
+    if (!wsi_wl_surface->display)
+       wsi_wl_display_finish(&temp_display);
+@@ -3496,7 +3500,7 @@ wsi_wl_surface_create_swapchain(VkIcdSurfaceBase *icd_surface,
+       const VkSurfacePresentModeEXT mode =
+             { VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_EXT, NULL, pCreateInfo->presentMode };
+ 
+-      uint32_t min_images = wsi_wl_surface_get_min_image_count(wsi_wl_surface->display, &mode);
++      uint32_t min_images = wsi_wl_surface_get_min_image_count(wsi_device, wsi_wl_surface->display, &mode);
+       bool requires_image_count_bump = min_images == WSI_WL_BUMPED_NUM_IMAGES;
+       if (requires_image_count_bump)
+          num_images = MAX2(min_images, num_images);
+@@ -3684,7 +3688,8 @@ fail:
+ VkResult
+ wsi_wl_init_wsi(struct wsi_device *wsi_device,
+                 const VkAllocationCallbacks *alloc,
+-                VkPhysicalDevice physical_device)
++                VkPhysicalDevice physical_device,
++                const struct driOptionCache *dri_options)
+ {
+    struct wsi_wayland *wsi;
+    VkResult result;
+@@ -3710,6 +3715,14 @@ wsi_wl_init_wsi(struct wsi_device *wsi_device,
+ 
+    wsi_device->wsi[VK_ICD_WSI_PLATFORM_WAYLAND] = &wsi->base;
+ 
++   if (dri_options)
++   {
++      if (driCheckOption(dri_options, "vk_override_min_image_count", DRI_INT)) {
++         wsi_device->wayland.override_minImageCount =
++            driQueryOptioni(dri_options, "vk_override_min_image_count");
++      }
++   }
++
+    return VK_SUCCESS;
+ 
+ fail:
+diff --git a/src/vulkan/wsi/wsi_common_x11.c b/src/vulkan/wsi/wsi_common_x11.c
+index 65b7fdf7212..ea5d3750f46 100644
+--- a/src/vulkan/wsi/wsi_common_x11.c
++++ b/src/vulkan/wsi/wsi_common_x11.c
+@@ -2876,9 +2876,9 @@ wsi_x11_init_wsi(struct wsi_device *wsi_device,
+    }
+ 
+    if (dri_options) {
+-      if (driCheckOption(dri_options, "vk_x11_override_min_image_count", DRI_INT)) {
++      if (driCheckOption(dri_options, "vk_override_min_image_count", DRI_INT)) {
+          wsi_device->x11.override_minImageCount =
+-            driQueryOptioni(dri_options, "vk_x11_override_min_image_count");
++            driQueryOptioni(dri_options, "vk_override_min_image_count");
+       }
+       if (driCheckOption(dri_options, "vk_x11_strict_image_count", DRI_BOOL)) {
+          wsi_device->x11.strict_imageCount =
+-- 
+2.49.0
+
+
+From 71a603439c89eb97a0cedf9733dbd4202294175a Mon Sep 17 00:00:00 2001
+From: Kyle Gospodnetich <me@kylegospodneti.ch>
+Date: Sun, 18 May 2025 09:59:41 -0700
+Subject: [PATCH 12/12] vulkan/wsi/wayland: Move drm syncobj to swapchain
+
+---
+ src/vulkan/wsi/wsi_common_wayland.c | 81 +++++++++++++++--------------
+ 1 file changed, 43 insertions(+), 38 deletions(-)
+
+diff --git a/src/vulkan/wsi/wsi_common_wayland.c b/src/vulkan/wsi/wsi_common_wayland.c
+index 1f1adf4ddf9..12c7b5256f9 100644
+--- a/src/vulkan/wsi/wsi_common_wayland.c
++++ b/src/vulkan/wsi/wsi_common_wayland.c
+@@ -194,13 +194,9 @@ struct wsi_wl_surface {
+    struct zwp_linux_dmabuf_feedback_v1 *wl_dmabuf_feedback;
+    struct dmabuf_feedback dmabuf_feedback, pending_dmabuf_feedback;
+ 
+-   struct wp_linux_drm_syncobj_surface_v1 *wl_syncobj_surface;
+-
+    struct vk_instance *instance;
+ 
+    struct {
+-      struct wp_color_management_surface_v1 *color_surface;
+-      int color_surface_refcount;
+       VkColorSpaceKHR colorspace;
+       VkHdrMetadataEXT hdr_metadata;
+       bool has_hdr_metadata;
+@@ -214,6 +210,7 @@ struct wsi_wl_swapchain {
+    struct wp_tearing_control_v1 *tearing_control;
+    struct wp_fifo_v1 *fifo;
+    struct wp_commit_timer_v1 *commit_timer;
++   struct wp_linux_drm_syncobj_surface_v1 *wl_syncobj_surface;
+ 
+    struct wl_callback *frame;
+ 
+@@ -256,6 +253,8 @@ struct wsi_wl_swapchain {
+    } present_ids;
+ 
+    struct {
++      struct wp_color_management_surface_v1 *color_surface;
++      int color_surface_refcount;
+       VkColorSpaceKHR colorspace;
+       VkHdrMetadataEXT hdr_metadata;
+       bool has_hdr_metadata;
+@@ -1154,22 +1153,23 @@ needs_color_surface(struct wsi_wl_display *display, VkColorSpaceKHR colorspace)
+ }
+ 
+ static void
+-wsi_wl_surface_add_color_refcount(struct wsi_wl_surface *wsi_surface)
++wsi_wl_swapchain_add_color_refcount(struct wsi_wl_swapchain *wsi_swapchain)
+ {
+-   wsi_surface->color.color_surface_refcount++;
+-   if (wsi_surface->color.color_surface_refcount == 1) {
+-      wsi_surface->color.color_surface =
++   const struct wsi_wl_surface *wsi_surface = wsi_swapchain->wsi_wl_surface;
++   wsi_swapchain->color.color_surface_refcount++;
++   if (wsi_swapchain->color.color_surface_refcount == 1) {
++      wsi_swapchain->color.color_surface =
+          wp_color_manager_v1_get_surface(wsi_surface->display->color_manager, wsi_surface->surface);
+    }
+ }
+ 
+ static void
+-wsi_wl_surface_remove_color_refcount(struct wsi_wl_surface *wsi_surface)
++wsi_wl_swapchain_remove_color_refcount(struct wsi_wl_swapchain *wsi_swapchain)
+ {
+-   wsi_surface->color.color_surface_refcount--;
+-   if (wsi_surface->color.color_surface_refcount == 0) {
+-      wp_color_management_surface_v1_destroy(wsi_surface->color.color_surface);
+-      wsi_surface->color.color_surface = NULL;
++   wsi_swapchain->color.color_surface_refcount--;
++   if (wsi_swapchain->color.color_surface_refcount == 0) {
++      wp_color_management_surface_v1_destroy(wsi_swapchain->color.color_surface);
++      wsi_swapchain->color.color_surface = NULL;
+    }
+ }
+ 
+@@ -1237,13 +1237,14 @@ wsi_wl_swapchain_update_colorspace(struct wsi_wl_swapchain *chain)
+       }
+    }
+ 
+-   bool new_color_surface = !surface->color.color_surface;
++   bool new_color_surface = !chain->color.color_surface;
+    bool needs_color_surface_new = needs_color_surface(display, chain->color.colorspace);
+-   bool needs_color_surface_old = needs_color_surface(display, surface->color.colorspace);
++   bool needs_color_surface_old = chain->color.color_surface &&
++      needs_color_surface(display, chain->color.colorspace);
+    if ((new_color_surface || !needs_color_surface_old) && needs_color_surface_new) {
+-      wsi_wl_surface_add_color_refcount(surface);
++      wsi_wl_swapchain_add_color_refcount(chain);
+    } else if (needs_color_surface_old && !needs_color_surface_new) {
+-      wsi_wl_surface_remove_color_refcount(surface);
++      wsi_wl_swapchain_remove_color_refcount(chain);
+    }
+ 
+    struct wayland_hdr_metadata wayland_hdr_metadata = {
+@@ -1349,7 +1350,7 @@ wsi_wl_swapchain_update_colorspace(struct wsi_wl_swapchain *chain)
+       }
+    }
+ 
+-   wp_color_management_surface_v1_set_image_description(chain->wsi_wl_surface->color.color_surface,
++   wp_color_management_surface_v1_set_image_description(chain->color.color_surface,
+                                                         image_desc,
+                                                         WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL);
+    wp_image_description_v1_destroy(image_desc);
+@@ -2025,18 +2026,12 @@ wsi_wl_surface_destroy(VkIcdSurfaceBase *icd_surface, VkInstance _instance,
+    struct wsi_wl_surface *wsi_wl_surface =
+       wl_container_of((VkIcdSurfaceWayland *)icd_surface, wsi_wl_surface, base);
+ 
+-   if (wsi_wl_surface->wl_syncobj_surface)
+-      wp_linux_drm_syncobj_surface_v1_destroy(wsi_wl_surface->wl_syncobj_surface);
+-
+    if (wsi_wl_surface->wl_dmabuf_feedback) {
+       zwp_linux_dmabuf_feedback_v1_destroy(wsi_wl_surface->wl_dmabuf_feedback);
+       dmabuf_feedback_fini(&wsi_wl_surface->dmabuf_feedback);
+       dmabuf_feedback_fini(&wsi_wl_surface->pending_dmabuf_feedback);
+    }
+ 
+-   if (wsi_wl_surface->color.color_surface)
+-      wp_color_management_surface_v1_destroy(wsi_wl_surface->color.color_surface);
+-
+    if (wsi_wl_surface->surface)
+       wl_proxy_wrapper_destroy(wsi_wl_surface->surface);
+ 
+@@ -2314,15 +2309,6 @@ static VkResult wsi_wl_surface_init(struct wsi_wl_surface *wsi_wl_surface,
+                                  wsi_wl_surface->display->queue);
+    }
+ 
+-   if (wsi_wl_use_explicit_sync(wsi_wl_surface->display, wsi_device)) {
+-      wsi_wl_surface->wl_syncobj_surface =
+-         wp_linux_drm_syncobj_manager_v1_get_surface(wsi_wl_surface->display->wl_syncobj,
+-                                                     wsi_wl_surface->surface);
+-
+-      if (!wsi_wl_surface->wl_syncobj_surface)
+-         goto fail;
+-   }
+-
+    wsi_wl_surface_analytics_init(wsi_wl_surface, pAllocator);
+ 
+    return VK_SUCCESS;
+@@ -3004,11 +2990,11 @@ wsi_wl_swapchain_queue_present(struct wsi_swapchain *wsi_chain,
+       /* Incremented by signal in base queue_present. */
+       uint64_t acquire_point = image->base.explicit_sync[WSI_ES_ACQUIRE].timeline;
+       uint64_t release_point = image->base.explicit_sync[WSI_ES_RELEASE].timeline;
+-      wp_linux_drm_syncobj_surface_v1_set_acquire_point(wsi_wl_surface->wl_syncobj_surface,
++      wp_linux_drm_syncobj_surface_v1_set_acquire_point(chain->wl_syncobj_surface,
+                                                         image->wl_syncobj_timeline[WSI_ES_ACQUIRE],
+                                                         (uint32_t)(acquire_point >> 32),
+                                                         (uint32_t)(acquire_point & 0xffffffff));
+-      wp_linux_drm_syncobj_surface_v1_set_release_point(wsi_wl_surface->wl_syncobj_surface,
++      wp_linux_drm_syncobj_surface_v1_set_release_point(chain->wl_syncobj_surface,
+                                                         image->wl_syncobj_timeline[WSI_ES_RELEASE],
+                                                         (uint32_t)(release_point >> 32),
+                                                         (uint32_t)(release_point & 0xffffffff));
+@@ -3351,9 +3337,10 @@ wsi_wl_swapchain_chain_free(struct wsi_wl_swapchain *chain,
+       wl_callback_destroy(chain->frame);
+    if (chain->tearing_control)
+       wp_tearing_control_v1_destroy(chain->tearing_control);
+-   if (needs_color_surface(wsi_wl_surface->display, chain->color.colorspace) &&
+-       wsi_wl_surface->color.color_surface) {
+-      wsi_wl_surface_remove_color_refcount(wsi_wl_surface);
++   if (chain->wl_syncobj_surface)
++      wp_linux_drm_syncobj_surface_v1_destroy(chain->wl_syncobj_surface);
++   if (chain->color.color_surface) {
++      wp_color_management_surface_v1_destroy(chain->color.color_surface);
+    }
+ 
+    /* Only unregister if we are the non-retired swapchain, or
+@@ -3471,6 +3458,15 @@ wsi_wl_surface_create_swapchain(VkIcdSurfaceBase *icd_surface,
+          wp_commit_timer_v1_destroy(old_chain->commit_timer);
+          old_chain->commit_timer = NULL;
+       }
++      if (old_chain->wl_syncobj_surface) {
++         wp_linux_drm_syncobj_surface_v1_destroy(old_chain->wl_syncobj_surface);
++         old_chain->wl_syncobj_surface = NULL;
++      }
++      if (old_chain->color.color_surface) {
++         wp_color_management_surface_v1_destroy(old_chain->color.color_surface);
++         old_chain->color.color_surface_refcount = 0;
++         old_chain->color.color_surface = NULL;
++      }
+    }
+ 
+    /* Take ownership of the wsi_wl_surface */
+@@ -3519,6 +3515,15 @@ wsi_wl_surface_create_swapchain(VkIcdSurfaceBase *icd_surface,
+                                                           WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC);
+    }
+ 
++   if (wsi_wl_use_explicit_sync(wsi_wl_surface->display, wsi_device)) {
++      chain->wl_syncobj_surface =
++         wp_linux_drm_syncobj_manager_v1_get_surface(wsi_wl_surface->display->wl_syncobj,
++                                                     wsi_wl_surface->surface);
++
++      if (!chain->wl_syncobj_surface)
++         goto fail;
++   }
++
+    chain->color.colorspace = pCreateInfo->imageColorSpace;
+ 
+    enum wsi_wl_buffer_type buffer_type;
 -- 
 2.49.0
 

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -79,8 +79,8 @@ Summary:        Mesa graphics libraries
 # This should not break anything by default as the Mesa stream is ***EXPLICITLY***
 # disabled by default, and has to be enabled manually. See `terra/release/terra-mesa.repo` for details.
 Epoch:          1
-Version:        25.0.6
-Release:        1%?dist
+Version:        25.1.0
+Release:        3%?dist
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [chore: Add more patches for DOOM: The Dark Ages & Proton GE/Wine Wayland (#4878)](https://github.com/terrapkg/packages/pull/4878)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)