### PR TITLE
[f41] fix(rpcs3): yaml-cpp is also vendored (#5196)

### DIFF
--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -1,4 +1,4 @@
-%global __requires_exclude ^((libwolfssl\\.so.*)|(libFusion\\.so.*)|(libasmjit\\.so.*)|(libcubeb\\.so.*)|(libdiscord-rpc\\.so.*)|(libglslang\\.so.*)|(librtmidi\\.so.*))$
+%global __requires_exclude ^((libwolfssl\\.so.*)|(libFusion\\.so.*)|(libasmjit\\.so.*)|(libcubeb\\.so.*)|(libdiscord-rpc\\.so.*)|(libglslang\\.so.*)|(librtmidi\\.so.*)(libyaml-cpp\\.so.*))$
 %global _distro_extra_cflags -Wno-uninitialized
 %global _distro_extra_cxxflags -include %_includedir/c++/*/cstdint
 # GLIBCXX_ASSERTIONS is known to break RPCS3
@@ -12,7 +12,7 @@
 
 Name:           rpcs3
 Version:        %(echo %{ver} | sed 's/-/^/g')
-Release:        2%?dist
+Release:        3%?dist
 Summary:        PlayStation 3 emulator and debugger
 License:        GPL-2.0-only
 URL:            https://github.com/RPCS3/rpcs3

--- a/anda/games/rpcs3/update.rhai
+++ b/anda/games/rpcs3/update.rhai
@@ -5,4 +5,5 @@ rpm.global("ver", v);
 if rpm.changed () {
      let c = find("Commit <a href=\"https://github.com/RPCS3/rpcs3/commit/([\\w\\d]+)\" target=\"_blank\"", html, 1);
      rpm.global("commit", c);
+     rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(rpcs3): yaml-cpp is also vendored (#5196)](https://github.com/terrapkg/packages/pull/5196)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)