### PR TITLE
[el10] fix(deadbeef): Missing = (#5661)

### DIFF
--- a/anda/multimedia/deadbeef/deadbeef.spec
+++ b/anda/multimedia/deadbeef/deadbeef.spec
@@ -6,7 +6,7 @@
 
 Name:           deadbeef
 Version:        0.2.2.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        An audio player for GNU/Linux
 
 License:        GPL-2.0-or later AND LGPL-2.0-or-later and BSD and MIT AND Zlib
@@ -44,7 +44,7 @@ BuildRequires:  pkgconfig(opusfile)
 BuildRequires:  libdispatch-devel
 
 Requires:       hicolor-icon-theme
-Requires:       %{name}-plugins%{?_isa} %evr
+Requires:       %{name}-plugins%{?_isa} = %evr
 
 Recommends:     deadbeef-mpris2-plugin
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(deadbeef): Missing &#x3D; (#5661)](https://github.com/terrapkg/packages/pull/5661)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)