### PR TITLE
[el10] fix(kanata): rust2rpm (#5613)

### DIFF
--- a/anda/tools/kanata/kanata-fix-metadata-auto.diff
+++ b/anda/tools/kanata/kanata-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- kanata-*/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ kanata-*/Cargo.toml	2025-02-24T02:18:17.384667+00:00
-@@ -124,23 +124,9 @@
+--- kanata-1.9.0/Cargo.toml	1970-01-01T00:00:01+00:00
++++ kanata-1.9.0/Cargo.toml	2025-06-23T09:19:38.121344+00:00
+@@ -45,23 +45,9 @@
      "kanata-parser/gui",
      "win_sendinput_send_scancodes",
      "win_llhook_read_scancodes",
@@ -24,7 +24,7 @@
      "kanata-parser/interception_driver",
  ]
  passthru_ahk = [
-@@ -154,9 +140,7 @@
+@@ -75,9 +61,7 @@
  wasm = ["instant/wasm-bindgen"]
  win_llhook_read_scancodes = ["kanata-parser/win_llhook_read_scancodes"]
  win_manifest = [
@@ -34,10 +34,10 @@
  ]
  win_sendinput_send_scancodes = ["kanata-parser/win_sendinput_send_scancodes"]
  zippychord = ["kanata-parser/zippychord"]
-@@ -192,91 +176,2 @@
+@@ -186,97 +170,9 @@
  [target.'cfg(target_os = "linux")'.dependencies.signal-hook]
  version = "0.3.14"
--
+ 
 -[target.'cfg(target_os = "macos")'.dependencies.core-graphics]
 -version = "0.24.0"
 -
@@ -126,3 +126,10 @@
 -[target.'cfg(target_os = "windows")'.build-dependencies.regex]
 -version = "1.10.4"
 -optional = true
+-
+ [profile.release]
+ opt-level = "z"
+ lto = "fat"
+ codegen-units = 1
+ panic = "abort"
++


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(kanata): rust2rpm (#5613)](https://github.com/terrapkg/packages/pull/5613)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)