### PR TITLE
[f42] fix(kio): rm patch (#5847)

### DIFF
--- a/anda/desktops/kde/kf6-kio/kf6-kio.spec
+++ b/anda/desktops/kde/kf6-kio/kf6-kio.spec
@@ -28,9 +28,6 @@ Patch0:  0001-Give-the-kuriikwsfiltereng_private-a-VERSION-and-SOV.patch
 Patch101: kio-no-help-protocol.patch
 %endif
 
-# https://invent.kde.org/frameworks/kio/-/merge_requests/1556
-Patch201: 1556.patch
-
 Provides:       kf6-%{framework}
 BuildRequires:  extra-cmake-modules
 BuildRequires:  gcc-c++


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `f42`:
 - [fix(kio): rm patch (#5847)](https://github.com/terrapkg/packages/pull/5847)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)