### PR TITLE
[f42] fix(chezmoi)?: try using latest go.sum (#5385)

### DIFF
--- a/anda/langs/go/chezmoi/chezmoi.spec
+++ b/anda/langs/go/chezmoi/chezmoi.spec
@@ -43,6 +43,10 @@ Source:         %{gosource}
 
 %build
 %define gomodulesmode GO111MODULE=on
+%define __gobuild_extldflags -X main.version=%version -X main.builtBy=%vendor
+go clean -modcache
+rm go.sum
+go mod tidy
 %gobuild -o %{gobuilddir}/bin/chezmoi .
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(chezmoi)?: try using latest go.sum (#5385)](https://github.com/terrapkg/packages/pull/5385)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)