### PR TITLE
chore(zig-master): Update patches

### DIFF
--- a/anda/langs/zig/bootstrap/0001-increase-upper-bounds-of-main-zig-executable-to-10G.patch
+++ b/anda/langs/zig/bootstrap/0001-increase-upper-bounds-of-main-zig-executable-to-10G.patch
@@ -1,11 +1,11 @@
---- a/build.zig	2025-04-23 22:33:17.801652844 -0500
-+++ b/build.zig	2025-04-23 22:34:14.127282140 -0500
-@@ -679,7 +679,7 @@
- 
+--- a/build.zig	2025-05-21 00:23:29.485933582 -0500
++++ b/build.zig	2025-05-21 00:25:06.001631897 -0500
+@@ -690,7 +690,7 @@
+ fn addCompilerStep(b: *std.Build, options: AddCompilerModOptions) *std.Build.Step.Compile {
      const exe = b.addExecutable(.{
          .name = "zig",
 -        .max_rss = 7_800_000_000,
 +        .max_rss = 10_000_000_000,
-         .root_module = compiler_mod,
+         .root_module = addCompilerMod(b, options),
      });
      exe.stack_size = stack_size;

--- a/anda/langs/zig/master/0001-increase-upper-bounds-of-main-zig-executable-to-10G.patch
+++ b/anda/langs/zig/master/0001-increase-upper-bounds-of-main-zig-executable-to-10G.patch
@@ -1,11 +1,11 @@
---- a/build.zig	2025-04-23 22:33:17.801652844 -0500
-+++ b/build.zig	2025-04-23 22:34:14.127282140 -0500
-@@ -679,7 +679,7 @@
- 
+--- a/build.zig	2025-05-21 00:23:29.485933582 -0500
++++ b/build.zig	2025-05-21 00:25:06.001631897 -0500
+@@ -690,7 +690,7 @@
+ fn addCompilerStep(b: *std.Build, options: AddCompilerModOptions) *std.Build.Step.Compile {
      const exe = b.addExecutable(.{
          .name = "zig",
 -        .max_rss = 7_800_000_000,
 +        .max_rss = 10_000_000_000,
-         .root_module = compiler_mod,
+         .root_module = addCompilerMod(b, options),
      });
      exe.stack_size = stack_size;

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -13,7 +13,7 @@
 %global zig_cache_dir %{builddir}/zig-cache
 
 Name:           zig-master
-Version:        0.15.0~dev.582+f2077f57a
+Version:        0.15.0~dev.621+a63f7875f
 Release:        1%?dist
 Summary:        Master builds of the Zig language
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -13,7 +13,7 @@
 %global zig_cache_dir %{builddir}/zig-cache
 
 Name:           zig-master
-Version:        0.15.0~dev.621+a63f7875f
+Version:        0.15.0~dev.582+f2077f57a
 Release:        1%?dist
 Summary:        Master builds of the Zig language
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1


### PR DESCRIPTION
Note: This will fail on the full build. Expected, it has not been able to update without the bootstrap.