### PR TITLE
[f41] fix(legcord-nightly): Disable stripping (#5604)

### DIFF
--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,7 +1,8 @@
 %global commit 0b1a005936552abd5aed144bdc0ca5a82f2fa682
 %global commit_date 20250622
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%define debug_package %nil
+%global debug_package %nil
+%global __strip /bin/true
 %global __provides_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
 %ifnarch aarch64 
 %global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\aarch64*\\.so.*))$


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(legcord-nightly): Disable stripping (#5604)](https://github.com/terrapkg/packages/pull/5604)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)