### PR TITLE
[f41] feat(falcond): Track Gitea instead of GitHub mirror (#5904)

### DIFF
--- a/anda/system/falcond/update.rhai
+++ b/anda/system/falcond/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("PikaOS-Linux/falcond"));
+rpm.version(get("https://git.pika-os.com/api/v1/repos/general-packages/falcond/releases").json_arr()[0].tag_name);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(falcond): Track Gitea instead of GitHub mirror (#5904)](https://github.com/terrapkg/packages/pull/5904)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)