### PR TITLE
[el10] Fix: gsctool (#5765)

### DIFF
--- a/anda/tools/gsctool/gsctool.spec
+++ b/anda/tools/gsctool/gsctool.spec
@@ -2,12 +2,13 @@
 %define shortcommit %(c=%{commit}; echo ${c:0:12})
 Name:           gsctool
 Version:        git+%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Chromium OS EC utilities
 
 License:      BSD-3-Clause
 URL:          https://chromium.googlesource.com/chromiumos/platform/ec  
 Source0:      https://chromium.googlesource.com/chromiumos/platform/ec/+archive/%{commit}.tar.gz#/%{name}-git+%{commit}.tar.gz
+Source1:      https://chromium.googlesource.com/chromium/src/+/HEAD/LICENSE
 
 BuildRequires:  pkgconfig
 BuildRequires:  pkgconfig(libusb-1.0)
@@ -29,11 +30,11 @@ pushd extra/usb_updater
 %install
 pushd extra/usb_updater
 install -D -m 755 gsctool %{buildroot}%{_bindir}/gsctool
-
+install -Dm 644 %{SOURCE1} %{buildroot}%{_licensedir}/%{name}/LICENSE
 
 %files
 %{_bindir}/gsctool
-
+%license %{_licensedir}/%{name}/LICENSE
 
 %changelog
 * Wed Mar 27 2024 Cappy Ishihara <cappy@cappuchino.xyz>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Fix: gsctool (#5765)](https://github.com/terrapkg/packages/pull/5765)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)