### PR TITLE
[f42] fix(melody): Build deps, don't generate buildrequires (#5542)

### DIFF
--- a/anda/tools/melody/melody.spec
+++ b/anda/tools/melody/melody.spec
@@ -15,6 +15,12 @@ BuildArch:      noarch
 
 BuildRequires:  python3-devel
 BuildRequires:  pyproject-rpm-macros
+BuildRequires:  python3dist(anytree)
+BuildRequires:  python3dist(click)
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pyyaml)
+BuildRequires:  python3dist(poetry-core)
+BuildRequires:  python3dist(rich)
 
 Requires:       python3-dnf
 Requires:       python3-melody = %{version}-%{release}
@@ -29,9 +35,6 @@ Summary:        %{summary}
 
 %prep
 %autosetup -p1 -n melody-main
-
-%generate_buildrequires
-%pyproject_buildrequires -r
 
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(melody): Build deps, don&#x27;t generate buildrequires (#5542)](https://github.com/terrapkg/packages/pull/5542)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)