### PR TITLE
[el10] fix: anda-srpm-macros (#5377)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -1,6 +1,6 @@
 Name:           anda-srpm-macros
 Version:        0.2.15
-Release:        1%?dist
+Release:        2%?dist
 Summary:        SRPM macros for extra Fedora packages
 
 License:        MIT
@@ -28,7 +28,7 @@ done
 install -Dpm755 *.sh -t %buildroot%_libexecdir/%name/
 
 %files
-%_libexecdir/%name/
+%attr(0755, root, root) %_libexecdir/%name/*.sh
 %{_rpmmacrodir}/macros.anda
 %{_rpmmacrodir}/macros.caching
 %{_rpmmacrodir}/macros.cargo_extra


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: anda-srpm-macros (#5377)](https://github.com/terrapkg/packages/pull/5377)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)