### PR TITLE
[frawhide] fix(ghostty): Update Vim deps for subpackage (#5711)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -9,7 +9,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif
@@ -117,9 +117,10 @@ This package enables Nautilus integration for Ghostty.
 
 %package        vim
 Summary:        Vim plugins for Ghostty
-Supplements:    (%{name} and vim)
+Supplements:    (%{name} and vim-filesystem)
 Requires:       %{name} = %{evr}
-Requires:       vim
+Requires:       vim-enhanced
+Requires:       vim-filesystem
 BuildArch:      noarch
 
 %description    vim

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -90,9 +90,10 @@ This package enables Nautilus integration for Ghostty.
 
 %package        vim
 Summary:        Vim plugins for Ghostty
-Supplements:    (%{name} and vim)
+Supplements:    (%{name} and vim-filesystem)
 Requires:       %{name} = %{evr}
-Requires:       vim
+Requires:       vim-enhanced
+Requires:       vim-filesystem
 BuildArch:      noarch
 
 %description    vim


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [fix(ghostty): Update Vim deps for subpackage (#5711)](https://github.com/terrapkg/packages/pull/5711)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)