### PR TITLE
[f41] docs(readme): add instructions for EL, notes for extras (#5341)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,51 @@
 Terra is a rolling-release Fedora repository for all the software you need.
 With Terra, you can install the latest packages knowing that quality and security are assured.
 
+See the introduction at [our website](https://terra.fyralabs.com).
+
 This monorepo contains the package manifests for all packages in Terra.
 
 ## Installation
+
+### Fedora
+
 ```bash
-sudo dnf install --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' --setopt='terra.gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc' terra-release
+sudo dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
 ```
-You should also install the `terra-release` package so that when our infrastructure has any migrations, you can be assured that your Terra installation will still work as-is.
+
+If you are using immutable/atomic editions of Fedora, run the following commands instead:
+
+```bash
+curl -fsSL https://github.com/terrapkg/subatomic-repos/raw/main/terra.repo | pkexec tee /etc/yum.repos.d/terra.repo
+sudo rpm-ostree install terra-release
+```
+
+Optionally, you can install `terra-release-extra` to use the Extras repository. This also installs the Nvidia, and Mesa streams but does not enable them.
+
+### Enterprise Linux (EL)
+
+Only EL10 is supported. Not all packages available in Terra are available in Terra EL at this time.
+
+Terra EL requires the EPEL repos, which may be installed with:
+
+```bash
+sudo dnf install 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-$releasever.noarch.rpm'
+```
+
+And Terra EL itself can be installed with:
+
+```bash
+sudo dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' terra-release
+```
 
 ## Documentation
-Our documentation can be found on our [Devdocs](https://developer.fyralabs.com/terra/). Alternatively, the GitHub Wiki contains older versions of the documentations.
+
+Our documentation can be found on our [Devdocs](https://developer.fyralabs.com/terra/).
 
 ## Questions?
-Feel free to reach out on [Discord](https://discord.gg/5fdPuxTg5Q). We're always happy to help!
+
+Feel free to reach out by [joining our community](https://wiki.ultramarine-linux.org/en/community/community/). We're always happy to help!
+
+- [Contribution Guide](https://developer.fyralabs.com/terra/contributing)
+- [FAQ](https://developer.fyralabs.com/terra/faq)
+- [Policy](https://developer.fyralabs.com/terra/policy)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [docs(readme): add instructions for EL, notes for extras (#5341)](https://github.com/terrapkg/packages/pull/5341)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)