### PR TITLE
[f42] Nerdfetch package (#5856)

### DIFF
--- a/anda/tools/nerdfetch/anda.hcl
+++ b/anda/tools/nerdfetch/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "nerdfetch-tools.spec"
+  }
+}

--- a/anda/tools/nerdfetch/nerdfetch-tools.spec
+++ b/anda/tools/nerdfetch/nerdfetch-tools.spec
@@ -1,0 +1,33 @@
+Name: nerdfetch
+Version: 8.4.0
+Release: 1%?dist
+Summary: A POSIX *nix fetch script using Nerdfonts 
+
+License: MIT
+URL: https://github.com/ThatOneCalculator/NerdFetch
+Source0: %url/archive/refs/tags/v%version.tar.gz
+
+BuildArch: noarch
+Requires: /usr/bin/sh
+Requires: nerdfontssymbolsonly-nerd-fonts
+
+%description
+A POSIX *nix (Linux, macOS, Android, BSD, etc) fetch script using Nerdfonts (and others)
+
+%prep
+%autosetup -n NerdFetch-%version
+
+%build
+
+
+%install 
+install -Dpm755 nerdfetch %buildroot%_bindir/nerdfetch
+
+%files
+%license LICENSE
+%doc README.md
+%_bindir/nerdfetch
+
+%changelog
+* Tue Jul 16 2025 dotdot0 - 8.4.0-1
+- Initial Package 

--- a/anda/tools/nerdfetch/update.rhai
+++ b/anda/tools/nerdfetch/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("ThatOneCalculator/NerdFetch"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Nerdfetch package (#5856)](https://github.com/terrapkg/packages/pull/5856)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)