### PR TITLE
[f41] fix(ghostty-nightly): Rely on ncurses for terminfo and fix for Zig 0.14.0/>= 42 changes (#4084)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -31,7 +31,7 @@ BuildRequires:  minisign
 BuildRequires:  ncurses
 BuildRequires:  ncurses-devel
 BuildRequires:  pandoc-cli
-BuildRequires:  zig
+BuildRequires:  zig >= 0.14.0
 BuildRequires:  pkgconfig(blueprint-compiler)
 BuildRequires:  pkgconfig(bzip2)
 BuildRequires:  pkgconfig(freetype2)
@@ -44,8 +44,8 @@ BuildRequires:  pkgconfig(libpng)
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  pkgconfig(oniguruma)
 BuildRequires:  pkgconfig(zlib)
-Requires:       %{name}-terminfo
-Requires:       %{name}-shell-integration
+Requires:       %{name}-terminfo = %{version}-%{release}
+Requires:       %{name}-shell-integration = %{version}-%{release}
 Requires:       gtk4
 Requires:       gtk4-layer-shell
 Requires:       libadwaita
@@ -112,26 +112,18 @@ This package contains files allowing Ghostty to integrate with various shells.
 
 %package        terminfo
 Summary:        Ghostty terminfo
+%if 0%{?fedora} >= 42
+Requires:       ncurses-term >= 6.5-5.20250125
+%endif
 Supplements:    %{name}
 %if 0%{?fedora} <= 41
 Provides:       %{name}-terminfo = %{commit_date}.%{shortcommit}
 %endif
-%if 0%{?fedora} >= 42
-Requires:       ncurses-term >= 6.5-5.20250125%{?dist}
-%endif
+Obsoletes:      %{name}-terminfo-source < %{version}-%{release}
 BuildArch:      noarch
 
 %description    terminfo
 Ghostty's terminfo. Needed for basic terminal function.
-
-%package        terminfo-source
-Summary:        Source files for Ghostty's terminfo
-Requires:       %{name}
-Requires:       %{name}-terminfo
-BuildArch:      noarch
-
-%description    terminfo-source
-This package contains files for Ghostty's terminfo. Available for debugging use.
 
 %prep
 /usr/bin/minisign -V -m %{SOURCE0} -x %{SOURCE1} -P %{public_key}
@@ -150,17 +142,16 @@ zig build \
     --prefix "%{_prefix}" --prefix-lib-dir "%{_libdir}" \
     --prefix-exe-dir "%{_bindir}" --prefix-include-dir "%{_includedir}" \
     --verbose \
+    --build-id=sha1 \
     -Dversion-string="%{ver}-dev+%{shortcommit}" \
     -Dcpu=baseline \
     -Dstrip=false \
     -Dpie=true \
-    -Demit-docs \
-    -Demit-termcap \
-    -Demit-terminfo
+    -Demit-docs 
 
-#Don't conflict with ncurses-term on F42 and up
+# Don't conflict with ncurses-term on F42 and up
 %if 0%{?fedora} >= 42
-rm -rf %{buildroot}%{_datadir}/terminfo/g/ghostty
+rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 %endif
 
 %find_lang %{reverse_dns}
@@ -175,6 +166,7 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/ghostty
 %{_datadir}/%{base_name}/doc
 %{_datadir}/%{base_name}/themes
 %{_datadir}/kio/servicemenus/%{reverse_dns}.desktop
+%{_datadir}/metainfo/%{reverse_dns}.metainfo.xml
 %{_datadir}/nautilus-python/extensions/%{base_name}.py
 %{_datadir}/nvim/site/compiler/%{base_name}.vim
 %{_datadir}/nvim/site/ftdetect/%{base_name}.vim
@@ -221,11 +213,10 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/ghostty
 %endif
 %{_datadir}/terminfo/x/xterm-%{base_name}
 
-%files terminfo-source
-%{_datadir}/terminfo/%{base_name}.termcap
-%{_datadir}/terminfo/%{base_name}.terminfo
-
 %changelog
+* Sat May 31 2025 Gilver E. <rockgrub@disroot.org> - 1.1.4~tip^20250531git1ff9162
+- Updated for Zig 0.14.0
+- Updated for ncurses-term compatibility in Fedora 42 and Rawhide
 * Wed Mar 05 2025 Gilver E. <rockgrub@disroot.org>
 - Update to 1.1.3~tip^20250305git66e8d91-2%{?dist}
  * Ghostty now has localization support via gettext as well as corresponding localization files


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix(ghostty-nightly): Rely on ncurses for terminfo and fix for Zig 0.14.0/&gt;&#x3D; 42 changes (#4084)](https://github.com/terrapkg/packages/pull/4084)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)