### PR TITLE
[f41] fix(anda): dep on script directly? (#5320)

### DIFF
--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -6,7 +6,7 @@
 
 Name:           rust-anda
 Version:        0.4.12
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Andaman Build toolchain
 
 License:        MIT
@@ -38,7 +38,7 @@ Requires:       rpm-build
 Requires:       createrepo_c
 Requires:       git-core
 Requires:       libgit2
-Requires:       util-linux-script
+Requires:       script
 
 %description -n %{crate} %{_description}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(anda): dep on script directly? (#5320)](https://github.com/terrapkg/packages/pull/5320)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)