### PR TITLE
[f41] add: neovim-default-editor (#5880)

### DIFF
--- a/anda/tools/neovim-default-editor/anda.hcl
+++ b/anda/tools/neovim-default-editor/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "neovim-default-editor.spec"
+	}
+	labels {
+		updbranch = 1
+	}
+}

--- a/anda/tools/neovim-default-editor/neovim-default-editor.spec
+++ b/anda/tools/neovim-default-editor/neovim-default-editor.spec
@@ -1,0 +1,44 @@
+%global commit abde842fa612fccf0f665462b4bd0b721f6b8f0e
+
+Name:          neovim-default-editor
+# Version, release, and epoch are inherited from the editor package just like other default editors
+Version:       0.11.3
+Release:       1%?dist
+Epoch: 0
+# Inherited from Neovim itself
+License:       Apache-2.0 AND Vim AND MIT
+Summary:       Sets Neovim as the default editor
+URL:           https://neovim.io
+Source0:       https://raw.githubusercontent.com/terrapkg/pkg-neovim-default-editor/%{commit}/neovim-default-editor.csh
+Source1:       https://raw.githubusercontent.com/terrapkg/pkg-neovim-default-editor/%{commit}/neovim-default-editor.sh
+Source2:       https://raw.githubusercontent.com/terrapkg/pkg-neovim-default-editor/%{commit}/neovim-default-editor.fish
+# For EVR macro
+BuildRequires: anda-srpm-macros
+Requires:      default-editor
+Requires:      neovim
+# All default editor packages MUST provide this
+Provides:      system-default-editor
+BuildArch:     noarch
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%description
+This package ensures the EDITOR shell variable
+is set in common shells to Neovim.
+
+%build
+# Nothing
+
+%install
+install -Dpm644 %{SOURCE0} -t %{buildroot}%{_sysconfdir}/profile.d/
+install -Dpm644 %{SOURCE1} -t %{buildroot}%{_sysconfdir}/profile.d/
+install -Dpm644 %{SOURCE2} -t %{buildroot}%{_datadir}/fish/vendor_conf.d/
+
+%files
+%dir %{_sysconfdir}/profile.d
+%config(noreplace) %{_sysconfdir}/profile.d/neovim-default-editor.*
+%dir %{_datadir}/fish/vendor_conf.d
+%{_datadir}/fish/vendor_conf.d/neovim-default-editor.fish
+
+%changelog
+* Fri Jul 18 2025 Gilver E. <rockgrub@disroot.org> - 0.11.3-1
+- Initial package

--- a/anda/tools/neovim-default-editor/update.rhai
+++ b/anda/tools/neovim-default-editor/update.rhai
@@ -1,0 +1,8 @@
+import "andax/bump_extras.rhai" as bump;
+
+let v = bump::bodhi_vr("neovim", bump::as_bodhi_ver(labels.branch));
+let e = sh("dnf rq --qf='%{epoch}' neovim --repo=fedora,updates", #{"stdout": "piped"}).ctx.stdout;
+
+rpm.version(v[1]);
+rpm.release(v[2]);
+rpm.f = sub(`^Epoch: (.+?)$`, "Epoch: " + e, rpm.f);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: neovim-default-editor (#5880)](https://github.com/terrapkg/packages/pull/5880)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)