### PR TITLE
Add: futility

### DIFF
--- a/anda/tools/futility/anda.hcl
+++ b/anda/tools/futility/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "futility.spec"
+	}
+}

--- a/anda/tools/futility/futility.spec
+++ b/anda/tools/futility/futility.spec
@@ -1,7 +1,7 @@
 %define commit 5adf9508431b8c703eb60dde2fed0381079f7423
 %define shortcommit %(c=%{commit}; echo ${c:0:12})
 
-Name:           futility
+Name:           chromium-futility
 Version:        git+%{shortcommit}
 Release:        1%{?dist}
 Summary:        Chromium OS EC utilities
@@ -38,10 +38,10 @@ ln -s /usr/include/libflashrom.h firmware/include/libflashrom.h
 %make_build BUILD=futility CFLAGS="-I%{_includedir} $CFLAGS" V=1
 
 %install
-install -Dm 755 futility %{buildroot}%{_bindir}/futility
+install -Dm 755 futility %{buildroot}%{_bindir}/chromium-futility
 
 %files
-%{_bindir}/futility
+%{_bindir}/chromium-futility
 %license LICENSE
 %doc README docs/
 

--- a/anda/tools/futility/futility.spec
+++ b/anda/tools/futility/futility.spec
@@ -1,0 +1,50 @@
+%define commit 5adf9508431b8c703eb60dde2fed0381079f7423
+%define shortcommit %(c=%{commit}; echo ${c:0:12})
+
+Name:           futility
+Version:        git+%{shortcommit}
+Release:        1%{?dist}
+Summary:        Chromium OS EC utilities
+
+License:        BSD-3-Clause
+URL:            https://chromium.googlesource.com/chromiumos/platform/
+Source0:        https://chromium.googlesource.com/chromiumos/platform/vboot_reference/+archive/refs/heads/main.tar.gz
+
+BuildRequires:  make libxcrypt libxcrypt-devel
+BuildRequires:  pkgconfig(libcrypto)
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  glibc
+BuildRequires:  gcc
+BuildRequires:  nss
+BuildRequires:  nss-devel
+BuildRequires:  flashrom-cros
+BuildRequires:  flashrom-cros-devel
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+Chromium OS EC utilities
+
+%prep
+%autosetup -c
+echo "INCLUDES += -I%{_includedir}" | cat - Makefile > Makefile.new
+mv Makefile.new Makefile
+ln -s /usr/include/libflashrom.h firmware/include/libflashrom.h
+
+%build
+%dnl export CFLAGS="$CFLAGS -I%{_includedir}/libflashrom.h"
+%dnl export CFLAGS="$CFLAGS -I%{_includedir}"
+%dnl make BUILD=futility
+%make_build BUILD=futility CFLAGS="-I%{_includedir} $CFLAGS" V=1
+
+%install
+install -Dm 755 futility %{buildroot}%{_bindir}/futility
+
+%files
+%{_bindir}/futility
+%license LICENSE
+%doc README docs/
+
+%changelog
+* Fri Jul 04 2025 Owen Zimmerman <owen@fyralabs.com>
+- initial package


### PR DESCRIPTION
(remaking this to merge into 42)

I have no idea why this doesn't work.

flashrom-cros-devel provides /usr/include/libflashrom.h, but this package fails to see that file. Seemed it was not looking in /usr/include, but even by patching the makefile it still does not work. If someone else has any ideas/suggestions that would be great, not sure how to proceed here otherwise.
