### PR TITLE
[f42] add: hyprlang.nightly (#5371)

### DIFF
--- a/anda/desktops/waylands/hyprlang/anda.hcl
+++ b/anda/desktops/waylands/hyprlang/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+	rpm {
+		spec = "hyprlang.nightly.spec"
+	}
+	labels {
+		nightly = 1
+		subrepo = "extras"
+	}
+}

--- a/anda/desktops/waylands/hyprlang/hyprlang.nightly.spec
+++ b/anda/desktops/waylands/hyprlang/hyprlang.nightly.spec
@@ -1,0 +1,57 @@
+#? https://src.fedoraproject.org/rpms/hyprlang/blob/rawhide/f/hyprlang.spec
+
+%global realname hyprlang
+%global ver 0.6.3
+%global commit 1bfb84f54d50c7ae6558c794d3cfd5f6a7e6e676
+%global commit_date 20250606
+%global shortcommit %{sub %commit 1 7}
+
+Name:           %realname.nightly
+Version:        %ver^%{commit_date}git.%shortcommit
+Release:        1%?dist
+Summary:        The official implementation library for the hypr config language
+
+License:        LGPL-3.0-only
+URL:            https://github.com/hyprwm/hyprlang
+Source0:        %url/archive/%commit.tar.gz
+
+# https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
+ExcludeArch:    %{ix86}
+
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+BuildRequires:  (pkgconfig(hyprutils) with hyprutils.nightly-devel)
+
+Provides:		%realname = %evr
+Conflicts:		%realname
+
+%description
+%{summary}.
+
+%package        devel
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Provides:		%realname-devel = %evr
+Conflicts:		%realname-devel
+%pkg_devel_files
+
+%prep
+%autosetup -p1 -n %realname-%commit
+
+%build
+%cmake
+%cmake_build
+
+%install
+%cmake_install
+
+%check
+%ctest
+
+%files
+%license LICENSE
+%doc README.md
+%{_libdir}/libhyprlang.so.2
+%{_libdir}/libhyprlang.so.%{ver}
+
+%changelog
+%autochangelog

--- a/anda/desktops/waylands/hyprlang/update.rhai
+++ b/anda/desktops/waylands/hyprlang/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("hyprwm/hyprlang"));
+if rpm.changed() {
+	rpm.global("ver", gh_rawfile("hyprwm/hyprlang", "main", "VERSION"));
+	rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: hyprlang.nightly (#5371)](https://github.com/terrapkg/packages/pull/5371)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)