### PR TITLE
[f42] fix(wine-dxvk): Call rpm.changed() correctly (#5150)

### DIFF
--- a/anda/system/wine-dxvk/update.rhai
+++ b/anda/system/wine-dxvk/update.rhai
@@ -1,5 +1,5 @@
 rpm.version(gh("doitsujin/dxvk"));
-if rpm.changed {
+if rpm.changed() {
     let json = get("https://api.github.com/repos/doitsujin/dxvk/contents/subprojects").json_arr();
     rpm.global("libdisplay_commit", json[0].sha);
     let rawfile = get("https://gitlab.freedesktop.org/emersion/libdisplay-info/-/raw/main/meson.build?ref_type=heads");


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(wine-dxvk): Call rpm.changed() correctly (#5150)](https://github.com/terrapkg/packages/pull/5150)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)