### PR TITLE
[el10] fix?????: Bump epoch on GStreamer bad plugins (#4937)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/gstreamer1-plugins-bad.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/gstreamer1-plugins-bad.spec
@@ -1,23 +1,26 @@
 %define _legacy_common_support 1
+%global __brp_check_rpaths %{nil}
 %global         majorminor 1.0
 
 Name:           gstreamer1-plugins-bad
-Version:        1.24.11
-Release:        3%{?dist}
+Version:        1.26.1
+Release:        1%?dist
+Epoch:          2
 Summary:        GStreamer streaming media framework "bad" plugins
-License:        LGPLv2+ and LGPLv2
+License:        LGPL-2.0-or-later and LGPL-2.0-only
 URL:            http://gstreamer.freedesktop.org/
 
 Source0:        https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-%{version}.tar.xz
 Source1:        gstreamer-bad.metainfo.xml
 
+# Requires Provides with and without _isa defined due to package dependencies
 Obsoletes:      %{name}-free < %{?epoch}:%{version}-%{release}
 Provides:       %{name}-free = %{?epoch}:%{version}-%{release}
 Provides:       %{name}-free%{?_isa} = %{?epoch}:%{version}-%{release}
 Obsoletes:      %{name}-free-extras < %{?epoch}:%{version}-%{release}
 Provides:       %{name}-free-extras = %{?epoch}:%{version}-%{release}
 Provides:       %{name}-free-extras%{?_isa} = %{?epoch}:%{version}-%{release}
-Obsoletes:      %{name}-freeworld < %{?epoch}:%{version}-%{release}
+#Obsoletes:      %{name}-freeworld < %{?epoch}:%{version}-%{release}
 Provides:       %{name}-freeworld = %{?epoch}:%{version}-%{release}
 Provides:       %{name}-freeworld%{?_isa} = %{?epoch}:%{version}-%{release}
 Obsoletes:      %{name}-nonfree < %{?epoch}:%{version}-%{release}
@@ -35,13 +38,17 @@ Provides:       gstreamer1-plugin-openh264%{?_isa} = %{?epoch}:%{version}-%{rele
 Obsoletes:      gstreamer1-svt-hevc < %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-svt-hevc = %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-svt-hevc%{?_isa} = %{?epoch}:%{version}-%{release}
-Obsoletes:      %{name}-free-libs < %{?epoch}:%{version}-%{release}
-Provides:       %{name}-free-libs = %{?epoch}:%{version}-%{release}
-Provides:       %{name}-free-libs%{?_isa} = %{?epoch}:%{version}-%{release}
+Obsoletes:      gstreamer1-plugin-vaapi < %{?epoch}:%{version}-%{release}
+Provides:       gstreamer1-plugin-vaapi = %{?epoch}:%{version}-%{release}
+Provides:       gstreamer1-plugin-vaapi%{?_isa} = %{?epoch}:%{version}-%{release}
+Requires:       %{name}-libs = %{?epoch}:%{version}-%{release}
+
 BuildRequires:  gcc-c++
 BuildRequires:  meson >= 0.62
+
 BuildRequires:  gstreamer1-devel >= %{version}
 BuildRequires:  gstreamer1-plugins-base-devel >= %{version}
+
 BuildRequires:  bzip2-devel
 BuildRequires:  check
 BuildRequires:  exempi-devel
@@ -52,21 +59,25 @@ BuildRequires:  glslc
 BuildRequires:  gobject-introspection-devel >= 1.31.1
 BuildRequires:  gsm-devel
 BuildRequires:  ladspa-devel
+BuildRequires:  libatomic
 BuildRequires:  libcdaudio-devel
 BuildRequires:  libmicrodns-devel
+#BuildRequires:  libmpcdec-devel - Old API
 BuildRequires:  mesa-libGL-devel
 BuildRequires:  mesa-libGLU-devel
-BuildRequires:  orc-devel >= 0.4.17
 BuildRequires:  srt-devel
 BuildRequires:  vulkan-devel
 BuildRequires:  xvidcore-devel
-BuildRequires:  pkgconfig(aom)
+
+
+BuildRequires:  pkgconfig(aom) >= 3.0.2
 BuildRequires:  pkgconfig(avtp)
 BuildRequires:  pkgconfig(bluez) >= 5.0
 BuildRequires:  pkgconfig(cairo)
 BuildRequires:  pkgconfig(clutter-1.0) >= 1.8
 BuildRequires:  pkgconfig(clutter-glx-1.0) >= 1.8
 BuildRequires:  pkgconfig(clutter-x11-1.0) >= 1.8
+#BuildRequires:  pkgconfig(dssim)
 BuildRequires:  pkgconfig(dvdnav) >= 4.1.2
 BuildRequires:  pkgconfig(dvdread) >= 4.1.2
 BuildRequires:  pkgconfig(egl)
@@ -79,7 +90,8 @@ BuildRequires:  pkgconfig(glesv2)
 BuildRequires:  pkgconfig(gmodule-export-2.0)
 BuildRequires:  pkgconfig(gmodule-no-export-2.0)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
-BuildRequires:  pkgconfig(gstreamer-1.0) >= %{version}
+#BuildRequires:  pkgconfig(google_cloud_cpp_storage) >= 1.25.0
+BuildRequires:  pkgconfig(gstreamer-1.0)
 BuildRequires:  pkgconfig(gstreamer-allocators-1.0)
 BuildRequires:  pkgconfig(gstreamer-app-1.0)
 BuildRequires:  pkgconfig(gstreamer-audio-1.0)
@@ -90,6 +102,7 @@ BuildRequires:  pkgconfig(gstreamer-fft-1.0)
 BuildRequires:  pkgconfig(gstreamer-gl-1.0)
 BuildRequires:  pkgconfig(gstreamer-gl-egl-1.0)
 BuildRequires:  pkgconfig(gstreamer-gl-prototypes-1.0)
+#BuildRequires:  pkgconfig(gstreamer-gl-viv-fb-1.0)
 BuildRequires:  pkgconfig(gstreamer-gl-wayland-1.0)
 BuildRequires:  pkgconfig(gstreamer-gl-x11-1.0)
 BuildRequires:  pkgconfig(gstreamer-net-1.0)
@@ -110,37 +123,41 @@ BuildRequires:  pkgconfig(lcms2) >= 2.7
 BuildRequires:  pkgconfig(ldacBT-enc)
 BuildRequires:  pkgconfig(libass) >= 0.10.2
 BuildRequires:  pkgconfig(libbs2b) >= 3.1.0
+BuildRequires:  pkgconfig(lcevc_dec)
 BuildRequires:  pkgconfig(libchromaprint)
 BuildRequires:  pkgconfig(libcrypto)
 BuildRequires:  pkgconfig(libcurl) >= 7.55.0
 BuildRequires:  pkgconfig(libdca)
 BuildRequires:  pkgconfig(libdc1394-2) >= 2.2.5
-BuildRequires:  pkgconfig(libde265)
-BuildRequires:  pkgconfig(libdrm) >= 2.4.104
+BuildRequires:  pkgconfig(libde265) >= 0.9
+BuildRequires:  pkgconfig(libdrm) >= 2.4.108
 BuildRequires:  pkgconfig(libexif) >= 0.6.16
 BuildRequires:  pkgconfig(libfreeaptx) >= 0.1.1
 BuildRequires:  pkgconfig(libmodplug)
+#BuildRequires:  pkgconfig(libonnxruntime) >= 1.16.1
 BuildRequires:  pkgconfig(libopenjp2) >= 2.2
 BuildRequires:  pkgconfig(libopenmpt)
+#BuildRequires:  pkgconfig(libopenni2) >= 0.26
 BuildRequires:  pkgconfig(libpng) >= 1.0
 BuildRequires:  pkgconfig(libqrencode)
 BuildRequires:  pkgconfig(librsvg-2.0) >= 2.36.2
 BuildRequires:  pkgconfig(librtmp)
 BuildRequires:  pkgconfig(libSoundTouch)
-BuildRequires:  pkgconfig(libsoup-2.4) >= 2.48
+BuildRequires:  pkgconfig(libsoup-3.0)
 BuildRequires:  pkgconfig(libsrtp2) >= 2.1.0
 BuildRequires:  pkgconfig(libssh2) >= 1.4.3
 BuildRequires:  pkgconfig(libusb-1.0)
-BuildRequires:  pkgconfig(libva)
-BuildRequires:  pkgconfig(libva-drm)
-BuildRequires:  pkgconfig(libva-x11)
+BuildRequires:  pkgconfig(libva) >= 1.18
+BuildRequires:  pkgconfig(libva-drm) >= 1.18
+BuildRequires:  pkgconfig(libva-x11) >= 1.18
 BuildRequires:  pkgconfig(libvisual-0.4) >= 0.4.0
 BuildRequires:  pkgconfig(libwebp) >= 0.2.1
-BuildRequires:  pkgconfig(libxml-2.0) >= 2.8
+BuildRequires:  pkgconfig(libwebpmux) >= 0.2.1
+BuildRequires:  pkgconfig(libxml-2.0) >= 2.9.2
 BuildRequires:  pkgconfig(lilv-0) >= 0.22
 BuildRequires:  pkgconfig(lrdf)
 BuildRequires:  pkgconfig(ltc) >= 1.1.4
-BuildRequires:  pkgconfig(mjpegtools)
+BuildRequires:  pkgconfig(mjpegtools) >= 2.0.0
 BuildRequires:  pkgconfig(nice) >= 0.1.20
 BuildRequires:  pkgconfig(neon) >= 0.27
 BuildRequires:  pkgconfig(nettle) >= 3.0
@@ -151,19 +168,17 @@ BuildRequires:  pkgconfig(OpenEXR)
 BuildRequires:  pkgconfig(openh264) >= 1.3.0
 BuildRequires:  pkgconfig(openssl) >= 1.0.1
 BuildRequires:  pkgconfig(opus) >= 0.9.4
+BuildRequires:  pkgconfig(orc-0.4)
 BuildRequires:  pkgconfig(pango)
 BuildRequires:  pkgconfig(pangocairo) >= 1.22.0
-BuildRequires:  pkgconfig(Qt5Core)
-BuildRequires:  pkgconfig(Qt5Gui)
-BuildRequires:  pkgconfig(Qt5Quick)
-BuildRequires:  pkgconfig(Qt5WaylandClient)
-BuildRequires:  pkgconfig(Qt5X11Extras)
 BuildRequires:  pkgconfig(sbc) >= 1.0
 BuildRequires:  pkgconfig(schroedinger-1.0) >= 1.0.10
 BuildRequires:  pkgconfig(sndfile) >= 1.0.16
+#BuildRequires:  pkgconfig(soundtouch-1.4)
 BuildRequires:  pkgconfig(spandsp) >= 0.0.6
 BuildRequires:  pkgconfig(srt) >= 1.3.0
 BuildRequires:  pkgconfig(SvtAv1Enc) >= 1.1
+#BuildRequires:  pkgconfig(SvtJpegxs) >= 0.9
 BuildRequires:  pkgconfig(tiger) >= 0.3.2
 BuildRequires:  pkgconfig(vo-aacenc)
 BuildRequires:  pkgconfig(vo-amrwbenc) >= 0.1.0
@@ -173,16 +188,22 @@ BuildRequires:  pkgconfig(wayland-cursor) >= 1.15
 BuildRequires:  pkgconfig(wayland-egl) >= 1.15
 BuildRequires:  pkgconfig(wayland-protocols) >= 1.15
 BuildRequires:  pkgconfig(wayland-server) >= 1.15
-BuildRequires:  pkgconfig(webrtc-audio-processing-1)
+#BuildRequires:  pkgconfig(webrtc-audio-coding-1)
+BuildRequires:  pkgconfig(webrtc-audio-processing-1) >= 1.0
+#BuildRequires:  pkgconfig(webrtc-audio-processing-2) >= 2.0
+#BuildRequires:  pkgconfig(webview2)
+BuildRequires:  pkgconfig(wildmidi) >= 0.4.2
+#BuildRequires:  pkgconfig(wpe-webkit-1.1) >= 2.28
+#BuildRequires:  pkgconfig(wpebackend-fdo-1.0) >= 1.8
 BuildRequires:  pkgconfig(x11)
 BuildRequires:  pkgconfig(x265)
 BuildRequires:  pkgconfig(xcb) >= 1.10
 BuildRequires:  pkgconfig(xkbcommon) >= 0.8
 BuildRequires:  pkgconfig(xkbcommon-x11)
-BuildRequires:  pkgconfig(wildmidi) >= 0.4.2
-BuildRequires:  pkgconfig(zbar) >= 0.9
+BuildRequires:  pkgconfig(zbar) >= 0.23.1
 BuildRequires:  pkgconfig(zvbi-0.2)
-BuildRequires:  pkgconfig(zxing)
+BuildRequires:  pkgconfig(zxing) >= 1.4.0
+
 %ifarch x86_64
 BuildRequires:  pkgconfig(libmfx) >= 1.0
 BuildRequires:  pkgconfig(libmfx) <= 1.99
@@ -206,6 +227,17 @@ Provides:       %{name}-free-fluidsynth%{?_isa} = %{?epoch}:%{version}-%{release
 
 %description    fluidsynth
 This package contains the GStreamer Fluidsynth plugin.
+
+
+%package        libs
+Summary:        Runtime libraries for the GStreamer "bad" plugins
+Obsoletes:      %{name}-free-libs < %{?epoch}:%{version}-%{release}
+Provides:       %{name}-free-libs = %{?epoch}:%{version}-%{release}
+Provides:       %{name}-free-libs%{?_isa} = %{?epoch}:%{version}-%{release}
+Requires:       %{name} = %{?epoch}:%{version}-%{release}
+
+%description    libs
+%summary.
 
 %package        devel
 Summary:        Development files for the GStreamer "bad" plugins
@@ -231,7 +263,7 @@ Provides:       %{name}-free-devel%{?_isa} = %{?epoch}:%{version}-%{release}
   -D aja=disabled \
   -D amfcodec=disabled \
   -D analyticsoverlay=enabled \
-  -D androidmedia=enabled \
+  -D androidmedia=disabled \
   -D aom=enabled \
   -D applemedia=enabled \
   -D asfmux=enabled \
@@ -256,6 +288,7 @@ Provides:       %{name}-free-devel%{?_isa} = %{?epoch}:%{version}-%{release}
   -D codectimestamper=enabled \
   -D coloreffects=enabled \
   -D colormanagement=enabled \
+  -D cuda-nvmm=disabled \
   -D curl=enabled \
   -D curl-ssh2=enabled \
   -D d3d11=disabled \
@@ -324,6 +357,8 @@ Provides:       %{name}-free-devel%{?_isa} = %{?epoch}:%{version}-%{release}
   -D ladspa=enabled \
   -D ladspa-rdf=enabled \
   -D lc3=enabled \
+  -D lcevcdecoder=enabled \
+  -D lcevcencoder=disabled \
   -D ldac=enabled \
   -D libde265=enabled \
   -D librfb=enabled \
@@ -347,6 +382,8 @@ Provides:       %{name}-free-devel%{?_isa} = %{?epoch}:%{version}-%{release}
   -D netsim=enabled \
   -D nls=enabled \
   -D nvcodec=enabled \
+  -D nvcomp=disabled \
+  -D nvdswrapper=disabled \
   -D onnx=disabled \
   -D onvif=enabled \
   -D openal=enabled \
@@ -361,7 +398,7 @@ Provides:       %{name}-free-devel%{?_isa} = %{?epoch}:%{version}-%{release}
   -D opus=enabled \
   -D orc=enabled \
   -D package-name="Fedora GStreamer-plugins-bad package" \
-  -D package-origin="https://gstreamer.freedesktop.org" \
+  -D package-origin="https://terra.fyralabs.com" \
   -D pcapparse=enabled \
   -D pnm=enabled \
   -D proxy=enabled \
@@ -392,6 +429,7 @@ Provides:       %{name}-free-devel%{?_isa} = %{?epoch}:%{version}-%{release}
   -D srtp=enabled \
   -D subenc=enabled \
   -D svtav1=enabled \
+  -D svtjpegxs=disabled \
   -D svthevcenc=disabled \
   -D switchbin=enabled \
   -D teletext=enabled \
@@ -416,12 +454,14 @@ Provides:       %{name}-free-devel%{?_isa} = %{?epoch}:%{version}-%{release}
   -D voamrwbenc=enabled \
   -D vulkan=enabled \
   -D vulkan-video=enabled \
+  -D vulkan-windowing=x11,wayland \
   -D wasapi=disabled \
   -D wasapi2=disabled \
   -D wayland=enabled \
   -D webp=enabled \
   -D webrtc=enabled \
   -D webrtcdsp=enabled \
+  -D webview2=enabled \
   -D wic=enabled \
   -D wildmidi=enabled \
   -D win32ipc=disabled \
@@ -442,9 +482,6 @@ Provides:       %{name}-free-devel%{?_isa} = %{?epoch}:%{version}-%{release}
   -D msdk=disabled \
   -D qsv=disabled \
 %endif
-%if "%?version" < "1.25.1"
-  -D asio-sdk-path=enabled
-%endif
 
 %meson_build
 
@@ -459,47 +496,7 @@ install -p -m 644 -D %{SOURCE1} %{buildroot}%{_metainfodir}/gstreamer-bad.metain
 %doc AUTHORS NEWS README.md RELEASE REQUIREMENTS
 %{_bindir}/gst-transcoder-1.0
 %{_metainfodir}/gstreamer-bad.metainfo.xml
-%{_libdir}/girepository-%{majorminor}/CudaGst-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstAnalytics-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstBadAudio-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstCodecs-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstCuda-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstDxva-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstInsertBin-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstMpegts-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstMse-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstPlayer-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstPlay-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstTranscoder-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstVa-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstVulkan-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstVulkanWayland-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstVulkanXCB-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/GstWebRTC-%{majorminor}.typelib
-%{_libdir}/libgstadaptivedemux-%{majorminor}.so.*
-%{_libdir}/libgstanalytics-%{majorminor}.so.*
-%{_libdir}/libgstbadaudio-%{majorminor}.so.*
-%{_libdir}/libgstbasecamerabinsrc-%{majorminor}.so.*
-%{_libdir}/libgstcodecparsers-%{majorminor}.so.*
-%{_libdir}/libgstcodecs-%{majorminor}.so.*
-%{_libdir}/libgstcuda-%{majorminor}.so.*
-%{_libdir}/libgstdxva-%{majorminor}.so.*
-%{_libdir}/libgstinsertbin-%{majorminor}.so.*
-%{_libdir}/libgstisoff-%{majorminor}.so.*
-%{_libdir}/libgstmpegts-%{majorminor}.so.*
-%{_libdir}/libgstmse-%{majorminor}.so.*
-%{_libdir}/libgstopencv-%{majorminor}.so.*
-%{_libdir}/libgstphotography-%{majorminor}.so.*
-%{_libdir}/libgstplayer-%{majorminor}.so.*
-%{_libdir}/libgstplay-%{majorminor}.so.*
-%{_libdir}/libgstsctp-%{majorminor}.so.*
-%{_libdir}/libgsttranscoder-%{majorminor}.so.*
-%{_libdir}/libgsturidownloader-%{majorminor}.so.*
-%{_libdir}/libgstva-%{majorminor}.so.*
-%{_libdir}/libgstvulkan-%{majorminor}.so.*
-%{_libdir}/libgstwayland-%{majorminor}.so.*
-%{_libdir}/libgstwebrtc-%{majorminor}.so.*
-%{_libdir}/libgstwebrtcnice-%{majorminor}.so.*
+# Encoder profiles
 %dir %{_datadir}/gstreamer-%{majorminor}/encoding-profiles/
 %dir %{_datadir}/gstreamer-%{majorminor}/encoding-profiles/device/
 %{_datadir}/gstreamer-%{majorminor}/encoding-profiles/device/dvd.gep
@@ -515,9 +512,11 @@ install -p -m 644 -D %{SOURCE1} %{buildroot}%{_metainfodir}/gstreamer-bad.metain
 %{_datadir}/gstreamer-%{majorminor}/encoding-profiles/file-extension/webm.gep
 %dir %{_datadir}/gstreamer-%{majorminor}/encoding-profiles/online-services/
 %{_datadir}/gstreamer-%{majorminor}/encoding-profiles/online-services/youtube.gep
+# Presets
 %dir %{_datadir}/gstreamer-%{majorminor}/presets
 %{_datadir}/gstreamer-%{majorminor}/presets/GstFreeverb.prs
 %{_datadir}/gstreamer-%{majorminor}/presets/GstVoAmrwbEnc.prs
+# Plugins
 %{_libdir}/gstreamer-%{majorminor}/libgstaccurip.so
 %{_libdir}/gstreamer-%{majorminor}/libgstadpcmdec.so
 %{_libdir}/gstreamer-%{majorminor}/libgstadpcmenc.so
@@ -584,6 +583,7 @@ install -p -m 644 -D %{SOURCE1} %{buildroot}%{_metainfodir}/gstreamer-bad.metain
 %{_libdir}/gstreamer-%{majorminor}/libgstkms.so
 %{_libdir}/gstreamer-%{majorminor}/libgstladspa.so
 %{_libdir}/gstreamer-%{majorminor}/libgstlc3.so
+%{_libdir}/gstreamer-%{majorminor}/libgstlcevcdecoder.so
 %{_libdir}/gstreamer-%{majorminor}/libgstldac.so
 %{_libdir}/gstreamer-%{majorminor}/libgstlegacyrawparse.so
 %{_libdir}/gstreamer-%{majorminor}/libgstlv2.so
@@ -647,6 +647,7 @@ install -p -m 644 -D %{SOURCE1} %{buildroot}%{_metainfodir}/gstreamer-bad.metain
 %{_libdir}/gstreamer-%{majorminor}/libgstsubenc.so
 %{_libdir}/gstreamer-%{majorminor}/libgstswitchbin.so
 %{_libdir}/gstreamer-%{majorminor}/libgstteletext.so
+%{_libdir}/gstreamer-%{majorminor}/libgsttensordecoders.so
 %{_libdir}/gstreamer-%{majorminor}/libgsttimecode.so
 %{_libdir}/gstreamer-%{majorminor}/libgsttranscode.so
 %{_libdir}/gstreamer-%{majorminor}/libgstttmlsubs.so
@@ -677,6 +678,34 @@ install -p -m 644 -D %{SOURCE1} %{buildroot}%{_metainfodir}/gstreamer-bad.metain
 %{_libdir}/gstreamer-%{majorminor}/libgstfluidsynthmidi.so
 %{_libdir}/gstreamer-%{majorminor}/libgstmidi.so
 %{_libdir}/gstreamer-%{majorminor}/libgstwildmidi.so
+
+%files libs
+%{_libdir}/girepository-%{majorminor}/CudaGst-%{majorminor}.typelib
+%{_libdir}/girepository-%{majorminor}/Gst*-%{majorminor}.typelib
+%{_libdir}/libgstadaptivedemux-%{majorminor}.so.*
+%{_libdir}/libgstanalytics-%{majorminor}.so.*
+%{_libdir}/libgstbadaudio-%{majorminor}.so.*
+%{_libdir}/libgstbasecamerabinsrc-%{majorminor}.so.*
+%{_libdir}/libgstcodecparsers-%{majorminor}.so.*
+%{_libdir}/libgstcodecs-%{majorminor}.so.*
+%{_libdir}/libgstcuda-%{majorminor}.so.*
+%{_libdir}/libgstdxva-%{majorminor}.so.*
+%{_libdir}/libgstinsertbin-%{majorminor}.so.*
+%{_libdir}/libgstisoff-%{majorminor}.so.*
+%{_libdir}/libgstmpegts-%{majorminor}.so.*
+%{_libdir}/libgstmse-%{majorminor}.so.*
+%{_libdir}/libgstopencv-%{majorminor}.so.*
+%{_libdir}/libgstphotography-%{majorminor}.so.*
+%{_libdir}/libgstplayer-%{majorminor}.so.*
+%{_libdir}/libgstplay-%{majorminor}.so.*
+%{_libdir}/libgstsctp-%{majorminor}.so.*
+%{_libdir}/libgsttranscoder-%{majorminor}.so.*
+%{_libdir}/libgsturidownloader-%{majorminor}.so.*
+%{_libdir}/libgstva-%{majorminor}.so.*
+%{_libdir}/libgstvulkan-%{majorminor}.so.*
+%{_libdir}/libgstwayland-%{majorminor}.so.*
+%{_libdir}/libgstwebrtc-%{majorminor}.so.*
+%{_libdir}/libgstwebrtcnice-%{majorminor}.so.*
 
 %files devel
 %{_datadir}/gir-%{majorminor}/CudaGst-%{majorminor}.gir


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix?????: Bump epoch on GStreamer bad plugins (#4937)](https://github.com/terrapkg/packages/pull/4937)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)