### PR TITLE
[el10] fix(hyprlock): swap sdbus (#5478)

### DIFF
--- a/anda/desktops/waylands/hyprlock/ci_setup.rhai
+++ b/anda/desktops/waylands/hyprlock/ci_setup.rhai
@@ -1,0 +1,1 @@
+sh("dnf swap sdbus-cpp sdbus-cpp.terra -y --allowerasing", #{});


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(hyprlock): swap sdbus (#5478)](https://github.com/terrapkg/packages/pull/5478)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)