### PR TITLE
[el10] fix(ffmpeg): Move to Extras due to library deps (#4916)

### DIFF
--- a/anda/multimedia/ffmpeg/anda.hcl
+++ b/anda/multimedia/ffmpeg/anda.hcl
@@ -6,5 +6,6 @@ project pkg {
     labels {
         updbranch = 1
         mock = 1
+        subrepo = "extras"
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(ffmpeg): Move to Extras due to library deps (#4916)](https://github.com/terrapkg/packages/pull/4916)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)