### PR TITLE
[f40] add: vpkedit (#1284)

### DIFF
--- a/anda/apps/vpkedit/anda.hcl
+++ b/anda/apps/vpkedit/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "vpkedit.spec"
+  }
+}

--- a/anda/apps/vpkedit/update.rhai
+++ b/anda/apps/vpkedit/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("craftablescience/VPKEdit"));

--- a/anda/apps/vpkedit/vpkedit.spec
+++ b/anda/apps/vpkedit/vpkedit.spec
@@ -1,0 +1,52 @@
+Name:           vpkedit
+Version:        4.4.2
+Release:        1%?dist
+Summary:        A CLI/GUI tool to create, read, and write several pack file formats
+License:        MIT
+URL:            https://github.com/craftablescience/VPKEdit
+Requires:       qt6-qtbase hicolor-icon-theme
+Suggests:       qt6-qtwayland
+Packager:       madonuko <mado@fyralabs.com>
+BuildRequires:  cmake git-core gcc gcc-c++ binutils
+BuildRequires:  cmake(Qt6)
+BuildRequires:  cmake(Qt6Svg)
+BuildRequires:  cmake(Qt6Linguist)
+BuildRequires:  cmake(Qt6Charts)
+BuildRequires:  cmake(Qt6LinguistTools)
+ExclusiveArch:  x86_64
+
+%description
+VPKEdit is an open source MIT-licensed tool that can extract from, preview the
+contents of and write to several pack file formats. It also supports creating
+new VPKs.
+
+
+%prep
+%git_clone %url v%version
+
+
+%build
+%cmake -DCMAKE_INSTALL_PREFIX=%_libdir/%name   # -DVPKEDIT_BUILD_LIBC=ON
+%cmake_build
+
+
+%install
+%cmake_install
+pushd %buildroot%_libdir/%name
+rm -rf libQt*
+popd
+ln -sf %_libdir/vpkedit/vpkedit %buildroot%_bindir/vpkedit
+ln -sf %_libdir/vpkedit/vpkeditcli %buildroot%_bindir/vpkeditcli
+sed -i 's@Exec=/opt/vpkedit/@Exec=@g' %buildroot%_datadir/applications/vpkedit.desktop
+
+
+%files
+%doc README.md CREDITS.md
+%license LICENSE
+%_bindir/vpkedit
+%_bindir/vpkeditcli
+%_libdir/%name/
+%_datadir/applications/vpkedit.desktop
+%_iconsdir/hicolor/128x128/mimetypes/application-x-vpkedit.png
+%_datadir/mime/packages/vpkedit.xml
+%_datadir/pixmaps/vpkedit.png


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f40`:
 - [add: vpkedit (#1284)](https://github.com/terrapkg/packages/pull/1284)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)