### PR TITLE
[el10] feat(rnote): use cargo macros (#5565)

### DIFF
--- a/anda/langs/rust/rnote/rnote.spec
+++ b/anda/langs/rust/rnote/rnote.spec
@@ -1,15 +1,17 @@
-%global build_rustflags %build_rustflags -C link-arg=-fuse-ld=mold
 %global rustflags_debuginfo 1
 
 Name:           rnote
 Version:        0.12.0
-Release:        1%?dist
-Summary:        Sketch and take handwritten notes.
+Release:        2%?dist
+Summary:        Sketch and take handwritten notes
 License:        GPL-3.0
 URL:            https://github.com/flxzt/rnote
+Packager:       madonuko <mado@fyralabs.com>
 Source0:        %{url}/archive/refs/tags/v%version.tar.gz
-Requires:       gtk4
-BuildRequires:  cargo meson cmake libappstream-glib gcc-c++ pkgconfig(alsa) alsa-lib clang-devel python desktop-file-utils mold
+Recommends:     rnote-cli = %evr
+BuildRequires:  rust-packaging
+BuildRequires:  cargo meson cmake libappstream-glib gcc-c++ alsa-lib clang-devel python desktop-file-utils mold
+BuildRequires:  pkgconfig(alsa)
 BuildRequires:  pkgconfig(glib-2.0) >= 2.66
 BuildRequires:  pkgconfig(gtk4) >= 4.7
 BuildRequires:  pkgconfig(libadwaita-1) >= 1.2
@@ -21,12 +23,22 @@ notes and to annotate documents and pictures. Targeted at students, teachers
 and those who own a drawing tablet, it provides features like PDF and picture
 import/export, an infinite canvas and an adaptive UI for big and small screens.
 
+%package cli
+Summary: The cli version of rnote (`rnote-cli`)
+License: GPL-3.0
+
+%description cli
+This provides the `rnote-cli` binary. For more information, see the `rnote` package.
+
+
 %prep
 %autosetup -n rnote-%{version}
-
+%cargo_prep_online
 
 %build
 %meson
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
 %meson_build
 
 
@@ -36,8 +48,7 @@ import/export, an infinite canvas and an adaptive UI for big and small screens.
 
 %files
 %doc README.md
-%license LICENSE
-%_bindir/rnote-cli
+%license LICENSE LICENSE.dependencies
 %_bindir/rnote
 %_datadir/thumbnailers/rnote.thumbnailer
 %_datadir/applications/com.github.flxzt.rnote.desktop
@@ -51,10 +62,7 @@ import/export, an infinite canvas and an adaptive UI for big and small screens.
 %_datadir/rnote/
 %_datadir/fonts/rnote-fonts/
 
-
-%changelog
-* Wed Nov 2 2022 windowsboy111 <windowsboy111@fyralabs.com> - 0.5.7-1
-- Fix requires
-
-* Sun Oct 23 2022 windowsboy111 <windowsboy111@fyralabs.com> - 0.5.7-1
-- Initial package
+%files cli
+%doc README.md
+%license LICENSE LICENSE.dependencies
+%_bindir/rnote-cli


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(rnote): use cargo macros (#5565)](https://github.com/terrapkg/packages/pull/5565)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)