### PR TITLE
[el10] fix(rpcs3): Don't disable static linking, use Mock (#5347)

### DIFF
--- a/anda/games/rpcs3/anda.hcl
+++ b/anda/games/rpcs3/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "rpcs3.spec"
 	}
+        labels {
+                mock = 1
+        }
 }

--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -1,4 +1,3 @@
-%global __requires_exclude ^((libwolfssl\\.so.*)|(libFusion\\.so.*)|(libasmjit\\.so.*)|(libcubeb\\.so.*)|(libdiscord-rpc\\.so.*)|(libglslang\\.so.*)|(librtmidi\\.so.*)|(libyaml-cpp\\.so.*)|(libSPIRV\\.so.*)|(libhidapi-hidraw\\.so.*)|(libpugixml\\.so.*))$
 %global _distro_extra_cflags -Wno-uninitialized
 %global _distro_extra_cxxflags -include %_includedir/c++/*/cstdint
 # GLIBCXX_ASSERTIONS is known to break RPCS3
@@ -12,7 +11,7 @@
 
 Name:           rpcs3
 Version:        %(echo %{ver} | sed 's/-/^/g')
-Release:        4%?dist
+Release:        2%?dist
 Summary:        PlayStation 3 emulator and debugger
 License:        GPL-2.0-only
 URL:            https://github.com/RPCS3/rpcs3
@@ -63,12 +62,10 @@ BuildRequires:  qt6-qtbase-private-devel vulkan-devel jack-audio-connection-kit-
 
 %build
 # Looking at the CMakeLists.txt, this is the intended compiler and there are no fixes for GCC on aarch64
-export CC=clang
-export CXX=clang++
 %cmake -DDISABLE_LTO=TRUE                                \
-     -DZSTD_BUILD_SHARED=OFF                             \
     -DZSTD_BUILD_STATIC=ON                               \
     -DCMAKE_SKIP_RPATH=ON                                \
+    -DBUILD_SHARED_LIBS:BOOL=OFF                         \
     -DUSE_NATIVE_INSTRUCTIONS=OFF                        \
     -DCMAKE_C_FLAGS="$CFLAGS"                            \
     -DCMAKE_CXX_FLAGS="$CXXFLAGS"                        \
@@ -87,6 +84,8 @@ export CXX=clang++
     -DUSE_SYSTEM_FLATBUFFERS=OFF                         \
     -DUSE_SYSTEM_PUGIXML=OFF                             \
     -DUSE_SYSTEM_WOLFSSL=OFF                             \
+    -DCMAKE_C_COMPILER=clang                             \
+    -DCMAKE_CXX_COMPILER=clang++                         \
     -DCMAKE_LINKER=mold                                  \
     -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS -fuse-ld=mold" \
     -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -fuse-ld=mold"    


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(rpcs3): Don't disable static linking, use Mock (#5347)](https://github.com/terrapkg/packages/pull/5347)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)