### PR TITLE
[el10] feat(andax): helpers for parsing spec files (#4994)

### DIFF
--- a/andax/spec.rhai
+++ b/andax/spec.rhai
@@ -1,0 +1,20 @@
+fn get_version(rpm) {
+    return `(?m)^Version:\s*(.+)$`.find(rpm.f, 1);
+}
+
+fn get_release(rpm) {
+    let r = `(?m)^Release:\s*(.+)$`.find(rpm.f, 1);
+    r = sub(`(?m)(%\??dist|%\{\??dist\})\s*$`, "", r);
+    r.replace("%autorelease", "1");
+    return r;
+}
+
+/// Only supports one-liner `%global`s!
+fn get_global(rpm, macro) {
+    return `(?m)^%global\s+${macro}\s+(.+)$`.find(rpm.f, 1);
+}
+
+/// Only supports one-liner `%define`s!
+fn get_define(rpm, macro) {
+    return `(?m)^%define\s+${macro}\s+(.+)$`.find(rpm.f, 1);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(andax): helpers for parsing spec files (#4994)](https://github.com/terrapkg/packages/pull/4994)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)