### PR TITLE
[f42] fix(hypridle): trim the version correctly (#5453)

### DIFF
--- a/anda/desktops/waylands/hypridle/hypridle.spec
+++ b/anda/desktops/waylands/hypridle/hypridle.spec
@@ -1,7 +1,5 @@
 Name:			hypridle
 Version:		0.1.6
-
-
 Release:		1%?dist
 Summary:		Hyprland's idle daemon
 License:		BSD-3-Clause

--- a/anda/desktops/waylands/hypridle/update.rhai
+++ b/anda/desktops/waylands/hypridle/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh_rawfile("hyprwm/hypridle", "main", "VERSION"));
+let v = gh_rawfile("hyprwm/hypridle", "main", "VERSION");
+v.trim();
+rpm.version(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(hypridle): trim the version correctly (#5453)](https://github.com/terrapkg/packages/pull/5453)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)