### PR TITLE
[f42] fix(vpkedit): Don't disable static linking (#5464)

### DIFF
--- a/anda/apps/vpkedit/vpkedit.spec
+++ b/anda/apps/vpkedit/vpkedit.spec
@@ -1,6 +1,6 @@
 Name:           vpkedit
 Version:        4.4.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A CLI/GUI tool to create, read, and write several pack file formats
 License:        MIT
 URL:            https://github.com/craftablescience/VPKEdit
@@ -26,7 +26,9 @@ new VPKs.
 
 
 %build
-%cmake -DCMAKE_INSTALL_PREFIX=%_libdir/%name   # -DVPKEDIT_BUILD_LIBC=ON
+%cmake -DCMAKE_INSTALL_PREFIX=%_libdir/%name \
+   -DBUILD_SHARED_LIBS:BOOL=OFF
+#   -DVPKEDIT_BUILD_LIBC=ON
 %cmake_build
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(vpkedit): Don&#x27;t disable static linking (#5464)](https://github.com/terrapkg/packages/pull/5464)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)