### PR TITLE
[f40] fix(swww): more build dependencies (#5059)

### DIFF
--- a/anda/desktops/waylands/swww/swww.spec
+++ b/anda/desktops/waylands/swww/swww.spec
@@ -3,14 +3,17 @@ Version:        0.10.0
 Release:        1%?dist
 Summary:        Wallpaper daemon for Wayland
 SourceLicense:  GPL-3.0-only
-License:        (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0) AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
+License:        (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-3-Clause AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:            https://github.com/LGFae/swww
 Source0:		%url/archive/refs/tags/v%version.tar.gz
+Packager:       madonuko <mado@fyralabs.com>
 BuildRequires:  anda-srpm-macros rust-packaging rpm_macro(bash_completions_dir) mold
 BuildRequires:  scdoc
 BuildRequires:  zstd
 BuildRequires:  pkgconfig(liblz4)
 BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-protocols)
 
 %description
 swww is a wallpaper daemon for Wayland that is controlled
@@ -56,8 +59,8 @@ Zsh command-line completion support for %{name}.
 ./doc/gen.sh
 
 %install
-%{cargo_install} &
-cd daemon && %{cargo_install} &
+(cd client && %{cargo_install}) &
+(cd daemon && %{cargo_install}) &
 wait
 install -Dm644 -T completions/swww.bash %buildroot%bash_completions_dir/swww
 install -Dm644 -T completions/swww.fish %buildroot%fish_completions_dir/swww.fish
@@ -73,7 +76,6 @@ install -Dm644 -t %buildroot%_mandir/man1 doc/generated/swww*1
 %_mandir/man1/%name-clear.1.gz
 %_mandir/man1/%name-daemon.1.gz
 %_mandir/man1/%name-img.1.gz
-%_mandir/man1/%name-init.1.gz
 %_mandir/man1/%name-kill.1.gz
 %_mandir/man1/%name-query.1.gz
 %_mandir/man1/%name-restore.1.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(swww): more build dependencies (#5059)](https://github.com/terrapkg/packages/pull/5059)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)