### PR TITLE
[f41] fix(hyprlock): explicit builddeps from terra (#5462)

### DIFF
--- a/anda/desktops/waylands/hyprlock/hyprlock.spec
+++ b/anda/desktops/waylands/hyprlock/hyprlock.spec
@@ -1,37 +1,5 @@
 Name:			hyprlock
 Version:		0.8.2
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 Release:		1%?dist
 Summary:		Hyprland's GPU-accelerated screen locking utility
 License:		BSD-3-Clause
@@ -43,7 +11,7 @@ BuildRequires:	pkgconfig(cairo)
 BuildRequires:	(pkgconfig(hyprgraphics) with hyprgraphics.nightly-devel)
 BuildRequires:	pkgconfig(hyprland-protocols)
 BuildRequires:	(pkgconfig(hyprlang) with hyprlang.nightly-devel)
-BuildRequires:	pkgconfig(hyprutils)
+BuildRequires:	(pkgconfig(hyprutils) with hyprutils.nightly-devel)
 BuildRequires:	(pkgconfig(hyprwayland-scanner) with hyprwayland-scanner.nightly-devel)
 BuildRequires:	mesa-libgbm-devel
 BuildRequires:	mesa-libGL-devel
@@ -52,7 +20,7 @@ BuildRequires:	pkgconfig(pango)
 BuildRequires:	pkgconfig(wayland-client)
 BuildRequires:	pkgconfig(wayland-protocols)
 BuildRequires:	pkgconfig(xkbcommon)
-BuildRequires:	pkgconfig(sdbus-c++) >= 2.0.0
+BuildRequires:	pkgconfig(sdbus-c++) >= 2.1.0
 BuildRequires:	pkgconfig(libjpeg)
 BuildRequires:	pkgconfig(libwebp)
 BuildRequires:	pkgconfig(libmagic)

--- a/anda/desktops/waylands/hyprlock/update.rhai
+++ b/anda/desktops/waylands/hyprlock/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh_rawfile("hyprwm/hyprlock", "main", "VERSION"));
+let v = gh_rawfile("hyprwm/hyprlock", "main", "VERSION");
+v.trim();
+rpm.version(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(hyprlock): explicit builddeps from terra (#5462)](https://github.com/terrapkg/packages/pull/5462)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)