### PR TITLE
[el10] chore: Bump out of sync packages (#5296)

### DIFF
--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -16,7 +16,7 @@
 %global comet_version 0.2.0
 
 Name:          %{shortname}-games-launcher
-Version:       2.17.1
+Version:       2.17.2
 Release:       1%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause

--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,5 +1,5 @@
-%global commit 216c7ba7321b31f098e892f4fa8294da6f404889
-%global commit_date 20250502
+%global commit eced36223a7683dec87af0f6496a5c01ff757bab
+%global commit_date 20250610
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           readymade-git
@@ -60,6 +60,5 @@ ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_da
 %_datadir/polkit-1/actions/com.fyralabs.pkexec.readymade.policy
 %_datadir/applications/com.fyralabs.Readymade.desktop
 %_datadir/applications/liveinst.desktop
-%_datadir/readymade
+%ghost %_datadir/readymade
 %_datadir/icons/hicolor/scalable/apps/com.fyralabs.Readymade.svg
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [chore: Bump out of sync packages (#5296)](https://github.com/terrapkg/packages/pull/5296)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)