### PR TITLE
[f41] fix(flashprog): update urls and license (#5408)

### DIFF
--- a/anda/tools/flashprog/flashprog.spec
+++ b/anda/tools/flashprog/flashprog.spec
@@ -5,11 +5,11 @@ It supports a wide range of flash chips (most commonly found in SOIC8, DIP8, SOI
 
 Name:           flashprog
 Version:        1.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Utility for detecting, reading, writing, verifying and erasing flash chips
 
-License:        GPL-2.0
-URL:            https://review.sourcearcade.org/flashprog
+License:        GPL-2.0-only
+URL:            https://flashprog.org
 
 Packager:       sadlerm <lerm@chromebooks.lol>
 
@@ -42,7 +42,7 @@ Summary:        Development headers for flashprog
 
 
 %prep
-%git_clone %{url} v%{version}
+%git_clone https://review.sourcearcade.org/flashprog v%{version}
 
 %build
 %make_build PREFIX=%{_prefix}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(flashprog): update urls and license (#5408)](https://github.com/terrapkg/packages/pull/5408)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)