### PR TITLE
[el10] feat(modern-colorthief): Enable docs (#4885)

### DIFF
--- a/anda/tools/modern-colorthief/modern-colorthief.spec
+++ b/anda/tools/modern-colorthief/modern-colorthief.spec
@@ -1,5 +1,5 @@
 %global pypi_name modern_colorthief
-%bcond docs 0
+%bcond docs 1
 %bcond test 1
 
 # The srcrpm is not prefixed with Python because the source is mostly Rust


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(modern-colorthief): Enable docs (#4885)](https://github.com/terrapkg/packages/pull/4885)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)