### PR TITLE
[el10] fix(mesa): Track download page by description to always return the latest version (#5148)

### DIFF
--- a/anda/lib/mesa/update.rhai
+++ b/anda/lib/mesa/update.rhai
@@ -1,5 +1,2 @@
-let v = gitlab_tag("gitlab.freedesktop.org", "176");
-v.crop(5);
-if `[\d.]+-rc\d+`.find_all(v).len == 0 {
-  rpm.version(v);
-}
+let v = find(`mesa-([\d.]+).tar.xz`, get("https://archive.mesa3d.org/?C=D;O=D"), 1);
+rpm.version(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(mesa): Track download page by description to always return the latest version (#5148)](https://github.com/terrapkg/packages/pull/5148)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)