### PR TITLE
[f41] chore(zig-master): Update patches (#4936)

### DIFF
--- a/anda/langs/zig/bootstrap/0001-increase-upper-bounds-of-main-zig-executable-to-10G.patch
+++ b/anda/langs/zig/bootstrap/0001-increase-upper-bounds-of-main-zig-executable-to-10G.patch
@@ -1,11 +1,11 @@
---- a/build.zig	2025-04-23 22:33:17.801652844 -0500
-+++ b/build.zig	2025-04-23 22:34:14.127282140 -0500
-@@ -679,7 +679,7 @@
- 
+--- a/build.zig	2025-05-21 00:23:29.485933582 -0500
++++ b/build.zig	2025-05-21 00:25:06.001631897 -0500
+@@ -690,7 +690,7 @@
+ fn addCompilerStep(b: *std.Build, options: AddCompilerModOptions) *std.Build.Step.Compile {
      const exe = b.addExecutable(.{
          .name = "zig",
 -        .max_rss = 7_800_000_000,
 +        .max_rss = 10_000_000_000,
-         .root_module = compiler_mod,
+         .root_module = addCompilerMod(b, options),
      });
      exe.stack_size = stack_size;

--- a/anda/langs/zig/master/0001-increase-upper-bounds-of-main-zig-executable-to-10G.patch
+++ b/anda/langs/zig/master/0001-increase-upper-bounds-of-main-zig-executable-to-10G.patch
@@ -1,11 +1,11 @@
---- a/build.zig	2025-04-23 22:33:17.801652844 -0500
-+++ b/build.zig	2025-04-23 22:34:14.127282140 -0500
-@@ -679,7 +679,7 @@
- 
+--- a/build.zig	2025-05-21 00:23:29.485933582 -0500
++++ b/build.zig	2025-05-21 00:25:06.001631897 -0500
+@@ -690,7 +690,7 @@
+ fn addCompilerStep(b: *std.Build, options: AddCompilerModOptions) *std.Build.Step.Compile {
      const exe = b.addExecutable(.{
          .name = "zig",
 -        .max_rss = 7_800_000_000,
 +        .max_rss = 10_000_000_000,
-         .root_module = compiler_mod,
+         .root_module = addCompilerMod(b, options),
      });
      exe.stack_size = stack_size;


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(zig-master): Update patches (#4936)](https://github.com/terrapkg/packages/pull/4936)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)