### PR TITLE
[el10] Fix: virtualsmartcard license install (#5644)

### DIFF
--- a/anda/tools/virtualsmartcard/virtualsmartcard.spec
+++ b/anda/tools/virtualsmartcard/virtualsmartcard.spec
@@ -1,6 +1,6 @@
 Name:           virtualsmartcard
 Version:        0.10 
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Smart card emulator and driver for networked smart card reader/emulator
 URL:            https://frankmorgner.github.io/vsmartcard/index.html
 Source0:        https://github.com/frankmorgner/vsmartcard/releases/download/%name-%version/%name-%version.tar.gz
@@ -34,6 +34,7 @@ autoreconf --verbose --install
 %{_sysconfdir}/reader.conf.d/vpcd
 %{_bindir}/vpcd-config
 %doc docs
+%license COPYING
  
 %changelog
 * Wed Jun 25 2025 june-fish <git@june.fish>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Fix: virtualsmartcard license install (#5644)](https://github.com/terrapkg/packages/pull/5644)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)