### PR TITLE
[f41] bump(nightly): mpv-nightly ghostty-nightly zed-nightly grabnim astal Carla-nightly scx-scheds-nightly spotx-bash (#5690)

### DIFF
--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,6 +1,6 @@
-%global commit ed8954e8cf2d92d7f2df22aeeb9b6087f76ef89e
+%global commit 591522c38fcae403980989c060e332227aa5c04e
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250628
+%global commit_date 20250629
 %global ver 0.40.0
 
 Name:           mpv-nightly

--- a/anda/apps/ruffle/ruffle-nightly.spec
+++ b/anda/apps/ruffle/ruffle-nightly.spec
@@ -1,4 +1,4 @@
-%global ver 2025-06-27
+%global ver 2025-06-29
 %global goodver %(echo %ver | sed 's/-//g')
 %global __brp_mangle_shebangs %{nil}
 %bcond_without mold

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 206d41844e88176a398f149e8e2c8f6e2fdbd28a
+%global commit 2637400904e2c35978006272fc96005be08729cf
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-06-27
+%global fulldate 2025-06-28
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.1.4

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit bbf16bda75587626cc1e2bb959e714d817aeffec
+%global commit e5bcd720e1715f1905734f05bdd752b45fb57966
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250628
+%global commit_date 20250629
 %global ver 0.194.0
 
 %bcond_with check

--- a/anda/langs/nim/grabnim/grabnim.spec
+++ b/anda/langs/nim/grabnim/grabnim.spec
@@ -1,5 +1,5 @@
-%global commit 8499635c56018b22dd4efbd20e274fae045c569b
-%global commit_date 20250628
+%global commit 923731e4325dcd2ce38648f456873128b97ac395
+%global commit_date 20250629
 %global shortcommit %{sub %commit 1 7}
 
 Name:			grabnim

--- a/anda/lib/astal/astal/astal.spec
+++ b/anda/lib/astal/astal/astal.spec
@@ -1,7 +1,7 @@
 
-%global commit 95c6d6dbaf0eaa71a17abf02c20bfca7371956c1
+%global commit ac90f09385a2295da9fdc108aaba4a317aaeacc7
 %global shortcommit %{sub %commit 1 7}
-%global commit_date 20250628
+%global commit_date 20250629
 
 Name:			astal
 Version:		0^%commit_date.%shortcommit

--- a/anda/multimedia/carla/Carla-nightly.spec
+++ b/anda/multimedia/carla/Carla-nightly.spec
@@ -1,8 +1,8 @@
 %global pname   carla
 %global ver     v2.5.9
-%global commit  54ebc831f54d37b23a400f85cb3d44637718d52e
+%global commit  e8ee9d8a2864a4398d18e180ae3e8622e38a6350
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250623
+%global commit_date 20250629
 
 Name:           Carla-nightly
 Version:        %(echo %ver | tr -d 'v')^%commit_date.git~%shortcommit

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 28b3527321b65087bb7c5dc15cfa94b23fe1aa03
+%global commit 7fb5424345e3cae54d9df099fbb76d280774ae96
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20250628
+%global commitdate 20250629
 %global ver 1.0.13
 
 Name:           scx-scheds-nightly

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,5 +1,5 @@
-%global commit 181fd7fc8fe838237660a46ae096570d869bc30f
-%global commit_date 20250619
+%global commit da5fe58e1436206d2dfce270a1567c5a5805d786
+%global commit_date 20250629
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           spotx-bash


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [bump(nightly): mpv-nightly ghostty-nightly zed-nightly grabnim astal Carla-nightly scx-scheds-nightly spotx-bash (#5690)](https://github.com/terrapkg/packages/pull/5690)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)