### PR TITLE
fix(kmod-nvidia): Only update the spec if the module version has been published

### DIFF
--- a/anda/system/nvidia/kmod-nvidia/update.rhai
+++ b/anda/system/nvidia/kmod-nvidia/update.rhai
@@ -1,7 +1,11 @@
 import "andax/nvidia.rhai" as nvidia;
 import "andax/spec.rhai" as spec;
 
-rpm.version(nvidia::nvidia_driver_version());
+let v = nvidia::nvidia_driver_version();
+let m = gh("NVIDIA/open-gpu-kernel-modules");
+if m == v {
+rpm.version(v);
+}
 
 // Rebuild the package whenever the Alma kernel updates
 let releasever = labels.branch;

--- a/anda/system/nvidia/kmod-nvidia/update.rhai
+++ b/anda/system/nvidia/kmod-nvidia/update.rhai
@@ -4,7 +4,7 @@ import "andax/spec.rhai" as spec;
 let v = nvidia::nvidia_driver_version();
 let m = gh("NVIDIA/open-gpu-kernel-modules");
 if m == v {
-rpm.version(v);
+    rpm.version(v);
 }
 
 // Rebuild the package whenever the Alma kernel updates


### PR DESCRIPTION
The reason this isn't tracking GH directly is I want it to track our drivers and they have published beta stuff on the GitHub before, I'm not sure of a better way to check the GitHub tags/releases against what we want.