### PR TITLE
[el10] fix(steam): Track beta branch (#5032)

### DIFF
--- a/anda/games/steam/update.rhai
+++ b/anda/games/steam/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(find(`\nVersion:\s+1:(.+?)\s`, get("https://repo.steampowered.com/steam/archive/stable/steam_latest.dsc"), 1));
+rpm.version(find(`\nVersion:\s+1:(.+?)\s`, get("https://repo.steampowered.com/steam/archive/beta/steam_latest-beta.dsc"), 1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(steam): Track beta branch (#5032)](https://github.com/terrapkg/packages/pull/5032)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)