### PR TITLE
fix: do not run file triggers if installed on an atomic distro

### DIFF
--- a/anda/tools/sbctl/sbctl.spec
+++ b/anda/tools/sbctl/sbctl.spec
@@ -42,7 +42,7 @@ export GOPATH=%{_builddir}/go
 
 
 %transfiletriggerin -P 1 -- /boot /efi /usr/lib /usr/libexec
-if if [[ ! -f /run/ostree-booted ]] && grep -q -m 1 -e '\.efi$' -e '/vmlinuz$'; then
+if [[ ! -f /run/ostree-booted ]] && grep -q -m 1 -e '\.efi$' -e '/vmlinuz$'; then
     exec </dev/null
     %{_bindir}/sbctl sign-all -g
 fi

--- a/anda/tools/sbctl/sbctl.spec
+++ b/anda/tools/sbctl/sbctl.spec
@@ -1,6 +1,6 @@
 Name:           sbctl
 Version:        0.17
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Secure Boot key manager
 
 License:        MIT
@@ -61,6 +61,9 @@ fi
 
 
 %changelog
+* Sat May 24 2025 Esteve Fernandez <esteve@apache.org> - 0.17-2
+- Do not run file triggers on atomic systems
+
 * Sat Mar 30 2024 Cappy Ishihara <cappy@cappuchino.xyz> - 0.13-1
 - Push to Terra
 

--- a/anda/tools/sbctl/sbctl.spec
+++ b/anda/tools/sbctl/sbctl.spec
@@ -42,7 +42,7 @@ export GOPATH=%{_builddir}/go
 
 
 %transfiletriggerin -P 1 -- /boot /efi /usr/lib /usr/libexec
-if grep -q -m 1 -e '\.efi$' -e '/vmlinuz$'; then
+if if [[ ! -f /run/ostree-booted ]] && grep -q -m 1 -e '\.efi$' -e '/vmlinuz$'; then
     exec </dev/null
     %{_bindir}/sbctl sign-all -g
 fi


### PR DESCRIPTION
`sbctl` fails to install on atomic distros (e.g. Silverblue, Bluefin, etc.) because `/var/lib` is read-only. Error log:

```bash
> rpm-ostree install sbctl
Checking out tree 81c530d... done
Enabled rpm-md repositories: updates fedora terra-extras terra google-chrome rpmfusion-nonfree-nvidia-driver rpmfusion-nonfree-steam copr:copr.fedorainfracloud.org:phracek:PyCharm brave-browser hashicorp updates-archive
Importing rpm-md... done
rpm-md repo 'updates' (cached); generated: 2025-05-24T01:12:47Z solvables: 14442
rpm-md repo 'fedora' (cached); generated: 2025-04-09T11:06:59Z solvables: 76879
rpm-md repo 'terra-extras' (cached); generated: 2025-05-22T09:58:39Z solvables: 315
rpm-md repo 'terra' (cached); generated: 2025-05-24T06:34:19Z solvables: 2464
rpm-md repo 'google-chrome' (cached); generated: 2025-05-22T16:00:41Z solvables: 4
rpm-md repo 'rpmfusion-nonfree-nvidia-driver' (cached); generated: 2025-05-02T23:55:38Z solvables: 17
rpm-md repo 'rpmfusion-nonfree-steam' (cached); generated: 2025-04-18T08:19:16Z solvables: 1
rpm-md repo 'copr:copr.fedorainfracloud.org:phracek:PyCharm' (cached); generated: 2025-05-20T06:03:29Z solvables: 5
rpm-md repo 'brave-browser' (cached); generated: 2025-05-15T16:08:17Z solvables: 348
rpm-md repo 'hashicorp' (cached); generated: 2025-05-21T23:27:08Z solvables: 2520
rpm-md repo 'updates-archive' (cached); generated: 2025-05-24T01:25:50Z solvables: 15460
Resolving dependencies... done
Checking out packages... done
Running systemd-sysusers... done
Running pre scripts... done
Running post scripts... done
Running posttrans scripts... done
error: Executing %transfiletriggerin for sbctl: bwrap(/bin/sh): Child process killed by signal 1; run `journalctl -t 'rpm-ostree(sbctl.transfiletriggerin)'` for more information
```

```bash
> journalctl -t 'rpm-ostree(sbctl.transfiletriggerin)'
-- Boot 46a7367a19d04aa8b1ce3387c81f8b90 --
May 24 11:56:52 carbonara rpm-ostree(sbctl.transfiletriggerin)[6392]: Generating EFI bundles....
May 24 11:56:52 carbonara rpm-ostree(sbctl.transfiletriggerin)[6392]: mkdir /var/lib/sbctl: read-only file system
```