### PR TITLE
[f41] feat: Make WINE dep on the compat package (#4923)

### DIFF
--- a/anda/system/wine/dev/wine-dev.spec
+++ b/anda/system/wine/dev/wine-dev.spec
@@ -19,7 +19,7 @@
 # Also less confusing because it has a devel package
 Name:       wine-dev
 Version:    %(echo %{cleanver} | sed 's/-/~/g')
-Release:    1%?dist
+Release:    2%?dist
 Epoch:      1
 Summary:    WINE Is Not An Emulator - runs MS Windows programs
 License:    LGPL-2.0-or-later
@@ -143,6 +143,7 @@ Conflicts:  %{name}64
 %if 0%{?fedora} < 40
 Requires:   %{name}-common = %{epoch}:%{version}-%{release}
 %endif
+Requires:   %{compat_package} = %{epoch}:%{version}-%{release}
 Provides:   %{lib_name} = %{epoch}:%{version}-%{release}
 Provides:   %{name}-bin = %{epoch}:%{version}-%{release}
 Obsoletes:  %{lib_name} <= %{epoch}:%{version}-%{release}

--- a/anda/system/wine/stable/update.rhai
+++ b/anda/system/wine/stable/update.rhai
@@ -1,6 +1,8 @@
-let matches = (find_all("[\\d.]+[.]0", get("https://dl.winehq.org/wine/source/"))); // Only find versions ending in .0. Stable WINE always ends in .0
-matches.dedup();
-// Sort for the largest match, the sed and tr commands remove everything preventing sort from working correctly
-let v = sh(`echo ${matches} | sed 's/,//g' | sed 's/\[//g' | sed 's/\]//g' | sed 's/"//g' | tr ' ' '\n' | sort -nr | tr '\n' ' '`, #{"stdout": "piped"}).ctx.stdout;
-v.truncate(4);
-rpm.version(v);
+let v = [];
+// Only find versions ending in .0. Stable WINE always ends in .0
+for matches in find_all("[\\d.]+\\.0", get("https://dl.winehq.org/wine/source/")) {
+        v += matches[0].parse_float();
+}
+v.dedup();
+v.sort();
+rpm.version(v[v.len()-1]);

--- a/anda/system/wine/stable/wine-stable.spec
+++ b/anda/system/wine/stable/wine-stable.spec
@@ -12,7 +12,7 @@
 
 Name:       wine-stable
 Version:    10.0
-Release:    1
+Release:    2%{?dist}
 Epoch:      1
 Summary:    WINE Is Not An Emulator - runs MS Windows programs
 License:    LGPL-2.0-or-later
@@ -136,6 +136,7 @@ Conflicts:  %{name}64
 %if 0%{?fedora} < 40
 Requires:   %{name}-common = %{epoch}:%{version}-%{release}
 %endif
+Requires:   %{compat_package} = %{epoch}:%{version}-%{release}
 Provides:   %{lib_name} = %{epoch}:%{version}-%{release}
 Provides:   %{name}-bin = %{epoch}:%{version}-%{release}
 Obsoletes:  %{lib_name} <= %{epoch}:%{version}-%{release}

--- a/anda/system/wine/staging/update.rhai
+++ b/anda/system/wine/staging/update.rhai
@@ -3,10 +3,10 @@ v.crop(1);
 rpm.version(v);
 if rpm.changed () {
     rpm.release();
-    // Only find versions ending in .x (point releases)
-    let matches = (find_all("[\\d.]+[.]x", get("https://dl.winehq.org/wine/source/")));
+    // Only find versions ending in .x (point releases). Staging is always point releases.
+    let matches = (find_all("[\\d.]+\\.x", get("https://dl.winehq.org/wine/source/")));
     matches.dedup();
-    let s = sh(`echo ${matches} | sed 's/,//g' | sed 's/\[//g' | sed 's/\]//g' | sed 's/"//g' | tr ' ' '\n' | sort -nr | tr '\n' ' '`, #{"stdout": "piped"}).ctx.stdout;
+    let s = sh(`echo ${matches} | sed 's/,//g;s/\[//g;s/\]//g;s/"//g' | tr ' ' '\n' | sort -nr | tr '\n' ' '`, #{"stdout": "piped"}).ctx.stdout;
     s.truncate(4);
     rpm.global("srcmajor", s);
 }

--- a/anda/system/wine/staging/wine-staging.spec
+++ b/anda/system/wine/staging/wine-staging.spec
@@ -18,8 +18,8 @@
 
 
 Name:       wine-staging
-Version:    10.7
-Release:    1
+Version:    10.8
+Release:    2%?dist
 Epoch:      1
 Summary:    WINE Is Not An Emulator - runs MS Windows programs
 License:    LGPL-2.0-or-later
@@ -148,6 +148,7 @@ Conflicts:  %{name}64
 %if 0%{?fedora} < 40
 Requires:   %{name}-common = %{epoch}:%{version}-%{release}
 %endif
+Requires:   %{compat_package} = %{epoch}:%{version}-%{release}
 Provides:   %{lib_name} = %{epoch}:%{version}-%{release}
 Obsoletes:  %{lib_name} <= %{epoch}:%{version}-%{release}
 Provides:   %{name}-bin = %{epoch}:%{version}-%{release}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat: Make WINE dep on the compat package (#4923)](https://github.com/terrapkg/packages/pull/4923)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)