### PR TITLE
[f40] fix(anda): More things Fedora changed on 42 (#5336)

### DIFF
--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -6,7 +6,7 @@
 
 Name:           rust-anda
 Version:        0.4.12
-Release:        4%?dist
+Release:        5%?dist
 Summary:        Andaman Build toolchain
 
 License:        MIT
@@ -30,12 +30,13 @@ Andaman Build toolchain.}
 
 %package     -n %{crate}
 Summary:        %{summary}
-Requires:       mock-scm
+Requires:       mock
 Requires:       rpm-build
 Requires:       createrepo_c
 Requires:       git-core
 Requires:       libgit2
 %if 0%{?fedora} >= 42
+Requires:       mock-filesystem
 Requires:       util-linux-script
 %endif
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(anda): More things Fedora changed on 42 (#5336)](https://github.com/terrapkg/packages/pull/5336)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)