### PR TITLE
[el10] bump: discord discord-openasar sheldon yt-dlp-git (#5722)

### DIFF
--- a/anda/apps/discord-openasar/discord-openasar.spec
+++ b/anda/apps/discord-openasar/discord-openasar.spec
@@ -6,7 +6,7 @@
 %global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
 
 Name:           discord-openasar
-Version:        0.0.98
+Version:        0.0.100
 Release:        1%?dist
 Summary:        A snappier Discord rewrite with features like further customization and theming
 License:        MIT AND https://discord.com/terms

--- a/anda/apps/discord/discord.spec
+++ b/anda/apps/discord/discord.spec
@@ -6,7 +6,7 @@
 %global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
 
 Name:			discord
-Version:		0.0.98
+Version:		0.0.100
 Release:		1%?dist
 Summary:		Free Voice and Text Chat for Gamers
 URL:			https://discord.com

--- a/anda/tools/sheldon/sheldon.spec
+++ b/anda/tools/sheldon/sheldon.spec
@@ -4,7 +4,7 @@
 %global crate sheldon
 
 Name:           rust-sheldon
-Version:        0.8.2
+Version:        0.8.3
 Release:        1%?dist
 Summary:        Fast, configurable, shell plugin manager
 

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,7 +2,7 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2025.06.29.164942
+Version:        2025.07.01.112417
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump: discord discord-openasar sheldon yt-dlp-git (#5722)](https://github.com/terrapkg/packages/pull/5722)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)