### PR TITLE
[f42] feat(eza): Add manpages and shell completions (#5926)

### DIFF
--- a/anda/langs/rust/eza/eza-fix-metadata-auto.diff
+++ b/anda/langs/rust/eza/eza-fix-metadata-auto.diff
@@ -1,11 +1,11 @@
---- eza-0.21.0/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ eza-0.21.0/Cargo.toml	2025-04-16T03:47:21.617301+00:00
-@@ -231,12 +231,6 @@
+--- eza-0.23.0/Cargo.toml	1970-01-01 08:00:01.000000000 +0800
++++ eza-0.23.0/Cargo.toml	2025-07-23 12:49:16.775971979 +0800
+@@ -225,12 +225,5 @@
  [target.'cfg(target_os = "linux")'.dependencies.proc-mounts]
  version = "0.3"
  
 -[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
--version = "0.59.0"
+-version = "0.60.2"
 -features = [
 -    "Win32_System_Console",
 -    "Win32_Foundation",
@@ -13,4 +13,3 @@
 -
  [target."cfg(unix)".dependencies.uzers]
  version = "0.12.1"
-+

--- a/anda/langs/rust/eza/rust-eza.spec
+++ b/anda/langs/rust/eza/rust-eza.spec
@@ -5,7 +5,7 @@
 
 Name:           rust-eza
 Version:        0.23.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Modern replacement for ls
 
 License:        EUPL-1.2
@@ -15,6 +15,7 @@ Source:         %{crates_source}
 Patch:          eza-fix-metadata-auto.diff
 
 BuildRequires:  anda-srpm-macros cargo-rpm-macros >= 24
+BuildRequires:  pandoc
 
 %global _description %{expand:
 A modern replacement for ls.}
@@ -40,6 +41,10 @@ License:        (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apa
 %doc SECURITY.md
 %doc TESTING.md
 %{_bindir}/eza
+%{_mandir}/man1/eza.1.gz
+%{_mandir}/man5/eza_colors{,-explanation}.5.gz
+
+%pkg_completion -Bfzn %{crate}
 
 %package        devel
 Summary:        %{summary}
@@ -178,8 +183,19 @@ use the "vendored-openssl" feature of the "%{crate}" crate.
 %{cargo_license_summary_online}
 %{cargo_license_online} > LICENSE.dependencies
 
+pandoc --standalone -f markdown -t man man/eza.1.md > man/eza.1
+pandoc --standalone -f markdown -t man man/eza_colors.5.md > man/eza_colors.5
+pandoc --standalone -f markdown -t man man/eza_colors-explanation.5.md > man/eza_colors-explanation.5
+
 %install
 %cargo_install
+
+install -Dpm 0644 completions/bash/eza      -t %{buildroot}%{bash_completions_dir}/
+install -Dpm 0644 completions/fish/eza.fish -t %{buildroot}%{fish_completions_dir}/
+install -Dpm 0644 completions/zsh/_eza      -t %{buildroot}%{zsh_completions_dir}/
+install -Dpm 0644 man/eza.1                     -t %{buildroot}%{_mandir}/man1/
+install -Dpm 0644 man/eza_colors.5              -t %{buildroot}%{_mandir}/man5/
+install -Dpm 0644 man/eza_colors-explanation.5  -t %{buildroot}%{_mandir}/man5/
 
 %if %{with check}
 %check


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(eza): Add manpages and shell completions (#5926)](https://github.com/terrapkg/packages/pull/5926)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)