### PR TITLE
[frawhide] add: deadbeef-mpris2-plugin (#5654)

### DIFF
--- a/anda/multimedia/deadbeef-mpris2-plugin/anda.hcl
+++ b/anda/multimedia/deadbeef-mpris2-plugin/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "deadbeef-mpris2-plugin.spec"
+	}
+	labels {
+		subrepo = "extras"
+	}
+}

--- a/anda/multimedia/deadbeef-mpris2-plugin/deadbeef-mpris2-plugin.spec
+++ b/anda/multimedia/deadbeef-mpris2-plugin/deadbeef-mpris2-plugin.spec
@@ -1,0 +1,51 @@
+#? https://github.com/rpmfusion/deadbeef-mpris2-plugin/
+
+Name:           deadbeef-mpris2-plugin
+Version:        1.16
+Release:        1%{?dist}
+Summary:        MPRISv2 plugin for the DeaDBeeF music player
+
+License:        GPLv2+
+URL:            https://github.com/DeaDBeeF-Player/%{name}
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+# Build for armv7hl failed
+# https://github.com/DeaDBeeF-Player/deadbeef/issues/2538
+ExcludeArch:    armv7hl
+
+BuildRequires:  gcc
+BuildRequires:  automake
+BuildRequires:  libtool
+BuildRequires:  glib2-devel
+BuildRequires:  deadbeef-devel
+
+Requires:       deadbeef%{?_isa}
+
+%description
+This plugin aims to implement the MPRISv2 for DeaDBeeF.
+
+The original MPRIS plugin for DeaDBeef does not work anymore and seems
+to be orphaned. The original plugin supported MPRISv1 AND MPRISv2. This plugin
+will only support version two.
+
+%prep
+%autosetup
+autoreconf -fiv
+
+
+%build
+%configure \
+ --disable-silent-rules \
+ --disable-static
+%{make_build}
+
+
+%install
+%{make_install}
+rm %{buildroot}%{_libdir}/deadbeef/mpris.*a
+
+
+%files
+%doc README
+%license LICENSE
+%{_libdir}/deadbeef/mpris.*

--- a/anda/multimedia/deadbeef-mpris2-plugin/update.rhai
+++ b/anda/multimedia/deadbeef-mpris2-plugin/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("DeaDBeeF-Player/deadbeef-mpris2-plugin"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [add: deadbeef-mpris2-plugin (#5654)](https://github.com/terrapkg/packages/pull/5654)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)