### PR TITLE
[el10] bump(cbmem): 25.06 (#5803)

### DIFF
--- a/anda/tools/cbmem/cbmem.spec
+++ b/anda/tools/cbmem/cbmem.spec
@@ -1,7 +1,7 @@
 %define debug_package %nil
 
 Name:           cbmem
-Version:        25.03
+Version:        25.06
 Release:        1%?dist
 Summary:        Prints out coreboot mem table information
 URL:            https://review.coreboot.org


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `el10`:
 - [bump(cbmem): 25.06 (#5803)](https://github.com/terrapkg/packages/pull/5803)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)