### PR TITLE
fix/feat(ghostty): Add new files in Tip, move files that depend on other packages to subpackages

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -218,7 +218,6 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 %{_mandir}/man1/%{base_name}.1.gz
 %{_mandir}/man5/%{base_name}.5.gz
 %{_userunitdir}/%{appid}.service
-%{_prefix}/lib/dbus-1/services/%{appid}.service
 
 %files bash-completion
 %{bash_completions_dir}/%{base_name}.bash

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -205,6 +205,7 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 %{_datadir}/%{base_name}/doc
 %{_datadir}/%{base_name}/themes
 %{_datadir}/metainfo/%{appid}.metainfo.xml
+%{_datadir}/dbus-1/services/%{appid}.service
 %{_iconsdir}/hicolor/16x16/apps/%{appid}.png
 %{_iconsdir}/hicolor/16x16@2/apps/%{appid}.png
 %{_iconsdir}/hicolor/32x32/apps/%{appid}.png

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,4 +1,4 @@
-%global commit 98b1af8353077b608713d30a9863cbc6e008d034
+%global commit 206d41844e88176a398f149e8e2c8f6e2fdbd28a
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global fulldate 2025-06-27
 %global commit_date %(echo %{fulldate} | sed 's/-//g')

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -265,6 +265,15 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 %endif
 %{_datadir}/terminfo/x/xterm-%{base_name}
 
+%post
+%systemd_user_post %{appid}.service
+
+%preun
+%systemd_user_preun %{appid}.service
+
+%postun
+%systemd_user_postun %{appid}.service
+
 %changelog
 * Sat May 31 2025 Gilver E. <rockgrub@disroot.org> - 1.1.4~tip^20250531git1ff9162
 - Updated for Zig 0.14.0

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -5,7 +5,7 @@
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.1.4
 %global base_name ghostty
-%global reverse_dns com.mitchellh.%{base_name}
+%global appid com.mitchellh.%{base_name}
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
@@ -27,6 +27,7 @@ BuildRequires:  minisign
 BuildRequires:  ncurses
 BuildRequires:  ncurses-devel
 BuildRequires:  pandoc-cli
+BuildRequires:  systemd-rpm-macros
 BuildRequires:  zig >= 0.14.0
 BuildRequires:  zig-rpm-macros
 BuildRequires:  pkgconfig(blueprint-compiler)
@@ -43,6 +44,7 @@ BuildRequires:  pkgconfig(oniguruma)
 BuildRequires:  pkgconfig(zlib)
 Requires:       %{name}-terminfo = %{evr}
 Requires:       %{name}-shell-integration = %{evr}
+Requires:       (%{name}-kio = %{evr} if kf6-kio)
 Requires:       gtk4
 Requires:       gtk4-layer-shell
 Requires:       libadwaita
@@ -96,6 +98,53 @@ BuildArch:      noarch
 %description    zsh-completion
 Zsh shell completion for Ghostty.
 
+%package        kio
+Summary:        KIO support for Ghostty
+Requires:       %{name} = %{evr}
+BuildArch:      noarch
+
+%description    kio
+This package allows Ghostty to interact with KIO.
+
+%package        nautilus
+Summary:        Nautilus menu support for Ghostty
+Supplements:    (%{name} and nautilus)
+Requires:       %{name} = %{evr}
+BuildArch:      noarch
+
+%description    nautilus
+This package enables Nautilus integration for Ghostty.
+
+%package        vim
+Summary:        Vim plugins for Ghostty
+Supplements:    (%{name} and vim)
+Requires:       %{name} = %{evr}
+Requires:       vim
+BuildArch:      noarch
+
+%description    vim
+This package provides the Ghostty Vim plugins.
+
+%package        neovim
+Summary:        Neovim plugins for Ghostty
+Supplements:    (%{name} and neovim)
+Requires:       %{name} = %{evr}
+Requires:       neovim
+BuildArch:      noarch
+
+%description    neovim
+This package provides the Neovim plugins for Ghostty.
+
+%package        bat-syntax
+Summary:        Bat syntax for Ghostty
+Supplements:    (%{name} and bat)
+Requires:       %{name} = %{evr}
+Requires:       bat
+BuildArch:      noarch
+
+%description    bat-syntax
+This package provides the Bat syntax files for Ghostty.
+
 %package        shell-integration
 Summary:        Ghostty shell integration
 Supplements:    %{name}
