### PR TITLE
[f42] fix(kf6-kio): Fully obsolete .switcheroo packages (#5235)

### DIFF
--- a/anda/desktops/kde/kf6-kio/kf6-kio.spec
+++ b/anda/desktops/kde/kf6-kio/kf6-kio.spec
@@ -5,11 +5,10 @@
 
 Name:    kf6-%{framework}
 Version: %{majmin_ver_kf6}.0
-Release: 3%{?dist}.switcheroo
+Release: 4%{?dist}.switcheroo
 Summary: KDE Frameworks 6 Tier 3 solution for filesystem abstraction
 
-Provides: kf6-%{framework}.switcheroo = %version-%release
-Obsoletes: kf6-%{framework}.switcheroo < 6.13.0-2
+Obsoletes: kf6-%{framework}.switcheroo < 6.14.0-4
 
 License: BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND LGPL-3.0-only AND (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only) AND MIT
 URL:     https://invent.kde.org/frameworks/%{framework}
@@ -102,7 +101,7 @@ Requires:       cmake(KF6Solid)
 Requires:       cmake(KF6XmlGui)
 Requires:       cmake(KF6WindowSystem)
 Requires:       qt6-qtbase-devel
-Provides:       kf6-kio-devel = %version-%release
+Obsoletes:      kf6-kio.switcheroo-devel < 6.14.0-4
 %description    devel
 The %{name}-devel package contains libraries and header files for
 developing applications that use %{name}.
@@ -111,8 +110,7 @@ developing applications that use %{name}.
 Summary:        Documentation files for %{name}
 Requires:       %{name}-core = %{version}-%{release}
 BuildArch:      noarch
-Provides:       kf6-kio-doc = %version-%release
-Obsoletes:      kf6-kio-doc <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-doc < 6.14.0-4
 %description    doc
 Documentation for %{name}.
 
@@ -123,16 +121,14 @@ Requires:       %{name}-core-libs%{?_isa} = %{version}-%{release}
 Requires:       %{name}-doc = %{version}-%{release}
 Requires:       kf6-filesystem
 Recommends:     switcheroo-control
-Provides:       kf6-kio-core = %version-%release
-Obsoletes:      kf6-kio-core <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-core < 6.14.0-4
 %description    core
 KIOCore library provides core non-GUI components for working with KIO.
 
 %package        core-libs
 Summary:        Runtime libraries for KIO Core
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
-Provides:       kf6-kio-core-libs = %version-%release
-Obsoletes:      kf6-kio-core-libs <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-core-libs < 6.14.0-4
 %description    core-libs
 %{summary}.
 
@@ -142,8 +138,7 @@ Summary:        Widgets for KIO Framework
 ## included here for completeness, even those -core already has a dependency.
 %{?kf6_kinit_requires}
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
-Provides:       kf6-kio-widgets = %version-%release
-Obsoletes:      kf6-kio-widgets <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-widgets < 6.14.0-4
 %description    widgets
 KIOWidgets contains classes that provide generic job control, progress
 reporting, etc.
@@ -151,16 +146,14 @@ reporting, etc.
 %package        widgets-libs
 Summary:        Runtime libraries for KIO Widgets library
 Requires:       %{name}-widgets%{?_isa} = %{version}-%{release}
-Provides:       kf6-kio-widgets-libs = %version-%release
-Obsoletes:      kf6-kio-widgets-libs <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-widgets-libs < 6.14.0-4
 %description    widgets-libs
 %{summary}.
 
 %package        file-widgets
 Summary:        Widgets for file-handling for KIO Framework
 Requires:       %{name}-widgets%{?_isa} = %{version}-%{release}
-Provides:       kf6-kio-file-widgets = %version-%release
-Obsoletes:      kf6-kio-file-widgets <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-file-widgets < 6.14.0-4
 %description    file-widgets
 The KIOFileWidgets library provides the file selection dialog and
 its components.
@@ -169,15 +162,14 @@ its components.
 Summary:        Gui components for the KIO Framework
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
 Provides:       kf6-kio-gui = %version-%release
-Obsoletes:      kf6-kio-gui <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-gui < 6.14.0-4
 %description    gui
 %{summary}.
 
 %package        qch-doc
 Summary:        Developer Documentation files for %{name}
 BuildArch:      noarch
-Provides:       kf6-kio-qch-doc = %version-%release
-Obsoletes:      kf6-kio-qch-doc <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-qch-doc < 6.14.0-4
 %description    qch-doc
 Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(kf6-kio): Fully obsolete .switcheroo packages (#5235)](https://github.com/terrapkg/packages/pull/5235)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)