### PR TITLE
[el10] fix(hypridle): require sdbus-cpp.terra-devel (#5450)

### DIFF
--- a/anda/desktops/waylands/hypridle/ci_setup.rhai
+++ b/anda/desktops/waylands/hypridle/ci_setup.rhai
@@ -1,0 +1,1 @@
+sh("dnf swap sdbus-cpp sdbus-cpp.terra -y --allowerasing", #{});

--- a/anda/desktops/waylands/hypridle/hypridle.spec
+++ b/anda/desktops/waylands/hypridle/hypridle.spec
@@ -11,7 +11,7 @@ BuildRequires:	pkgconfig(wayland-client)
 BuildRequires:	pkgconfig(wayland-protocols)
 BuildRequires:	(pkgconfig(hyprland-protocols) with hyprland-protocols.nightly-devel)
 BuildRequires:	(pkgconfig(hyprlang) with hyprlang.nightly-devel)
-BuildRequires:	pkgconfig(sdbus-c++)
+BuildRequires:	(pkgconfig(sdbus-c++) with sdbus-cpp.terra-devel)
 BuildRequires:	(pkgconfig(hyprwayland-scanner) with hyprwayland-scanner.nightly-devel)
 BuildRequires:	(pkgconfig(hyprutils) with hyprutils.nightly-devel)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(hypridle): require sdbus-cpp.terra-devel (#5450)](https://github.com/terrapkg/packages/pull/5450)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)