### PR TITLE
[f42] fix(nekoray): pre script download extra module? (#5809)

### DIFF
--- a/anda/apps/nekoray/nekoray.spec
+++ b/anda/apps/nekoray/nekoray.spec
@@ -52,7 +52,7 @@ Summary: %{summary}
 %autosetup -p1 -n %{name}-%{version}
 sed -i 's~find_package(Protobuf CONFIG REQUIRED)~find_package(Protobuf REQUIRED)~' cmake/myproto.cmake
 sed -i 's~add_library(qhotkey 3rdparty/QHotkey/qhotkey.cpp)~add_library(qhotkey STATIC 3rdparty/QHotkey/qhotkey.cpp)~' cmake/QHotkey.cmake
-sed -i 's~ImageFormat::BGRA~ImageFormat::BGR~' 3rdparty/ZxingQtReader.hpp
+# sed -i 's~ImageFormat::BGRA~ImageFormat::BGR~' 3rdparty/ZxingQtReader.hpp
 pushd core/server
 %{fetch_vendor}
 popd

--- a/anda/apps/nekoray/pre.sh
+++ b/anda/apps/nekoray/pre.sh
@@ -4,6 +4,7 @@ version=$(rpmspec --query --queryformat "%{VERSION}\n" nekoray.spec | uniq)
 
 tar -xzf "nekoray-${version}.tar.gz"
 pushd "nekoray-${version}/core/server"
+ go mod download github.com/stretchr/testify 
  go mod vendor
  tar -czf "${sourcedir}/vendor-${version}.tar.gz" vendor
 popd


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(nekoray): pre script download extra module? (#5809)](https://github.com/terrapkg/packages/pull/5809)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)