### PR TITLE
[f41] bump: lomiri-system-settings (#5307)

### DIFF
--- a/anda/desktops/lomiri-unity/lomiri-system-settings/lomiri-system-settings.spec
+++ b/anda/desktops/lomiri-unity/lomiri-system-settings/lomiri-system-settings.spec
@@ -1,5 +1,5 @@
 %global forgeurl https://gitlab.com/ubports/development/core/lomiri-system-settings
-%global commit 8ea4a5730db308b73b3e3a9d6935477700091bfd
+%global commit 265ba4edb2c7e6aab58d1557dd59c01a3cb88c07
 %forgemeta
 
 Name:       lomiri-system-settings


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [bump: lomiri-system-settings (#5307)](https://github.com/terrapkg/packages/pull/5307)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)