@@ -145,40 +194,31 @@ DESTDIR="%{buildroot}" \
 rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 %endif
 
-%find_lang %{reverse_dns}
+%find_lang %{appid}
 
-%files -f %{reverse_dns}.lang
+%files -f %{appid}.lang
 %doc README.md
 %license LICENSE
 %{_bindir}/%{base_name}
-%{_datadir}/applications/%{reverse_dns}.desktop
-%{_datadir}/bat/syntaxes/%{base_name}.sublime-syntax
+%{_datadir}/applications/%{appid}.desktop
 %dir %{_datadir}/%{base_name}
 %{_datadir}/%{base_name}/doc
 %{_datadir}/%{base_name}/themes
-%{_datadir}/kio/servicemenus/%{reverse_dns}.desktop
-%{_datadir}/metainfo/%{reverse_dns}.metainfo.xml
-%{_datadir}/nautilus-python/extensions/%{base_name}.py
-%{_datadir}/nvim/site/compiler/%{base_name}.vim
-%{_datadir}/nvim/site/ftdetect/%{base_name}.vim
-%{_datadir}/nvim/site/ftplugin/%{base_name}.vim
-%{_datadir}/nvim/site/syntax/%{base_name}.vim
-%{_datadir}/vim/vimfiles/compiler/%{base_name}.vim
-%{_datadir}/vim/vimfiles/ftdetect/%{base_name}.vim
-%{_datadir}/vim/vimfiles/ftplugin/%{base_name}.vim
-%{_datadir}/vim/vimfiles/syntax/%{base_name}.vim
-%{_iconsdir}/hicolor/16x16/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/16x16@2/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/32x32/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/32x32@2/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/128x128/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/128x128@2/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/256x256/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/256x256@2/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/512x512/apps/%{reverse_dns}.png
-%{_iconsdir}/hicolor/1024x1024/apps/%{reverse_dns}.png
+%{_datadir}/metainfo/%{appid}.metainfo.xml
+%{_iconsdir}/hicolor/16x16/apps/%{appid}.png
+%{_iconsdir}/hicolor/16x16@2/apps/%{appid}.png
+%{_iconsdir}/hicolor/32x32/apps/%{appid}.png
+%{_iconsdir}/hicolor/32x32@2/apps/%{appid}.png
+%{_iconsdir}/hicolor/128x128/apps/%{appid}.png
+%{_iconsdir}/hicolor/128x128@2/apps/%{appid}.png
+%{_iconsdir}/hicolor/256x256/apps/%{appid}.png
+%{_iconsdir}/hicolor/256x256@2/apps/%{appid}.png
+%{_iconsdir}/hicolor/512x512/apps/%{appid}.png
+%{_iconsdir}/hicolor/1024x1024/apps/%{appid}.png
 %{_mandir}/man1/%{base_name}.1.gz
 %{_mandir}/man5/%{base_name}.5.gz
+%{_userunitdir}/%{appid}.service
+%{_prefix}/lib/dbus-1/services/%{appid}.service
 
 %files bash-completion
 %{bash_completions_dir}/%{base_name}.bash
@@ -188,6 +228,27 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 
 %files zsh-completion
 %{zsh_completions_dir}/_%{base_name}
+
+%files kio
+%{_datadir}/kio/servicemenus/%{appid}.desktop
+
+%files nautilus
+%{_datadir}/nautilus-python/extensions/%{base_name}.py
+
+%files vim
+%{_datadir}/vim/vimfiles/compiler/%{base_name}.vim
+%{_datadir}/vim/vimfiles/ftdetect/%{base_name}.vim
+%{_datadir}/vim/vimfiles/ftplugin/%{base_name}.vim
+%{_datadir}/vim/vimfiles/syntax/%{base_name}.vim
+
+%files neovim
+%{_datadir}/nvim/site/compiler/%{base_name}.vim
+%{_datadir}/nvim/site/ftdetect/%{base_name}.vim
+%{_datadir}/nvim/site/ftplugin/%{base_name}.vim
+%{_datadir}/nvim/site/syntax/%{base_name}.vim
+
+%files bat-syntax
+%{_datadir}/bat/syntaxes/%{base_name}.sublime-syntax
 
 %files shell-integration
 %dir %{_datadir}/%{base_name}/shell-integration

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -18,7 +18,7 @@ BuildRequires:  minisign
 BuildRequires:  ncurses
 BuildRequires:  ncurses-devel
 BuildRequires:  pandoc-cli
