### PR TITLE
[el10] fix(ffmpeg): maybe also exit 0 (#5526)

### DIFF
--- a/anda/multimedia/ffmpeg/update.rhai
+++ b/anda/multimedia/ffmpeg/update.rhai
@@ -8,7 +8,7 @@ open_file("anda/multimedia/ffmpeg/VERSION_tesseract.txt", "w").write(bump::bodhi
 open_file("anda/multimedia/ffmpeg/VERSION_vvenc.txt", "w").write(bump::madoguchi("vvenc-libs", labels.branch));
 
 let dir = sub(`/[^/]+`, "", __script_path);
-if sh("[[ `git status " + dir + "--porcelain` ]] && exit 1", #{}).ctx.rc == 1 {
+if sh("[[ `git status " + dir + "--porcelain` ]] && exit 1 || exit 0", #{}).ctx.rc == 1 {
     let rel = spec::get_release(rpm).parse_int();
     rpm.release(rel + 1);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(ffmpeg): maybe also exit 0 (#5526)](https://github.com/terrapkg/packages/pull/5526)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)