### PR TITLE
[f41] chore(terra-mock-configs): Update to non-dev (#4868)

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,6 +1,6 @@
 Name:           terra-mock-configs
 Version:        1.5.0
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        Mock configs for Terra repos
 
@@ -27,13 +27,13 @@ Obsoletes: anda-mock-configs < 3-2%{?dist}
 mkdir -p %{buildroot}%{_sysusersdir}
 mkdir -p %{buildroot}%{_sysconfdir}/mock/templates
 
-# not copying terra-el.tpl as that might be a duplicate
-cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el-dev.tpl
+# not copying terra-el-dev.tpl as we aren't using dev
+cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el.tpl
 cp -v *.cfg %{buildroot}%{_sysconfdir}/mock/
 
 %files
 %config %{_sysconfdir}/mock/templates/terra.tpl
-%config %{_sysconfdir}/mock/templates/terra-el-dev.tpl
+%config %{_sysconfdir}/mock/templates/terra-el.tpl
 %config %{_sysconfdir}/mock/terra-*-x86_64.cfg
 %config %{_sysconfdir}/mock/terra-*-aarch64.cfg
 %config %{_sysconfdir}/mock/terra-*-i386.cfg


### PR DESCRIPTION
# Backport

This will backport the following commits from `el10` to `f41`:
 - [chore(terra-mock-configs): Update to non-dev (#4868)](https://github.com/terrapkg/packages/pull/4868)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)