-BuildRequires:  zig >= 0.14.0
+BuildRequires:  zig = 0.14.0
 BuildRequires:  pkgconfig(bzip2)
 BuildRequires:  pkgconfig(freetype2)
 BuildRequires:  pkgconfig(fontconfig)

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -1,6 +1,6 @@
 # Signing key from https://github.com/ghostty-org/ghostty/blob/main/PACKAGING.md
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
-%global appid com.mitchellh.%{name}
+%global appid com.mitchellh.ghostty
 
 Name:           ghostty
 Version:        1.1.3
@@ -150,7 +150,7 @@ Source files for Ghostty's terminfo. Available for debugging use.
 /usr/bin/minisign -V -m %{SOURCE0} -x %{SOURCE1} -P %{public_key}
 %autosetup
 
-export ZIG_GLOBAL_CACHE_DIR="%{cache_dir}"
+export ZIG_GLOBAL_CACHE_DIR="%{_zig_cache_dir}"
 zig build --fetch
 zig fetch git+https://github.com/zigimg/zigimg#3a667bdb3d7f0955a5a51c8468eac83210c1439e
 zig fetch git+https://github.com/mitchellh/libxev#f6a672a78436d8efee1aa847a43a900ad773618b

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -1,10 +1,6 @@
 # Signing key from https://github.com/ghostty-org/ghostty/blob/main/PACKAGING.md
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
-%if 0%{?fedora} <= 40
-%global cache_dir %{_builddir}/zig-cache
-%else
-%global cache_dir %{builddir}/zig-cache
-%endif
+%global appid com.mitchellh.%{name}
 
 Name:           ghostty
 Version:        1.1.3
@@ -179,11 +175,11 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/ghostty
 %files
 %doc README.md
 %license LICENSE
-%{_bindir}/%{base_name}
+%{_bindir}/%{name}
 %{_datadir}/applications/%{appid}.desktop
-%dir %{_datadir}/%{base_name}
-%{_datadir}/%{base_name}/doc
-%{_datadir}/%{base_name}/themes
+%dir %{_datadir}/%{name}
+%{_datadir}/%{name}/doc
+%{_datadir}/%{name}/themes
 %{_datadir}/metainfo/%{appid}.metainfo.xml
 %{_iconsdir}/hicolor/16x16/apps/%{appid}.png
 %{_iconsdir}/hicolor/16x16@2/apps/%{appid}.png
@@ -195,49 +191,49 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/ghostty
 %{_iconsdir}/hicolor/256x256@2/apps/%{appid}.png
 %{_iconsdir}/hicolor/512x512/apps/%{appid}.png
 %{_iconsdir}/hicolor/1024x1024/apps/%{appid}.png
-%{_mandir}/man1/%{base_name}.1.gz
-%{_mandir}/man5/%{base_name}.5.gz
+%{_mandir}/man1/%{name}.1.gz
+%{_mandir}/man5/%{name}.5.gz
 %{_userunitdir}/%{appid}.service
 %{_prefix}/lib/dbus-1/services/%{appid}.service
 
 %files bash-completion
-%{bash_completions_dir}/%{base_name}.bash
+%{bash_completions_dir}/%{name}.bash
 
 %files fish-completion
-%{fish_completions_dir}/%{base_name}.fish
+%{fish_completions_dir}/%{name}.fish
 
 %files zsh-completion
-%{zsh_completions_dir}/_%{base_name}
+%{zsh_completions_dir}/_%{name}
 
 %files kio
 %{_datadir}/kio/servicemenus/%{appid}.desktop
 
 %files nautilus
-%{_datadir}/nautilus-python/extensions/%{base_name}.py
+%{_datadir}/nautilus-python/extensions/%{name}.py
 
 %files vim
