### PR TITLE
chore: Switch downloads to Zig community mirrors

### DIFF
--- a/anda/langs/zig/bootstrap/update.rhai
+++ b/anda/langs/zig/bootstrap/update.rhai
@@ -4,4 +4,10 @@ let v = json.master.version;
 rpm.global("ver", v);
 if rpm.changed() {
    rpm.release();
+   // Update the Zig version in the script
+   sh(`sed -i 's/version=.*/version=${v}/' anda/langs/zig/choose-mirror.sh`, #{});
+   // This could be done with the rhai-rand Crate but Anda does not use this currently
+   let mirror = sh("anda/langs/zig/choose-mirror.sh", #{"stdout": "piped"}).ctx.stdout;
+   mirror.pop();
+   rpm.global("mirror_url", mirror);
 }

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -25,7 +25,7 @@
     --cache-dir "%{zig_cache_dir}" \
     --global-cache-dir "%{zig_cache_dir}" \
     \
-    -Dversion-string="%(v=%{ver}; echo ${v:0:6})" \
+    -Dversion-string="%(v=%{version}; echo ${v:0:6})" \
     -Dstatic-llvm=false \
     -Denable-llvm=true \
     -Dno-langref=true \
@@ -36,6 +36,7 @@
 %global zig_install_options %zig_build_options %{shrink: \
     --prefix "%{_prefix}" \
 }
+%global mirror_url https://pkg.machengine.org/zig
 
 Name:           zig-master-bootstrap
 Version:        %(echo %{ver} | sed 's/-/~/g')
@@ -43,8 +44,8 @@ Release:        1%?dist
 Summary:        Boostrap builds for Zig.
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
-Source0:        %{url}/builds/zig-%{ver}.tar.xz
-Source1:        %{url}/builds/zig-%{ver}.tar.xz.minisig
+Source0:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz
+Source1:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
 Patch3:         0005-link.Elf-add-root-directory-of-libraries-to-linker-p.patch
 BuildRequires:  cmake

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -44,8 +44,8 @@ Release:        1%?dist
 Summary:        Boostrap builds for Zig.
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
-Source0:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz
-Source1:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz.minisig
+Source0:        %{mirror_url}/zig-%{ver}.tar.xz
+Source1:        %{mirror_url}/zig-%{ver}.tar.xz.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
 Patch3:         0005-link.Elf-add-root-directory-of-libraries-to-linker-p.patch
 BuildRequires:  cmake

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -25,7 +25,7 @@
     --cache-dir "%{zig_cache_dir}" \
     --global-cache-dir "%{zig_cache_dir}" \
     \
-    -Dversion-string="%(v=%{version}; echo ${v:0:6})" \
+    -Dversion-string="%(v=%{ver}; echo ${v:0:6})" \
     -Dstatic-llvm=false \
     -Denable-llvm=true \
     -Dno-langref=true \

--- a/anda/langs/zig/choose-mirror.sh
+++ b/anda/langs/zig/choose-mirror.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+version=0.15.0-dev.1232+869ef0060
+
+# Self explanatory
+function randomize_mirrors() {
+  mirrors=("https://pkg.machengine.org/zig" "https://zigmirror.hryx.net/zig" "https://zig.linus.dev/zig" "https://zig.squirl.dev" "https://zig.florent.dev")
+  number=${#mirrors[@]}
+  index=$(( RANDOM % number ))
+  mirror=${mirrors[$index]}
+}
+
+# ONLY export mirrors to the update scripts if they connect on both files
+until curl -If $mirror/zig-${version}.tar.xz &>/dev/null && curl -If $mirror/zig-${version}.tar.xz.minisg &>/dev/null; do
+  randomize_mirrors
+done
+
+echo $mirror
+
+exit 0

--- a/anda/langs/zig/choose-mirror.sh
+++ b/anda/langs/zig/choose-mirror.sh
@@ -4,9 +4,7 @@ version=0.15.0-dev.1232+869ef0060
 
 # Self explanatory
 function randomize_mirrors() {
-  ## Benched mirrors (will be added back if issues with them are resolved):
-  # "https://zig.squirl.dev"
-  mirrors=("https://pkg.machengine.org/zig" "https://zigmirror.hryx.net/zig" "https://zig.linus.dev/zig" "https://zig.florent.dev")
+  mirrors=("https://pkg.machengine.org/zig" "https://zigmirror.hryx.net/zig" "https://zig.linus.dev/zig" "https://zig.squirl.dev" "https://zig.florent.dev")
   number=${#mirrors[@]}
   index=$(( RANDOM % number ))
   mirror=${mirrors[$index]}
@@ -14,7 +12,6 @@ function randomize_mirrors() {
 
 # ONLY export mirrors to the update scripts if they connect on both files
 until curl -If $mirror/zig-${version}.tar.xz &>/dev/null && curl -If $mirror/zig-${version}.tar.xz.minisig &>/dev/null; do
-  echo "404"
   randomize_mirrors
 done
 

--- a/anda/langs/zig/choose-mirror.sh
+++ b/anda/langs/zig/choose-mirror.sh
@@ -4,7 +4,9 @@ version=0.15.0-dev.1232+869ef0060
 
 # Self explanatory
 function randomize_mirrors() {
-  mirrors=("https://pkg.machengine.org/zig" "https://zigmirror.hryx.net/zig" "https://zig.linus.dev/zig" "https://zig.squirl.dev" "https://zig.florent.dev")
+  ## Benched mirrors (will be added back if issues with them are resolved):
+  # "https://zig.squirl.dev"
+  mirrors=("https://pkg.machengine.org/zig" "https://zigmirror.hryx.net/zig" "https://zig.linus.dev/zig" "https://zig.florent.dev")
   number=${#mirrors[@]}
   index=$(( RANDOM % number ))
   mirror=${mirrors[$index]}
@@ -12,6 +14,7 @@ function randomize_mirrors() {
 
 # ONLY export mirrors to the update scripts if they connect on both files
 until curl -If $mirror/zig-${version}.tar.xz &>/dev/null && curl -If $mirror/zig-${version}.tar.xz.minisig &>/dev/null; do
+  echo "404"
   randomize_mirrors
 done
 

--- a/anda/langs/zig/choose-mirror.sh
+++ b/anda/langs/zig/choose-mirror.sh
@@ -11,7 +11,7 @@ function randomize_mirrors() {
 }
 
 # ONLY export mirrors to the update scripts if they connect on both files
-until curl -If $mirror/zig-${version}.tar.xz &>/dev/null && curl -If $mirror/zig-${version}.tar.xz.minisg &>/dev/null; do
+until curl -If $mirror/zig-${version}.tar.xz &>/dev/null && curl -If $mirror/zig-${version}.tar.xz.minisig &>/dev/null; do
   randomize_mirrors
 done
 

--- a/anda/langs/zig/master/update.rhai
+++ b/anda/langs/zig/master/update.rhai
@@ -1,3 +1,9 @@
 import "andax/bump_extras.rhai" as bump;
 
 rpm.version(bump::madoguchi("zig-master-bootstrap", labels.branch));
+if rpm.changed() {
+   // This could be done with the rhai-rand Crate but Anda does not use this currently
+   let mirror = sh("anda/langs/zig/choose-mirror.sh", #{"stdout": "piped"}).ctx.stdout;
+   mirror.pop();
+   rpm.global("mirror_url", mirror);
+}

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -79,7 +79,7 @@ Packager:       Gilver E. <rockgrub@disroot.org>
     --cache-dir "%{zig_cache_dir}" \
     --global-cache-dir "%{zig_cache_dir}" \
     \
-    -Dversion-string="%(v=%{version}; echo ${v:0:6})" \
+    -Dversion-string="%(v=%{version_no_tilde}; echo ${v:0:6})" \
     -Dstatic-llvm=false \
     -Denable-llvm=true \
     -Dno-langref=true \

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -79,7 +79,7 @@ Packager:       Gilver E. <rockgrub@disroot.org>
     --cache-dir "%{zig_cache_dir}" \
     --global-cache-dir "%{zig_cache_dir}" \
     \
-    -Dversion-string="%(v=%{ver}; echo ${v:0:6})" \
+    -Dversion-string="%(v=%{version}; echo ${v:0:6})" \
     -Dstatic-llvm=false \
     -Denable-llvm=true \
     -Dno-langref=true \

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -11,30 +11,6 @@
 %bcond docs      %{without bootstrap}
 %bcond test      1
 %global zig_cache_dir %{builddir}/zig-cache
-%global zig_build_options %{shrink: \
-    --verbose \
-    --release=fast \
-    --summary all \
-    \
-    -Dtarget=native \
-    -Dcpu=baseline \
-    --zig-lib-dir lib \
-    --build-id=sha1 \
-    \
-    --cache-dir "%{zig_cache_dir}" \
-    --global-cache-dir "%{zig_cache_dir}" \
-    \
-    -Dversion-string="%(v=%{version}; echo ${v:0:6})" \
-    -Dstatic-llvm=false \
-    -Denable-llvm=true \
-    -Dno-langref=true \
-    -Dstd-docs=false \
-    -Dpie \
-    -Dconfig_h="%{__cmake_builddir}/config.h" \
-}
-%global zig_install_options %zig_build_options %{shrink: \
-    --prefix "%{_prefix}" \
-}
 %global mirror_url https://pkg.machengine.org/zig
 
 Name:           zig-master
@@ -88,6 +64,32 @@ Provides:       bundled(wasi-libc) = d03829489904d38c624f6de9983190f1e5e7c9c5
 Conflicts:      zig
 ExclusiveArch:  %{zig_arches}
 Packager:       Gilver E. <rockgrub@disroot.org>
+
+# Must be defined AFTER the version is
+%global zig_build_options %{shrink: \
+    --verbose \
+    --release=fast \
+    --summary all \
+    \
+    -Dtarget=native \
+    -Dcpu=baseline \
+    --zig-lib-dir lib \
+    --build-id=sha1 \
+    \
+    --cache-dir "%{zig_cache_dir}" \
+    --global-cache-dir "%{zig_cache_dir}" \
+    \
+    -Dversion-string="%(v=%{ver}; echo ${v:0:6})" \
+    -Dstatic-llvm=false \
+    -Denable-llvm=true \
+    -Dno-langref=true \
+    -Dstd-docs=false \
+    -Dpie \
+    -Dconfig_h="%{__cmake_builddir}/config.h" \
+}
+%global zig_install_options %zig_build_options %{shrink: \
+    --prefix "%{_prefix}" \
+}
 
 %description
 Zig is an open source alternative to C. 

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -11,6 +11,31 @@
 %bcond docs      %{without bootstrap}
 %bcond test      1
 %global zig_cache_dir %{builddir}/zig-cache
+%global zig_build_options %{shrink: \
+    --verbose \
+    --release=fast \
+    --summary all \
+    \
+    -Dtarget=native \
+    -Dcpu=baseline \
+    --zig-lib-dir lib \
+    --build-id=sha1 \
+    \
+    --cache-dir "%{zig_cache_dir}" \
+    --global-cache-dir "%{zig_cache_dir}" \
+    \
+    -Dversion-string="%(v=%{version}; echo ${v:0:6})" \
+    -Dstatic-llvm=false \
+    -Denable-llvm=true \
+    -Dno-langref=true \
+    -Dstd-docs=false \
+    -Dpie \
+    -Dconfig_h="%{__cmake_builddir}/config.h" \
+}
+%global zig_install_options %zig_build_options %{shrink: \
+    --prefix "%{_prefix}" \
+}
+%global mirror_url https://pkg.machengine.org/zig
 
 Name:           zig-master
 Version:        0.15.0~dev.1232+869ef0060
@@ -18,8 +43,8 @@ Release:        1%?dist
 Summary:        Master builds of the Zig language
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
-Source0:        %{url}/builds/zig-%{version_no_tilde}.tar.xz
-Source1:        %{url}/builds/zig-%{version_no_tilde}.tar.xz.minisig
+Source0:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz
+Source1:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
 Patch3:         0005-link.Elf-add-root-directory-of-libraries-to-linker-p.patch
 BuildRequires:  cmake
@@ -63,32 +88,6 @@ Provides:       bundled(wasi-libc) = d03829489904d38c624f6de9983190f1e5e7c9c5
 Conflicts:      zig
 ExclusiveArch:  %{zig_arches}
 Packager:       Gilver E. <rockgrub@disroot.org>
-
-# Must be defined AFTER the version is
-%global zig_build_options %{shrink: \
-    --verbose \
-    --release=fast \
-    --summary all \
-    \
-    -Dtarget=native \
-    -Dcpu=baseline \
-    --zig-lib-dir lib \
-    --build-id=sha1 \
-    \
-    --cache-dir "%{zig_cache_dir}" \
-    --global-cache-dir "%{zig_cache_dir}" \
-    \
-    -Dversion-string="%(v=%{version_no_tilde}; echo ${v:0:6})" \
-    -Dstatic-llvm=false \
-    -Denable-llvm=true \
-    -Dno-langref=true \
-    -Dstd-docs=false \
-    -Dpie \
-    -Dconfig_h="%{__cmake_builddir}/config.h" \
-}
-%global zig_install_options %zig_build_options %{shrink: \
-    --prefix "%{_prefix}" \
-}
 
 %description
 Zig is an open source alternative to C. 


### PR DESCRIPTION
Upstream has requested that CI builds fetch sources from the community hosted mirrors instead, and to use them randomly to do so. https://ziglang.org/download/community-mirrors

So I did.