### PR TITLE
[el10] bump(depthcharge-tools): 0.6.3 (#5804)

### DIFF
--- a/anda/system/depthcharge-tools/depthcharge-tools.spec
+++ b/anda/system/depthcharge-tools/depthcharge-tools.spec
@@ -1,10 +1,10 @@
 Name:			depthcharge-tools
-Version:		0.6.2
-Release:		2%?dist
+Version:		0.6.3
+Release:		1%?dist
 Summary:		Tools to manage the Chrome OS bootloader
 License:		GPL-2.0-or-later
-URL:			https://github.com/alpernebbi/depthcharge-tools
-Source0:		%url/archive/v%version/v%version.tar.gz
+URL:			https://gitlab.postmarketos.org/postmarketOS/depthcharge-tools
+Source0:		%url/-/archive/v%version/%name-v%version.tar.gz
 Requires:		vboot-utils dtc gzip lz4 python3-setuptools uboot-tools vboot-utils xz
 BuildRequires:	python3-setuptools python3-rpm-macros systemd-rpm-macros redhat-rpm-config python3-docutils
 BuildArch:		noarch
@@ -16,7 +16,7 @@ with depthcharge, the Chrome OS bootloader.
 %pkg_completion -Bz mkdepthcharge depthchargectl
 
 %prep
-%autosetup
+%autosetup -n %name-v%version
 
 %build
 python3 setup.py build

--- a/anda/system/depthcharge-tools/update.rhai
+++ b/anda/system/depthcharge-tools/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("alpernebbi/depthcharge-tools"));
+rpm.version(gitlab_tag("gitlab.postmarketos.org", "685"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump(depthcharge-tools): 0.6.3 (#5804)](https://github.com/terrapkg/packages/pull/5804)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)