### PR TITLE
[el10] fix(wine-dev): Handle inconsistent updates (#4906)

### DIFF
--- a/anda/system/wine/dev/update.rhai
+++ b/anda/system/wine/dev/update.rhai
@@ -1,12 +1,11 @@
 let v = (gitlab_tag("gitlab.winehq.org", "5"));
-v.crop(1);
 rpm.global("ver", v); // Sometimes the development branch includes RC candidates
 if rpm.changed () {
     rpm.release();
-    // Only find versions ending in .x (point releases)
-    let matches = (find_all("[\\d.]+[.]x", get("https://dl.winehq.org/wine/source/")));
+    // Find the current highest release
+    let matches = (find_all("[\\d.]+\\.[0x]", get("https://dl.winehq.org/wine/source/")));
     matches.dedup();
-    let s = sh(`echo ${matches} | sed 's/,//g' | sed 's/\[//g' | sed 's/\]//g' | sed 's/"//g' | tr ' ' '\n' | sort -nr | tr '\n' ' '`, #{"stdout": "piped"}).ctx.stdout;
+    let s = sh(`echo ${matches} | sed 's/,//g;s/\[//g;s/\]//g;s/"//g' | tr ' ' '\n' | sort -nr | tr '\n' ' '`, #{"stdout": "piped"}).ctx.stdout;
     s.truncate(4);
     rpm.global("srcmajor", s);
 }

--- a/anda/system/wine/dev/wine-dev.spec
+++ b/anda/system/wine/dev/wine-dev.spec
@@ -9,7 +9,8 @@
 %global _prefix 	/usr/share/wine-dev
 %global srcmajor 10.x
 # Make this as a variable instead in case of WINE RCs
-%global ver 10.7
+%global ver wine-10.8
+%global cleanver %(echo %{ver} | sed 's/v//g;s/wine-//g')
 
 # This is unfortunate but a lot of Fedora's/SUSE's hardening flags break WINE
 %undefine _hardened_build
@@ -17,8 +18,8 @@
 # Upstream WineHQ names this -devel, I have renamed it dev to signify it is the dev branch
 # Also less confusing because it has a devel package
 Name:       wine-dev
-Version:    %(echo %{ver} | sed 's/-/~/g')
-Release:    1
+Version:    %(echo %{cleanver} | sed 's/-/~/g')
+Release:    1%?dist
 Epoch:      1
 Summary:    WINE Is Not An Emulator - runs MS Windows programs
 License:    LGPL-2.0-or-later
@@ -48,8 +49,8 @@ URL:        https://www.winehq.org
 %endif
 %endif
 
-Source0:	https://dl.winehq.org/wine/source/%{srcmajor}/wine-%{ver}.tar.xz
-Source1:	https://dl.winehq.org/wine/source/%{srcmajor}/wine-%{version}.tar.xz.sign
+Source0:	https://dl.winehq.org/wine/source/%{srcmajor}/wine-%{cleanver}.tar.xz
+Source1:	https://dl.winehq.org/wine/source/%{srcmajor}/wine-%{cleanver}.tar.xz.sign
 
 # Alexandres key
 Source99:	wine.keyring


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(wine-dev): Handle inconsistent updates (#4906)](https://github.com/terrapkg/packages/pull/4906)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)