### PR TITLE
[el10] chore(scenefx): Update build dependencies and files (#5624)

### DIFF
--- a/anda/lib/scenefx/scenefx.spec
+++ b/anda/lib/scenefx/scenefx.spec
@@ -25,7 +25,7 @@ BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols) >= 1.32
 BuildRequires:  pkgconfig(wayland-scanner)
 BuildRequires:  pkgconfig(wayland-server) >= 1.22
-BuildRequires:  pkgconfig(wlroots-0.18)
+BuildRequires:  pkgconfig(wlroots-0.19)
 
 
 Packager:       Atmois <atmois@atmois.com>
@@ -65,9 +65,9 @@ MESON_OPTIONS=(
 %files
 %license LICENSE
 %doc README.md
-%{_libdir}/lib%{name}-0.2.so
+%{_libdir}/lib%{name}-*.so
 
 
 %files  devel
-%{_includedir}/%{name}-0.2/*
-%{_libdir}/pkgconfig/%{name}-0.2.pc
+%{_includedir}/%{name}-*/*
+%{_libdir}/pkgconfig/%{name}-*.pc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(scenefx): Update build dependencies and files (#5624)](https://github.com/terrapkg/packages/pull/5624)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)