### PR TITLE
fix(steam): Track beta branch

### DIFF
--- a/anda/games/steam/update.rhai
+++ b/anda/games/steam/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(find(`\nVersion:\s+1:(.+?)\s`, get("https://repo.steampowered.com/steam/archive/stable/steam_latest.dsc"), 1));
+rpm.version(find(`\nVersion:\s+1:(.+?)\s`, get("https://repo.steampowered.com/steam/archive/beta/steam_latest-beta.dsc"), 1));


### PR DESCRIPTION
Negativo and RPM Fusion track this branch for RPM versions, currently this is causing a conflict between us and them. Just bumping the version with this script should resolve it.