### PR TITLE
[frawhide] fix(choosenim): remove patch (#5802)

### DIFF
--- a/anda/langs/nim/choosenim/choosenim.spec
+++ b/anda/langs/nim/choosenim/choosenim.spec
@@ -1,4 +1,3 @@
-
 Name:			choosenim
 Version:		0.8.16
 Release:		1%?dist
@@ -6,8 +5,6 @@ Summary:		Easily install and manage multiple versions of the Nim programming lan
 License:		BSD-3-Clause
 URL:			https://github.com/nim-lang/choosenim
 Source0:        %url/archive/refs/tags/v%version.tar.gz
-# Fix for https://github.com/nim-lang/choosenim/issues/13
-Patch0:         https://patch-diff.githubusercontent.com/raw/nim-lang/choosenim/pull/38.patch
 Packager:		madonuko <mado@fyralabs.com>
 BuildRequires:  nim
 BuildRequires:	git-core anda-srpm-macros


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [fix(choosenim): remove patch (#5802)](https://github.com/terrapkg/packages/pull/5802)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)