### PR TITLE
[el10] chore(kf6-kio): Switch to Mock builds for future updates (#5597)

### DIFF
--- a/anda/desktops/kde/kf6-kio/anda.hcl
+++ b/anda/desktops/kde/kf6-kio/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
 	labels {
 		subrepo = "extras"
 		updbranch = 1
+                mock = 1
 	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `el10`:
 - [chore(kf6-kio): Switch to Mock builds for future updates (#5597)](https://github.com/terrapkg/packages/pull/5597)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)