### PR TITLE
[f41] fix(sbctl): Make it actually work on Fedora (#5689)

### DIFF
--- a/anda/tools/sbctl/sbctl-batch-sign
+++ b/anda/tools/sbctl/sbctl-batch-sign
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# sbctl-batch-sign is a helper script designed to make it easier for users to sign files needed for Secure Boot support.
+# The obvious case in which this script helps a lot is when dual booting Windows as there are a lot of files by Windows that need to be signed in EFI.
+set -e
+
+if [ -f /boot/limine.conf ]; then
+    echo "Limine detected, please do not use this script."
+    exit 0
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: This script must be run with root privileges."
+    exit 1
+fi
+
+export ESP_PATH=/boot
+sbctl verify 2>/dev/null | awk '/✗/ {print $2}' | while IFS= read -r entry; do
+    if [[ "$entry" =~ ^.*/EFI/(Microsoft|Windows) || "$entry" == *.mui || "$entry" == *.dll
+        || "$entry" =~ ^/boot/grub ]]; then
+        continue
+    fi
+    sbctl sign -s "$entry"
+done

--- a/anda/tools/sbctl/sbctl.spec
+++ b/anda/tools/sbctl/sbctl.spec
@@ -1,16 +1,20 @@
 Name:           sbctl
 Version:        0.17
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Secure Boot key manager
 
 License:        MIT
 URL:            https://github.com/Foxboron/sbctl
 Source0:        https://github.com/Foxboron/sbctl/releases/download/%{version}/sbctl-%{version}.tar.gz
+## Based on CachyOS's batch sign script
+# https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/bin/sbctl-batch-sign
+Source1:        %{name}-batch-sign
 
 ExclusiveArch:  %{golang_arches}
 
 Requires:       binutils
 Requires:       util-linux
+Requires(post): bash
 
 Recommends:     systemd-udev
 
@@ -39,12 +43,12 @@ export GOPATH=%{_builddir}/go
 
 %install
 %make_install PREFIX=%{_prefix}
-
+install -Dm755 %{SOURCE1} -t %{buildroot}%{_bindir}
 
 %transfiletriggerin -P 1 -- /boot /efi /usr/lib /usr/libexec
 if [[ ! -f /run/ostree-booted ]] && grep -q -m 1 -e '\.efi$' -e '/vmlinuz$'; then
     exec </dev/null
-    %{_bindir}/sbctl sign-all -g
+    %{_bindir}/sbctl-batch-sign
 fi
 
 
@@ -52,6 +56,7 @@ fi
 %license LICENSE
 %doc README.md
 %{_bindir}/sbctl
+%{_bindir}/sbctl-batch-sign
 %{_prefix}/lib/kernel/install.d/91-sbctl.install
 %{_mandir}/man8/sbctl.8*
 %{_mandir}/man5/sbctl.conf.5*


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix(sbctl): Make it actually work on Fedora (#5689)](https://github.com/terrapkg/packages/pull/5689)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)