### PR TITLE
[f42] fix(wine-stable): Turn update variable into string (#5152)

### DIFF
--- a/anda/system/wine/stable/update.rhai
+++ b/anda/system/wine/stable/update.rhai
@@ -5,4 +5,4 @@ for matches in find_all("[\\d.]+\\.0", get("https://dl.winehq.org/wine/source/")
 }
 v.dedup();
 v.sort();
-rpm.version(v[v.len()-1]);
+rpm.version(`${v[v.len()-1]}`);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(wine-stable): Turn update variable into string (#5152)](https://github.com/terrapkg/packages/pull/5152)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)