-%{_datadir}/vim/vimfiles/compiler/%{base_name}.vim
-%{_datadir}/vim/vimfiles/ftdetect/%{base_name}.vim
-%{_datadir}/vim/vimfiles/ftplugin/%{base_name}.vim
-%{_datadir}/vim/vimfiles/syntax/%{base_name}.vim
+%{_datadir}/vim/vimfiles/compiler/%{name}.vim
+%{_datadir}/vim/vimfiles/ftdetect/%{name}.vim
+%{_datadir}/vim/vimfiles/ftplugin/%{name}.vim
+%{_datadir}/vim/vimfiles/syntax/%{name}.vim
 
 %files neovim
-%{_datadir}/nvim/site/compiler/%{base_name}.vim
-%{_datadir}/nvim/site/ftdetect/%{base_name}.vim
-%{_datadir}/nvim/site/ftplugin/%{base_name}.vim
-%{_datadir}/nvim/site/syntax/%{base_name}.vim
+%{_datadir}/nvim/site/compiler/%{name}.vim
+%{_datadir}/nvim/site/ftdetect/%{name}.vim
+%{_datadir}/nvim/site/ftplugin/%{name}.vim
+%{_datadir}/nvim/site/syntax/%{name}.vim
 
 %files bat-syntax
-%{_datadir}/bat/syntaxes/%{base_name}.sublime-syntax
+%{_datadir}/bat/syntaxes/%{name}.sublime-syntax
 
 %files shell-integration
-%dir %{_datadir}/%{base_name}/shell-integration
-%{_datadir}/%{base_name}/shell-integration/bash/bash-preexec.sh
-%{_datadir}/%{base_name}/shell-integration/bash/%{base_name}.bash
-%{_datadir}/%{base_name}/shell-integration/elvish/lib/%{base_name}-integration.elv
-%{_datadir}/%{base_name}/shell-integration/fish/vendor_conf.d/%{base_name}-shell-integration.fish
-%{_datadir}/%{base_name}/shell-integration/zsh/.zshenv
-%{_datadir}/%{base_name}/shell-integration/zsh/%{base_name}-integration
+%dir %{_datadir}/%{name}/shell-integration
+%{_datadir}/%{name}/shell-integration/bash/bash-preexec.sh
+%{_datadir}/%{name}/shell-integration/bash/%{name}.bash
+%{_datadir}/%{name}/shell-integration/elvish/lib/%{name}-integration.elv
+%{_datadir}/%{name}/shell-integration/fish/vendor_conf.d/%{name}-shell-integration.fish
+%{_datadir}/%{name}/shell-integration/zsh/.zshenv
+%{_datadir}/%{name}/shell-integration/zsh/%{name}-integration
 
 %files terminfo
 %if 0%{?fedora} < 42

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -8,12 +8,13 @@
 
 Name:           ghostty
 Version:        1.1.3
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
 URL:            https://ghostty.org/
 Source0:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz
 Source1:        https://release.files.ghostty.org/%{version}/ghostty-%{version}.tar.gz.minisig
+BuildRequires:  anda-srpm-macros >= 0.2.15
 BuildRequires:  gtk4-devel
 BuildRequires:  libadwaita-devel
 BuildRequires:  libX11-devel
@@ -21,7 +22,7 @@ BuildRequires:  minisign
 BuildRequires:  ncurses
 BuildRequires:  ncurses-devel
 BuildRequires:  pandoc-cli
-BuildRequires:  zig
+BuildRequires:  zig >= 0.14.0
 BuildRequires:  pkgconfig(bzip2)
 BuildRequires:  pkgconfig(freetype2)
 BuildRequires:  pkgconfig(fontconfig)
@@ -34,6 +35,7 @@ BuildRequires:  pkgconfig(oniguruma)
 BuildRequires:  pkgconfig(zlib)
 Requires:       %{name}-terminfo = %{version}-%{release}
 Requires:       %{name}-shell-integration = %{version}-%{release}
+Requires:       (%{name}-kio = %{evr} if kf6-kio)
 Requires:       gtk4
 Requires:       libadwaita
 Conflicts:      ghostty-nightly
@@ -72,6 +74,53 @@ BuildArch:      noarch
 %description    zsh-completion
 Zsh shell completion for Ghostty.
 
