### PR TITLE
fix(anda): Ifcond to build on EL10

### DIFF
--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -17,7 +17,11 @@ ExclusiveArch:  %{rust_arches}
 
 BuildRequires:  rust-packaging >= 21
 BuildRequires:  anda-srpm-macros
+%if 0%{?rhel}
+BuildRequires:  openssl-devel
+%else
 BuildRequires:  openssl-devel-engine
+%endif
 BuildRequires:  git-core
 BuildRequires:  libgit2-devel
 BuildRequires:  libssh2-devel

--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -17,9 +17,8 @@ ExclusiveArch:  %{rust_arches}
 
 BuildRequires:  rust-packaging >= 21
 BuildRequires:  anda-srpm-macros
-%if 0%{?rhel}
 BuildRequires:  openssl-devel
-%else
+%if 0%{?fedora}
 BuildRequires:  openssl-devel-engine
 %endif
 BuildRequires:  git-core


### PR DESCRIPTION
Anda is out of sync on EL10 and can't update due to the specs being different, this should allow us to normalize them.

I will likely have to manually backport this.