### PR TITLE
[el10] chore: Deprecate F40 (#5130)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
   "repoOwner": "terrapkg",
   "repoName": "packages",
   "resetAuthor": true,
-  "targetBranchChoices": ["el10", "f40", "f41", "f42", "frawhide"],
+  "targetBranchChoices": ["el10", "f41", "f42", "frawhide"],
   "branchLabelMapping": {
     "^sync-(.+)$": "$1"
   }

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         branch:
           - frawhide
-          - f40
           - f41
           - el10
     container:

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - frawhide
       - f41
-      - f40
       - el10
     paths:
       - comps.xml

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -46,7 +46,6 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
-            copy_over f40 || true
             copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -46,7 +46,6 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
-            copy_over f40 || true
             copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -46,7 +46,6 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
-            copy_over f40 || true
             copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: Deprecate F40 (#5130)](https://github.com/terrapkg/packages/pull/5130)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)