### PR TITLE
[f40] fix(heroic-games-launcher): Electron builder needs NPM now (#5027)

### DIFF
--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -29,6 +29,7 @@ BuildRequires: gcc-c++
 BuildRequires: git
 BuildRequires: make
 BuildRequires: nodejs
+BuildRequires: nodejs-npm
 BuildRequires: pnpm
 BuildRequires: python3
 Requires:      alsa-lib
@@ -51,7 +52,6 @@ Heroic is a Free and Open Source Epic, GOG, and Amazon Prime Games launcher for 
 
 %prep
 %git_clone https://github.com/%{org_name}/%{git_name} v%{version}
-desktop-file-edit --set-key=Exec --set-value="/usr/share/%{shortname}/%{shortname} %u" flatpak/%{reverse_dns}.desktop
 
 %build
 pnpm install
@@ -62,11 +62,10 @@ pnpm dist:linux
 mkdir -p %{buildroot}%{_datadir}/%{shortname}
 mv $(find . -iname "*LICENSE*" -not -path "./node_modules/*" -and -not -path "./public/*") .
 mv LICENSE node-font-list.LICENSE
-rm -rf dist/linux-unpacked/resources/app.asar.unpacked/node_modules/font-list/libs/darwin
-rm -rf dist/linux-unpacked/resources/app.asar.unpacked/node_modules/font-list/libs/win32
+rm -rf dist/linux-unpacked/resources/app.asar.unpacked/node_modules/font-list/libs/{darwin,win32}
 %ifarch aarch64
-### Needs testing once aarch64 Heroic is complete:
-#rm -rf dist/linux-unpacked/resources/app.asar.unpacked/build/bin/x64
+# Keep the x86_64 Windows binaries run through Wine just in case
+rm -rf dist/linux-unpacked/resources/app.asar.unpacked/build/bin/x64/{darwin,linux}
 mv dist/linux-arm64-unpacked/* %{buildroot}%{_datadir}/%{shortname}
 %else
 rm -rf dist/linux-unpacked/resources/app.asar.unpacked/build/bin/arm64
@@ -84,7 +83,7 @@ install -Dm644 dist/.icon-set/icon_128x128.png %{buildroot}%{_iconsdir}/hicolor/
 install -Dm644 dist/.icon-set/icon_256x256.png %{buildroot}%{_iconsdir}/hicolor/256x256/apps/%{reverse_dns}.png
 install -Dm644 dist/.icon-set/icon_512x512.png %{buildroot}%{_iconsdir}/hicolor/512x512/apps/%{reverse_dns}.png
 install -Dm644 dist/.icon-set/icon_1024.png %{buildroot}%{_iconsdir}/hicolor/1024x1024/apps/%{reverse_dns}.png
-install -Dm644 flatpak/%{reverse_dns}.desktop -t %{buildroot}%{_datadir}/applications/
+desktop-file-install --set-key=Exec --set-value="/usr/share/%{shortname}/%{shortname} %u" flatpak/%{reverse_dns}.desktop
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{reverse_dns}.desktop


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(heroic-games-launcher): Electron builder needs NPM now (#5027)](https://github.com/terrapkg/packages/pull/5027)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)