### PR TITLE
[f40] fix(joshuto): Don't mangle shebangs (#4930)

### DIFF
--- a/anda/langs/rust/joshuto/rust-joshuto.spec
+++ b/anda/langs/rust/joshuto/rust-joshuto.spec
@@ -2,6 +2,7 @@
 %bcond_without check
 
 %global crate joshuto
+%global __brp_mangle_shebangs %{nil}
 
 Name:           rust-joshuto
 Version:        0.9.9


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(joshuto): Don&#x27;t mangle shebangs (#4930)](https://github.com/terrapkg/packages/pull/4930)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)