### PR TITLE
[f42] add: cbmem (#3323)

### DIFF
--- a/anda/tools/cbmem/anda.hcl
+++ b/anda/tools/cbmem/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "cbmem.spec"
+	}
+}

--- a/anda/tools/cbmem/cbmem.spec
+++ b/anda/tools/cbmem/cbmem.spec
@@ -1,0 +1,32 @@
+%define debug_package %nil
+
+Name:           cbmem
+Version:        25.03
+Release:        1%?dist
+Summary:        Prints out coreboot mem table information
+URL:            https://review.coreboot.org
+License:        BSD-3-Clause AND Apache-2.0 AND CC-BY-SA-3.0 AND GPL-2.0-only AND GPL-3.0-or-later AND ISC AND BSD-2-Clause-Patent AND BSD-4-Clause-UC AND CC-PDDC AND GPL-2.0-or-later AND HPND-sell-varient AND LGPL-2.1-or-later AND BSD-2-Clause AND CC-BY-4.0 AND GPL-3.0-only AND HPND AND X11 AND MIT 
+BuildRequires:  gcc g++ make cmake ncurses-devel iasl git anda-srpm-macros
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+Prints out coreboot mem table information in JSON by default, and also implements the basic cbmem -list and -console commands.
+
+%prep
+%git_clone %url/coreboot %version
+
+%build
+cd util/cbmem
+%make_build CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS"
+
+%install
+install -Dm 755 util/cbmem/cbmem %buildroot%_bindir/cbmem
+
+%files
+%doc util/cbmem/description.md
+%license LICENSES/*
+%{_bindir}/cbmem
+
+%changelog
+* Sun Jun 15 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial Package

--- a/anda/tools/cbmem/update.rhai
+++ b/anda/tools/cbmem/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("coreboot/coreboot"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: cbmem (#3323)](https://github.com/terrapkg/packages/pull/3323)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)