### PR TITLE
[f41] feat(modern-colorthief): Enable tests (#4884)

### DIFF
--- a/anda/tools/modern-colorthief/modern-colorthief.spec
+++ b/anda/tools/modern-colorthief/modern-colorthief.spec
@@ -1,6 +1,6 @@
 %global pypi_name modern_colorthief
 %bcond docs 0
-%bcond test 0
+%bcond test 1
 
 # The srcrpm is not prefixed with Python because the source is mostly Rust
 Name:          modern-colorthief
@@ -25,6 +25,8 @@ BuildRequires: python3dist(modern-colorthief)
 BuildRequires: python3dist(myst-parser)
 BuildRequires: python3dist(shibuya)
 BuildRequires: python3dist(sphinx)
+%elif %{with test}
+BuildRequires: python3dist(modern-colorthief)
 %endif
 %if %{with test}
 %if 0%{?fedora} <= 42 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [feat(modern-colorthief): Enable tests (#4884)](https://github.com/terrapkg/packages/pull/4884)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)