### PR TITLE
[f41] feat(ci): add no_upload_srpms label (#5758)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,6 +1,8 @@
 # for each folder in anda/
 # generate a new workflow for each folder in anda/
 name: Automatically build packages
+permissions:
+  contents: read
 on:
   push:
     paths:
@@ -97,7 +99,7 @@ jobs:
             terra${{ matrix.version }}${{ matrix.pkg.labels['subrepo'] && '-$subrepo' || '' }} anda-build/rpm/rpms/*
 
       - name: Upload source packages to subatomic
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && matrix.pkg.labels['no_upload_srpms'] != '1'
         run: |
           subrepo="${{ matrix.pkg.labels.subrepo }}"
           subatomic-cli upload --prune \

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,5 +1,6 @@
 name: Bootstrap Andaman and Subatomic
-
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Manual Builds
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:
@@ -90,17 +92,20 @@ jobs:
 
       - name: Upload packages to subatomic
         run: |
+          subrepo="${{ fromJson(steps.art.outputs.labels).subrepo }}"
           subatomic-cli upload --prune \
             --server https://subatomic.fyralabs.com \
             --token ${{ secrets.SUBATOMIC_TOKEN }} \
-            terra${{ matrix.version }} anda-build/rpm/rpms/*
+            terra${{ matrix.version }}${{ fromJson(steps.art.outputs.labels)['subrepo'] && '-$subrepo' }} anda-build/rpm/rpms/*
 
       - name: Upload source packages to subatomic
+        if: fromJson(steps.art.outputs.labels)['no_upload_srpms'] != '1'
         run: |
+          subrepo="${{ fromJson(steps.art.outputs.labels).subrepo }}"
           subatomic-cli upload --prune \
             --server https://subatomic.fyralabs.com \
             --token ${{ secrets.SUBATOMIC_TOKEN }} \
-            terra${{ matrix.version }}-source anda-build/rpm/srpm/*
+            terra${{ matrix.version }}${{ fromJson(steps.art.outputs.labels)['subrepo'] && '-$subrepo' }}-source anda-build/rpm/srpm/*
 
       - name: Notify Madoguchi (Success)
         if: success()

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -1,4 +1,6 @@
 name: JSON Build
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:
@@ -67,6 +69,7 @@ jobs:
             terra${{ matrix.version }}${{ matrix.pkg.labels['subrepo'] && '-$subrepo' || '' }} anda-build/rpm/rpms/*
 
       - name: Upload source packages to subatomic
+        if: matrix.pkg.labels['no_upload_srpms'] != '1'
         run: |
           subrepo="${{ matrix.pkg.labels.subrepo }}"
           subatomic-cli upload --prune \

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,5 +1,7 @@
 name: Automatic backport/sync action
-
+permissions:
+  contents: write
+  pull-requests: write
 on:
   pull_request_target:
     types: ["labeled", "closed"]

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -1,4 +1,6 @@
 name: Update per branch
+permissions:
+  contents: write
 on:
   schedule:
     - cron: "*/30 * * * *"

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -1,4 +1,6 @@
 name: Push comps updates
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -1,4 +1,6 @@
 name: Nightly Update
+permissions:
+  contents: write
 on:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -1,4 +1,6 @@
 name: Weekly Update
+permissions:
+  contents: write
 on:
   schedule:
     - cron: "0 0 * * 0"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,4 +1,6 @@
 name: Update
+permissions:
+  contents: write
 on:
   schedule:
     - cron: "*/10 * * * *"

--- a/anda/fonts/nerd-fonts/anda.hcl
+++ b/anda/fonts/nerd-fonts/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
 	rpm {
 		spec = "nerd-fonts.spec"
 	}
+	labels {
+		no_upload_srpms = 1
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(ci): add no_upload_srpms label (#5758)](https://github.com/terrapkg/packages/pull/5758)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)