### PR TITLE
fix(zapret): build again

### DIFF
--- a/anda/misc/zapret/build-dont-strip.patch
+++ b/anda/misc/zapret/build-dont-strip.patch
@@ -1,19 +1,26 @@
-From 77ade97f4c3a1acc5955feeac3bf6e83e0f4d22e Mon Sep 17 00:00:00 2001
+From eb811f9950a3b00dab37ce194adf43140789c58e Mon Sep 17 00:00:00 2001
 From: VirtualFreeEx <contact@ffi.lol>
-Date: Thu, 1 May 2025 18:21:33 +0300
-Subject: [PATCH 2/2] build: dont strip
+Date: Fri, 20 Jun 2025 07:07:50 +0300
+Subject: [PATCH 1/2] build: dont strip
 
 ---
- ip2net/Makefile | 6 +++---
- mdig/Makefile   | 8 ++++----
- nfq/Makefile    | 4 ++--
- tpws/Makefile   | 8 ++++----
- 4 files changed, 13 insertions(+), 13 deletions(-)
+ ip2net/Makefile |  8 ++++----
+ mdig/Makefile   | 10 +++++-----
+ nfq/Makefile    |  6 +++---
+ tpws/Makefile   | 10 +++++-----
+ 4 files changed, 17 insertions(+), 17 deletions(-)
 
 diff --git a/ip2net/Makefile b/ip2net/Makefile
-index 484f3d7..209ad3c 100644
+index 484f3d7..c3c68be 100644
 --- a/ip2net/Makefile
 +++ b/ip2net/Makefile
+@@ -1,5 +1,5 @@
+ CC ?= gcc
+-CFLAGS += -std=gnu99 -Os -flto=auto
++CFLAGS += -g -std=gnu99 -Os -flto=auto
+ CFLAGS_BSD = -Wno-address-of-packed-member
+ CFLAGS_WIN = -static
+ LIBS = 
 @@ -9,14 +9,14 @@ SRC_FILES = ip2net.c qsort.c
  all: ip2net
  
@@ -41,9 +48,16 @@ index 484f3d7..209ad3c 100644
  clean:
  	rm -f ip2net *.o
 diff --git a/mdig/Makefile b/mdig/Makefile
-index 21b6c84..a9ea0e1 100644
+index 21b6c84..d841433 100644
 --- a/mdig/Makefile
 +++ b/mdig/Makefile
+@@ -1,5 +1,5 @@
+ CC ?= gcc
+-CFLAGS += -std=gnu99 -Os
++CFLAGS += -g -std=gnu99 -Os
+ CFLAGS_BSD = -Wno-address-of-packed-member
+ CFLAGS_WIN = -static
+ LIBS = -lpthread
 @@ -10,15 +10,15 @@ SRC_FILES = *.c
  all: mdig
  
@@ -73,10 +87,17 @@ index 21b6c84..a9ea0e1 100644
  clean:
  	rm -f mdig *.o
 diff --git a/nfq/Makefile b/nfq/Makefile
-index 85a29e4..4b6491b 100644
+index f368101..3cb9559 100644
 --- a/nfq/Makefile
 +++ b/nfq/Makefile
