### PR TITLE
chore(woeusb-ng): Explicitly build dep on pyproject-rpm-macros

### DIFF
--- a/anda/apps/woeusb-ng/WoeUSB-ng.spec
+++ b/anda/apps/woeusb-ng/WoeUSB-ng.spec
@@ -8,7 +8,7 @@ URL:            https://github.com/WoeUSB/WoeUSB-ng
 Source:         https://github.com/WoeUSB/WoeUSB-ng/archive/refs/tags/v%version.tar.gz
 Patch0:         https://patch-diff.githubusercontent.com/raw/WoeUSB/WoeUSB-ng/pull/79.patch
 BuildArch:      noarch
-BuildRequires:  python3-devel python3-installer
+BuildRequires:  python3-devel python3-installer pyproject-rpm-macros python3dist(pip)
 
 %global _description %{expand:
 WoeUSB-ng is a simple tool that enable you to create your own usb stick windows installer from an iso image or a real DVD. This is a rewrite of original WoeUSB.}

--- a/anda/apps/woeusb-ng/WoeUSB-ng.spec
+++ b/anda/apps/woeusb-ng/WoeUSB-ng.spec
@@ -8,7 +8,7 @@ URL:            https://github.com/WoeUSB/WoeUSB-ng
 Source:         https://github.com/WoeUSB/WoeUSB-ng/archive/refs/tags/v%version.tar.gz
 Patch0:         https://patch-diff.githubusercontent.com/raw/WoeUSB/WoeUSB-ng/pull/79.patch
 BuildArch:      noarch
-BuildRequires:  python3-devel python3-installer pyproject-rpm-macros python3dist(pip)
+BuildRequires:  python3-devel python3-installer pyproject-rpm-macros python3dist(pip) python3dist(setuptools)
 
 %global _description %{expand:
 WoeUSB-ng is a simple tool that enable you to create your own usb stick windows installer from an iso image or a real DVD. This is a rewrite of original WoeUSB.}

--- a/anda/apps/woeusb-ng/WoeUSB-ng.spec
+++ b/anda/apps/woeusb-ng/WoeUSB-ng.spec
@@ -8,7 +8,7 @@ URL:            https://github.com/WoeUSB/WoeUSB-ng
 Source:         https://github.com/WoeUSB/WoeUSB-ng/archive/refs/tags/v%version.tar.gz
 Patch0:         https://patch-diff.githubusercontent.com/raw/WoeUSB/WoeUSB-ng/pull/79.patch
 BuildArch:      noarch
-BuildRequires:  python3-devel python3-installer pyproject-rpm-macros python3dist(pip) python3dist(setuptools)
+BuildRequires:  python3-devel python3-installer pyproject-rpm-macros python3dist(pip) python3dist(setuptools) python3dist(termcolor) python3dist(wxpython)
 
 %global _description %{expand:
 WoeUSB-ng is a simple tool that enable you to create your own usb stick windows installer from an iso image or a real DVD. This is a rewrite of original WoeUSB.}


### PR DESCRIPTION
Slowly working on fixable EL issues but

Basically `python3-devel` pulls this on Fedora but not on EL because IDK reasons?