### PR TITLE
[f42] fix(mise): include `usage` dep for completions subpkgs (#4988)

### DIFF
--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -48,6 +48,7 @@ URL:            https://mise.jdx.dev/
 Summary:        Bash completion for %crate
 Requires:       %{crate} = %{version}-%{release}
 Requires:       bash-completion
+Requires:       usage
 Supplements:    (%{crate} and bash-completion)
 
 %description -n %crate-bash-completion
@@ -57,6 +58,7 @@ Bash command line completion support for %{crate}.
 Summary:        Fish completion for %{crate}
 Requires:       %{crate} = %{version}-%{release}
 Requires:       fish
+Requires:       usage
 Supplements:    (%{crate} and fish)
 
 %description -n %crate-fish-completion
@@ -66,6 +68,7 @@ Fish command line completion support for %{crate}.
 Summary:        Zsh completion for %{crate}
 Requires:       %{crate} = %{version}-%{release}
 Requires:       zsh
+Requires:       usage
 Supplements:    (%{crate} and zsh)
 
 %description -n %crate-zsh-completion


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(mise): include &#x60;usage&#x60; dep for completions subpkgs (#4988)](https://github.com/terrapkg/packages/pull/4988)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)