### PR TITLE
[f41] add: rtl8821cu driver (#5118)

### DIFF
--- a/anda/system/rtl8821cu/akmod/anda.hcl
+++ b/anda/system/rtl8821cu/akmod/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+    rpm {
+        spec = "rtl8821cu-kmod.spec"
+    }
+   	labels {
+		mock = 1
+		updbranch = 1
+	}
+}

--- a/anda/system/rtl8821cu/akmod/rtl8821cu-kmod.spec
+++ b/anda/system/rtl8821cu/akmod/rtl8821cu-kmod.spec
@@ -1,0 +1,67 @@
+%global commit d74134a1c68f59f2b80cdd6c6afb8c1a8a687cbf
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20250508
+%global ver 5.12.0.4
+%global modulename rtl8821cu
+%global git_name 8821cu-20210916
+%define buildforkernels akmod
+%global debug_package %{nil}
+%global _description %{expand:
+Linux Driver for USB Wi-Fi Adapters that are based on the RTL8811CU, RTL8821CU, RTL8821CUH, and RTL8731AU chipsets.}
+
+Name:          %{modulename}-kmod
+Version:       %{ver}^%{commit_date}git.%{shortcommit}
+Release:       1%{?dist}
+Summary:       Linux Driver for USB Wi-Fi Adapters using RTL8821 chipsets
+License:       GPL-2.0-only
+URL:           https://github.com/morrownr/8821cu-20210916
+Source0:       %{url}/archive/%{commit}.tar.gz#/%{git_name}-%{shortcommit}.tar.gz
+BuildRequires: kmodtool
+BuildRequires: systemd-rpm-macros
+Requires:      %{modulename}-kmod-common = %{version}
+Requires:      akmods
+Conflicts:     dkms-%{modulename}
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description %_description
+
+%prep
+%{?kmodtool_check}
+kmodtool  --target %{_target_cpu}  --repo terra --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%autosetup -n %{git_name}-%{commit}
+
+%ifarch armv7hl
+sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/g' Makefile
+sed -i 's/CONFIG_PLATFORM_ARM_RPI = n/CONFIG_PLATFORM_ARM_RPI = y/g' Makefile
+%elifarch aarch64
+sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/g' Makefile
+sed -i 's/CONFIG_PLATFORM_ARM_RPI = y/CONFIG_PLATFORM_ARM_RPI = n/g' Makefile
+sed -i 's/CONFIG_PLATFORM_ARM64_RPI = n/CONFIG_PLATFORM_ARM64_RPI = y/g' Makefile
+%endif
+
+for kernel_version in %{?kernel_versions}; do
+    mkdir _kmod_build_${kernel_version%%___*}
+    cp -fr core hal include os_dep platform Kconfig Makefile halmac.mk _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version in %{?kernel_versions}; do
+    pushd _kmod_build_${kernel_version%%___*}/
+        %make_build -C "${kernel_version##*___}" M=$(pwd) VERSION="v%{version}" modules
+    popd
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+    mkdir -p %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+    install -p -m 0755 _kmod_build_${kernel_version%%___*}/*.ko \
+        %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+done
+%{?akmod_install}
+
+%changelog
+* Wed May 28 2025 Gilver E. <rockgrub@disroot.org> - 5.12.0.4^20250508git.d74134a-1
+- Initial package

--- a/anda/system/rtl8821cu/akmod/update.rhai
+++ b/anda/system/rtl8821cu/akmod/update.rhai
@@ -1,0 +1,12 @@
+let c = sh("cat anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec | grep '%global commit ' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commit_date", d);
+    let v = sh("cat anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}

--- a/anda/system/rtl8821cu/dkms/anda.hcl
+++ b/anda/system/rtl8821cu/dkms/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "dkms-rtl8821cu.spec"
+    }
+    labels {
+        updbranch = 1
+    }
+}

--- a/anda/system/rtl8821cu/dkms/dkms-rtl8821cu.spec
+++ b/anda/system/rtl8821cu/dkms/dkms-rtl8821cu.spec
@@ -1,0 +1,78 @@
+%global commit d74134a1c68f59f2b80cdd6c6afb8c1a8a687cbf
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20250508
+%global ver 5.12.0.4
+%global modulename rtl8821cu
+%global git_name 8821cu-20210916
+%global debug_package %{nil}
+%global _description %{expand:
+Linux Driver for USB Wi-Fi Adapters that are based on the RTL8811CU, RTL8821CU, RTL8821CUH, and RTL8731AU chipsets.}
+
+Name:          dkms-%{modulename}
+Version:       %{ver}^%{commit_date}git.%{shortcommit}
+Release:       1%{?dist}
+Summary:       Linux Driver for USB Wi-Fi Adapters using RTL8821 chipsets
+License:       GPL-2.0-only
+URL:           https://github.com/morrownr/8821cu-20210916
+Source0:       %{url}/archive/%{commit}.tar.gz#/%{git_name}-%{shortcommit}.tar.gz
+Source1:       no-weak-modules.conf
+BuildRequires: sed
+BuildRequires: systemd-rpm-macros
+Requires:      %{modulename}-kmod-common = %{version}
+Requires:      dkms
+# Required for DKMS to build the kmod
+Requires:      gcc
+Requires:      bc
+Requires:      make
+Provides:      %{modulename}-kmod
+Conflicts:     akmod-%{modulename}
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%description %_description
+
+%prep
+%autosetup -n %{git_name}-%{commit}
+
+sed -i 's/PACKAGE_VERSION=".*"/PACKAGE_VERSION="%{version}"/g' dkms.conf
+
+# Technically this package is noarch. However it cannot be built that way due to arch dependencies for the built kmod.
+%ifarch armv7hl
+sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/g' Makefile
+sed -i 's/CONFIG_PLATFORM_ARM_RPI = n/CONFIG_PLATFORM_ARM_RPI = y/g' Makefile
+%elifarch aarch64
+sed -i 's/CONFIG_PLATFORM_I386_PC = y/CONFIG_PLATFORM_I386_PC = n/g' Makefile
+sed -i 's/CONFIG_PLATFORM_ARM_RPI = y/CONFIG_PLATFORM_ARM_RPI = n/g' Makefile
+sed -i 's/CONFIG_PLATFORM_ARM64_RPI = n/CONFIG_PLATFORM_ARM64_RPI = y/g' Makefile
+%endif
+
+%build
+# Hi, I'm empty.
+
+%install
+mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+cp -fr core hal include os_dep platform Kconfig Makefile halmac.mk dkms-make.sh dkms.conf %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+
+%if 0%{?fedora}
+# Do not enable weak modules support in Fedora (no kABI):
+install -Dpm644 %{SOURCE1} %{buildroot}%{_sysconfdir}/dkms/%{modulename}.conf
+%endif
+
+%post
+dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{modulename} -v %{version} -q || :
+dkms install -m %{modulename} -v %{version} -q --force || :
+
+%preun
+# Remove all versions from DKMS registry:
+dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
+
+%files
+%{_usrsrc}/%{modulename}-%{version}/
+%if 0%{?fedora}
+%{_sysconfdir}/dkms/%{modulename}.conf
+%endif
+
+%changelog
+* Wed May 28 2025 Gilver E. <rockgrub@disroot.org> - 5.12.0.4^20250508git.d74134a-1
+- Initial package

--- a/anda/system/rtl8821cu/dkms/no-weak-modules.conf
+++ b/anda/system/rtl8821cu/dkms/no-weak-modules.conf
@@ -1,0 +1,1 @@
+NO_WEAK_MODULES="yes"

--- a/anda/system/rtl8821cu/dkms/update.rhai
+++ b/anda/system/rtl8821cu/dkms/update.rhai
@@ -1,0 +1,12 @@
+let c = sh("cat anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec | grep '%global commit ' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec | grep '%global commit_date' | sed -E 's/.+commit_date //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commit_date", d);
+    let v = sh("cat anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}

--- a/anda/system/rtl8821cu/kmod-common/anda.hcl
+++ b/anda/system/rtl8821cu/kmod-common/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "rtl8821cu-kmod-common.spec"
+    }
+   	labels {
+		nightly = "1"
+	}
+}

--- a/anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec
+++ b/anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec
@@ -1,0 +1,51 @@
+%global commit d74134a1c68f59f2b80cdd6c6afb8c1a8a687cbf
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20250508
+%global ver 5.12.0.4
+%global modulename rtl8821cu
+%global git_name 8821cu-20210916
+%global debug_package %{nil}
+
+Name:           %{modulename}-kmod-common
+Version:        %{ver}^%{commit_date}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Common files and documentation for the rtl8821cu driver
+License:        GPL-2.0-only
+URL:            https://github.com/morrownr/8821cu-20210916
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{git_name}-%{shortcommit}.tar.gz
+BuildRequires:  systemd-rpm-macros
+Requires:       rtl8821cu-kmod = %{version}
+BuildArch:      noarch
+Packager:       Gilver E. <rockgrub@disroot.org>
+
+%description
+Necessary files for the %{modulename} driver.
+
+%package -n     %{modulename}-doc
+Summary:        Docs for the rtl8821cu driver
+
+%description -n %{modulename}-doc
+Documentation files for the Linux rtl8821cu driver.
+
+%prep
+%autosetup -n %{git_name}-%{commit}
+
+%build
+# Empty build section for RPM reasons
+
+%install
+install -Dm644 8821cu.conf -t %{buildroot}%{_modprobedir}
+
+%files
+%doc README.md
+%license LICENSE
+%{_modprobedir}/8821cu.conf
+
+%files -n %{modulename}-doc
+%doc FAQ.md
+%doc supported-device-IDs
+%doc docs/*
+
+%changelog
+* Wed May 28 2025 Gilver E. <rockgrub@disroot.org> - 5.12.0.4^20250508git.d74134a-1
+- Initial package

--- a/anda/system/rtl8821cu/kmod-common/update.rhai
+++ b/anda/system/rtl8821cu/kmod-common/update.rhai
@@ -1,0 +1,8 @@
+rpm.global("commit", gh_commit("morrownr/8821cu-20210916"));
+	if rpm.changed() {
+		rpm.global("commit_date", date());
+		rpm.release();
+                let v = find(`PACKAGE_VERSION="([\d.]+)"`, gh_rawfile("morrownr/8821cu-20210916", "main", "dkms.conf"), 1);
+                rpm.global("ver", v);
+	}
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: rtl8821cu driver (#5118)](https://github.com/terrapkg/packages/pull/5118)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)