### PR TITLE
[f42] feat(ffmpeg): bump release automatically when files changed (#5073)

### DIFF
--- a/anda/multimedia/ffmpeg/update.rhai
+++ b/anda/multimedia/ffmpeg/update.rhai
@@ -1,17 +1,10 @@
 import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
 
 rpm.version(find(`<small>ffmpeg-([\d.]+?)\.tar\.xz</small>`, get("https://ffmpeg.org/download.html"), 1));
 
-let branch = labels.branch;
-if branch.starts_with("f") {
-	branch.crop(1); // remove the `f`
-}
+open_file("anda/multimedia/ffmpeg/VERSION_x265.txt", "w").write(bump::madoguchi("x265", labels.branch));
+open_file("anda/multimedia/ffmpeg/VERSION_tesseract.txt", "w").write(bump::bodhi("tesseract", bump::as_bodhi_ver(labels.branch)));
+open_file("anda/multimedia/ffmpeg/VERSION_vvenc.txt", "w").write(bump::madoguchi("vvenc-libs", labels.branch));
 
-let ffmpeg_ver = get(`https://madoguchi.fyralabs.com/v4/terra${branch}/packages/x265`).json().ver;
-open_file("anda/multimedia/ffmpeg/VERSION_x265.txt", "w").write(ffmpeg_ver);
-
-let tesseract_ver = bump::bodhi("tesseract", bump::as_bodhi_ver(labels.branch));
-open_file("anda/multimedia/ffmpeg/VERSION_tesseract.txt", "w").write(tesseract_ver);
-
-let vvenc_ver = get(`https://madoguchi.fyralabs.com/v4/terra${branch}/packages/vvenc-libs`).json().ver;
-open_file("anda/multimedia/ffmpeg/VERSION_vvenc.txt", "w").write(vvenc_ver);
+import "andax/ci/bump_release.rhai";

--- a/andax/ci/bump_release.rhai
+++ b/andax/ci/bump_release.rhai
@@ -1,0 +1,7 @@
+import "andax/spec.rhai" as spec;
+
+let dir = sub(`/[^/]+`, "", __script_path);
+
+if sh("[[ `git status " + dir + "--porcelain` ]] && exit 1", #{}).ctx.rc == 1 {
+	spec::bump_release(rpm);
+}

--- a/andax/spec.rhai
+++ b/andax/spec.rhai
@@ -18,3 +18,7 @@ fn get_global(rpm, macro) {
 fn get_define(rpm, macro) {
     return `(?m)^%define\s+${macro}\s+(.+)$`.find(rpm.f, 1);
 }
+
+fn bump_release(rpm) {
+    rpm.release(`${rpm.get_release().parse_int() + 1}`);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(ffmpeg): bump release automatically when files changed (#5073)](https://github.com/terrapkg/packages/pull/5073)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)