### PR TITLE
[f41] fix(wine-dxvk): update.rhai typo (#5129)

### DIFF
--- a/anda/system/wine-dxvk/update.rhai
+++ b/anda/system/wine-dxvk/update.rhai
@@ -1,4 +1,4 @@
-rpm.version(gh("doitsujin/dxvk");
+rpm.version(gh("doitsujin/dxvk"));
 if rpm.changed {
     let json = get("https://api.github.com/repos/doitsujin/dxvk/contents/subprojects").json_arr();
     rpm.global("libdisplay_commit", json[0].sha);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(wine-dxvk): update.rhai typo (#5129)](https://github.com/terrapkg/packages/pull/5129)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)