### PR TITLE
[f42] fix?(micro-default-editor): Just dep on Micro (#5710)

### DIFF
--- a/anda/tools/micro-default-editor/micro-default-editor.spec
+++ b/anda/tools/micro-default-editor/micro-default-editor.spec
@@ -15,7 +15,7 @@ Source2:       https://raw.githubusercontent.com/terrapkg/pkg-micro-default-edit
 # For EVR macro
 BuildRequires: anda-srpm-macros
 Requires:      default-editor
-Requires:      (micro = %{evr} or micro-nightly)
+Requires:      micro
 # All default editor packages MUST provide this
 Provides:      system-default-editor
 BuildArch:     noarch

--- a/anda/tools/micro-default-editor/update.rhai
+++ b/anda/tools/micro-default-editor/update.rhai
@@ -1,9 +1,9 @@
-let v = sh("dnf info micro | grep Version | grep -Eo '[0-9]+\\.[0-9]+.*'", #{"stdout": "piped"}).ctx.stdout;
+let v = sh("dnf info micro -y | grep Version | grep -Eo '[0-9]+\\.[0-9]+.*'", #{"stdout": "piped"}).ctx.stdout;
 v.pop();
 rpm.version(v);
-let r = sh("dnf info micro | grep Release | grep -Eo '[0-9]+' | head -1", #{"stdout": "piped"}).ctx.stdout;
+let r = sh("dnf info micro -y | grep Release | grep -Eo '[0-9]+' | head -1", #{"stdout": "piped"}).ctx.stdout;
 r.pop();
 rpm.f = sub(`Release: (.+?)\n`, "Release: " + r + "%{?dist}\n", rpm.f);
-let e = sh("dnf info micro | grep Epoch | grep -Eo '[0-9]+'", #{"stdout": "piped"}).ctx.stdout;
+let e = sh("dnf info micro -y | grep Epoch | grep -Eo '[0-9]+'", #{"stdout": "piped"}).ctx.stdout;
 e.pop();
 rpm.f = sub(`Epoch: (.+?)\n`, "Epoch: " + e + "\n", rpm.f);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix?(micro-default-editor): Just dep on Micro (#5710)](https://github.com/terrapkg/packages/pull/5710)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)