### PR TITLE
[f42] fix: feishin (#5351)

### DIFF
--- a/anda/apps/feishin/feishin.spec
+++ b/anda/apps/feishin/feishin.spec
@@ -13,7 +13,8 @@ License:		GPL-3.0
 URL:			https://github.com/jeffvli/feishin
 Source0:		%url/archive/refs/tags/v%version.tar.gz
 Requires:		fuse mpv
-BuildRequires:	nodejs20-npm jq libxcrypt-compat
+Packager:		madonuko <mado@fyralabs.com>
+BuildRequires:	jq libxcrypt-compat pnpm
 
 %description
 %summary.
@@ -38,13 +39,9 @@ Keywords=Music;Jellyfin;Audio;Stream;Sonixd
 EOF
 
 %build
-export PATH="$PATH:$(pwd)/bin"
-mkdir bin
-ln -s /usr/bin/node-20 bin/node
-ln -s /usr/bin/npm-20 bin/npm
-npm-20 install --legacy-peer-deps
-npm-20 run postinstall
-npm-20 run build
+pnpm i
+pnpm run postinstall
+pnpm run build
 %ifarch x86_64
 
 %define a linux
@@ -52,11 +49,11 @@ npm-20 run build
 %define a arm64
 %endif
 
-npx-20 electron-builder --linux dir --%a
+pnpm exec electron-builder --linux dir --%a
 
 %install
 mkdir -p %buildroot%_datadir/{pixmaps,applications} %buildroot%_bindir
-mv release/build/*-unpacked %buildroot%_datadir/feishin
+mv dist/*-unpacked %buildroot%_datadir/feishin
 install -Dm644 assets/icons/icon.png %buildroot%_datadir/pixmaps/feishin.png
 ln -s %_datadir/feishin/feishin %buildroot%_bindir/feishin
 install -Dm644 feishin.desktop %buildroot%_datadir/applications/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: feishin (#5351)](https://github.com/terrapkg/packages/pull/5351)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)