### PR TITLE
[f42] add: bdf2sfd (#5636)

### DIFF
--- a/anda/tools/bdf2sfd/anda.hcl
+++ b/anda/tools/bdf2sfd/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "bdf2sfd.spec"
+  }
+}

--- a/anda/tools/bdf2sfd/bdf2sfd.spec
+++ b/anda/tools/bdf2sfd/bdf2sfd.spec
@@ -1,0 +1,30 @@
+Name:			bdf2sfd
+Version:		1.1.9
+Release:		1%?dist
+Summary:		BDF to SFD converter, allowing to vectorize bitmap fonts
+License:		BSD-2-Clause
+URL:			https://github.com/fcambus/bdf2sfd
+Source0:		%url/archive/refs/tags/1.1.9.tar.gz
+BuildRequires:	cmake gcc
+
+%description
+bdf2sfd is a BDF to SFD converter, allowing to vectorize bitmap fonts.
+
+It works by converting each pixel of a glyph to a polygon, which produces
+large and unoptimized SFD files that should be post-processed using FontForge.
+
+%prep
+%autosetup
+
+%build
+%cmake
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%doc README.md ChangeLog AUTHORS THANKS
+%license LICENSE
+%_bindir/%name
+%_mandir/man1/%name.*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: bdf2sfd (#5636)](https://github.com/terrapkg/packages/pull/5636)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)