### PR TITLE
[f42] add: hyprland-protocols.nightly (#5384)

### DIFF
--- a/anda/desktops/waylands/hyprland-protocols/anda.hcl
+++ b/anda/desktops/waylands/hyprland-protocols/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "hyprland-protocols.nightly.spec"
+  }
+  labels {
+    nightly = 1
+    subrepo = "extras"
+  }
+}

--- a/anda/desktops/waylands/hyprland-protocols/hyprland-protocols.nightly.spec
+++ b/anda/desktops/waylands/hyprland-protocols/hyprland-protocols.nightly.spec
@@ -1,0 +1,53 @@
+#? https://src.fedoraproject.org/rpms/hyprland-protocols/blob/rawhide/f/hyprland-protocols.spec
+
+%global realname hyprland-protocols
+%global ver 0.6.4
+%global commit 613878cb6f459c5e323aaafe1e6f388ac8a36330
+%global commit_date 20250604
+%global shortcommit %{sub %commit 1 7}
+
+Name:           %realname.nightly
+Version:        %ver^%{commit_date}git.%shortcommit
+Release:        1%?dist
+Summary:        Wayland protocol extensions for Hyprland
+BuildArch:      noarch
+
+License:        BSD-3-Clause
+URL:            https://github.com/hyprwm/hyprland-protocols
+Source0:        %url/archive/%commit.tar.gz
+
+BuildRequires:  meson
+Packager:		madonuko <mado@fyralabs.com>
+Provides:		%realname = %evr
+Conflicts:		%realname
+
+%description
+%{summary}.
+
+%package        devel
+Summary:        Wayland protocol extensions for Hyprland
+Provides:		%realname-devel = %evr
+Conflicts:		%realname-devel
+
+%description    devel
+%{summary}.
+
+
+%prep
+%autosetup -p1 -n %realname-%commit
+
+
+%build
+%meson
+%meson_build
+
+
+%install
+%meson_install
+
+
+%files devel
+%license LICENSE
+%doc README.md
+%{_datadir}/pkgconfig/%{realname}.pc
+%{_datadir}/%{realname}/

--- a/anda/desktops/waylands/hyprland-protocols/update.rhai
+++ b/anda/desktops/waylands/hyprland-protocols/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("hyprwm/hyprlang-protocols"));
+if rpm.changed() {
+	rpm.global("ver", gh_rawfile("hyprwm/hyprlang-protocols", "main", "VERSION"));
+	rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: hyprland-protocols.nightly (#5384)](https://github.com/terrapkg/packages/pull/5384)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)