### PR TITLE
[f40] fix(atac): try --locked (#5386)

### DIFF
--- a/anda/devs/atac/atac.spec
+++ b/anda/devs/atac/atac.spec
@@ -37,6 +37,7 @@ and account-less.}
 %build
 %{cargo_license_summary_online}
 %{cargo_license_online} > LICENSE.dependencies
+%{cargo_build} --locked
 
 %install
-%cargo_install
+%crate_install_bin


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [fix(atac): try --locked (#5386)](https://github.com/terrapkg/packages/pull/5386)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)