### PR TITLE
[frawhide] fix(ffmpeg): Add $ to update script (#5557)

### DIFF
--- a/anda/multimedia/ffmpeg/update.rhai
+++ b/anda/multimedia/ffmpeg/update.rhai
@@ -7,7 +7,7 @@ open_file("anda/multimedia/ffmpeg/VERSION_x265.txt", "w").write(bump::madoguchi(
 open_file("anda/multimedia/ffmpeg/VERSION_tesseract.txt", "w").write(bump::bodhi("tesseract", bump::as_bodhi_ver(labels.branch)));
 open_file("anda/multimedia/ffmpeg/VERSION_vvenc.txt", "w").write(bump::madoguchi("vvenc-libs", labels.branch));
 
-let dir = sub(`/[^/]+`, "", __script_path);
+let dir = sub(`/[^/]+$`, "", __script_path);
 if sh("[[ `git status " + dir + " --porcelain` ]] && exit 1 || exit 0", #{}).ctx.rc == 1 {
     let rel = spec::get_release(rpm).parse_int();
     rpm.release(rel + 1);


### PR DESCRIPTION
# Backport

This will backport the following commits from `el10` to `frawhide`:
 - [fix(ffmpeg): Add $ to update script (#5557)](https://github.com/terrapkg/packages/pull/5557)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)