### PR TITLE
[el10] chore: Switch downloads to Zig community mirrors (#5937)

### DIFF
--- a/anda/langs/zig/bootstrap/update.rhai
+++ b/anda/langs/zig/bootstrap/update.rhai
@@ -4,4 +4,10 @@ let v = json.master.version;
 rpm.global("ver", v);
 if rpm.changed() {
    rpm.release();
+   // Update the Zig version in the script
+   sh(`sed -i 's/version=.*/version=${v}/' anda/langs/zig/choose-mirror.sh`, #{});
+   // This could be done with the rhai-rand Crate but Anda does not use this currently
+   let mirror = sh("anda/langs/zig/choose-mirror.sh", #{"stdout": "piped"}).ctx.stdout;
+   mirror.pop();
+   rpm.global("mirror_url", mirror);
 }

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -36,6 +36,7 @@
 %global zig_install_options %zig_build_options %{shrink: \
     --prefix "%{_prefix}" \
 }
+%global mirror_url https://pkg.machengine.org/zig
 
 Name:           zig-master-bootstrap
 Version:        %(echo %{ver} | sed 's/-/~/g')
@@ -43,8 +44,8 @@ Release:        1%?dist
 Summary:        Boostrap builds for Zig.
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
-Source0:        %{url}/builds/zig-%{ver}.tar.xz
-Source1:        %{url}/builds/zig-%{ver}.tar.xz.minisig
+Source0:        %{mirror_url}/zig-%{ver}.tar.xz
+Source1:        %{mirror_url}/zig-%{ver}.tar.xz.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
 Patch3:         0005-link.Elf-add-root-directory-of-libraries-to-linker-p.patch
 BuildRequires:  cmake

--- a/anda/langs/zig/choose-mirror.sh
+++ b/anda/langs/zig/choose-mirror.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+version=0.15.0-dev.1232+869ef0060
+
+# Self explanatory
+function randomize_mirrors() {
+  mirrors=("https://pkg.machengine.org/zig" "https://zigmirror.hryx.net/zig" "https://zig.linus.dev/zig" "https://zig.squirl.dev" "https://zig.florent.dev")
+  number=${#mirrors[@]}
+  index=$(( RANDOM % number ))
+  mirror=${mirrors[$index]}
+}
+
+# ONLY export mirrors to the update scripts if they connect on both files
+until curl -If $mirror/zig-${version}.tar.xz &>/dev/null && curl -If $mirror/zig-${version}.tar.xz.minisig &>/dev/null; do
+  randomize_mirrors
+done
+
+echo $mirror
+
+exit 0

--- a/anda/langs/zig/master/update.rhai
+++ b/anda/langs/zig/master/update.rhai
@@ -1,3 +1,9 @@
 import "andax/bump_extras.rhai" as bump;
 
 rpm.version(bump::madoguchi("zig-master-bootstrap", labels.branch));
+if rpm.changed() {
+   // This could be done with the rhai-rand Crate but Anda does not use this currently
+   let mirror = sh("anda/langs/zig/choose-mirror.sh", #{"stdout": "piped"}).ctx.stdout;
+   mirror.pop();
+   rpm.global("mirror_url", mirror);
+}

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -11,6 +11,7 @@
 %bcond docs      %{without bootstrap}
 %bcond test      1
 %global zig_cache_dir %{builddir}/zig-cache
+%global mirror_url https://pkg.machengine.org/zig
 
 Name:           zig-master
 Version:        0.15.0~dev.646+ef35c3d5f
@@ -18,8 +19,8 @@ Release:        2%?dist
 Summary:        Master builds of the Zig language
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
-Source0:        %{url}/builds/zig-%{version_no_tilde}.tar.xz
-Source1:        %{url}/builds/zig-%{version_no_tilde}.tar.xz.minisig
+Source0:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz
+Source1:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
 Patch3:         0005-link.Elf-add-root-directory-of-libraries-to-linker-p.patch
 BuildRequires:  cmake


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: Switch downloads to Zig community mirrors (#5937)](https://github.com/terrapkg/packages/pull/5937)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)