### PR TITLE
[f42] fix(lovely-injector): Don't update a non-existant global (#5165)

### DIFF
--- a/anda/lib/lovely-injector/update.rhai
+++ b/anda/lib/lovely-injector/update.rhai
@@ -1,1 +1,1 @@
-rpm.global("ver",gh("ethangreen-dev/lovely-injector"));
+rpm.version(gh("ethangreen-dev/lovely-injector"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(lovely-injector): Don&#x27;t update a non-existant global (#5165)](https://github.com/terrapkg/packages/pull/5165)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)