### PR TITLE
[f42] add: libcufile and libcusolver (#5292)

### DIFF
--- a/anda/lib/nvidia/libcufile/anda.hcl
+++ b/anda/lib/nvidia/libcufile/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+    rpm {
+        spec = "libcufile.spec"
+    }
+    labels {
+	    subrepo = "nvidia"
+	    updbranch = 1
+    }
+}

--- a/anda/lib/nvidia/libcufile/cufile.pc
+++ b/anda/lib/nvidia/libcufile/cufile.pc
@@ -1,0 +1,8 @@
+libdir=LIBDIR
+includedir=INCLUDE_DIR
+
+Name: cufile
+Description: GPUDirect Storage Library
+Version: CUDA_VERSION
+Libs: -L${libdir} -lnvjpeg
+Cflags: -I${includedir}

--- a/anda/lib/nvidia/libcufile/libcufile.spec
+++ b/anda/lib/nvidia/libcufile/libcufile.spec
@@ -1,0 +1,130 @@
+%global debug_package %{nil}
+%global __strip /bin/true
+%global _missing_build_ids_terminate_build 0
+%global _build_id_links none
+%global major_package_version 12-8
+
+Name:           libcufile
+Epoch:          1
+Version:        1.13.0.11
+Release:        1%{?dist}
+Summary:        NVIDIA GPUDirect Storage library (cuFile)
+License:        CUDA Toolkit
+URL:            https://developer.nvidia.com/cuda-toolkit
+ExclusiveArch:  aarch64 x86_64
+
+Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{name}/linux-x86_64/%{name}-linux-x86_64-%{version}-archive.tar.xz
+Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{name}/linux-sbsa/%{name}-linux-sbsa-%{version}-archive.tar.xz
+Source2:        cufile.pc
+
+Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
+
+%description
+NVIDIA GPUDirect Storage library is used in applications and frameworks to
+leverage GDS technology and describes the intent, context, and operation of
+those APIs, which are part of the GDS technology.
+
+NVIDIA® Magnum IO GPUDirect® Storage (GDS) is part of the GPUDirect family. GDS
+enables a direct data path for direct memory access (DMA) transfers between GPU
+memory and storage, which avoids a bounce buffer through the CPU. This direct
+path increases system bandwidth and decreases the latency and utilization load
+on the CPU.
+
+%package devel
+Summary:        Development files for NVIDIA GPUDirect Storage library (cuFile)
+Requires:       %{name}%{_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Conflicts:      %{name}-devel-%{major_package_version} < %{?epoch:%{epoch}:}%{version}
+
+%description devel
+This package provides development files for the NVIDIA GPUDirect Storage library
+(cuFile).
+
+%package static
+Summary:        Static libraries for NVIDIA GPUDirect Storage library (cuFile)
+Requires:       %{name}-devel%{_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+
+%description static
+This package contains static libraries for NVIDIA GPUDirect Storage library
+(cuFile).
+
+%package tools
+Summary:        NVIDIA GPUDirect Storage library (cuFile) tools and samples
+Requires:       %{name}%{_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       gds-tools-%{major_package_version} = %{?epoch:%{epoch}:}%{version}-%{release}
+Obsoletes:      gds-tools-%{major_package_version} < %{?epoch:%{epoch}:}%{version}
+
+%description tools
+This package provides tools and samples for the NVIDIA GPUDirect Storage library
+(cuFile).
+
+%prep
+%ifarch x86_64
+%setup -q -n %{name}-linux-x86_64-%{version}-archive
+%endif
+
+%ifarch aarch64
+%setup -q -T -b 1 -n %{name}-linux-sbsa-%{version}-archive
+%endif
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_includedir}
+mkdir -p %{buildroot}%{_libdir}
+mkdir -p %{buildroot}%{_libdir}/pkgconfig
+mkdir -p %{buildroot}%{_mandir}
+mkdir -p %{buildroot}%{_sysconfdir}
+
+cp -fr tools/gds* %{buildroot}%{_bindir}/
+cp -fr include/* %{buildroot}%{_includedir}/
+cp -fr lib/lib* %{buildroot}%{_libdir}/
+cp -fr %{SOURCE2} %{buildroot}/%{_libdir}/pkgconfig/
+cp -fr man/man3 %{buildroot}%{_mandir}/
+cp -fr etc/* %{buildroot}%{_sysconfdir}/
+
+# Set proper variables
+sed -i \
+    -e 's|CUDA_VERSION|%{version}|g' \
+    -e 's|LIBDIR|%{_libdir}|g' \
+    -e 's|INCLUDE_DIR|%{_includedir}|g' \
+    %{buildroot}/%{_libdir}/pkgconfig/*.pc
+
+%files
+%license LICENSE
+%doc README
+%config %{_sysconfdir}/cufile.json
+%{_libdir}/libcufile_rdma.so.*
+%{_libdir}/libcufile.so.*
+
+%files devel
+%{_includedir}/cufile.h
+%{_libdir}/libcufile_rdma.so
+%{_libdir}/libcufile.so
+%{_libdir}/pkgconfig/cufile.pc
+%{_mandir}/man3/CUfileFSOps.3*
+%{_mandir}/man3/cufileRDMAInfo.3*
+%{_mandir}/man3/cufile.h.3*
+%{_mandir}/man3/CUfileDrvProps.3*
+%{_mandir}/man3/CUfileDescr_t.3*
+%{_mandir}/man3/CUfileError.3*
+%{_mandir}/man3/CUfileIOParams.3*
+%{_mandir}/man3/CUfileIOEvents.3*
+%{_mandir}/man3/CUfileOpError.h.3*
+
+%files static
+%{_libdir}/libcufile_rdma_static.a
+%{_libdir}/libcufile_static.a
+
+%files tools
+%doc tools/README
+%doc tools/*.gdsio tools/*.cfg
+%{_bindir}/gdscheck
+%{_bindir}/gdscheck.py
+%{_bindir}/gdscp
+%{_bindir}/gdsio
+%{_bindir}/gdsio_verify
+%{_bindir}/gds_log_collection.py
+%{_bindir}/gds_perf.sh
+%{_bindir}/gds_stats
+
+%changelog
+%autochangelog

--- a/anda/lib/nvidia/libcufile/update.rhai
+++ b/anda/lib/nvidia/libcufile/update.rhai
@@ -1,0 +1,3 @@
+import "andax/nvidia.rhai" as nvidia;
+
+rpm.version(nvidia::nvidia_component_version("libcufile"));

--- a/anda/lib/nvidia/libcusolver/anda.hcl
+++ b/anda/lib/nvidia/libcusolver/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+    rpm {
+        spec = "libcusolver.spec"
+    }
+    labels {
+	    subrepo = "nvidia"
+	    updbranch = 1
+    }
+}

--- a/anda/lib/nvidia/libcusolver/cusolver.pc
+++ b/anda/lib/nvidia/libcusolver/cusolver.pc
@@ -1,0 +1,8 @@
+libdir=LIBDIR
+includedir=INCLUDE_DIR
+
+Name: cusolver
+Description: A LAPACK-like library on dense and sparse linear algebra
+Version: CUDA_VERSION
+Libs: -L${libdir} -lcusolver
+Cflags: -I${includedir}

--- a/anda/lib/nvidia/libcusolver/libcusolver.spec
+++ b/anda/lib/nvidia/libcusolver/libcusolver.spec
@@ -1,0 +1,91 @@
+%global debug_package %{nil}
+%global __strip /bin/true
+%global _missing_build_ids_terminate_build 0
+%global _build_id_links none
+%global major_package_version 12-8
+
+Name:           libcusolver
+Epoch:          2
+Version:        11.7.2.55
+Release:        1%{?dist}
+Summary:        NVIDIA cuSOLVER library
+License:        CUDA Toolkit
+URL:            https://developer.nvidia.com/cuda-toolkit
+ExclusiveArch:  x86_64 aarch64
+
+Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{name}/linux-x86_64/%{name}-linux-x86_64-%{version}-archive.tar.xz
+Source1:        https://developer.download.nvidia.com/compute/cuda/redist/%{name}/linux-sbsa/%{name}-linux-sbsa-%{version}-archive.tar.xz
+Source3:        cusolver.pc
+
+Requires:       libgomp%{_isa}
+Conflicts:      %{name}-%{major_package_version} < %{?epoch:%{epoch}:}%{version}-%{release}
+
+%description
+The NVIDIA cuSOLVER library provides a collection of dense and sparse direct
+solvers which deliver significant acceleration for Computer Vision, CFD,
+Computational Chemistry, and Linear Optimization applications.
+
+%package devel
+Summary:        Development files for NVIDIA cuSOLVER library
+Requires:       %{name}%{_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Conflicts:      %{name}-devel-%{major_package_version} < %{?epoch:%{epoch}:}%{version}
+
+%description devel
+This package provides development files for the NVIDIA cuSOLVER library.
+
+%package static
+Summary:        Static libraries for NVIDIA cuSOLVER
+Requires:       %{name}-devel%{_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+
+%description static
+This package contains static libraries for NVIDIA cuSOLVER.
+
+%prep
+%ifarch x86_64
+%setup -q -n %{name}-linux-x86_64-%{version}-archive
+%endif
+
+%ifarch aarch64
+%setup -q -T -b 1 -n %{name}-linux-sbsa-%{version}-archive
+%endif
+
+%install
+mkdir -p %{buildroot}%{_includedir}
+mkdir -p %{buildroot}%{_libdir}
+mkdir -p %{buildroot}%{_libdir}/pkgconfig/
+
+cp -fr include/* %{buildroot}%{_includedir}/
+cp -fr lib/lib* %{buildroot}%{_libdir}/
+cp -fr %{SOURCE3} %{buildroot}/%{_libdir}/pkgconfig/
+
+# Set proper variables
+sed -i \
+    -e 's|CUDA_VERSION|%{version}|g' \
+    -e 's|LIBDIR|%{_libdir}|g' \
+    -e 's|INCLUDE_DIR|%{_includedir}|g' \
+    %{buildroot}/%{_libdir}/pkgconfig/*.pc
+
+%files
+%license LICENSE
+%{_libdir}/libcusolver.so.*
+%{_libdir}/libcusolverMg.so.*
+
+%files devel
+%{_includedir}/cusolver_common.h
+%{_includedir}/cusolverDn.h
+%{_includedir}/cusolverMg.h
+%{_includedir}/cusolverRf.h
+%{_includedir}/cusolverSp.h
+%{_includedir}/cusolverSp_LOWLEVEL_PREVIEW.h
+%{_libdir}/libcusolver.so
+%{_libdir}/libcusolverMg.so
+%{_libdir}/libcusolver_lapack_static.a
+%{_libdir}/libcusolver_metis_static.a
+%{_libdir}/libmetis_static.a
+%{_libdir}/pkgconfig/cusolver.pc
+
+%files static
+%{_libdir}/libcusolver_static.a
+
+%changelog
+%autochangelog

--- a/anda/lib/nvidia/libcusolver/update.rhai
+++ b/anda/lib/nvidia/libcusolver/update.rhai
@@ -1,0 +1,3 @@
+import "andax/nvidia.rhai" as nvidia;
+
+rpm.version(nvidia::nvidia_component_version("libcusolver"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: libcufile and libcusolver (#5292)](https://github.com/terrapkg/packages/pull/5292)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)