### PR TITLE
fix: remove `espanso-path` from the list of crates of `espanso` app

### DIFF
--- a/anda/tools/espanso-wayland/espanso-wayland.spec
+++ b/anda/tools/espanso-wayland/espanso-wayland.spec
@@ -31,7 +31,7 @@ cd espanso
 
 %build
 cd espanso
-%cargo_build -n -f vendored-tls,"wayland",modulo -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-modulo,espanso-package,espanso-path,espanso-render,espanso-ui}
+%cargo_build -n -f vendored-tls,"wayland",modulo -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-modulo,espanso-package,espanso-render,espanso-ui}
 
 %install
 mkdir -p %buildroot%_bindir

--- a/anda/tools/espanso-x11/espanso-x11.spec
+++ b/anda/tools/espanso-x11/espanso-x11.spec
@@ -31,7 +31,7 @@ cd espanso
 
 %build
 cd espanso
-%cargo_build -n -f vendored-tls,"default" -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-modulo,espanso-package,espanso-path,espanso-render,espanso-ui}
+%cargo_build -n -f vendored-tls,"default" -- --package={espanso,espanso-clipboard,espanso-config,espanso-detect,espanso-engine,espanso-info,espanso-inject,espanso-ipc,espanso-kvs,espanso-mac-utils,espanso-match,espanso-modulo,espanso-package,espanso-render,espanso-ui}
 
 %install
 mkdir -p %buildroot%_bindir


### PR DESCRIPTION
Hey! Espanso maintainer here. A user pointed me that yesterday the CI of terra failed because of:

> rpmbuild │ error: package ID specification `espanso-path` did not match any packages

That's because we merged the `espanso-path` crate with the main `espanso` crate in the PR https://github.com/espanso/espanso/pull/2286
So that's why it doesn't work

I believe this should fix the CI (at least from this error) 😇