### PR TITLE
[f41] chore(anda-srpm-macros): Add new files (#5793)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -34,6 +34,8 @@ install -Dpm755 *.sh -t %buildroot%_libexecdir/%name/
 %{_rpmmacrodir}/macros.cargo_extra
 %{_rpmmacrodir}/macros.go_extra
 %{_rpmmacrodir}/macros.nim_extra
+%{_rpmmacrodir}/macros.nodejs_extra
+%{_rpmmacrodir}/macros.web-assets_extra
 %{_rpmmacrodir}/macros.zig_extra
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(anda-srpm-macros): Add new files (#5793)](https://github.com/terrapkg/packages/pull/5793)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)