### PR TITLE
[el10] chore: Bump packages on <= 42 (#5214)

### DIFF
--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -7,8 +7,8 @@
 # Need to get rid of everything Clang can't use and undefine -Wunused-command-line-argument where possible due to the project's build flags
 %global build_cflags %(echo %{build_cflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
 %global build_cxxflags %(echo %{build_cxxflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs\=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
-%global commit 68d25733443297c892b956fff8cd3e7c38c3744e
-%global ver 0.0.37-17986
+%global commit 4704c032096540fa452d4dc7e12e7390b63f6a92
+%global ver 0.0.37-17990
 
 Name:           rpcs3
 Version:        %(echo %{ver} | sed 's/-/^/g')

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -7,7 +7,7 @@
 %define         llvm_compat 20
 %endif
 %global         llvm_version 20.0.0
-%global         ver 0.15.0-dev.670+1a08c83eb
+%global         ver 0.15.0-dev.671+c907866d5
 %bcond bootstrap 1
 %bcond docs      %{without bootstrap}
 %bcond test      1

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,7 +2,7 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2025.05.30.232602
+Version:        2025.06.01.232826
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [chore: Bump packages on &lt;&#x3D; 42 (#5214)](https://github.com/terrapkg/packages/pull/5214)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)