### PR TITLE
[f41] fix(rpcs3): zlib-ng-compat is no more (#5184)

### DIFF
--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -19,7 +19,6 @@ URL:            https://github.com/RPCS3/rpcs3
 %dnl Source0:        %url/archive/refs/tags/v%version.tar.gz
 BuildRequires:  anda-srpm-macros glew openal-soft cmake vulkan-validation-layers git-core mold
 BuildRequires:  clang
-BuildRequires:  lld
 BuildRequires:  cmake(FAudio)
 BuildRequires:  cmake(OpenAL)
 BuildRequires:  cmake(OpenCV)
@@ -43,9 +42,7 @@ BuildRequires:  pkgconfig(libpng)
 BuildRequires:  pkgconfig(alsa)
 BuildRequires:  pkgconfig(pugixml)
 BuildRequires:  pkgconfig(xkbcommon)
-%if 0%{?fedora} < 42
-BuildRequires:  pkgconfg(zlib)
-%endif
+BuildRequires:  pkgconfig(zlib)
 BuildRequires:  pkgconfig(sdl2)
 BuildRequires:  pkgconfig(libavcodec)
 BuildRequires:  pkgconfig(libavformat)
@@ -84,9 +81,7 @@ export CXX=clang++
     -DUSE_DISCORD_RPC=ON                                 \
     -DUSE_SYSTEM_FFMPEG=ON                               \
     -DUSE_SYSTEM_LIBPNG=ON                               \
-%if 0%{?fedora} < 42
     -DUSE_SYSTEM_ZLIB=ON                                 \
-%endif
     -DUSE_SYSTEM_OPENCV=ON                               \
     -DUSE_SYSTEM_CURL=ON                                 \
     -DUSE_SYSTEM_FLATBUFFERS=OFF                         \


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(rpcs3): zlib-ng-compat is no more (#5184)](https://github.com/terrapkg/packages/pull/5184)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)