### PR TITLE
[f42] fix(carla): update.rhai (#5693)

### DIFF
--- a/anda/multimedia/carla/update.rhai
+++ b/anda/multimedia/carla/update.rhai
@@ -2,5 +2,7 @@ rpm.global("commit", gh_commit("falkTX/Carla"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commit_date", date());
-    rpm.global("ver", gh("falkTX/Carla"));
+    let v = gh("falkTX/Carla");
+    v.crop(1);
+    rpm.global("ver", v);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(carla): update.rhai (#5693)](https://github.com/terrapkg/packages/pull/5693)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)