### PR TITLE
[f42] fix(dracut-strip-trigger): support other kernels (#5798)

### DIFF
--- a/anda/system/dracut-strip-trigger/dracut-strip-trigger.spec
+++ b/anda/system/dracut-strip-trigger/dracut-strip-trigger.spec
@@ -1,6 +1,6 @@
 Name:		dracut-strip-trigger
 Version:	0
-Release:	1%?dist
+Release:	2%?dist
 Summary:	Strip initramfs aggressively
 License:	GPL-3.0-only
 Requires(post): dracut
@@ -29,7 +29,7 @@ dracut --force --parallel --regenerate-all --hostonly --strip --aggressive-strip
 echo 'All non-rescue initramfs have been regenerated.'
 echo 'If you have problems booting up, use the rescue image, then uninstall `%name`.'
 
-%triggerin -- kernel
+%triggerin -- installonlypkg(kernel)
 dracut --force --hostonly --strip --aggressive-strip
 
 %postun


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(dracut-strip-trigger): support other kernels (#5798)](https://github.com/terrapkg/packages/pull/5798)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)