### PR TITLE
[f41] fix(mise): rust2rpm again (#5103)

### DIFF
--- a/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
+++ b/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- mise-2025.3.0/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ mise-2025.3.0/Cargo.toml	2025-03-02T07:08:39.544459+00:00
-@@ -469,18 +469,6 @@
+--- mise-2025.5.15/Cargo.toml	1970-01-01T00:00:01+00:00
++++ mise-2025.5.15/Cargo.toml	2025-05-28T15:40:58.219641+00:00
+@@ -475,25 +475,6 @@
  optional = true
  default-features = false
  
@@ -16,10 +16,17 @@
 -[target."cfg(windows)".dependencies.sevenz-rust]
 -version = "0.6"
 -
+-[target."cfg(windows)".dependencies.winapi]
+-version = "0.3.9"
+-features = [
+-    "consoleapi",
+-    "minwindef",
+-]
+-
  [lints.clippy]
  borrowed_box = "allow"
  
-@@ -495,3 +483,4 @@
+@@ -508,3 +489,4 @@
  [profile.serious]
  lto = true
  inherits = "release"

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -30,7 +30,7 @@ The front-end to your dev env.}
 
 %package     -n %{crate}
 Summary:        %{summary}
-License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND BSL-1.0 AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND MIT AND (MIT AND (MIT OR Apache-2.0)) AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT)
+License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CDLA-Permissive-2.0 AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
 URL:            https://mise.jdx.dev/
 
 %description -n %{crate} %{_description}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(mise): rust2rpm again (#5103)](https://github.com/terrapkg/packages/pull/5103)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)