### PR TITLE
[el10] fix(hyprutils): bump so ver (#5655)

### DIFF
--- a/anda/desktops/waylands/hyprutils/hyprutils.nightly.spec
+++ b/anda/desktops/waylands/hyprutils/hyprutils.nightly.spec
@@ -52,4 +52,4 @@ Conflicts:		%realname-devel
 %license LICENSE
 %doc README.md
 %{_libdir}/lib%{realname}.so.%{ver}
-%{_libdir}/lib%{realname}.so.6
+%{_libdir}/lib%{realname}.so.*


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [fix(hyprutils): bump so ver (#5655)](https://github.com/terrapkg/packages/pull/5655)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)