### PR TITLE
[f40] add: Haishoku (#4968)

### DIFF
--- a/anda/langs/python/haishoku/anda.hcl
+++ b/anda/langs/python/haishoku/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "python-haishoku.spec"
+    }
+}

--- a/anda/langs/python/haishoku/python-haishoku.spec
+++ b/anda/langs/python/haishoku/python-haishoku.spec
@@ -1,0 +1,50 @@
+%global pypi_name haishoku
+%global _description1 %{expand:
+Haishoku is a development tool for grabbing the dominant color or representative color palette from an image, it depends on Python3 and Pillow.}
+%global _description2 %{expand:
+Haishoku is a development tool for grabbing the dominant color or representative color palette from an image.}
+
+Name:           python-%{pypi_name}
+Version:        1.1.8
+Release:        1%{?dist}
+Summary:        A development tool for grabbing the dominant color or representative color palette from an image
+License:        MIT
+URL:            https://github.com/LanceGin/haishoku
+Source0:        %{pypi_source}
+BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(setuptools)
+BuildArch:      noarch
+Packager:       Gilver E. <rockgrub@disroot.org>
+
+%description %_description1
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Requires:       python3dist(pillow)
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name} %_description2
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+
+%files -n python3-%{pypi_name}
+# This project does have README files but they are not included in the PyPi source
+%doc PKG-INFO
+%license LICENSE
+%{python3_sitelib}/%{pypi_name}/
+%{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
+
+%changelog
+* Thu May 22 2025 Gilver E. <rockgrub@disroot.org> - 1.1.8-1
+- Initial package.

--- a/anda/langs/python/haishoku/update.rhai
+++ b/anda/langs/python/haishoku/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("haishoku"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: Haishoku (#4968)](https://github.com/terrapkg/packages/pull/4968)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)