### PR TITLE
[f42] fix(LCEVEdev): files (#5561)

### DIFF
--- a/anda/multimedia/lcevcdec/LCEVCdec.spec
+++ b/anda/multimedia/lcevcdec/LCEVCdec.spec
@@ -150,7 +150,7 @@ python3 src/func_tests/run_tests.py
 
 %files devel
 %{_includedir}/LCEVC
-%{_includedir}/lcevc_config.h
+#{_includedir}/lcevc_config.h
 %{_libdir}/liblcevc_dec_api.so
 %{_libdir}/liblcevc_dec_core.so
 %{_libdir}/pkgconfig/lcevc_dec.pc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(LCEVEdev): files (#5561)](https://github.com/terrapkg/packages/pull/5561)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)