### PR TITLE
[el10] Revert "bump(branch): micro-default-editor" (#5836)

### DIFF
--- a/anda/tools/micro-default-editor/micro-default-editor.spec
+++ b/anda/tools/micro-default-editor/micro-default-editor.spec
@@ -2,9 +2,9 @@
 
 Name:          micro-default-editor
 # Version, release, and epoch are inherited from the editor package just like other default editors
-Version:       
+Version:       2.0.11
 Release: 10%{?dist}
-Epoch: 
+Epoch: 0
 # Inherited from Micro itself
 License:       MIT and ASL 2.0
 Summary:       Sets Micro as the default editor


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Revert &quot;bump(branch): micro-default-editor&quot; (#5836)](https://github.com/terrapkg/packages/pull/5836)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)