### PR TITLE
[el10] bump: lomiri-system-settings (#5686)

### DIFF
--- a/anda/desktops/lomiri-unity/lomiri-system-settings/lomiri-system-settings.spec
+++ b/anda/desktops/lomiri-unity/lomiri-system-settings/lomiri-system-settings.spec
@@ -1,5 +1,5 @@
 %global forgeurl https://gitlab.com/ubports/development/core/lomiri-system-settings
-%global commit fcc7fe7570da28147906b6779d2f0587ae4ee854
+%global commit 02ac06d78c2f92dafb20d060b8f14d2a889674c8
 %forgemeta
 
 Name:       lomiri-system-settings


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump: lomiri-system-settings (#5686)](https://github.com/terrapkg/packages/pull/5686)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)