### PR TITLE
[f41] fix(intel-lpmd): install files to the correct place (#5550)

### DIFF
--- a/anda/system/intel-lpmd/intel-lpmd.spec
+++ b/anda/system/intel-lpmd/intel-lpmd.spec
@@ -28,7 +28,6 @@ sed -i 's@mandb || true@@' Makefile.am
 %install
 %make_install
 
-mv %buildroot{%_usr%_sysconfdir/intel_lpmd,%_sysconfdir}
 %if "%_sbindir" == "%_bindir"
 mv %buildroot{%_usr/sbin/*,%_bindir}
 %endif
@@ -42,6 +41,6 @@ mv %buildroot{%_usr/sbin/*,%_bindir}
 %_mandir/man5/intel_lpmd_config.xml.5.gz
 %_mandir/man8/intel_lpmd.8.*
 %_mandir/man8/intel_lpmd_control.8.*
-%_sysconfdir/intel_lpmd/
+%_usr%_sysconfdir/intel_lpmd/
 %_sysconfdir/dbus-1/system.d/org.freedesktop.intel_lpmd.conf
 %_unitdir/intel_lpmd.service


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(intel-lpmd): install files to the correct place (#5550)](https://github.com/terrapkg/packages/pull/5550)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)