### PR TITLE
[f41] fix(bun): use baseline instead (#5003)

### DIFF
--- a/anda/devs/bun/bun-bin.spec
+++ b/anda/devs/bun/bun-bin.spec
@@ -1,13 +1,13 @@
 %define debug_package %nil
 %ifarch x86_64
-%global a x64
+%global a x64-baseline
 %elifarch aarch64
 %global a aarch64
 %endif
 
 Name:			bun-bin
 Version:		1.2.14
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one
 License:		MIT
 URL:			https://bun.sh
@@ -17,10 +17,37 @@ BuildRequires:	unzip
 %description
 %summary.
 
+
+%package bash-completion
+Summary:		Bash completion for %{name}
+Requires:		%{name} = %{version}-%{release}
+Requires: 		bash-completion
+Supplements:	(%{name} and bash-completion)
+
+%description bash-completion
+Bash command line completion support for %{name}.
+
+%package fish-completion
+Summary:		Fish completion for %{name}
+Requires:		%{name} = %{version}-%{release}
+Requires:		fish
+Supplements:	(%{name} and fish)
+
+%description fish-completion
+Fish command line completion support for %{name}.
+
+%package zsh-completion
+Summary:		Zsh completion for %{name}
+Requires:		%{name} = %{version}-%{release}
+Requires:		zsh
+Supplements:	(%{name} and zsh)
+
+%description zsh-completion
+Zsh command line completion support for %{name}.
+
+
 %prep
-unzip %SOURCE0
-%global buildsubdir bun-linux-%a
-cd %buildsubdir
+%autosetup -n bun-linux-%a
 cat<<EOF > LICENSE
 MIT License
 
@@ -61,6 +88,12 @@ ln -s bun %buildroot%_bindir/bunx
 %license LICENSE
 %_bindir/bun
 %_bindir/bunx
+
+%files bash-completion
 %bash_completions_dir/bun.bash
+
+%files fish-completion
 %fish_completions_dir/bun.fish
+
+%files zsh-completion
 %zsh_completions_dir/_bun


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(bun): use baseline instead (#5003)](https://github.com/terrapkg/packages/pull/5003)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)