### PR TITLE
[f41] fix(wine-dxvk): Rewrite scriptlets, fix deps (#4924)

### DIFF
--- a/anda/system/wine-dxvk/wine-dxvk.spec
+++ b/anda/system/wine-dxvk/wine-dxvk.spec
@@ -20,9 +20,11 @@
 %global mingw_build_win32 1
 %endif
 
+%global wine_lib_dir %{_datadir}/wine-staging/lib64
+
 Name:           terra-wine-dxvk
 Version:        2.6.1
-Release:        1
+Release:        2%{?dist}
 Summary:        Vulkan-based implementation of D3D8, 9, 10 and 11 for Linux / Wine
 
 License:        zlib AND MIT
@@ -62,21 +64,24 @@ BuildRequires:  mingw32-spirv-headers
 
 Requires(pre):  vulkan-tools
 
-Requires:       wine-staging%{?_isa}
-Requires:       wine-dxvk-dxgi%{?_isa} = %{version}-%{release}
+# Disable ISA dep on WINE until I figure out what we are doing with 32-bit WINE, currently these are non-WOW64 builds
+Requires:       terra-wine-staging
+Requires:       terra-wine-dxvk-dxgi%{?_isa} = %{version}-%{release}
 Requires:       vulkan-loader%{?_isa}
 
 # We want x86_64 users to always have also 32 bit lib, it's the same what wine does
 %ifarch x86_64
-Requires:       wine-dxvk(x86-32) = %{version}-%{release}
+Requires:       terra-wine-dxvk(x86-32) = %{version}-%{release}
 %endif
 
 # Recommend also d3d8, d3d9, and d3d10
-Recommends:     wine-dxvk-d3d8%{?_isa}  = %{version}-%{release}
-Recommends:     wine-dxvk-d3d9%{?_isa}  = %{version}-%{release}
-Recommends:     wine-dxvk-d3d10%{?_isa} = %{version}-%{release}
+Recommends:     terra-wine-dxvk-d3d8%{?_isa}  = %{version}-%{release}
+Recommends:     terra-wine-dxvk-d3d9%{?_isa}  = %{version}-%{release}
+Recommends:     terra-wine-dxvk-d3d10%{?_isa} = %{version}-%{release}
 
-Requires(posttrans):   %{_sbindir}/alternatives wine-staging%{?_isa}
+# I'm looking into setting these up for the different WINE builds
+# Huge WIP
+Requires(posttrans):   %{_sbindir}/alternatives wine-staging
 Requires(preun):       %{_sbindir}/alternatives
 
 ExclusiveArch:  %{ix86} x86_64
@@ -153,76 +158,76 @@ winebuild --builtin %buildroot%mingw_sysroot/mingw/bin/d3d9.dll
 winebuild --builtin %buildroot%mingw_sysroot/mingw/bin/d3d10core.dll
 winebuild --builtin %buildroot%mingw_sysroot/mingw/bin/d3d11.dll
 
-mkdir -p %{buildroot}%{_libdir}/wine/%{winepedir}/
-install -p -m 644 %buildroot%mingw_sysroot/mingw/bin/dxgi.dll %{buildroot}%{_libdir}/wine/%{winepedir}/dxvk-dxgi.dll
-install -p -m 644 %buildroot%mingw_sysroot/mingw/bin/d3d8.dll %{buildroot}%{_libdir}/wine/%{winepedir}/dxvk-d3d8.dll
-install -p -m 644 %buildroot%mingw_sysroot/mingw/bin/d3d9.dll %{buildroot}%{_libdir}/wine/%{winepedir}/dxvk-d3d9.dll
-install -p -m 644 %buildroot%mingw_sysroot/mingw/bin/d3d10core.dll %{buildroot}%{_libdir}/wine/%{winepedir}/dxvk-d3d10core.dll
-install -p -m 644 %buildroot%mingw_sysroot/mingw/bin/d3d11.dll %{buildroot}%{_libdir}/wine/%{winepedir}/dxvk-d3d11.dll
+install -Dpm644 %buildroot%mingw_sysroot/mingw/bin/dxgi.dll %{buildroot}%{wine_lib_dir}/wine/%{winepedir}/dxvk-dxgi.dll
+install -Dpm644 %buildroot%mingw_sysroot/mingw/bin/d3d8.dll %{buildroot}%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d8.dll
+install -Dpm644 %buildroot%mingw_sysroot/mingw/bin/d3d9.dll %{buildroot}%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d9.dll
+install -Dpm644 %buildroot%mingw_sysroot/mingw/bin/d3d10core.dll %{buildroot}%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d10core.dll
+install -Dpm644 %buildroot%mingw_sysroot/mingw/bin/d3d11.dll %{buildroot}%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d11.dll
 
 # Clean-up
 rm -rf %buildroot%mingw_sysroot/mingw
 
+
+
 %posttrans
 if vulkaninfo |& grep "ERROR_INITIALIZATION_FAILED\|ERROR_SURFACE_LOST_KHR\|Vulkan support is incomplete" > /dev/null; then
-    %{_sbindir}/alternatives --install %{_libdir}/wine/%{winepedir}/d3d11.dll 'wine-d3d11%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d11.dll 5
+    %{_sbindir}/alternatives --install %{wine_lib_dir}/wine/%{winepedir}/d3d11.dll 'wine-d3d11%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d11.dll 5
 else
-    %{_sbindir}/alternatives --install %{_libdir}/wine/%{winepedir}/d3d11.dll 'wine-d3d11%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d11.dll 20
+    %{_sbindir}/alternatives --install %{wine_lib_dir}/wine/%{winepedir}/d3d11.dll 'wine-d3d11%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d11.dll 20
 fi
 
 %posttrans dxgi
 if vulkaninfo |& grep "ERROR_INITIALIZATION_FAILED\|ERROR_SURFACE_LOST_KHR\|Vulkan support is incomplete" > /dev/null; then
-    %{_sbindir}/alternatives --install %{_libdir}/wine/%{winepedir}/dxgi.dll 'wine-dxgi%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-dxgi.dll 5
+    %{_sbindir}/alternatives --install %{wine_lib_dir}/wine/%{winepedir}/dxgi.dll 'wine-dxgi%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-dxgi.dll 5
 else
-    %{_sbindir}/alternatives --install %{_libdir}/wine/%{winepedir}/dxgi.dll 'wine-dxgi%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-dxgi.dll 20
+    %{_sbindir}/alternatives --install %{wine_lib_dir}/wine/%{winepedir}/dxgi.dll 'wine-dxgi%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-dxgi.dll 20
 fi
 
 %posttrans d3d10
 if vulkaninfo |& grep "ERROR_INITIALIZATION_FAILED\|ERROR_SURFACE_LOST_KHR\|Vulkan support is incomplete" > /dev/null; then
-    %{_sbindir}/alternatives --install %{_libdir}/wine/%{winepedir}/d3d10core.dll 'wine-d3d10core%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d10core.dll 5
+    %{_sbindir}/alternatives --install %{wine_lib_dir}/wine/%{winepedir}/d3d10core.dll 'wine-d3d10core%{?_isa}'%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d10core.dll 5
 else
-    %{_sbindir}/alternatives --install %{_libdir}/wine/%{winepedir}/d3d10core.dll 'wine-d3d10core%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d10core.dll 20
+    %{_sbindir}/alternatives --install %{wine_lib_dir}/wine/%{winepedir}/d3d10core.dll 'wine-d3d10core%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d10core.dll 20
 fi
 
 %posttrans d3d9
 if vulkaninfo |& grep "ERROR_INITIALIZATION_FAILED\|ERROR_SURFACE_LOST_KHR\|Vulkan support is incomplete" > /dev/null; then
-    %{_sbindir}/alternatives --install %{_libdir}/wine/%{winepedir}/d3d9.dll 'wine-d3d9%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d9.dll 5
+    %{_sbindir}/alternatives --install %{wine_lib_dir}/wine/%{winepedir}/d3d9.dll 'wine-d3d9%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d9.dll 5
 else
-    %{_sbindir}/alternatives --install %{_libdir}/wine/%{winepedir}/d3d9.dll 'wine-d3d9%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d9.dll 20
+    %{_sbindir}/alternatives --install %{wine_lib_dir}/wine/%{winepedir}/d3d9.dll 'wine-d3d9%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d9.dll 20
 fi
 
 %postun
-%{_sbindir}/alternatives --remove 'wine-d3d11%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d11.dll
+%{_sbindir}/alternatives --remove 'wine-d3d11%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d11.dll
 
 %postun d3d10
-%{_sbindir}/alternatives --remove 'wine-d3d10core%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d10core.dll
+%{_sbindir}/alternatives --remove 'wine-d3d10core%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d10core.dll
 
 %postun d3d9
-%{_sbindir}/alternatives --remove 'wine-d3d9%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-d3d9.dll
+%{_sbindir}/alternatives --remove 'wine-d3d9%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d9.dll
 
 %postun dxgi
-%{_sbindir}/alternatives --remove 'wine-dxgi%{?_isa}' %{_libdir}/wine/%{winepedir}/dxvk-dxgi.dll
-
+%{_sbindir}/alternatives --remove 'wine-dxgi%{?_isa}' %{wine_lib_dir}/wine/%{winepedir}/dxvk-dxgi.dll
 %files
 %license LICENSE
 %doc README.md
-%{_libdir}/wine/%{winepedir}/dxvk-d3d11.dll
+%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d11.dll
 
 %files d3d10
 %license LICENSE
-%{_libdir}/wine/%{winepedir}/dxvk-d3d10core.dll
+%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d10core.dll
 
 %files d3d9
 %license LICENSE
-%{_libdir}/wine/%{winepedir}/dxvk-d3d9.dll
+%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d9.dll
 
 %files d3d8
 %license LICENSE
-%{_libdir}/wine/%{winepedir}/dxvk-d3d8.dll
+%{wine_lib_dir}/wine/%{winepedir}/dxvk-d3d8.dll
 
 %files dxgi
 %license LICENSE
-%{_libdir}/wine/%{winepedir}/dxvk-dxgi.dll
+%{wine_lib_dir}/wine/%{winepedir}/dxvk-dxgi.dll
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(wine-dxvk): Rewrite scriptlets, fix deps (#4924)](https://github.com/terrapkg/packages/pull/4924)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)