### PR TITLE
[f41] fix?(legcord): Use Mock (#5286)

### DIFF
--- a/anda/apps/legcord/nightly/anda.hcl
+++ b/anda/apps/legcord/nightly/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		nightly = 1
+                mock = 1
 	}
 }

--- a/anda/apps/legcord/stable/anda.hcl
+++ b/anda/apps/legcord/stable/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "legcord.spec"
 	}
-}
+        labels {
+                mock =1
+        } 
+} 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix?(legcord): Use Mock (#5286)](https://github.com/terrapkg/packages/pull/5286)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)