### PR TITLE
[el10] chore(umstellar): Update to modern Python build system (#5233)

### DIFF
--- a/anda/tools/umstellar/anda.hcl
+++ b/anda/tools/umstellar/anda.hcl
@@ -1,4 +1,5 @@
 project "pkg" {
+        arches = ["x86_64"]
     rpm {
         spec = "umstellar.spec"
     }

--- a/anda/tools/umstellar/umstellar.spec
+++ b/anda/tools/umstellar/umstellar.spec
@@ -2,13 +2,15 @@
 %global pypi_name umstellar
 %global pypi_version 0.2.0
 
-Name:           python-%{pypi_name}
+Name:           %{pypi_name}
 Version:        %{pypi_version}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Ultramarine Quickstart Tool
 
 Provides:       python3-%{pypi_name} = %{version}-%{release}
 Provides:       %{pypi_name} = %{version}-%{release}
+Obsoletes:      python3-%{pypi_name} < 0.2.0-2
+Requires:       python3-%{pypi_name} = %{version}-%{release}
 
 License:        GPL-3.0
 URL:            https://github.com/Ultramarine-Linux/stellar
@@ -16,6 +18,7 @@ Source0:        %{url}/archive/v%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
+BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 
 %description
@@ -33,30 +36,45 @@ Summary:        %{summary}
 Requires:       python3dist(requests)
 Requires:       python3dist(pygobject)
 Requires:       anaconda-core
-%description -n python3-%{pypi_name}
+Requires:       %{pypi_name} = %{version}-%{release}
+BuildArch:      noarch
 
+%description -n python3-%{pypi_name}
 Stellar is a quick-and-dirty GUI post-install menu for
 Ultramarine Linux
-
 
 %prep
 %autosetup -n stellar-%{pypi_version}
 
 %build
+%if 0%{?fedora} <= 41
 %py3_build
+%else
+%pyproject_wheel
+%endif
 
 %install
+%if 0%{?fedora} <= 41
 %py3_install
+%else
+%pyproject_install
+%endif
 
 # install kickstart file
 install -D -m 644 example.ks %{buildroot}%{_datadir}/anaconda/post-scripts/stellar.ks
 
-%files -n python3-%{pypi_name}
+%files
 %license LICENSE
 %doc README.md
-%{python3_sitelib}/%{pypi_name}
-%{python3_sitelib}/%{pypi_name}-%{pypi_version}-py%{python3_version}.egg-info
 %{_datadir}/anaconda/post-scripts/stellar.ks
+
+%files -n python3-%{pypi_name}
+%{python3_sitelib}/%{pypi_name}
+%if 0%{?fedora} <= 41
+%{python3_sitelib}/%{pypi_name}-%{pypi_version}-py%{python3_version}.egg-info/
+%else
+%{python3_sitelib}/%{pypi_name}-%{version}.dist-info/
+%endif
 
 %changelog
 * Mon Apr 1 2024 Lleyton Gray <lleyton@fyralabs.com> - 0.2.0-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(umstellar): Update to modern Python build system (#5233)](https://github.com/terrapkg/packages/pull/5233)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)