### PR TITLE
[el10] add: hyprwayland-scanner.nightly (#5370)

### DIFF
--- a/anda/desktops/waylands/hyprwayland-scanner/anda.hcl
+++ b/anda/desktops/waylands/hyprwayland-scanner/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+	rpm {
+		spec = "hyprwayland-scanner.nightly.spec"
+	}
+	labels {
+		nightly = 1
+		subrepo = "extras"
+	}
+}

--- a/anda/desktops/waylands/hyprwayland-scanner/hyprwayland-scanner.nightly.spec
+++ b/anda/desktops/waylands/hyprwayland-scanner/hyprwayland-scanner.nightly.spec
@@ -1,0 +1,55 @@
+#? https://src.fedoraproject.org/rpms/hyprwayland-scanner/blob/rawhide/f/hyprwayland-scanner.spec
+
+%global realname hyprwayland-scanner
+%global ver 0.4.4
+%global commit 817918315ea016cc2d94004bfb3223b5fd9dfcc6
+%global shortcommit %{sub %commit 1 7}
+%global commit_date 20250614
+
+Name:           %realname.nightly
+Version:        %ver^%{commit_date}git.%shortcommit
+Release:        1%?dist
+Summary:        A Hyprland implementation of wayland-scanner, in and for C++
+
+License:        BSD-3-Clause
+URL:            https://github.com/hyprwm/hyprwayland-scanner
+Source0:        %url/archive/%commit.tar.gz
+
+# https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
+ExcludeArch:    %{ix86}
+
+BuildRequires:  cmake
+BuildRequires:  cmake(pugixml)
+BuildRequires:  gcc-c++
+
+Provides:		%realname = %evr
+Conflicts:		%realname
+Packager:		madonuko <mado@fyralabs.com>
+
+%description
+%{summary}.
+
+%package        devel
+Summary:        A Hyprland implementation of wayland-scanner, in and for C++
+Provides:		%realname-devel = %evr
+Conflicts:		%realname-devel
+
+%description    devel
+%{summary}.
+
+%prep
+%autosetup -p1 -n %realname-%commit
+
+%build
+%cmake
+%cmake_build
+
+%install
+%cmake_install
+
+%files devel
+%license LICENSE
+%doc README.md
+%{_bindir}/%{realname}
+%{_libdir}/pkgconfig/%{realname}.pc
+%{_libdir}/cmake/%{realname}/

--- a/anda/desktops/waylands/hyprwayland-scanner/update.rhai
+++ b/anda/desktops/waylands/hyprwayland-scanner/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("hyprwm/hyprwayland-scanner"));
+if rpm.changed() {
+	rpm.global("ver", gh_rawfile("hyprwm/hyprwayland-scanner", "main", "VERSION"));
+	rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: hyprwayland-scanner.nightly (#5370)](https://github.com/terrapkg/packages/pull/5370)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)