### PR TITLE
[f41] chore(zapret): bump to v71 (#5049)

### DIFF
--- a/anda/misc/zapret/update.rhai
+++ b/anda/misc/zapret/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("bol-van/zapret"));

--- a/anda/misc/zapret/zapret.spec
+++ b/anda/misc/zapret/zapret.spec
@@ -1,6 +1,6 @@
 Name:    zapret
-Version: 70.6
-Release: 6%{?dist}
+Version: 71
+Release: 1%{?dist}
 Summary: A multi-platform Deep Packet Inspection (DPI) bypass tool
 License: MIT 
 ExcludeArch: s390x
@@ -137,6 +137,8 @@ END
 %{_unitdir}/tpws@.service
 
 %changelog
+* Mon May 26 2025 libffi <contact@ffi.lol> - 71
+- Bump upstream.
 * Thu May 1 2025 libffi <contact@ffi.lol> - 70.6-6
 - Fix init.d breakages.
 * Thu May 1 2025 libffi <contact@ffi.lol> - 70.6-5


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(zapret): bump to v71 (#5049)](https://github.com/terrapkg/packages/pull/5049)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)