### PR TITLE
[el10] fix(sdbus-cpp): update.rhai (#5485)

### DIFF
--- a/anda/lib/sdbus-cpp/update.rhai
+++ b/anda/lib/sdbus-cpp/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(`(?m)^project\(sdbus-c\+\+ VERSION ([\d.]+) LANGUAGES CXX C\)$`.find(gh_rawfile("Kistler-Group/sdbus-cpp", "master", "CMakeLists.txt")));
+rpm.version(`(?m)^project\(sdbus-c\+\+ VERSION ([\d.]+) LANGUAGES CXX C\)$`.find(gh_rawfile("Kistler-Group/sdbus-cpp", "master", "CMakeLists.txt"), 1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(sdbus-cpp): update.rhai (#5485)](https://github.com/terrapkg/packages/pull/5485)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)