### PR TITLE
[f40] fix(pbpctrl): more builddeps (#4989)

### DIFF
--- a/anda/langs/rust/pbpctrl/pbpctrl.spec
+++ b/anda/langs/rust/pbpctrl/pbpctrl.spec
@@ -15,6 +15,9 @@ Source:         %url/archive/refs/tags/v%version.tar.gz
 Packager:       madonuko <mado@fyralabs.com>
 
 BuildRequires:  cargo-rpm-macros >= 24
+BuildRequires:  pkgconfig(dbus-1)
+BuildRequires:  protobuf-compiler
+BuildRequires:  protobuf-devel
 
 %global _description %{expand:
 Command-line utility for controlling Google Pixel Buds Pro.}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(pbpctrl): more builddeps (#4989)](https://github.com/terrapkg/packages/pull/4989)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)