### PR TITLE
[f41] chore: Bump packages on <= 42 (#5734)

### DIFF
--- a/anda/langs/nim/nimble/nimble.spec
+++ b/anda/langs/nim/nimble/nimble.spec
@@ -1,5 +1,5 @@
 Name:           nimble
-Version:        0.14.2
+Version:        0.20.0
 Release:        1%?dist
 Summary:        Package manager for the Nim programming language
 License:        BSD

--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,5 +1,5 @@
-%global commit cb4a987d9e92423f645056532b5e19e34de36a4d
-%global commit_date 20250611
+%global commit 5f9416645827ecf6ed781f2255afef1e05fd8e2f
+%global commit_date 20250702
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           readymade-git
@@ -63,3 +63,4 @@ ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_da
 %_datadir/applications/liveinst.desktop
 %ghost %_datadir/readymade
 %_datadir/icons/hicolor/scalable/apps/com.fyralabs.Readymade.svg
+

--- a/anda/system/readymade/stable/readymade.spec
+++ b/anda/system/readymade/stable/readymade.spec
@@ -1,5 +1,5 @@
 Name:           readymade
-Version:        0.12.2
+Version:        0.12.5
 Release:        1%?dist
 Summary:        Install ready-made distribution images!
 License:        GPL-3.0-or-later
@@ -53,6 +53,6 @@ ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_da
 %_datadir/polkit-1/actions/com.fyralabs.pkexec.readymade.policy
 %_datadir/applications/com.fyralabs.Readymade.desktop
 %_datadir/applications/liveinst.desktop
-%_datadir/readymade
+%ghost %_datadir/readymade
 %_datadir/icons/hicolor/scalable/apps/com.fyralabs.Readymade.svg
 

--- a/anda/tools/sheldon/sheldon.spec
+++ b/anda/tools/sheldon/sheldon.spec
@@ -4,7 +4,7 @@
 %global crate sheldon
 
 Name:           rust-sheldon
-Version:        0.8.3
+Version:        0.8.4
 Release:        1%?dist
 Summary:        Fast, configurable, shell plugin manager
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [chore: Bump packages on &lt;&#x3D; 42 (#5734)](https://github.com/terrapkg/packages/pull/5734)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)