### PR TITLE
[f42] chore: use %pkg_completion (#5110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 anda-build/
 **/*.tar*
+**/*.crate
+**/*.zip

--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -8,7 +8,7 @@
 
 Name:			flameshot.nightly
 Version:		%ver^%{commit_date}git.%shortcommit
-Release:		1%?dist
+Release:		2%?dist
 License:		GPL-3.0-or-later AND ASL-2.0 AND GPL-2.0-only AND LGPL-3.0-only AND FAL-1.3
 Summary:		Powerful yet simple to use screenshot software
 URL:			https://flameshot.org
@@ -57,32 +57,7 @@ Features:
  * Upload to Imgur
 
 
-%package bash-completion
-Summary:		Bash completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires: 		bash-completion
-Supplements:	(%{name} and bash-completion)
-
-%description bash-completion
-Bash command line completion support for %{name}.
-
-%package fish-completion
-Summary:		Fish completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires:		fish
-Supplements:	(%{name} and fish)
-
-%description fish-completion
-Fish command line completion support for %{name}.
-
-%package zsh-completion
-Summary:		Zsh completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires:		zsh
-Supplements:	(%{name} and zsh)
-
-%description zsh-completion
-Zsh command line completion support for %{name}.
+%pkg_completion -Bfz flameshot
 
 %package devel
 Summary:      Flameshot development files
@@ -125,15 +100,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_datadir}/icons/hicolor/*/apps/*.png
 %{_datadir}/icons/hicolor/scalable/apps/*.svg
 %{_mandir}/man1/flameshot.1*
-
-%files bash-completion
-%{bash_completions_dir}/flameshot
-
-%files fish-completion
-%{fish_completions_dir}/flameshot.fish
-
-%files zsh-completion
-%{zsh_completions_dir}/_flameshot
 
 %files devel
 %{_libdir}/lib%{devel_name}.so

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -5,7 +5,7 @@
 
 Name:           mpv-nightly
 Version:        %ver^%commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later
 Summary:        Movie player playing most video formats and DVDs
@@ -124,32 +124,7 @@ Requires: mpv-nightly-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 %description devel
 This package contains development header files and libraries for Mpv.
 
-%package bash-completion
-Summary: MPV Bash completion
-Requires: bash
-Requires: %{name}
-Supplements: (%{name} and bash)
-
-%description bash-completion
-Bash shell completion for MPV.
-
-%package fish-completion
-Summary: MPV Fish completion
-Requires: fish
-Requires: %{name}
-Supplements: (%{name} and fish)
-
-%description fish-completion
-Fish shell completion for MPV.
-
-%package zsh-completion
-Summary: MPV Zsh completion
-Requires: zsh
-Requires: %{name}
-Supplements: (%{name} and zsh)
-
-%description zsh-completion
-Zsh shell completion for MPV.
+%pkg_completion -Bfz mpv
 
 %prep
 %autosetup -p1 -n mpv-%commit
@@ -246,15 +221,3 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/mpv.desktop
 %{_includedir}/mpv/
 %{_libdir}/libmpv.so
 %{_libdir}/pkgconfig/mpv.pc
-
-%files bash-completion
-%{bash_completions_dir}/mpv
-
-%files fish-completion
-%{fish_completions_dir}/mpv.fish
-
-%files zsh-completion
-%{zsh_completions_dir}/_mpv
-
-%changelog
-%autochangelog

--- a/anda/desktops/waylands/swaylock-effects/swaylock-effects.spec
+++ b/anda/desktops/waylands/swaylock-effects/swaylock-effects.spec
@@ -3,7 +3,7 @@
 
 Name:           swaylock-effects
 Version:        1.7.0.0^1.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Swaylock, with fancy effects
 
 License:        MIT
@@ -31,32 +31,7 @@ Conflicts:      swaylock
 swaylock-effects is a fork of swaylock which adds built-in screenshots and image manipulation effects like blurring.
 
 
-%package bash-completion
-Summary:        Bash completion for %{name}
-Requires:       %{name} = %{version}-%{release}
-Requires:       bash-completion
-Supplements:    (%{name} and bash-completion)
-
-%description bash-completion
-Bash command-line completion support for %{name}.
-
-%package zsh-completion
-Summary:        Zsh completion for %{name}
-Requires:       %{name} = %{version}-%{release}
-Requires:       zsh
-Supplements:    (%{name} and zsh)
-
-%description zsh-completion
-Zsh command-line completion support for %{name}.
-
-%package fish-completion
-Summary:        Fish completion for %{name}
-Requires:       %{name} = %{version}-%{release}
-Requires:       fish
-Supplements:    (%{name} and fish)
-
-%description fish-completion
-Fish command-line completion support for %{name}.
+%pkg_completion -Bfz %binary_name
 
 
 %prep
@@ -78,15 +53,6 @@ Fish command-line completion support for %{name}.
 %{_bindir}/%{binary_name}
 %{_mandir}/man1/%{binary_name}.1.gz
 %config(noreplace) %{_sysconfdir}/pam.d/%{binary_name}
-
-%files bash-completion
-%{bash_completions_dir}/%{binary_name}
-
-%files zsh-completion
-%{zsh_completions_dir}/_%{binary_name}
-
-%files fish-completion
-%{fish_completions_dir}/%{binary_name}.fish
 
 
 %changelog

--- a/anda/desktops/waylands/wpaperd/wpaperd.spec
+++ b/anda/desktops/waylands/wpaperd/wpaperd.spec
@@ -1,9 +1,8 @@
-%global elvish_completions_dir %_datadir/elvish/lib/completions
-%bcond check 1
+%bcond check 0
 
 Name:           wpaperd
 Version:        1.2.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Modern wallpaper daemon for Wayland
 License:        (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND CC0-1.0 AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR Artistic-2.0) AND GPL-3.0+ AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 SourceLicense:  GPL-3.0-or-later
@@ -32,41 +31,7 @@ Supplements:    wpaperd
 %description doc
 Man papes for %name.
 
-%package bash-completion
-Summary:        Bash completion for %name
-Requires:       %{name} = %{version}-%{release}
-Requires:       bash-completion
-Supplements:    (%{name} and bash-completion)
-
-%description bash-completion
-Bash command line completion support for %{name}.
-
-%package elvish-completion
-Summary:        Elvish completion for %name
-Requires:       %{name} = %{version}-%{release}
-Requires:       elvish
-Supplements:    (%{name} and elvish-completion)
-
-%description elvish-completion
-Elvish command line completion support for %{name}.
-
-%package fish-completion
-Summary:        Fish completion for %{name}
-Requires:       %{name} = %{version}-%{release}
-Requires:       fish
-Supplements:    (%{name} and fish)
-
-%description fish-completion
-Fish command line completion support for %{name}.
-
-%package zsh-completion
-Summary:        Zsh completion for %{name}
-Requires:       %{name} = %{version}-%{release}
-Requires:       zsh
-Supplements:    (%{name} and zsh)
-
-%description zsh-completion
-Zsh command line completion support for %{name}.
+%pkg_completion -befz wpaperctl wpaperd
 
 
 %prep
@@ -110,22 +75,6 @@ install -Dpm644 -t %buildroot%zsh_completions_dir target/rpm/completions/_*
 %_mandir/man1/wpaperctl.1.gz
 %_mandir/man1/wpaperd.1.gz
 %_mandir/man5/wpaperd-output.5.gz
-
-%files bash-completion
-%bash_completions_dir/wpaperctl.bash
-%bash_completions_dir/wpaperd.bash
-
-%files elvish-completion
-%elvish_completions_dir/wpaperctl.elv
-%elvish_completions_dir/wpaperd.elv
-
-%files fish-completion
-%fish_completions_dir/wpaperctl.fish
-%fish_completions_dir/wpaperd.fish
-
-%files zsh-completion
-%zsh_completions_dir/_wpaperctl
-%zsh_completions_dir/_wpaperd
 
 %changelog
 * Fri Dec 20 2024 madonuko <mado@fyralabs.com> - 1.1.1-1

--- a/anda/devs/bun/bun-bin.spec
+++ b/anda/devs/bun/bun-bin.spec
@@ -7,7 +7,7 @@
 
 Name:			bun-bin
 Version:		1.2.15
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one
 License:		MIT
 URL:			https://bun.sh
@@ -17,34 +17,7 @@ BuildRequires:	unzip
 %description
 %summary.
 
-
-%package bash-completion
-Summary:		Bash completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires: 		bash-completion
-Supplements:	(%{name} and bash-completion)
-
-%description bash-completion
-Bash command line completion support for %{name}.
-
-%package fish-completion
-Summary:		Fish completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires:		fish
-Supplements:	(%{name} and fish)
-
-%description fish-completion
-Fish command line completion support for %{name}.
-
-%package zsh-completion
-Summary:		Zsh completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires:		zsh
-Supplements:	(%{name} and zsh)
-
-%description zsh-completion
-Zsh command line completion support for %{name}.
-
+%pkg_completion -bfz bun
 
 %prep
 %autosetup -n bun-linux-%a
@@ -88,12 +61,3 @@ ln -s bun %buildroot%_bindir/bunx
 %license LICENSE
 %_bindir/bun
 %_bindir/bunx
-
-%files bash-completion
-%bash_completions_dir/bun.bash
-
-%files fish-completion
-%fish_completions_dir/bun.fish
-
-%files zsh-completion
-%zsh_completions_dir/_bun

--- a/anda/devs/yadm/yadm.spec
+++ b/anda/devs/yadm/yadm.spec
@@ -1,6 +1,6 @@
 Name:			yadm
 Version:		3.5.0
-Release:		1%{?dist}
+Release:		2%{?dist}
 Summary:		Yet Another Dotfiles Manager
 
 License:        GPL-3.0-only
@@ -19,32 +19,7 @@ yadm supplies the ability to manage a subset of secure files, which are
 encrypted before they are included in the repository.
 
 
-%package bash-completion
-Summary:		Bash completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires: 		bash-completion
-Supplements:	(%{name} and bash-completion)
-
-%description bash-completion
-Bash command line completion support for %{name}.
-
-%package fish-completion
-Summary:		Fish completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires:		fish
-Supplements:	(%{name} and fish)
-
-%description fish-completion
-Fish command line completion support for %{name}.
-
-%package zsh-completion
-Summary:		Zsh completion for %{name}
-Requires:		%{name} = %{version}-%{release}
-Requires:		zsh
-Supplements:	(%{name} and zsh)
-
-%description zsh-completion
-Zsh command line completion support for %{name}.
+%pkg_completion -Bfz
 
 
 %prep
@@ -63,15 +38,6 @@ install -Dpm644 -t %buildroot%zsh_completions_dir completion/zsh/_yadm
 %license LICENSE
 %_bindir/yadm
 %_mandir/man1/yadm.1.gz
-
-%files bash-completion
-%bash_completions_dir/yadm
-
-%files fish-completion
-%fish_completions_dir/yadm.fish
-
-%files zsh-completion
-%zsh_completions_dir/_yadm
 
 %changelog
 * Sun May 05 2024 madonuko <mado@fyralabs.com> - 0.5-1

--- a/anda/langs/nim/nim/nim.spec
+++ b/anda/langs/nim/nim/nim.spec
@@ -3,7 +3,7 @@
 
 Name:			nim
 Version:		2.2.4
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Imperative, multi-paradigm, compiled programming language
 License:		MIT and BSD
 URL:			https://nim-lang.org
@@ -21,6 +21,8 @@ Nim is a compiled, garbage-collected systems programming language with a
 design that focuses on efficiency, expressiveness, and elegance (in that
 order of priority).
 
+
+%pkg_completion -B nim nimble
 
 %package tools
 Summary:	Tools for Nim programming language
@@ -138,8 +140,6 @@ cp -r %buildroot%_prefix/lib/nim/dist %buildroot%_datadir/nim/
 %_includedir/cycle.h
 %_includedir/nimbase.h
 %_datadir/nim
-%bash_completions_dir/nim
-%bash_completions_dir/nimble
 
 %files tools
 %license copying.txt

--- a/anda/langs/rust/typst/rust-typst.spec
+++ b/anda/langs/rust/typst/rust-typst.spec
@@ -5,7 +5,7 @@
 
 Name:           rust-typst
 Version:        0.13.1
-Release:        %autorelease
+Release:        2%?dist
 Summary:        New markup-based typesetting system that is powerful and easy to learn
 
 License:        Apache-2.0
@@ -43,42 +43,7 @@ Provides:       %crate-cli = %version-%release
 %_mandir/man1/typst.1.gz
 
 
-%package bash-completion
-Summary:		Bash completion for %{crate}
-Requires:		%{crate} = %{version}-%{release}
-Requires: 		bash-completion
-Supplements:	(%{crate} and bash-completion)
-
-%description bash-completion
-Bash command line completion support for %{crate}.
-
-%package fish-completion
-Summary:		Fish completion for %{crate}
-Requires:		%{crate} = %{version}-%{release}
-Requires:		fish
-Supplements:	(%{crate} and fish)
-
-%description fish-completion
-Fish command line completion support for %{crate}.
-
-%package zsh-completion
-Summary:		Zsh completion for %{crate}
-Requires:		%{crate} = %{version}-%{release}
-Requires:		zsh
-Supplements:	(%{crate} and zsh)
-
-%description zsh-completion
-Zsh command line completion support for %{crate}.
-
-
-%files bash-completion
-%{bash_completions_dir}/%{crate}
-
-%files fish-completion
-%{fish_completions_dir}/%{crate}.fish
-
-%files zsh-completion
-%{zsh_completions_dir}/_%{crate}
+%pkg_completion -Bfzn %crate
 
 
 %prep

--- a/anda/multimedia/x264/x264.spec
+++ b/anda/multimedia/x264/x264.spec
@@ -36,7 +36,7 @@
 Summary: H264/AVC video streams encoder
 Name: x264
 Version: 0.%{api}
-Release: 15%{?gver}%{?_with_bootstrap:_bootstrap}%{?dist}
+Release: 16%{?gver}%{?_with_bootstrap:_bootstrap}%{?dist}
 License: GPLv2+
 URL: https://www.videolan.org/developers/x264.html
 Source0: https://code.videolan.org/videolan/x264/-/archive/%gitversion.tar.bz2
@@ -92,6 +92,8 @@ x264 is a free library for encoding H264/AVC video streams, written from
 scratch.
 
 This package contains the development files.
+
+%pkg_completion -B x264
 
 %global x_configure \
 ./configure \\\
@@ -177,9 +179,6 @@ install -pm644 generic/{AUTHORS,COPYING} %{buildroot}%{_pkgdocdir}/
 
 %files
 %{_bindir}/x264
-%dir %{_datadir}/bash-completion
-%dir %{_datadir}/bash-completion/completions
-%{_datadir}/bash-completion/completions/x264
 
 %files libs
 %dir %{_pkgdocdir}

--- a/anda/multimedia/zrythm/zrythm.spec
+++ b/anda/multimedia/zrythm/zrythm.spec
@@ -2,7 +2,7 @@
 
 Name:           zrythm
 Version:        %(echo %v | sed 's@-@~@g' | sed 's@^v@@')
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Highly automated and intuitive digital audio workstation
 License:        AGPL-3.0-or-later
 Packager:       madonuko <mado@fyralabs.com>
@@ -97,6 +97,8 @@ tools, limitless automation capabilities, powerful
 mixing features, chord assistance and support for
 various plugin and file formats.
 
+%pkg_completion -Bf
+
 %prep
 %autosetup -n %name-%v
 
@@ -136,5 +138,3 @@ CXXFLAGS=$(echo "$CFLAGS -fuse-ld=mold" | sed -E "s@\b-Werror\b@@")
 %_datadir/mime/packages/org.zrythm.Zrythm-mime.xml
 %_datadir/metainfo/org.zrythm.Zrythm.appdata.xml
 %_mandir/man1/zrythm.1.*
-%bash_completions_dir/zrythm
-%fish_completions_dir/zrythm.fish

--- a/anda/system/depthcharge-tools/depthcharge-tools.spec
+++ b/anda/system/depthcharge-tools/depthcharge-tools.spec
@@ -1,6 +1,6 @@
 Name:			depthcharge-tools
 Version:		0.6.2
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Tools to manage the Chrome OS bootloader
 License:		GPL-2.0-or-later
 URL:			https://github.com/alpernebbi/depthcharge-tools
@@ -12,6 +12,8 @@ BuildArch:		noarch
 %description
 depthcharge-tools is a collection of tools that ease and automate interacting
 with depthcharge, the Chrome OS bootloader.
+
+%pkg_completion -Bz mkdepthcharge depthchargectl
 
 %prep
 %autosetup
@@ -26,7 +28,8 @@ install -Dm644 systemd/*.install %buildroot/usr/lib/kernel/install.d/
 install -Dm644 systemd/*.service %buildroot%_unitdir/
 install -Dm644 completions/_mkdepthcharge.bash %buildroot%bash_completions_dir/mkdepthcharge
 install -Dm644 completions/_depthchargectl.bash %buildroot%bash_completions_dir/depthchargectl
-install -Dm644 completions/_{mkdepthcharge,depthchargectl}.zsh %buildroot%zsh_completions_dir/
+install -Dm644 completions/_mkdepthcharge.zsh %buildroot%zsh_completions_dir/_mkdepthcharge
+install -Dm644 completions/_depthchargectl.zsh %buildroot%zsh_completions_dir/_depthchargectl
 rst2man mkdepthcharge.rst | gzip > mkdepthcharge.1.gz
 rst2man depthchargectl.rst | gzip > depthchargectl.1.gz
 install -Dm644 *.1.gz %buildroot%_mandir/man1/
@@ -36,10 +39,8 @@ install -Dm644 *.1.gz %buildroot%_mandir/man1/
 %license LICENSE
 %_bindir/{mkdepthcharge,depthchargectl}
 %_mandir/man1/{mkdepthcharge,depthchargectl}.1.gz
-%bash_completions_dir/{mkdepthcharge,depthchargectl}
 /usr/lib/kernel/install.d/90-depthcharge-tools.install
 %_unitdir/depthchargectl-bless.service
-%zsh_completions_dir/_{mkdepthcharge,depthchargectl}.zsh
 %_prefix/lib/python%python3_version/site-packages/depthcharge_tools-%version-py%python3_version.egg-info/
 %_prefix/lib/python%python3_version/site-packages/depthcharge_tools/
 

--- a/anda/system/surface-dtx-daemon/surface-dtx-daemon.spec
+++ b/anda/system/surface-dtx-daemon/surface-dtx-daemon.spec
@@ -4,7 +4,7 @@
 
 Name:           terra-surface-dtx-daemon
 Version:        %(echo %ver | sed 's/-/~/g')
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Surface Detachment System (DTX) Daemon
 License:        MIT
 URL:            https://github.com/linux-surface/surface-dtx-daemon
@@ -17,6 +17,8 @@ Obsoletes:      surface-dtx-daemon < 0.3.8~1-3
 Linux User-Space Detachment System (DTX) Daemon for the Surface ACPI Driver
 (and Surface Books). Currently only the Surface Book 2 is supported, due to
 lack of driver-support on the Surface Book 1. This may change in the future.
+
+%pkg_completion -Bfz surface-dtx-daemon surface-dtx-userd
 
 %prep
 %autosetup -n surface-dtx-daemon-%{ver2}
@@ -71,12 +73,6 @@ install -D -m644 "target/surface-dtx-userd.fish" "%{buildroot}/usr/share/fish/ve
 /usr/bin/surface-dtx-userd
 /usr/lib/systemd/system/surface-dtx-daemon.service
 /usr/lib/systemd/user/surface-dtx-userd.service
-/usr/share/bash-completion/completions/surface-dtx-daemon
-/usr/share/bash-completion/completions/surface-dtx-userd
-/usr/share/zsh/site-functions/_surface-dtx-daemon
-/usr/share/zsh/site-functions/_surface-dtx-userd
-/usr/share/fish/vendor_completions.d/surface-dtx-daemon.fish
-/usr/share/fish/vendor_completions.d/surface-dtx-userd.fish
 
 %changelog
 * Wed Feb 5 2025 Owen Zimmerman <owen@fyralabs.com>

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -6,7 +6,7 @@
 
 Name:           rust-mise
 Version:        2025.5.17
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Front-end to your dev env
 
 License:        MIT
@@ -44,45 +44,7 @@ URL:            https://mise.jdx.dev/
 %_mandir/man1/mise.1.gz
 
 
-%package -n %crate-bash-completion
-Summary:        Bash completion for %crate
-Requires:       %{crate} = %{version}-%{release}
-Requires:       bash-completion
-Requires:       usage
-Supplements:    (%{crate} and bash-completion)
-
-%description -n %crate-bash-completion
-Bash command line completion support for %{crate}.
-
-%package -n %crate-fish-completion
-Summary:        Fish completion for %{crate}
-Requires:       %{crate} = %{version}-%{release}
-Requires:       fish
-Requires:       usage
-Supplements:    (%{crate} and fish)
-
-%description -n %crate-fish-completion
-Fish command line completion support for %{crate}.
-
-%package -n %crate-zsh-completion
-Summary:        Zsh completion for %{crate}
-Requires:       %{crate} = %{version}-%{release}
-Requires:       zsh
-Requires:       usage
-Supplements:    (%{crate} and zsh)
-
-%description -n %crate-zsh-completion
-Zsh command line completion support for %{crate}.
-
-
-%files -n %crate-bash-completion
-%bash_completions_dir/mise.bash
-
-%files -n %crate-fish-completion
-%fish_completions_dir/mise.fish
-
-%files -n %crate-zsh-completion
-%zsh_completions_dir/_mise
+%pkg_completion -bfzn %crate
 
 
 %prep

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -6,7 +6,7 @@
 
 Name:			rpi-utils
 Version:		%{commit_date}.%{shortcommit}
-Release:		1%?dist
+Release:		2%?dist
 Summary:		A collection of scripts and simple applications for Raspberry Pi devices
 License:		BSD-3-Clause
 URL:			https://github.com/raspberrypi/utils
@@ -69,6 +69,8 @@ Summary:        A more powerful replacement for raspi-gpio, a tool for displayin
 %description    pinctrl
 %{summary}.
 
+%pkg_completion -Bn %name-pinctrl pinctrl
+
 %package        piolib
 Summary:        A library for accessing the Pi 5's PIO hardware
 %description    piolib
@@ -79,6 +81,8 @@ Summary:        Query the VideoCore for information
 %description    vcgencmd
 A command line utility that can get various pieces of information
 from the VideoCore GPU on the Raspberry Pi.
+
+%pkg_completion -Bn %name-vcgencmd vcgencmd
 
 %package        vcmailbox
 Summary:        Send messages to the VideoCore via the mailbox
@@ -143,7 +147,6 @@ Summary:        A tool to get VideoCore 'assert' or 'msg' logs with optional -f 
 %doc pinctrl/README.md
 %license LICENCE
 %{_bindir}/pinctrl
-%{_datadir}/bash-completion/completions/pinctrl
 %{_exec_prefix}/%{_lib}/libgpiolib.so.0
 %{_exec_prefix}/%{_lib}/libgpiolib.so
 
@@ -165,7 +168,6 @@ Summary:        A tool to get VideoCore 'assert' or 'msg' logs with optional -f 
 %license LICENCE
 %{_bindir}/vcgencmd
 %{_mandir}/man1/vcgencmd.1.gz
-%{_datadir}/bash-completion/completions/vcgencmd
 
 %files vclog
 %doc vclog/README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: use %pkg_completion (#5110)](https://github.com/terrapkg/packages/pull/5110)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)