### PR TITLE
[f41] feat(anda-srpm-macros): include required scripts (#5349)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -1,6 +1,6 @@
 Name:           anda-srpm-macros
 Version:        0.2.13
-Release:        1%?dist
+Release:        2%?dist
 Summary:        SRPM macros for extra Fedora packages
 
 License:        MIT
@@ -25,8 +25,10 @@ BuildArch:      noarch
 for file in ./macros.*; do
     install -Dpm644 -t %buildroot%_rpmmacrodir $file
 done
+install -Dpm755 *.sh -t %buildroot%_libexecdir/%name/
 
 %files
+%_libexecdir/%name/
 %{_rpmmacrodir}/macros.anda
 %{_rpmmacrodir}/macros.caching
 %{_rpmmacrodir}/macros.cargo_extra


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(anda-srpm-macros): include required scripts (#5349)](https://github.com/terrapkg/packages/pull/5349)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)