### PR TITLE
[f42] feat: set Vendor for packages built on CI (#4803)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -69,7 +69,7 @@ jobs:
           dnf5 builddep -y ${dir}/*.spec
 
       - name: Build with Andaman
-        run: anda build ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
+        run: anda build ${{ matrix.pkg.pkg }} -D "vendor Terra" -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
 
       - name: Generating artifact name
         id: art

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -46,15 +46,15 @@ jobs:
           echo "PATH=$PATH:/github/home/.cargo/bin" >> $GITHUB_ENV
           export PATH=$PATH:/github/home/.cargo/bin
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          anda build -rrpmbuild anda/terra/mock-configs/pkg
+          anda build -D "vendor Terra" -rrpmbuild anda/terra/mock-configs/pkg
       - name: Install terra-mock-configs
         run: dnf5 install -y anda-build/rpm/rpms/terra-mock-configs*.rpm
 
-      - name: Build trra-release
-        run: anda build -rrpmbuild anda/terra/release/pkg
+      - name: Build terra-release
+        run: anda build -D "vendor Terra" -rrpmbuild anda/terra/release/pkg
 
       - name: Build Subatomic
-        run: anda build -rrpmbuild anda/tools/buildsys/subatomic/pkg
+        run: anda build -D "vendor Terra" -rrpmbuild anda/tools/buildsys/subatomic/pkg
       - name: Install Subatomic
         run: dnf5 install -y ./anda-build/rpm/rpms/subatomic-*.rpm
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build with Andaman
-        run: anda build -c terra-${{ matrix.version }}-${{ matrix.arch }} anda/${{ matrix.pkg }}pkg
+        run: anda build -D "vendor Terra" -c terra-${{ matrix.version }}-${{ matrix.arch }} anda/${{ matrix.pkg }}pkg
 
       - name: Generating artifact name
         id: art

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -41,7 +41,7 @@ jobs:
           dnf5 builddep -y ${dir}/*.spec
 
       - name: Build with Andaman
-        run: anda build ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ contains(matrix.pkg.labels, 'mock') && '' || '-rrpmbuild' }}
+        run: anda build -D "vendor Terra" ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ contains(matrix.pkg.labels, 'mock') && '' || '-rrpmbuild' }}
 
       - name: Generating artifact name
         id: art


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat: set Vendor for packages built on CI (#4803)](https://github.com/terrapkg/packages/pull/4803)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)