### PR TITLE
[f42] fix(heroic): Drop no longer used license file (#5921)

### DIFF
--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -61,7 +61,6 @@ wait
 %install
 mkdir -p %{buildroot}%{_datadir}/%{shortname}
 mv $(find . -iname "*LICENSE*" -not -path "./node_modules/*" -and -not -path "./public/*") .
-mv LICENSE node-font-list.LICENSE
 rm -rf dist/linux-unpacked/resources/app.asar.unpacked/node_modules/font-list/libs/{darwin,win32}
 %ifarch aarch64
 # Keep the x86_64 Windows binaries run through Wine just in case
@@ -95,7 +94,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{reverse_dns}.deskto
 %license legendary.LICENSE
 %license LICENSES.chromium.html
 %license LICENSE.electron.txt
-%license node-font-list.LICENSE
 %dir %{_datadir}/%{shortname}
 %{_datadir}/%{shortname}/*
 %{_bindir}/%{shortname}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(heroic): Drop no longer used license file (#5921)](https://github.com/terrapkg/packages/pull/5921)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)