### PR TITLE
[f41] chore(.github/workflows/sync.yaml): Update to latest Action version (#4883)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,7 +23,7 @@ jobs:
           git config --global commit.gpgsign true
 
       - name: Backport Action
-        uses: sorenlouv/backport-github-action@v9.3.0
+        uses: sorenlouv/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.RABONEKO_BACKPORT_GITHUB_TOKEN }}
           auto_backport_label_prefix: sync-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(.github/workflows/sync.yaml): Update to latest Action version (#4883)](https://github.com/terrapkg/packages/pull/4883)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)