### PR TITLE
[el10] fix(rtaudio-nightly): Update build steps (#5903)

### DIFF
--- a/anda/multimedia/rtaudio/rtaudio-nightly.spec
+++ b/anda/multimedia/rtaudio/rtaudio-nightly.spec
@@ -13,6 +13,8 @@ URL:            https://github.com/thestk/rtaudio
 Source0:        %url/archive/%commit.tar.gz
 Packager:       madonuko <mado@fyralabs.com>
 BuildRequires:  alsa-lib-devel
+BuildRequires:  autoconf
+BuildRequires:  automake
 BuildRequires:  doxygen
 BuildRequires:  gcc-c++
 BuildRequires:  jack-audio-connection-kit-devel
@@ -62,9 +64,9 @@ done
 
 %build
 export CFLAGS="%optflags -fPIC"
+NOCONFIGURE=1 ./autogen.sh
 %configure --with-jack --with-alsa --with-pulse --enable-shared --disable-static --verbose
 %make_build
-
 
 %install
 %make_install

--- a/anda/multimedia/rtaudio/update.rhai
+++ b/anda/multimedia/rtaudio/update.rhai
@@ -1,1 +1,7 @@
-rpm.version(gh("thestk/rtaudio"));
+rpm.global("commit", gh_commit("thestk/rtaudio"));
+if rpm.changed() {
+    let v = gh("thestk/rtaudio");
+    v.crop(1);
+	rpm.global("ver", v);
+	rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(rtaudio-nightly): Update build steps (#5903)](https://github.com/terrapkg/packages/pull/5903)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)