### PR TITLE
[f42] fix(anda): List deps in the correct spot (#5315)

### DIFF
--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -6,7 +6,7 @@
 
 Name:           rust-anda
 Version:        0.4.12
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Andaman Build toolchain
 
 License:        MIT
@@ -26,13 +26,6 @@ BuildRequires:  libgit2-devel
 BuildRequires:  libssh2-devel
 BuildRequires:  mold
 
-Requires:       mock-scm
-Requires:       rpm-build
-Requires:       createrepo_c
-Requires:       git-core
-Requires:       libgit2
-Requires:       script
-
 %global _description %{expand:
 Andaman Build toolchain.}
 
@@ -40,6 +33,12 @@ Andaman Build toolchain.}
 
 %package     -n %{crate}
 Summary:        %{summary}
+Requires:       mock-scm
+Requires:       rpm-build
+Requires:       createrepo_c
+Requires:       git-core
+Requires:       libgit2
+Requires:       util-linux-script
 
 %description -n %{crate} %{_description}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(anda): List deps in the correct spot (#5315)](https://github.com/terrapkg/packages/pull/5315)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)