### PR TITLE
[el10] bump: rio v4l2loopback (#5870)

### DIFF
--- a/anda/devs/rio/rio.spec
+++ b/anda/devs/rio/rio.spec
@@ -4,7 +4,7 @@ A hardware-accelerated terminal emulator focusing to run in desktops and browser
 %bcond docs 1
 
 Name:          rio
-Version:       0.2.19
+Version:       0.2.21
 Release:       1%?dist
 Summary:       A hardware-accelerated terminal written in Rust.
 SourceLicense: MIT

--- a/anda/system/v4l2loopback/kmod-common/v4l2loopback.spec
+++ b/anda/system/v4l2loopback/kmod-common/v4l2loopback.spec
@@ -5,7 +5,7 @@
 
 Name:           v4l2loopback
 Summary:        Utils for V4L2 loopback devices
-Version:        0.15.0
+Version:        0.15.1
 Release:        1%?dist
 License:        GPL-2.0-or-later
 URL:            https://github.com/v4l2loopback/v4l2loopback


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump: rio v4l2loopback (#5870)](https://github.com/terrapkg/packages/pull/5870)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)