### PR TITLE
[f41] add: hyprgraphics (#5410)

### DIFF
--- a/anda/desktops/waylands/hyprgraphics/anda.hcl
+++ b/anda/desktops/waylands/hyprgraphics/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+  rpm {
+    spec = "hyprgraphics.nightly.spec"
+  }
+  labels {
+    nightly = 1
+    subrepo = "extras"
+  }
+}

--- a/anda/desktops/waylands/hyprgraphics/hyprgraphics.nightly.spec
+++ b/anda/desktops/waylands/hyprgraphics/hyprgraphics.nightly.spec
@@ -1,0 +1,67 @@
+#? https://src.fedoraproject.org/rpms/hyprgraphics/blob/rawhide/f/hyprgraphics.spec
+
+%global realname hyprgraphics
+%global ver 0.1.3
+%global commit c7225d73755a6c4c7c72f4d4f3925ea426e325a8
+%global commit_date 20250607
+%global shortcommit %{sub %commit 1 7}
+
+%bcond libjxl 1
+Name:           %realname.nightly
+Version:        %ver^%{commit_date}git.%shortcommit
+Release:        1%?dist
+Summary:        Graphics library for Hyprland
+
+License:        BSD-3-Clause
+URL:            https://github.com/hyprwm/hyprgraphics
+Source0:		%url/archive/%commit.tar.gz
+Packager:		madonuko <mado@fyralabs.com>
+
+# https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
+ExcludeArch:    %{ix86}
+
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+BuildRequires:  (pkgconfig(hyprlang) with hyprlang.nightly-devel)
+BuildRequires:  pkgconfig(cairo)
+BuildRequires:  (pkgconfig(hyprutils) with hyprutils.nightly-devel)
+BuildRequires:  pkgconfig(libjpeg)
+BuildRequires:  pkgconfig(libwebp)
+BuildRequires:  pkgconfig(libmagic)
+BuildRequires:  pkgconfig(spng)
+
+%if %{with libjxl}
+BuildRequires:  pkgconfig(libjxl)
+BuildRequires:  pkgconfig(libjxl_cms)
+BuildRequires:  pkgconfig(libjxl_threads)
+%endif
+
+%description
+%{summary}.
+
+%package        devel
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+%pkg_devel_files
+
+
+%prep
+%autosetup -p1 -n %realname-%commit
+
+%build
+%cmake
+%cmake_build
+
+%install
+%cmake_install
+
+%check
+%ifarch s390x
+rm tests/resource/images/hyprland.jpg
+%endif
+%ctest
+
+%files
+%license LICENSE
+%doc README.md
+%{_libdir}/libhyprgraphics.so.0
+%{_libdir}/libhyprgraphics.so.%{ver}

--- a/anda/desktops/waylands/hyprgraphics/update.rhai
+++ b/anda/desktops/waylands/hyprgraphics/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("hyprwm/hyprgraphics"));
+if rpm.changed() {
+	rpm.global("ver", gh_rawfile("hyprwm/hyprgraphics", "main", "VERSION"));
+	rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: hyprgraphics (#5410)](https://github.com/terrapkg/packages/pull/5410)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)