+%package        kio
+Summary:        KIO support for Ghostty
+Requires:       %{name} = %{evr}
+BuildArch:      noarch
+
+%description    kio
+This package allows Ghostty to interact with KIO.
+
+%package        nautilus
+Summary:        Nautilus menu support for Ghostty
+Supplements:    (%{name} and nautilus)
+Requires:       %{name} = %{evr}
+BuildArch:      noarch
+
+%description    nautilus
+This package enables Nautilus integration for Ghostty.
+
+%package        vim
+Summary:        Vim plugins for Ghostty
+Supplements:    (%{name} and vim)
+Requires:       %{name} = %{evr}
+Requires:       vim
+BuildArch:      noarch
+
+%description    vim
+This package provides the Ghostty Vim plugins.
+
+%package        neovim
+Summary:        Neovim plugins for Ghostty
+Supplements:    (%{name} and neovim)
+Requires:       %{name} = %{evr}
+Requires:       neovim
+BuildArch:      noarch
+
+%description    neovim
+This package provides the Neovim plugins for Ghostty.
+
+%package        bat-syntax
+Summary:        Bat syntax for Ghostty
+Supplements:    (%{name} and bat)
+Requires:       %{name} = %{evr}
+Requires:       bat
+BuildArch:      noarch
+
+%description    bat-syntax
+This package provides the Bat syntax files for Ghostty.
+
 %package        shell-integration
 Summary:        Ghostty shell integration
 Supplements:    %{name}
@@ -86,6 +135,7 @@ Supplements:    %{name}
 %if 0%{?fedora} >= 42
 Requires:       ncurses-term >= 6.5-5.20250125%{?dist}
 %endif
+Obsoletes:      %{name}-terminfo-source < %{evr}
 BuildArch:      noarch
 
 %description    terminfo
@@ -113,20 +163,13 @@ zig fetch git+https://github.com/mitchellh/libxev#f6a672a78436d8efee1aa847a43a90
 
 %install
 DESTDIR="%{buildroot}" \
-zig build \
-    --summary all \
-    --release=fast \
-    --system "%{cache_dir}/p" \
+%{zig_build_target -r fast} \
     --prefix "%{_prefix}" --prefix-lib-dir "%{_libdir}" \
     --prefix-exe-dir "%{_bindir}" --prefix-include-dir "%{_includedir}" \
-    --verbose \
-    -Dversion-string=%{version} \
-    -Dcpu=baseline \
+    -Dversion-string="%{version}" \
     -Dstrip=false \
     -Dpie=true \
-    -Demit-docs \
-    -Demit-termcap \
-    -Demit-terminfo
+    -Demit-docs
 
 #Don't conflict with ncurses-term on F42 and up
 %if 0%{?fedora} >= 42
@@ -136,49 +179,65 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/ghostty
 %files
 %doc README.md
 %license LICENSE
-%{_bindir}/ghostty
-%{_datadir}/applications/com.mitchellh.ghostty.desktop
-%{_datadir}/bat/syntaxes/ghostty.sublime-syntax
-%{_datadir}/ghostty/
-%{_datadir}/kio/servicemenus/com.mitchellh.ghostty.desktop
-%{_datadir}/nautilus-python/extensions/ghostty.py
-%{_datadir}/nvim/site/compiler/ghostty.vim
-%{_datadir}/nvim/site/ftdetect/ghostty.vim
-%{_datadir}/nvim/site/ftplugin/ghostty.vim
-%{_datadir}/nvim/site/syntax/ghostty.vim
-%{_datadir}/vim/vimfiles/compiler/ghostty.vim
-%{_datadir}/vim/vimfiles/ftdetect/ghostty.vim
-%{_datadir}/vim/vimfiles/ftplugin/ghostty.vim
-%{_datadir}/vim/vimfiles/syntax/ghostty.vim
-%{_iconsdir}/hicolor/16x16/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/16x16@2/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/32x32/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/32x32@2/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/128x128/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/128x128@2/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/256x256/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/256x256@2/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/512x512/apps/com.mitchellh.ghostty.png
-%{_iconsdir}/hicolor/1024x1024/apps/com.mitchellh.ghostty.png
-%{_mandir}/man1/ghostty.1.gz
-%{_mandir}/man5/ghostty.5.gz
+%{_bindir}/%{base_name}
+%{_datadir}/applications/%{appid}.desktop
+%dir %{_datadir}/%{base_name}
+%{_datadir}/%{base_name}/doc
+%{_datadir}/%{base_name}/themes
+%{_datadir}/metainfo/%{appid}.metainfo.xml
+%{_iconsdir}/hicolor/16x16/apps/%{appid}.png
+%{_iconsdir}/hicolor/16x16@2/apps/%{appid}.png
+%{_iconsdir}/hicolor/32x32/apps/%{appid}.png
+%{_iconsdir}/hicolor/32x32@2/apps/%{appid}.png
+%{_iconsdir}/hicolor/128x128/apps/%{appid}.png
+%{_iconsdir}/hicolor/128x128@2/apps/%{appid}.png
+%{_iconsdir}/hicolor/256x256/apps/%{appid}.png
+%{_iconsdir}/hicolor/256x256@2/apps/%{appid}.png
+%{_iconsdir}/hicolor/512x512/apps/%{appid}.png
+%{_iconsdir}/hicolor/1024x1024/apps/%{appid}.png
+%{_mandir}/man1/%{base_name}.1.gz
+%{_mandir}/man5/%{base_name}.5.gz
+%{_userunitdir}/%{appid}.service
+%{_prefix}/lib/dbus-1/services/%{appid}.service
 
 %files bash-completion
