### PR TITLE
[f41] chore(edit): RUSTC_BOOSTRAP=1 is enough now (#5508)

### DIFF
--- a/anda/devs/edit/edit.spec
+++ b/anda/devs/edit/edit.spec
@@ -1,12 +1,7 @@
 %global _description %{expand:
 An editor that pays homage to the classic MS-DOS Editor, but with a modern interface and input controls similar to VS Code.}
 %global crate edit
-%bcond rust_nightly 1
-%if %{with rust_nightly}
-%define __cargo /usr/bin/env CARGO_HOME=.cargo RUSTC_BOOTSTRAP=1 RUSTFLAGS='%{build_rustflags}' $HOME/.cargo/bin/cargo
-%define __rustc $HOME/.cargo/bin/rustc
-%define __rustdoc $HOME/.cargo/bin/rustdoc
-%endif
+%bcond rust_nightly 0
 
 Name:          %{crate}
 Version:       1.2.0
@@ -29,10 +24,7 @@ Packager:      Gilver E. <rockgrub@disroot.org>
 %prep
 %autosetup -n %{name}-%{version}
 %if %{with rust_nightly}
-rustup-init -y
-. "$HOME/.cargo/env"
-rustup toolchain install nightly
-rustup override set nightly
+%rustup_nightly
 %endif
 %cargo_prep_online
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(edit): RUSTC_BOOSTRAP&#x3D;1 is enough now (#5508)](https://github.com/terrapkg/packages/pull/5508)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)