### PR TITLE
[el10] chore(rpcs3): Re-enable system cURL on Rawhide, try to enable more system libraries (#5149)

### DIFF
--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -1,29 +1,25 @@
-%global _distro_extra_cflags -Wno-maybe-uninitialized -fuse-linker-plugin -fuse-ld=mold
+%global __requires_exclude ^((libwolfssl\\.so.*)|(libFusion\\.so.*)|(libasmjit\\.so.*)|(libcubeb\\.so.*)|(libdiscord-rpc\\.so.*)|(libglslang\\.so.*)|(librtmidi\\.so.*))$
+%global _distro_extra_cflags -Wno-uninitialized
 %global _distro_extra_cxxflags -include %_includedir/c++/*/cstdint
 # GLIBCXX_ASSERTIONS is known to break RPCS3
 %global build_cflags %(echo %{__build_flags_lang_c} | sed 's/-Wp,-D_GLIBCXX_ASSERTIONS//g') %{?_distro_extra_cflags}
 %global build_cxxflags %(echo %{__build_flags_lang_cxx} | sed 's/-Wp,-D_GLIBCXX_ASSERTIONS//g') %{?_distro_extra_cxxflags}
-%ifarch aarch64
 # Need to get rid of everything Clang can't use and undefine -Wunused-command-line-argument where possible due to the project's build flags
 %global build_cflags %(echo %{build_cflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
 %global build_cxxflags %(echo %{build_cxxflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs\=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
-%endif
 %global commit 382e62c7d8755fbd1bbeb1b70c44e211f2d5cdfa
 %global ver 0.0.36-17979
 
 Name:           rpcs3
 Version:        %(echo %{ver} | sed 's/-/^/g')
-Release:        1%?dist
+Release:        2%?dist
 Summary:        PlayStation 3 emulator and debugger
 License:        GPL-2.0-only
 URL:            https://github.com/RPCS3/rpcs3
 %dnl Source0:        %url/archive/refs/tags/v%version.tar.gz
 BuildRequires:  anda-srpm-macros glew openal-soft cmake vulkan-validation-layers git-core mold
-%ifarch x86_64
-BuildRequires:  gcc gcc-c++
-%elifarch aarch64
 BuildRequires:  clang
-%endif
+BuildRequires:  lld
 BuildRequires:  cmake(FAudio)
 BuildRequires:  cmake(OpenAL)
 BuildRequires:  cmake(OpenCV)
@@ -34,6 +30,7 @@ BuildRequires:  pkgconfig(sndio)
 BuildRequires:  pkgconfig(jack)
 BuildRequires:  pkgconfig(x11)
 BuildRequires:  pkgconfig(glew)
+BuildRequires:  pkgconfig(flatbuffers)
 BuildRequires:  pkgconfig(libzstd)
 BuildRequires:  pkgconfig(libusb-1.0)
 BuildRequires:  pkgconfig(libevdev)
@@ -42,8 +39,13 @@ BuildRequires:  pkgconfig(gl)
 BuildRequires:  pkgconfig(vulkan)
 BuildRequires:  pkgconfig(libffi)
 BuildRequires:  pkgconfig(libcurl)
+BuildRequires:  pkgconfig(libpng)
 BuildRequires:  pkgconfig(alsa)
+BuildRequires:  pkgconfig(pugixml)
 BuildRequires:  pkgconfig(xkbcommon)
+%if 0%{?fedora} < 42
+BuildRequires:  pkgconfg(zlib)
+%endif
 BuildRequires:  pkgconfig(sdl2)
 BuildRequires:  pkgconfig(libavcodec)
 BuildRequires:  pkgconfig(libavformat)
@@ -63,29 +65,36 @@ BuildRequires:  qt6-qtbase-private-devel vulkan-devel jack-audio-connection-kit-
 %git_clone %url %commit
 
 %build
-%ifarch aarch64
 # Looking at the CMakeLists.txt, this is the intended compiler and there are no fixes for GCC on aarch64
 export CC=clang
 export CXX=clang++
+%cmake -DDISABLE_LTO=TRUE                                \
+     -DZSTD_BUILD_SHARED=OFF                             \
+    -DZSTD_BUILD_STATIC=ON                               \
+    -DCMAKE_SKIP_RPATH=ON                                \
+    -DUSE_NATIVE_INSTRUCTIONS=OFF                        \
+    -DCMAKE_C_FLAGS="$CFLAGS"                            \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS"                        \
+    -DSTATIC_LINK_LLVM=OFF                               \
+    -DUSE_SYSTEM_FAUDIO=ON                               \
+    -DUSE_SDL=ON                                         \
+    -DUSE_SYSTEM_SDL=ON                                  \
+    -DBUILD_LLVM=OFF                                     \
+    -DUSE_PRECOMPILED_HEADERS=OFF                        \
+    -DUSE_DISCORD_RPC=ON                                 \
+    -DUSE_SYSTEM_FFMPEG=ON                               \
+    -DUSE_SYSTEM_LIBPNG=ON                               \
+%if 0%{?fedora} < 42
+    -DUSE_SYSTEM_ZLIB=ON                                 \
 %endif
-%cmake -DDISABLE_LTO=TRUE                              \
-    -DZSTD_BUILD_SHARED=OFF                            \
-    -DZSTD_BUILD_STATIC=ON                             \
-    -DUSE_NATIVE_INSTRUCTIONS=OFF                      \
-    -DCMAKE_C_FLAGS="$CFLAGS"                          \
-    -DCMAKE_CXX_FLAGS="$CXXFLAGS"                      \
-    -DSTATIC_LINK_LLVM=OFF                             \
-    -DUSE_SYSTEM_FAUDIO=ON                             \
-    -DUSE_SDL=ON                                       \
-    -DUSE_SYSTEM_SDL=ON                                \
-    -DBUILD_LLVM=OFF                                   \
-    -DUSE_PRECOMPILED_HEADERS=OFF                      \
-    -DUSE_DISCORD_RPC=ON                               \
-    -DUSE_SYSTEM_FFMPEG=ON                             \
-    -DUSE_SYSTEM_OPENCV=ON                             \
-%if 0%{?fedora} < 43
-    -DUSE_SYSTEM_CURL=ON
-%endif
+    -DUSE_SYSTEM_OPENCV=ON                               \
+    -DUSE_SYSTEM_CURL=ON                                 \
+    -DUSE_SYSTEM_FLATBUFFERS=OFF                         \
+    -DUSE_SYSTEM_PUGIXML=OFF                             \
+    -DUSE_SYSTEM_WOLFSSL=OFF                             \
+    -DCMAKE_LINKER=mold                                  \
+    -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS -fuse-ld=mold" \
+    -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -fuse-ld=mold"    
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(rpcs3): Re-enable system cURL on Rawhide, try to enable more system libraries (#5149)](https://github.com/terrapkg/packages/pull/5149)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)