### PR TITLE
[f41] add: spleen-fonts (#5637)

### DIFF
--- a/anda/fonts/spleen/anda.hcl
+++ b/anda/fonts/spleen/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "spleen-fonts.spec"
+	}
+}

--- a/anda/fonts/spleen/spleen-fonts.spec
+++ b/anda/fonts/spleen/spleen-fonts.spec
@@ -1,0 +1,42 @@
+%global __make bmake
+%global _make_output_sync %nil
+%global fontcontact security@fyralabs.com
+%global fontorg com.fyralabs.terra
+
+Version:		2.1.0
+Release:		1%?dist
+URL:			https://www.cambus.net/spleen-monospaced-bitmap-fonts/
+
+%global fontlicense       BSD-2-Clause
+%global fontlicenses      LICENSE
+%global fontdocs          FAQ ChangeLog AUTHORS README.md
+%global fontfamily        Spleen
+%global fontsummary       Monospaced bitmap fonts
+%global fonts             *.otf
+%global fontdescription   %fontsummary
+
+Source0:		https://github.com/fcambus/spleen/archive/refs/tags/%version.zip
+
+BuildRequires:	bmake fontforge
+BuildRequires:	bdf2sfd
+BuildRequires:  rpm_macro(fontpkg)
+
+%fontpkg
+
+%prep
+%autosetup -n spleen-%version
+
+%build
+%make_build sfd
+%make_build otf
+%fontbuild
+
+%install
+install -Dm644 fonts.alias *.otf -t %buildroot%_fontbasedir/%name/
+%fontinstall -a
+
+%check
+%fontcheck -a
+
+%fontfiles -a
+%_fontbasedir/%name/fonts.alias

--- a/anda/fonts/spleen/update.rhai
+++ b/anda/fonts/spleen/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("fcambus/spleen"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: spleen-fonts (#5637)](https://github.com/terrapkg/packages/pull/5637)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)