### PR TITLE
[frawhide] fix(zed-nightly): Build wants Rust nightly for now  (#5723)

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -4,6 +4,7 @@
 %global ver 0.194.0
 
 %bcond_with check
+%bcond nightly 1
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
@@ -47,6 +48,9 @@ BuildRequires:  perl-IPC-Cmd
 BuildRequires:  perl-File-Compare
 BuildRequires:  perl-File-Copy
 BuildRequires:  perl-lib
+%if %{with nightly}
+BuildRequires:  rustup
+%endif
 BuildRequires:  vulkan-loader
 
 %description
@@ -54,6 +58,9 @@ Code at the speed of thought - Zed is a high-performance, multiplayer code edito
 
 %prep
 %autosetup -n %{crate}-%{commit} -p1
+%if %{with nightly}
+%rustup_nightly
+%endif
 %cargo_prep_online
 
 export DO_STARTUP_NOTIFY="true"


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [fix(zed-nightly): Build wants Rust nightly for now  (#5723)](https://github.com/terrapkg/packages/pull/5723)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)