### PR TITLE
[f41] fix(v4l2-relayd): Change to nightly so commit date is accurate (#5465)

### DIFF
--- a/anda/system/v4l2-relayd/anda.hcl
+++ b/anda/system/v4l2-relayd/anda.hcl
@@ -3,6 +3,6 @@ project pkg {
     spec = "v4l2-relayd.spec"
   }
   labels {
-        weekly = 1
+        nightly = 1
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(v4l2-relayd): Change to nightly so commit date is accurate (#5465)](https://github.com/terrapkg/packages/pull/5465)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)