### PR TITLE
[f42] fix(andax/ci/bump_release): maybe import paths are relative? (#5489)

### DIFF
--- a/anda/multimedia/ffmpeg/ffmpeg.spec
+++ b/anda/multimedia/ffmpeg/ffmpeg.spec
@@ -12,7 +12,7 @@
 Summary:        A complete solution to record, convert and stream audio and video
 Name:           ffmpeg
 Version:        7.1.1
-Release:        3%{?dist}
+Release:        3%?dist
 License:        LGPL-3.0-or-later
 URL:            http://%{name}.org/
 Epoch:          1

--- a/anda/multimedia/ffmpeg/update.rhai
+++ b/anda/multimedia/ffmpeg/update.rhai
@@ -7,4 +7,8 @@ open_file("anda/multimedia/ffmpeg/VERSION_x265.txt", "w").write(bump::madoguchi(
 open_file("anda/multimedia/ffmpeg/VERSION_tesseract.txt", "w").write(bump::bodhi("tesseract", bump::as_bodhi_ver(labels.branch)));
 open_file("anda/multimedia/ffmpeg/VERSION_vvenc.txt", "w").write(bump::madoguchi("vvenc-libs", labels.branch));
 
-import "andax/ci/bump_release.rhai";
+let dir = sub(`/[^/]+`, "", __script_path);
+if sh("[[ `git status " + dir + "--porcelain` ]] && exit 1", #{}).ctx.rc == 1 {
+    let rel = spec::get_release(rpm).parse_int();
+    rpm.release(rel + 1);
+}

--- a/andax/ci/bump_release.rhai
+++ b/andax/ci/bump_release.rhai
@@ -1,7 +1,0 @@
-import "andax/spec.rhai" as spec;
-
-let dir = sub(`/[^/]+`, "", __script_path);
-
-if sh("[[ `git status " + dir + "--porcelain` ]] && exit 1", #{}).ctx.rc == 1 {
-	spec::bump_release(rpm);
-}

--- a/andax/spec.rhai
+++ b/andax/spec.rhai
@@ -1,24 +1,25 @@
-fn get_version(rpm) {
-    return `(?m)^Version:\s*(.+)$`.find(rpm.f, 1);
+fn get_version() {
+    return `(?m)^Version:\s*(.+)$`.find(this.f, 1);
 }
 
-fn get_release(rpm) {
-    let r = `(?m)^Release:\s*(.+)$`.find(rpm.f, 1);
+fn get_release() {
+    let r = `(?m)^Release:\s*(.+)$`.find(this.f, 1);
     r = sub(`(?m)(%\??dist|%\{\??dist\})\s*$`, "", r);
     r.replace("%autorelease", "1");
     return r;
 }
 
 /// Only supports one-liner `%global`s!
-fn get_global(rpm, macro) {
-    return `(?m)^%global\s+${macro}\s+(.+)$`.find(rpm.f, 1);
+fn get_global(macro) {
+    return `(?m)^%global\s+${macro}\s+(.+)$`.find(this.f, 1);
 }
 
 /// Only supports one-liner `%define`s!
-fn get_define(rpm, macro) {
-    return `(?m)^%define\s+${macro}\s+(.+)$`.find(rpm.f, 1);
+fn get_define(macro) {
+    return `(?m)^%define\s+${macro}\s+(.+)$`.find(this.f, 1);
 }
 
-fn bump_release(rpm) {
-    rpm.release(`${rpm.get_release().parse_int() + 1}`);
-}
+fn get_version(rpm) { rpm.get_version() }
+fn get_release(rpm) { rpm.get_release() }
+fn get_global(rpm, macro) { rpm.get_global(macro) }
+fn get_define(rpm, macro) { rpm.get_define(macro) }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(andax/ci/bump_release): maybe import paths are relative? (#5489)](https://github.com/terrapkg/packages/pull/5489)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)