### PR TITLE
[el10] fix(anda): The path solver cannot be used for deps (#5327)

### DIFF
--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -6,7 +6,7 @@
 
 Name:           rust-anda
 Version:        0.4.12
-Release:        3%?dist
+Release:        4%?dist
 Summary:        Andaman Build toolchain
 
 License:        MIT
@@ -38,7 +38,9 @@ Requires:       rpm-build
 Requires:       createrepo_c
 Requires:       git-core
 Requires:       libgit2
-Requires:       script
+%if 0%{?fedora} >= 42
+Requires:       util-linux-script
+%endif
 
 %description -n %{crate} %{_description}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(anda): The path solver cannot be used for deps (#5327)](https://github.com/terrapkg/packages/pull/5327)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)