### PR TITLE
[f41] fix(flutter): weird python requirement? (#5079)

### DIFF
--- a/anda/devs/flutter/flutter.spec
+++ b/anda/devs/flutter/flutter.spec
@@ -8,6 +8,7 @@ Group:			Development/Building
 Source0:		https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_%version-stable.tar.xz
 Requires:		bash curl git file which zip xz
 Recommends:		mesa-libGLU
+AutoReqProv:	no
 
 %description
 Flutter transforms the app development process. Build, test, and deploy
@@ -15,8 +16,6 @@ beautiful mobile, web, desktop, and embedded apps from a single codebase.
 
 %prep
 tar xf %SOURCE0
-
-%build
 
 %install
 mkdir -p %buildroot%_datadir %buildroot%_bindir


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(flutter): weird python requirement? (#5079)](https://github.com/terrapkg/packages/pull/5079)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)