### PR TITLE
[f42] add: hyprlock (#5411)

### DIFF
--- a/anda/desktops/waylands/hyprlock/anda.hcl
+++ b/anda/desktops/waylands/hyprlock/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "hyprlock.spec"
+	}
+}

--- a/anda/desktops/waylands/hyprlock/hyprlock.spec
+++ b/anda/desktops/waylands/hyprlock/hyprlock.spec
@@ -1,0 +1,46 @@
+Name:			hyprlock
+Version:		0.8.2
+Release:		1%?dist
+Summary:		Hyprland's GPU-accelerated screen locking utility
+License:		BSD-3-Clause
+URL:			https://github.com/hyprwm/%name
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+Packager:		madonuko <mado@fyralabs.com>
+BuildRequires:	cmake gcc gcc-c++
+BuildRequires:	pkgconfig(cairo)
+BuildRequires:	(pkgconfig(hyprgraphics) with hyprgraphics.nightly-devel)
+BuildRequires:	pkgconfig(hyprland-protocols)
+BuildRequires:	(pkgconfig(hyprlang) with hyprlang.nightly-devel)
+BuildRequires:	pkgconfig(hyprutils)
+BuildRequires:	(pkgconfig(hyprwayland-scanner) with hyprwayland-scanner.nightly-devel)
+BuildRequires:	mesa-libgbm-devel
+BuildRequires:	mesa-libGL-devel
+BuildRequires:	pkgconfig(pam)
+BuildRequires:	pkgconfig(pango)
+BuildRequires:	pkgconfig(wayland-client)
+BuildRequires:	pkgconfig(wayland-protocols)
+BuildRequires:	pkgconfig(xkbcommon)
+BuildRequires:	pkgconfig(sdbus-c++) >= 2.0.0
+BuildRequires:	pkgconfig(libjpeg)
+BuildRequires:	pkgconfig(libwebp)
+BuildRequires:	pkgconfig(libmagic)
+
+%description
+%summary.
+
+%prep
+%autosetup
+
+%build
+%cmake -DCMAKE_BUILD_TYPE:STRING=Release
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/%name
+%_pam_confdir/%name
+%_datadir/hypr/%name.conf

--- a/anda/desktops/waylands/hyprlock/update.rhai
+++ b/anda/desktops/waylands/hyprlock/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_rawfile("hyprwm/hyprlock", "main", "VERSION"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: hyprlock (#5411)](https://github.com/terrapkg/packages/pull/5411)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)