### PR TITLE
[f41] fix(mise): rust2rpm (#5612)

### DIFF
--- a/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
+++ b/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- mise-2025.5.15/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ mise-2025.5.15/Cargo.toml	2025-05-28T15:40:58.219641+00:00
-@@ -475,25 +475,6 @@
+--- mise-2025.6.6/Cargo.toml	1970-01-01T00:00:01+00:00
++++ mise-2025.6.6/Cargo.toml	2025-06-23T09:18:21.561501+00:00
+@@ -475,26 +475,6 @@
  optional = true
  default-features = false
  
@@ -8,6 +8,7 @@
 -version = "0.42"
 -features = [
 -    "archive-zip",
+-    "compression-zip-deflate",
 -    "signatures",
 -]
 -optional = true
@@ -26,7 +27,7 @@
  [lints.clippy]
  borrowed_box = "allow"
  
-@@ -508,3 +489,4 @@
+@@ -509,3 +489,4 @@
  [profile.serious]
  lto = true
  inherits = "release"


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(mise): rust2rpm (#5612)](https://github.com/terrapkg/packages/pull/5612)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)