### PR TITLE
[el10] fix(ci/json-build): don't install build deps when mock (#5128)

### DIFF
--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Install Build Dependencies
-        if: ${{ !contains(matrix.pkg.labels, 'mock') }}
+        if: ${{ matrix.pkg.labels.mock != '1' }}
         run: |
           dir=$(dirname ${{ matrix.pkg.pkg }})
           dnf builddep -y ${dir}/*.spec


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(ci/json-build): don't install build deps when mock (#5128)](https://github.com/terrapkg/packages/pull/5128)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)