### PR TITLE
[f42] add: hypridle (#5378)

### DIFF
--- a/anda/desktops/waylands/hypridle/anda.hcl
+++ b/anda/desktops/waylands/hypridle/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "hypridle.spec"
+	}
+}

--- a/anda/desktops/waylands/hypridle/hypridle.spec
+++ b/anda/desktops/waylands/hypridle/hypridle.spec
@@ -1,0 +1,45 @@
+Name:			hypridle
+Version:		0.1.6
+Release:		1%?dist
+Summary:		Hyprland's idle daemon
+License:		BSD-3-Clause
+URL:			https://github.com/hyprwm/hypridle
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+Packager:		madonuko <mado@fyralabs.com>
+BuildRequires:	cmake gcc gcc-c++
+BuildRequires:	pkgconfig(wayland-client)
+BuildRequires:	pkgconfig(wayland-protocols)
+BuildRequires:	(pkgconfig(hyprland-protocols) with hyprland-protocols.nightly-devel)
+BuildRequires:	(pkgconfig(hyprlang) with hyprlang.nightly-devel)
+BuildRequires:	pkgconfig(sdbus-c++)
+BuildRequires:	(pkgconfig(hyprwayland-scanner) with hyprwayland-scanner.nightly-devel)
+BuildRequires:	(pkgconfig(hyprutils) with hyprutils.nightly-devel)
+
+%description
+%summary.
+
+%prep
+%autosetup
+
+%build
+%cmake -DCMAKE_BUILD_TYPE:STRING=Release
+%cmake_build
+
+%install
+%cmake_install
+
+%post
+%systemd_user_post %name.service
+
+%preun
+%systemd_user_preun %name.service
+
+%postun
+%systemd_user_postun_with_restart %name.service
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/hypridle
+%_datadir/hypr/hypridle.conf
+%_userunitdir/%name.service

--- a/anda/desktops/waylands/hypridle/update.rhai
+++ b/anda/desktops/waylands/hypridle/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_rawfile("hyprwm/hypridle", "main", "VERSION"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: hypridle (#5378)](https://github.com/terrapkg/packages/pull/5378)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)