-@@ -16,10 +16,10 @@ SRC_FILES = *.c crypto/*.c
+@@ -1,5 +1,5 @@
+ CC ?= gcc
+-CFLAGS += -std=gnu99 -Os -flto=auto
++CFLAGS += -std=gnu99 -Os -flto=auto -g
+ CFLAGS_SYSTEMD = -DUSE_SYSTEMD
+ CFLAGS_BSD = -Wno-address-of-packed-member
+ CFLAGS_CYGWIN = -Wno-address-of-packed-member -static
+@@ -17,10 +17,10 @@ SRC_FILES = *.c crypto/*.c
  all: nfqws
  
  nfqws: $(SRC_FILES)
@@ -87,26 +108,33 @@ index 85a29e4..4b6491b 100644
 -	$(CC) -s $(CFLAGS) $(CFLAGS_SYSTEMD) -o nfqws $(SRC_FILES) $(LIBS_LINUX) $(LIBS_SYSTEMD) $(LDFLAGS)
 +	$(CC) $(CFLAGS) $(CFLAGS_SYSTEMD) -o nfqws $(SRC_FILES) $(LIBS_LINUX) $(LIBS_SYSTEMD) $(LDFLAGS)
  
- android: nfqws
- 
+ android: $(SRC_FILES)
+ 	$(CC) -s $(CFLAGS) -o nfqws $(SRC_FILES) $(LIBS_LINUX) $(LDFLAGS) $(LDFLAGS_ANDROID)
 diff --git a/tpws/Makefile b/tpws/Makefile
-index 2f53263..4fc1743 100644
+index e1270f8..47c4348 100644
 --- a/tpws/Makefile
 +++ b/tpws/Makefile
-@@ -11,16 +11,16 @@ SRC_FILES_ANDROID = $(SRC_FILES) andr/*.c
+@@ -1,5 +1,5 @@
+ CC ?= gcc
+-CFLAGS += -std=gnu99 -Os -flto=auto
++CFLAGS += -g -std=gnu99 -Os -flto=auto
+ CFLAGS_SYSTEMD = -DUSE_SYSTEMD
+ CFLAGS_BSD = -Wno-address-of-packed-member
+ LDFLAGS_ANDROID = -llog
+@@ -12,16 +12,16 @@ SRC_FILES_ANDROID = $(SRC_FILES) andr/*.c
  all: tpws
  
  tpws: $(SRC_FILES)
 -	$(CC) -s $(CFLAGS) -o tpws $(SRC_FILES) $(LIBS) $(LDFLAGS)
-+	$(CC) -g $(CFLAGS) -o tpws $(SRC_FILES) $(LIBS) $(LDFLAGS)
++	$(CC) $(CFLAGS) -o tpws $(SRC_FILES) $(LIBS) $(LDFLAGS)
  
  systemd: $(SRC_FILES)
 -	$(CC) -s $(CFLAGS) $(CFLAGS_SYSTEMD) -o tpws $(SRC_FILES) $(LIBS) $(LIBS_SYSTEMD) $(LDFLAGS)
-+	$(CC) -g $(CFLAGS) $(CFLAGS_SYSTEMD) -o tpws $(SRC_FILES) $(LIBS) $(LIBS_SYSTEMD) $(LDFLAGS)
++	$(CC) $(CFLAGS) $(CFLAGS_SYSTEMD) -o tpws $(SRC_FILES) $(LIBS) $(LIBS_SYSTEMD) $(LDFLAGS)
  
  android: $(SRC_FILES)
--	$(CC) -s $(CFLAGS) -o tpws $(SRC_FILES_ANDROID) $(LIBS_ANDROID) $(LDFLAGS)
-+	$(CC) -g $(CFLAGS) -o tpws $(SRC_FILES_ANDROID) $(LIBS_ANDROID) $(LDFLAGS)
+-	$(CC) -s $(CFLAGS) -o tpws $(SRC_FILES_ANDROID) $(LIBS_ANDROID) $(LDFLAGS) $(LDFLAGS_ANDROID)
++	$(CC) $(CFLAGS) -o tpws $(SRC_FILES_ANDROID) $(LIBS_ANDROID) $(LDFLAGS) $(LDFLAGS_ANDROID)
  
  bsd: $(SRC_FILES)
 -	$(CC) -s $(CFLAGS) $(CFLAGS_BSD) -Iepoll-shim/include -o tpws $(SRC_FILES) epoll-shim/src/*.c $(LIBS) $(LDFLAGS)

--- a/anda/misc/zapret/chore-move-to-different-dirs.patch
+++ b/anda/misc/zapret/chore-move-to-different-dirs.patch
@@ -1,7 +1,7 @@
-From 97c9edf12cad05fb8c682ce432a3e8e5ff4c1956 Mon Sep 17 00:00:00 2001
+From e6e3b033683453f3bffceb099ebe4195f35a3d7c Mon Sep 17 00:00:00 2001
 From: VirtualFreeEx <contact@ffi.lol>
-Date: Thu, 1 May 2025 18:22:41 +0300
-Subject: [PATCH 1/2] chore: move to different dirs
+Date: Fri, 20 Jun 2025 07:08:06 +0300
+Subject: [PATCH 2/2] chore: move to different dirs
 
 ---
  blockcheck.sh                             | 15 ++++++++-------
@@ -15,7 +15,7 @@ Subject: [PATCH 1/2] chore: move to different dirs
  8 files changed, 19 insertions(+), 20 deletions(-)
 
 diff --git a/blockcheck.sh b/blockcheck.sh
-index a827843..9fb0d2b 100755
+index 24ad898..1fa77ea 100755
 --- a/blockcheck.sh
 +++ b/blockcheck.sh
 @@ -3,9 +3,10 @@
@@ -49,7 +49,7 @@ index a827843..9fb0d2b 100755
  IPFW_RULE_NUM=${IPFW_RULE_NUM:-1}
  IPFW_DIVERT_PORT=${IPFW_DIVERT_PORT:-59780}
 diff --git a/config.default b/config.default
-index 3a79e59..6a4fc31 100644
+index ac04997..bee9a86 100644
 --- a/config.default
 +++ b/config.default
 @@ -1,9 +1,6 @@
@@ -63,7 +63,7 @@ index 3a79e59..6a4fc31 100644
  #WS_USER=nobody
  
 diff --git a/init.d/systemd/nfqws@.service b/init.d/systemd/nfqws@.service
-index ca1a6d5..3ddbbb5 100644
+index 5a18c7e..98daa37 100644
 --- a/init.d/systemd/nfqws@.service
 +++ b/init.d/systemd/nfqws@.service
 @@ -30,7 +30,7 @@ After=network.target
@@ -76,7 +76,7 @@ index ca1a6d5..3ddbbb5 100644
  Environment=CONFIG_DIR=/etc/zapret
  Environment=INSTANCE=%i
 diff --git a/init.d/systemd/tpws@.service b/init.d/systemd/tpws@.service
-index d6cce63..6ce1ca9 100644
+index c278008..62732b5 100644
 --- a/init.d/systemd/tpws@.service
 +++ b/init.d/systemd/tpws@.service
 @@ -30,7 +30,7 @@ After=network.target

--- a/anda/misc/zapret/zapret.spec
+++ b/anda/misc/zapret/zapret.spec
@@ -1,6 +1,6 @@
 Name:    zapret
 Version: 71.1.1
-Release: 1%?dist
+Release: 2%?dist
 Summary: A multi-platform Deep Packet Inspection (DPI) bypass tool
 License: MIT 
 ExcludeArch: s390x
@@ -16,6 +16,7 @@ BuildRequires: gcc
 BuildRequires: make
 BuildRequires: git
 # Headers.
+BuildRequires: libmnl-devel
 BuildRequires: libcap-devel
 BuildRequires: systemd-devel
 


### PR DESCRIPTION
previous build broke due to [zapret requiring libnml since recently](https://github.com/bol-van/zapret/commit/58d306b552a648b77368c79ce40fa687b25b1880), as well as the makefiles changing slightly

this should fix the build (and hopefully with it fix my ability to use services like discord since i rely on this program to connect to them)