### PR TITLE
[el10] add: netto (#5832)

### DIFF
--- a/anda/langs/nim/netto/anda.hcl
+++ b/anda/langs/nim/netto/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "netto.spec"
+	}
+}

--- a/anda/langs/nim/netto/netto.spec
+++ b/anda/langs/nim/netto/netto.spec
@@ -1,0 +1,30 @@
+Name:           netto
+Version:        0.1.0
+Release:        1%?dist
+Summary:        📡 GUI Network Applet
+License:        GPL-3.0-or-later
+URL:            https://github.com/madonuko/netto
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+BuildRequires:  anda-srpm-macros nim
+BuildRequires:  pkgconfig(libhelium-1)
+BuildRequires:  pkgconfig(libnm)
+
+%description
+ネット (codename 🫘 納豆) is the new solution for setting up a new network.
+Written proudly in libhelium and Nim, using libnm.
+
+%prep
+%autosetup -Sgit
+
+%build
+atlas init
+atlas rep atlas.lock
+%nim_c src/netto
+
+%install
+install -Dm755 src/netto -t %buildroot%_bindir
+
+%files
+%doc README.md
+%license LICENSE.md
+%_bindir/netto

--- a/anda/langs/nim/netto/update.rhai
+++ b/anda/langs/nim/netto/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("madonuko/netto"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [add: netto (#5832)](https://github.com/terrapkg/packages/pull/5832)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)