### PR TITLE
feat(heroic, steam): Recommend falcond OR gamemode

### DIFF
--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -16,7 +16,7 @@
 
 Name:          %{shortname}-games-launcher
 Version:       2.17.2
-Release:       1%?dist
+Release:       2%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com
@@ -37,7 +37,7 @@ Requires:      hicolor-icon-theme
 Requires:      nss
 Requires:      python3
 Requires:      which
-Recommends:    gamemode
+Recommends:    (falcond or gamemode)
 Recommends:    mangohud
 Recommends:    umu-launcher
 Provides:      bundled(comet) = %{comet_version}

--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -112,7 +112,7 @@ Requires:       SDL2%{?_isa}
 
 # Game performance is increased with gamemode (for games that support it)
 Recommends:     (falcond or gamemode)
-Recommends:     gamemode%{?_isa}
+Recommends:     (gamemode%{?_isa} if gamemode(x86-64))
 Recommends:     (gnome-shell-extension-appindicator if gnome-shell)
 
 Recommends:     (gnome-shell-extension-appindicator if gnome-shell)

--- a/anda/games/steam/steam.spec
+++ b/anda/games/steam/steam.spec
@@ -5,7 +5,7 @@
 
 Name:           steam
 Version:        1.0.0.83
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Installer for the Steam software distribution service
 # Redistribution and repackaging for Linux is allowed, see license file. udev rules are MIT.
 License:        Steam License Agreement and MIT
@@ -111,7 +111,7 @@ Requires:       SDL2%{?_isa}
 %endif
 
 # Game performance is increased with gamemode (for games that support it)
-Recommends:     gamemode
+Recommends:     (falcond or gamemode)
 Recommends:     gamemode%{?_isa}
 Recommends:     (gnome-shell-extension-appindicator if gnome-shell)
 


### PR DESCRIPTION
Since Falcond is a drop in replacement for Gamemode, either can be recommended but it must be one or the other as they conflict.