### PR TITLE
[f41] chore(modern-colorthief): pyproject-rpm-macros build dep (#4867)

### DIFF
--- a/anda/tools/modern-colorthief/modern-colorthief.spec
+++ b/anda/tools/modern-colorthief/modern-colorthief.spec
@@ -17,6 +17,7 @@ BuildRequires: cargo-rpm-macros
 BuildRequires: maturin
 BuildRequires: mold
 BuildRequires: python3-devel
+BuildRequires: pyproject-rpm-macros
 BuildRequires: python3dist(pip)
 BuildRequires: python3dist(setuptools)
 %if %{with docs}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(modern-colorthief): pyproject-rpm-macros build dep (#4867)](https://github.com/terrapkg/packages/pull/4867)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)