### PR TITLE
[f41] add: falcond and falcond-profiles (#5571)

### DIFF
--- a/anda/system/falcond-profiles/anda.hcl
+++ b/anda/system/falcond-profiles/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "falcond-profiles.spec"
+    }
+    labels {
+        nightly = 1
+    }
+}

--- a/anda/system/falcond-profiles/falcond-profiles.spec
+++ b/anda/system/falcond-profiles/falcond-profiles.spec
@@ -1,0 +1,41 @@
+%global commit 96c2cdfee69761d2c29caebb4b1e9ff7cc904f7a
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20250613
+
+Name:           falcond-profiles
+Version:        0^%{commit_date}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Profiles for falcond
+License:        MIT
+URL:            https://github.com/PikaOS-Linux/falcond-profiles
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
+Requires:       falcond
+BuildArch:      noarch
+Packager:       Gilver E. <rockgrub@disroot.org>
+
+%description
+This package contains the profiles needed for falcond.
+
+%prep
+%autosetup -n %{name}-%{commit}
+
+%build
+# Hi, I'm empty!
+
+%install
+install -Dm644 usr/share/falcond/system.conf -t %{buildroot}%{_datadir}/falcond/
+install -Dm644 usr/share/falcond/profiles/*.conf -t %{buildroot}%{_datadir}/falcond/profiles/
+install -Dm644 usr/share/falcond/profiles/handheld/* -t %{buildroot}%{_datadir}/falcond/profiles/handheld/
+install -Dm644 usr/share/falcond/profiles/htpc/* -t %{buildroot}%{_datadir}/falcond/profiles/htpc/
+
+%files
+%doc README.md
+%license LICENSE
+%{_datadir}/falcond/system.conf
+%{_datadir}/falcond/profiles/*.conf
+%{_datadir}/falcond/profiles/handheld/*.conf
+%{_datadir}/falcond/profiles/htpc/*.conf
+
+%changelog
+* Thu Jun 19 2025 Gilver E. <rockgrub@disroot.org> - 0^20250613git.96c2cdf-1
+- Initial package

--- a/anda/system/falcond-profiles/update.rhai
+++ b/anda/system/falcond-profiles/update.rhai
@@ -1,0 +1,6 @@
+rpm.global("commit", gh_commit("PikaOS-Linux/falcond-profiles"));
+	if rpm.changed() {
+		rpm.global("commit_date", date());
+		rpm.release();
+	}
+}

--- a/anda/system/falcond/anda.hcl
+++ b/anda/system/falcond/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "falcond.spec"
+    }
+}

--- a/anda/system/falcond/falcond.spec
+++ b/anda/system/falcond/falcond.spec
@@ -1,0 +1,54 @@
+%global _include_minidebuginfo 0
+
+Name:           falcond
+Version:        1.1.5
+Release:        1%{?dist}
+Summary:        Advanced Linux Gaming Performance Daemon
+License:        MIT
+URL:            https://git.pika-os.com/general-packages/falcond
+Source0:        %{url}/archive/v%{version}.tar.gz
+BuildRequires:  anda-srpm-macros >= 0.2.18
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  zig >= 0.14.0
+BuildRequires:  zig-rpm-macros
+Requires:       %{name}-profiles
+Requires:       (scx-scheds or scx-scheds-nightly)
+Conflicts:      gamemode
+Packager:       Gilver E. <rockgrub@disroot.org>
+
+%description
+falcond is a powerful system daemon designed to automatically optimize your Linux gaming experience. It intelligently manages system resources and performance settings on a per-game basis, eliminating the need to manually configure settings for each game.
+
+%prep
+%autosetup -n %{name}/%{name}
+
+%build
+
+%install
+install -Dm644 debian/%{name}.service -t %{buildroot}%{_unitdir}
+# When DNF supports microarchitectures the fallback option for -c can be used here instead
+DESTDIR="%{buildroot}" \
+%ifarch x86_64 x86_64_v2 x86_64_v3 x86_64_v4
+%{zig_build_target -r fast -c x86_64_v3 -s} \
+%elifarch aarch64
+%{zig_build_target -r fast -s} \
+%endif
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+%files
+%doc ../README.md
+%license ../LICENSE
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+
+%changelog
+* Thu Jun 19 2025 Gilver E. <rockgrub@disroot.org> - 1.1.5-1
+- Initial package

--- a/anda/system/falcond/update.rhai
+++ b/anda/system/falcond/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("PikaOS-Linux/falcond"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: falcond and falcond-profiles (#5571)](https://github.com/terrapkg/packages/pull/5571)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)