### PR TITLE
[f40] add: exquisite-linux-templates (#4861)

### DIFF
--- a/anda/misc/exquisite-linux-templates/anda.hcl
+++ b/anda/misc/exquisite-linux-templates/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+    arches = ["x86_64"]
+    rpm {
+        spec = "exquisite-linux-templates.spec"
+    }
+    labels {
+        weekly = 2
+    }
+}

--- a/anda/misc/exquisite-linux-templates/exquisite-linux-templates.spec
+++ b/anda/misc/exquisite-linux-templates/exquisite-linux-templates.spec
@@ -1,0 +1,30 @@
+%global commit 4f5ee4e125a5c202c30b620d8df4cb1a1494e8cd
+%global shortcommit %{sub %commit 1 7}
+%global commit_date 20250516
+
+Name:		exquisite-linux-templates
+Version:	0~%{commit_date}git.%shortcommit
+Release:	1%?dist
+Summary:	A collection of shared file templates for use in $HOME/Templates on Linux systems
+License:	MIT
+URL:		https://codeberg.org/nathandyer/%name
+Source0:	%url/archive/%commit.tar.gz
+BuildArch:	noarch
+
+%description
+%summary.
+
+Note that this only works with English. You should rename `~/Templates` to the corresponding
+string for your user language for the templates to take effect.
+
+%prep
+%autosetup -n %name
+
+%install
+mkdir -p %buildroot%_sysconfdir/skel/Templates
+mv templates %buildroot%_sysconfdir/skel/Templates/%name
+
+%files
+%doc README.md
+%license LICENSE
+%_sysconfdir/skel/Templates

--- a/anda/misc/exquisite-linux-templates/update.rhai
+++ b/anda/misc/exquisite-linux-templates/update.rhai
@@ -1,0 +1,6 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.global("commit", bump::codeberg_commit("nathandyer/exquisite-linux-templates"));
+if rpm.changed() {
+    rpm.global("commit_date", date());
+}

--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -1,3 +1,7 @@
+fn codeberg_commit(repo) {
+    return get(`https://codeberg.org/api/v1/repos/${repo}/commits?stat=false&verification=false&files=false&limit=1`).json_arr()[0].sha;
+}
+
 fn as_bodhi_ver(branch) {
     if branch.starts_with("el") {
         branch.crop(2);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: exquisite-linux-templates (#4861)](https://github.com/terrapkg/packages/pull/4861)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)