### PR TITLE
add: nodejs-backport

### DIFF
--- a/anda/devs/backport/anda.hcl
+++ b/anda/devs/backport/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	rpm {
+		spec = "nodejs-backport.spec"
+		pre_script = "setup.sh"
+	}
+}

--- a/anda/devs/backport/nodejs-backport.spec
+++ b/anda/devs/backport/nodejs-backport.spec
@@ -1,0 +1,61 @@
+%global debug_package %{nil}
+%global module backport
+%bcond test 1
+
+Name:          node-%{module}
+Version:       9.6.6
+Release:       1%{?dist}
+Summary:       Backport GitHub commits
+SourceLicense: Apache-2.0
+License:       Apache-2.0 AND
+URL:           https://github.com/sorenlouv/%{module}
+%dnl Source0:       http://registry.npmjs.org/%{module}/-/%{module}-%{version}.tgz
+# Source the tests
+Source1:       tests-%{version}.tar.bz2
+BuildRequires: bsdtar
+BuildRequires: nodejs-devel
+BuildRequires: nodejs-packaging
+BuildRequires: nodejs-npm
+ExclusiveArch: %{nodejs_arches} noarch
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%description
+A simple CLI tool that automates the process of backporting commits on a GitHub repo.
+
+%prep
+# Maybe I should make some NodeJS online macros...
+# Global flag is needed or the module WILL NOT WORK via commandline without some manual intervention
+npm install -g %{module}@%{version} --prefix=.
+%setup -T -D -n lib/node_modules/%{module}
+tar xjf %{SOURCE1}
+
+%build
+# Empty build section, because RPM reasons
+
+%install
+mkdir -p %{buildroot}%{nodejs_sitelib}/%{module}
+mkdir -p %{buildroot}%{_bindir}
+cp -r ./* -t %{buildroot}%{nodejs_sitelib}/%{module}
+ln -sf %{nodejs_sitelib}/%{module}/bin/%{module}  %{buildroot}%{_bindir}/%{module}
+
+# Should maybe package this so it's easier to call...
+npm install -g license-checker --prefix=.
+# This could also be made into a macro maybe?
+bin/license-checker | sed '/.*repository:.*/d;/.*publisher:.*/d;/.*email:.*/d;/.*url:.*/d;/.*path:.*/d;/.*licenseFile:.*/d;/.*noticeFile:.*/d' > LICENSE.modules
+
+%check
+%if %{with test}
+NODE_ENV=test %{builddir}/bin/%{module} -R tests
+%endif
+
+%files
+%doc CHANGELOG.md
+%doc README.md
+%license LICENSE.txt
+%license LICENSE.modules
+%{nodejs_sitelib}/%{module}/
+%{_bindir}/%{module}
+
+%changelog
+* Wed Jul 2 2025 Gilver E. <rockgrub@disroot.org> - 9.6.6-1
+- Initial package

--- a/anda/devs/backport/post.rhai
+++ b/anda/devs/backport/post.rhai
@@ -1,0 +1,1 @@
+sh("rm -rfv anda/devs/backport/*.tar.bz2", #{});

--- a/anda/devs/backport/setup.sh
+++ b/anda/devs/backport/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+## Some sources need to be fetched BEFORE the build process
+# Also I'm just better at scripting in Bash and calling the Rhai sh function hundreds of times times sounded like hell
+# Have I mentioned I hate runtime languages?
+
+node=backport
+# Enable logs for debugging
+set -x
+# I guess just $PWD doesn't work for this
+builddir=$(pwd)/anda/devs/$node
+
+# We only need the tests folder so sourcing the whole repo is overkill, Git can make a tarball of specific directories
+
+pushd $builddir
+ver=$(cat ./*.spec | grep -P -m1 'Version:' | sed -e 's/Version://g' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+url=$(sed -n 's/^URL:\s\(.*\)$/\1/p' ./*.spec | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/%{module}/$node/")
+dir=$node
+
+git clone --recurse-submodules -j$(nproc) $url.git
+
+pushd $dir
+# I'm not sure why .tar.bz2 is the tar format of choice for this but it's also what Fedora does so it's what I'm doing
+git archive --format=tar --prefix=tests/ v${ver}:src/test/ | bzip2 > ../tests-${ver}.tar.bz2
+popd
+rm -rf $dir
+
+exit 0

--- a/anda/devs/backport/update.rhai
+++ b/anda/devs/backport/update.rhai
@@ -1,0 +1,2 @@
+let json = get("https://registry.npmjs.org/backport").json();
+rpm.version(json["dist-tags"]["latest"]);

--- a/anda/devs/backport/update.rhai
+++ b/anda/devs/backport/update.rhai
@@ -1,1 +1,1 @@
-npm("backport");
+rpm.version(npm("backport"));

--- a/anda/devs/backport/update.rhai
+++ b/anda/devs/backport/update.rhai
@@ -1,2 +1,1 @@
-let json = get("https://registry.npmjs.org/backport").json();
-rpm.version(json["dist-tags"]["latest"]);
+npm("backport");


### PR DESCRIPTION
Honestly I should probably just Add the license checker and make it a build dep, that's probably a better idea..

I figured since I use this thing so often I may as well package it. It turns out packaging NodeJS packages as they're intended to be is kinda a pain without using NPM because Fedora puts them in such a weird location.