### PR TITLE
[el10] fix(nautilus-open-any-terminal): Macro typo, split subpackages to unconfuse macros on <= 41 (#5193)

### DIFF
--- a/anda/desktops/gnome/nautilus-open-any-terminal/anda.hcl
+++ b/anda/desktops/gnome/nautilus-open-any-terminal/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+        arches = ["x86_64"]
 	rpm {
 		spec = "nautilus-open-any-terminal.spec"
 	}

--- a/anda/desktops/gnome/nautilus-open-any-terminal/nautilus-open-any-terminal.spec
+++ b/anda/desktops/gnome/nautilus-open-any-terminal/nautilus-open-any-terminal.spec
@@ -1,8 +1,8 @@
 %global pypi_name nautilus_open_any_terminal
 
-Name:           python-nautilus-open-any-terminal
+Name:           nautilus-open-any-terminal
 Version:        0.6.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Context-menu entry for opening other terminal in Nautilus
 License:        GPL-3.0-only
 URL:            https://github.com/Stunkymonkey/nautilus-open-any-terminal
@@ -16,6 +16,9 @@ BuildRequires:  python3-devel
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(pip)
 BuildRequires:  gettext
+Requires:       python3-%{name} = %{version}-%{release}
+Requires:       %{name}-caja = %{version}-%{release}
+Obsoletes:      python3-%{name} < 0.6.1-2
 
 
 %global _description %{expand:
@@ -23,11 +26,22 @@ nautilus-open-any-terminal is an extension for nautilus, which adds an context-e
 
 %description %_description
 
-%package -n	python3-nautilus-open-any-terminal
-Summary:	%{summary}
-Provides:	nautilus-open-any-terminal = %evr
+%package -n	%{name}-caja
+Summary:	Caja files for %{name}
+Requires:	%{name} = %{version}-%{release}
+BuildArch:  noarch
 
-%description -n python3-nautilus-open-any-terminal %_description
+%description -n nautilus-open-any-terminal-caja
+Python-caja files for %{name}.
+
+
+%package -n	python3-nautilus-open-any-terminal
+Summary:	Python files for %{name}
+Requires:	%{name} = %{version}-%{release}
+BuildArch:  noarch
+
+%description -n python3-nautilus-open-any-terminal
+Python files for %{name}.
 
 
 %prep
@@ -49,7 +63,7 @@ cp %{S:1} %{S:2} .
 
 %install
 %if 0%{?fedora} <= 41
-%py3_build
+%py3_install
 %else
 %pyproject_install
 %pyproject_save_files -l %{pypi_name}
@@ -59,19 +73,29 @@ cp %{S:1} %{S:2} .
 #check
 #pyproject_check_import
 
-%if 0%{?fedora} <= 41
-%files -n python3-nautilus-open-any-terminal 
-%else
-%files -n python3-nautilus-open-any-terminal -f %{pyproject_files}
-%endif
+%files
 %doc README.md
 %license LICENSE
-%_datadir/caja-python/extensions/__pycache__/%{pypi_name}.cpython-*.pyc
-%_datadir/caja-python/extensions/nautilus_open_any_terminal.py
+# These are GNOME config files
 %_datadir/glib-2.0/schemas/com.github.stunkymonkey.nautilus-open-any-terminal.gschema.xml
 %_datadir/locale/*/LC_MESSAGES/nautilus-open-any-terminal.mo
-%_datadir/nautilus-python/extensions/__pycache__/%{pypi_name}.cpython-*.pyc
+# As asinine as it is these don't belong in a Python subpackage because they're Nautilus files
 %_datadir/nautilus-python/extensions/%{pypi_name}.py
+%if 0%{?fedora} > 41
+%_datadir/nautilus-python/extensions/__pycache__/%{pypi_name}.cpython-*.pyc
+%endif
+
+%files -n %{name}-caja
+# Congratulations! You have discovered a -caja subpackage
+%_datadir/caja-python/extensions/nautilus_open_any_terminal.py
+%if 0%{?fedora} > 41
+%_datadir/caja-python/extensions/__pycache__/%{pypi_name}.cpython-*.pyc
+%endif
+
 %if 0%{?fedora} <= 41
+%files -n python3-nautilus-open-any-terminal
+%{python3_sitelib}/%{pypi_name}/
 %{python3_sitelib}/%{pypi_name}-%{version}-py%{python3_version}.egg-info/
+%else
+%files -n python3-nautilus-open-any-terminal -f %{pyproject_files}
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(nautilus-open-any-terminal): Macro typo, split subpackages to unconfuse macros on &lt;&#x3D; 41 (#5193)](https://github.com/terrapkg/packages/pull/5193)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)