### PR TITLE
fix(ci/build): add `anda/` prefix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Notify Madoguchi (Success)
         if: success()
-        run: ./.github/workflows/mg.sh true "${{matrix.pkg}}" "${{matrix.version}}" "${{matrix.arch}}" "${{github.run_id}}" "${{secrets.MADOGUCHI_JWT}}" "$GITHUB_SHA"
+        run: ./.github/workflows/mg.sh true "anda/${{matrix.pkg}}pkg" "${{matrix.version}}" "${{matrix.arch}}" "${{github.run_id}}" "${{secrets.MADOGUCHI_JWT}}" "$GITHUB_SHA"
       - name: Notify Madoguchi (Failure)
         if: cancelled() || failure()
-        run: ./.github/workflows/mg.sh false "${{matrix.pkg}}" "${{matrix.version}}" "${{matrix.arch}}" "${{github.run_id}}" "${{secrets.MADOGUCHI_JWT}}" "$GITHUB_SHA"
+        run: ./.github/workflows/mg.sh false "anda/${{matrix.pkg}}pkg" "${{matrix.version}}" "${{matrix.arch}}" "${{github.run_id}}" "${{secrets.MADOGUCHI_JWT}}" "$GITHUB_SHA"


### PR DESCRIPTION
some packages are missing the `anda/` prefix in mg due to this exact reason