-%{bash_completions_dir}/ghostty.bash
+%{bash_completions_dir}/%{base_name}.bash
 
 %files fish-completion
-%{fish_completions_dir}/ghostty.fish
+%{fish_completions_dir}/%{base_name}.fish
 
 %files zsh-completion
-%{zsh_completions_dir}/_ghostty
+%{zsh_completions_dir}/_%{base_name}
+
+%files kio
+%{_datadir}/kio/servicemenus/%{appid}.desktop
+
+%files nautilus
+%{_datadir}/nautilus-python/extensions/%{base_name}.py
+
+%files vim
+%{_datadir}/vim/vimfiles/compiler/%{base_name}.vim
+%{_datadir}/vim/vimfiles/ftdetect/%{base_name}.vim
+%{_datadir}/vim/vimfiles/ftplugin/%{base_name}.vim
+%{_datadir}/vim/vimfiles/syntax/%{base_name}.vim
+
+%files neovim
+%{_datadir}/nvim/site/compiler/%{base_name}.vim
+%{_datadir}/nvim/site/ftdetect/%{base_name}.vim
+%{_datadir}/nvim/site/ftplugin/%{base_name}.vim
+%{_datadir}/nvim/site/syntax/%{base_name}.vim
+
+%files bat-syntax
+%{_datadir}/bat/syntaxes/%{base_name}.sublime-syntax
 
 %files shell-integration
-%{_datadir}/ghostty/shell-integration/bash/bash-preexec.sh
-%{_datadir}/ghostty/shell-integration/bash/ghostty.bash
-%{_datadir}/ghostty/shell-integration/elvish/lib/ghostty-integration.elv
-%{_datadir}/ghostty/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
-%{_datadir}/ghostty/shell-integration/zsh/.zshenv
-%{_datadir}/ghostty/shell-integration/zsh/ghostty-integration
+%dir %{_datadir}/%{base_name}/shell-integration
+%{_datadir}/%{base_name}/shell-integration/bash/bash-preexec.sh
+%{_datadir}/%{base_name}/shell-integration/bash/%{base_name}.bash
+%{_datadir}/%{base_name}/shell-integration/elvish/lib/%{base_name}-integration.elv
+%{_datadir}/%{base_name}/shell-integration/fish/vendor_conf.d/%{base_name}-shell-integration.fish
+%{_datadir}/%{base_name}/shell-integration/zsh/.zshenv
+%{_datadir}/%{base_name}/shell-integration/zsh/%{base_name}-integration
 
 %files terminfo
 %if 0%{?fedora} < 42

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -18,7 +18,8 @@ BuildRequires:  minisign
 BuildRequires:  ncurses
 BuildRequires:  ncurses-devel
 BuildRequires:  pandoc-cli
-BuildRequires:  zig = 0.14.0
+BuildRequires:  zig >= 0.14.0
+BuildRequires:  zig-rpm-macros
 BuildRequires:  pkgconfig(bzip2)
 BuildRequires:  pkgconfig(freetype2)
 BuildRequires:  pkgconfig(fontconfig)


### PR DESCRIPTION
This made the spec huge but I realized this was kinda a disaster as is to install because it was a TON of files that depended on other things to actually do anything.

This also depends on `systemd` now but I wasn't sure if I should add that as a hard dep since Fedora just uses that?