### PR TITLE
[f41] chore(scx-scheds): Add systemd post scripts just in case (#5677)

### DIFF
--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -5,7 +5,7 @@
 
 Name:           scx-scheds-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Nightly builds of sched_ext schedulers and tools
 SourceLicense:  GPL-2.0-only
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (LGPL-2.1-only OR BSD-2-Clause) AND LGPL-2.1 AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR MIT OR Apache-2.0) AND MPL-2.0-only and MPL-2.0-or-later AND (Unlicense OR MIT) AND Zlib
@@ -81,6 +81,18 @@ License:       GPL-2.0-only
 %meson_install
 
 %{cargo_license_online} > LICENSE.dependencies
+
+%post
+%systemd_post scx_loader.service
+%systemd_post scx.service
+
+%preun
+%systemd_preun scx_loader.service
+%systemd_preun scx.service
+
+%postun
+%systemd_postun_with_restart scx_loader.service
+%systemd_postun_with_restart scx.service
 
 %files
 %doc OVERVIEW.md

--- a/anda/system/scx-scheds/stable/scx-scheds.spec
+++ b/anda/system/scx-scheds/stable/scx-scheds.spec
@@ -1,6 +1,6 @@
 Name:           scx-scheds
 Version:        1.0.13
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        sched_ext schedulers and tools
 SourceLicense:  GPL-2.0-only
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (LGPL-2.1-only OR BSD-2-Clause) AND LGPL-2.1 AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR MIT OR Apache-2.0) AND MPL-2.0-only and MPL-2.0-or-later AND (Unlicense OR MIT) AND Zlib
@@ -72,6 +72,18 @@ License:       GPL-2.0-only
 %meson_install
 
 %{cargo_license_online} > LICENSE.dependencies
+
+%post
+%systemd_post scx_loader.service
+%systemd_post scx.service
+
+%preun
+%systemd_preun scx_loader.service
+%systemd_preun scx.service
+
+%postun
+%systemd_postun_with_restart scx_loader.service
+%systemd_postun_with_restart scx.service
 
 %files
 %doc OVERVIEW.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [chore(scx-scheds): Add systemd post scripts just in case (#5677)](https://github.com/terrapkg/packages/pull/5677)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)