### PR TITLE
[f42] fix: Bulk fixes of nightly packages/update scripts (#5899)

### DIFF
--- a/anda/apps/goofcord/nightly/update.rhai
+++ b/anda/apps/goofcord/nightly/update.rhai
@@ -1,6 +1,6 @@
 rpm.global("commit", gh_commit("Milkshiift/GoofCord"));
  if rpm.changed {
-   let v = gh_tag(""Milkshiift/GoofCord");
+   let v = gh_tag("Milkshiift/GoofCord");
    v.crop(1);
    rpm.global("ver", v);
    rpm.global("commit_date", date());

--- a/anda/desktops/waylands/hyprland-protocols/update.rhai
+++ b/anda/desktops/waylands/hyprland-protocols/update.rhai
@@ -1,5 +1,5 @@
-rpm.global("commit", gh_commit("hyprwm/hyprlang-protocols"));
+rpm.global("commit", gh_commit("hyprwm/hyprland-protocols"));
 if rpm.changed() {
-	rpm.global("ver", gh_rawfile("hyprwm/hyprlang-protocols", "main", "VERSION"));
+	rpm.global("ver", gh_rawfile("hyprwm/hyprland-protocols", "main", "VERSION"));
 	rpm.global("commit_date", date());
 }

--- a/anda/multimedia/rtaudio/rtaudio-nightly.spec
+++ b/anda/multimedia/rtaudio/rtaudio-nightly.spec
@@ -1,12 +1,16 @@
 #? https://src.fedoraproject.org/rpms/rtaudio/blob/db1aa72863ccbfd480e22c2f7aefb41ebb8e2360/f/rtaudio.spec
+%global commit 40e0d8140f14acd8552d2dc4f42dcc853274a12c
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20250430
+%global ver 6.0.1
 
 Name:           rtaudio-nightly
-Version:        6.0.1
+Version:        %{ver}^%{commit_date}.git.%{shortcommit}
 Release:        1%?dist
 Summary:        Real-time Audio I/O Library
 License:        MIT
-URL:            https://www.music.mcgill.ca/~gary/rtaudio/
-Source0:        %url/release/rtaudio-%version.tar.gz
+URL:            https://github.com/thestk/rtaudio
+Source0:        %url/archive/%commit.tar.gz
 Packager:       madonuko <mado@fyralabs.com>
 BuildRequires:  alsa-lib-devel
 BuildRequires:  doxygen
@@ -46,7 +50,7 @@ Provides:       rtaudio-devel = %version-%release
 
 
 %prep
-%autosetup -n rtaudio-%version
+%autosetup -n rtaudio-%commit
 # Fix encoding issues
 for file in tests/teststops.cpp; do
    sed 's|\r||' $file > $file.tmp

--- a/anda/multimedia/rtaudio/update.rhai
+++ b/anda/multimedia/rtaudio/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(find(`Latest Updates \(Version ([\d.]+)\)`, get("https://www.music.mcgill.ca/~gary/rtaudio/"), 1));
+rpm.version(gh("thestk/rtaudio"));

--- a/anda/system/falcond-profiles/update.rhai
+++ b/anda/system/falcond-profiles/update.rhai
@@ -2,5 +2,4 @@ rpm.global("commit", gh_commit("PikaOS-Linux/falcond-profiles"));
 	if rpm.changed() {
 		rpm.global("commit_date", date());
 		rpm.release();
-	}
 }

--- a/anda/system/rtl8821cu/kmod-common/update.rhai
+++ b/anda/system/rtl8821cu/kmod-common/update.rhai
@@ -4,5 +4,4 @@ rpm.global("commit", gh_commit("morrownr/8821cu-20210916"));
 		rpm.release();
                 let v = find(`PACKAGE_VERSION="([\d.]+)"`, gh_rawfile("morrownr/8821cu-20210916", "main", "dkms.conf"), 1);
                 rpm.global("ver", v);
-	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: Bulk fixes of nightly packages/update scripts (#5899)](https://github.com/terrapkg/packages/pull/5899)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)