### PR TITLE
[f41] chore(mpv-nightly): Update build (#5941)

### DIFF
--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,3 +1,6 @@
+# Disable X11 for RHEL 10+
+%bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
+
 %global commit 73c211871027bd804ddadf044d83ae7919693cfa
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20250727
@@ -42,8 +45,8 @@ BuildRequires:  pkgconfig(libavutil) >= 57.24.100
 BuildRequires:  pkgconfig(libbluray)
 BuildRequires:  pkgconfig(libcdio)
 BuildRequires:  pkgconfig(libcdio_paranoia)
-BuildRequires:  pkgconfig(libdisplay-info)
 BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(libdisplay-info)
 BuildRequires:  pkgconfig(libjpeg)
 BuildRequires:  pkgconfig(libpipewire-0.3) >= 0.3.19
 BuildRequires:  pkgconfig(libplacebo) >= 6.338.0
@@ -56,10 +59,8 @@ BuildRequires:  pkgconfig(mujs)
 BuildRequires:  pkgconfig(openal)
 BuildRequires:  pkgconfig(rubberband)
 BuildRequires:  pkgconfig(sdl2)
-BuildRequires:  pkgconfig(shaderc)
 BuildRequires:  pkgconfig(uchardet) >= 0.0.5
 BuildRequires:  pkgconfig(vapoursynth)
-BuildRequires:  pkgconfig(vdpau)
 BuildRequires:  pkgconfig(vulkan)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-cursor)
@@ -71,12 +72,15 @@ BuildRequires:  pkgconfig(xdamage)
 BuildRequires:  pkgconfig(xext)
 BuildRequires:  pkgconfig(xinerama)
 BuildRequires:  pkgconfig(xkbcommon)
-BuildRequires:  pkgconfig(xpresent)
 BuildRequires:  pkgconfig(xrandr)
-BuildRequires:  pkgconfig(xscrnsaver)
-BuildRequires:  pkgconfig(xv)
 BuildRequires:  pkgconfig(zimg) >= 2.9
 BuildRequires:  pkgconfig(zlib)
+%if %{with x11}
+BuildRequires:  pkgconfig(vdpau)
+BuildRequires:  pkgconfig(xpresent)
+BuildRequires:  pkgconfig(xscrnsaver)
+BuildRequires:  pkgconfig(xv)
+%endif
 
 Requires:       hicolor-icon-theme
 Provides:       mplayer-backend
@@ -146,10 +150,17 @@ sed -e "s|/usr/local/etc|%{_sysconfdir}/mpv|" -i etc/mpv.conf
     -Ddvdnav=enabled \
     -Degl-drm=enabled \
     -Degl-wayland=enabled \
+%if %{with x11}
     -Degl-x11=enabled \
+    -Dgl-x11=enabled \
+    -Dvaapi-x11=enabled \
+    -Dvdpau-gl-x11=enabled \
+    -Dvdpau=enabled \
+    -Dx11=enabled \
+    -Dxv=enabled \
+%endif
     -Degl=enabled \
     -Dgbm=enabled \
-    -Dgl-x11=enabled \
     -Dgl=enabled \
     -Dhtml-build=enabled \
     -Diconv=enabled \
@@ -174,22 +185,18 @@ sed -e "s|/usr/local/etc|%{_sysconfdir}/mpv|" -i etc/mpv.conf
     -Dsdl2-gamepad=enabled \
     -Dsdl2-video=enabled \
     -Dsdl2=enabled \
+    -Dshaderc=disabled \
     -Dsndio=disabled \
     -Dspirv-cross=disabled \
     -Duchardet=enabled \
     -Dvaapi-drm=enabled \
     -Dvaapi-wayland=enabled \
-    -Dvaapi-x11=enabled \
     -Dvaapi=enabled \
     -Dvapoursynth=enabled \
-    -Dvdpau-gl-x11=enabled \
-    -Dvdpau=enabled \
     -Dvector=enabled \
     -Dvulkan=enabled \
     -Dwayland=enabled \
     -Dwerror=false \
-    -Dx11=enabled \
-    -Dxv=enabled \
     -Dzimg=enabled \
     -Dzlib=enabled
 %meson_build
@@ -210,8 +217,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/mpv.desktop
 %{_datadir}/icons/hicolor/*/apps/mpv*.*
 %{_mandir}/man1/mpv.*
 %{_metainfodir}/mpv.metainfo.xml
-%dir %{_sysconfdir}/mpv/
-%config(noreplace) %{_sysconfdir}/mpv/encoding-profiles.conf
 
 %files libs
 %license LICENSE.GPL LICENSE.LGPL Copyright


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(mpv-nightly): Update build (#5941)](https://github.com/terrapkg/packages/pull/5941)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)