### PR TITLE
[f42] fix(youtube-music): bump npm (#5828)

### DIFF
--- a/anda/apps/youtube-music/youtube-music.spec
+++ b/anda/apps/youtube-music/youtube-music.spec
@@ -53,7 +53,7 @@ git checkout v%{version}
 %if 0%{?vendor_pnpm}
 curl -fsSL https://get.pnpm.io/install.sh | sh -
 source $HOME/.bashrc
-pnpm env use --global 20
+pnpm env use --global 22
 %endif
 pnpm install
 pnpm build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(youtube-music): bump npm (#5828)](https://github.com/terrapkg/packages/pull/5828)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)