### PR TITLE
[f40] fix(inputplumber): Makefile patch, update files (#4967)

### DIFF
--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -7,8 +7,9 @@ Summary:        Open source input router and remapper daemon for Linux
 License:        GPL-3.0-or-later
 URL:            https://github.com/ShadowBlip/InputPlumber
 Source0:        %{url}/archive/refs/tags/v%version.tar.gz
+Patch0:         make-install-dont-build.patch
 BuildRequires:  libevdev-devel libiio-devel git make cargo libudev-devel llvm-devel clang-devel
-BuildRequires:  rust-packaging cargo-rpm-macros mold rpm_macro(cargo_prep_online)
+BuildRequires:  rust-packaging cargo-rpm-macros mold rpm_macro(cargo_prep_online) systemd-rpm-macros
 Requires:       libevdev libiio
 Recommends:     steam gamescope-session linuxconsoletools
 Packager:       madonuko <mado@fyralabs.com>
@@ -46,5 +47,7 @@ keyboards) and translate their input to a variety of virtual device formats.
 %_unitdir/inputplumber.service
 %_unitdir/inputplumber-suspend.service
 %_udevhwdbdir/59-inputplumber.hwdb
+%_udevhwdbdir/60-inputplumber-autostart.hwdb
+%_udevrulesdir/90-inputplumber-autostart.rules
 %_datadir/dbus-1/system.d/org.shadowblip.InputPlumber.conf
 %_datadir/inputplumber/

--- a/anda/games/inputplumber/make-install-dont-build.patch
+++ b/anda/games/inputplumber/make-install-dont-build.patch
@@ -1,0 +1,13 @@
+--- a/Makefile	2025-05-21 22:56:09.064696169 -0500
++++ b/Makefile	2025-05-21 23:14:40.494058939 -0500
+@@ -41,8 +41,8 @@
+ 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+ 
+ .PHONY: install
+-install: build ## Install inputplumber to the given prefix (default: PREFIX=/usr)
+-	install -D -m 755 target/$(TARGET_ARCH)/$(BUILD_TYPE)/$(NAME) \
++install:
++	install -D -m 755 target/$(BUILD_TYPE)/$(NAME) \
+ 		$(PREFIX)/bin/$(NAME)
+ 	install -D -m 644 rootfs/usr/share/dbus-1/system.d/$(DBUS_NAME).conf \
+ 		$(PREFIX)/share/dbus-1/system.d/$(DBUS_NAME).conf


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(inputplumber): Makefile patch, update files (#4967)](https://github.com/terrapkg/packages/pull/4967)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)