### PR TITLE
[f42] fix(tdlib): set it to nightly (#5509)

### DIFF
--- a/anda/lib/tdlib/anda.hcl
+++ b/anda/lib/tdlib/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "tdlib-nightly.spec"
 	}
+	labels {
+		nightly = 1
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(tdlib): set it to nightly (#5509)](https://github.com/terrapkg/packages/pull/5509)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)