### PR TITLE
add: copyparty file server

### DIFF
--- a/anda/tools/copyparty/anda.hcl
+++ b/anda/tools/copyparty/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "copyparty.spec"
+    }
+}

--- a/anda/tools/copyparty/copyparty.spec
+++ b/anda/tools/copyparty/copyparty.spec
@@ -1,11 +1,11 @@
-%global debug_package %nil #needed to avoid "empty %files file" errors
+%global pypi_name copyparty
 
-Name:           copyparty
+Name:           %{pypi_name}
 Version:        1.18.6
 Release:        1%?dist
 Summary:        Portable, featureful, and fast file server 
 URL:            https://github.com/9001/copyparty
-Source0:        https://files.pythonhosted.org/packages/source/c/copyparty/copyparty-%version.tar.gz
+Source0:        %{pypi_source}
 License:        MIT
 BuildRequires:  python3-devel python3-pip pyproject-rpm-macros
 BuildRequires:  python3dist(wheel) python3dist(build) python3dist(jinja2)
@@ -20,10 +20,10 @@ Portable file server with accelerated resumable uploads, dedup, WebDAV,
 FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
 (runtime) deps (other than Python itself)
 
-%package -n     python3-copyparty
+%package -n     python3-%{pypi_name}
 Summary:        %{summary}
 
-%description -n python3-copyparty
+%description -n python3-%{pypi_name}
 
 Portable file server with accelerated resumable uploads, dedup, WebDAV, 
 FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
@@ -45,8 +45,8 @@ FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no
 %{_bindir}/partyfuse
 %{_bindir}/u2c
 
-%files -n python3-copyparty
-%{python3_sitelib}/copyparty*
+%files -n python3-%{pypi_name}
+%{python3_sitelib}/%{pypi_name}*
 
  
 %changelog

--- a/anda/tools/copyparty/copyparty.spec
+++ b/anda/tools/copyparty/copyparty.spec
@@ -1,20 +1,30 @@
 %global debug_package %nil #needed to avoid "empty %files file" errors
 
 Name:           copyparty
-Version:        1.18.5
+Version:        1.18.6
 Release:        1%?dist
 Summary:        Portable, featureful, and fast file server 
 URL:            https://github.com/9001/copyparty
-Source0:        %url/archive/refs/tags/v%version.tar.gz
+Source0:        https://files.pythonhosted.org/packages/source/c/copyparty/copyparty-%version.tar.gz
 License:        MIT
-BuildRequires:  python3-devel python3-pip
+BuildRequires:  python3-devel python3-pip pyproject-rpm-macros
 BuildRequires:  python3dist(wheel) python3dist(build) python3dist(jinja2)
 BuildRequires:  python3dist(setuptools) python3dist(installer)
 Requires:       python3
+Suggests:       ffmpeg python3dist(fuse)
 BuildArch:		noarch
 Packager:       Riley Loo <dev@zackerthescar.com>
 
 %description
+Portable file server with accelerated resumable uploads, dedup, WebDAV, 
+FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
+(runtime) deps (other than Python itself)
+
+%package -n     python3-copyparty
+Summary:        %{summary}
+
+%description -n python3-copyparty
+
 Portable file server with accelerated resumable uploads, dedup, WebDAV, 
 FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
 (runtime) deps (other than Python itself)
@@ -23,22 +33,23 @@ FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no
 %autosetup -n copyparty-%version
 
 %build
-python3 -m build
- 
+%pyproject_wheel
+
 %install
-python3 -m ensurepip
-python3 -m installer --destdir=%buildroot dist/*.whl
-rm -rf %buildroot/%python3_sitelib/*/__pycache__
-rm -rf %buildroot/usr/bin/*.py
+%pyproject_install
 
 %files
-%license /usr/share/doc/copyparty/LICENSE
-%doc /usr/share/doc/copyparty/README.md
-/usr/bin/copyparty
-/usr/bin/partyfuse
-/usr/bin/u2c
-/usr/lib/python3*/site-packages/copyparty*
+%license LICENSE
+%doc README.md
+%{_bindir}/copyparty
+%{_bindir}/partyfuse
+%{_bindir}/u2c
+
+%files -n python3-copyparty
+%{python3_sitelib}/copyparty*
+
  
 %changelog
+
 * Mon Jul 28 2025 Riley Loo <dev@zackerthescar.com>
 - Initial package

--- a/anda/tools/copyparty/copyparty.spec
+++ b/anda/tools/copyparty/copyparty.spec
@@ -1,0 +1,44 @@
+%global debug_package %nil #needed to avoid "empty %files file" errors
+
+Name:           copyparty
+Version:        1.18.5
+Release:        1%?dist
+Summary:        Portable, featureful, and fast file server 
+URL:            https://github.com/9001/copyparty
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+License:        MIT
+BuildRequires:  python3-devel python3-pip
+BuildRequires:  python3dist(wheel) python3dist(build) python3dist(jinja2)
+BuildRequires:  python3dist(setuptools) python3dist(installer)
+Requires:       python3
+BuildArch:		noarch
+Packager:       Riley Loo <dev@zackerthescar.com>
+
+%description
+Portable file server with accelerated resumable uploads, dedup, WebDAV, 
+FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
+(runtime) deps (other than Python itself)
+ 
+%prep
+%autosetup -n copyparty-%version
+
+%build
+python3 -m build
+ 
+%install
+python3 -m ensurepip
+python3 -m installer --destdir=%buildroot dist/*.whl
+rm -rf %buildroot/%python3_sitelib/*/__pycache__
+rm -rf %buildroot/usr/bin/*.py
+
+%files
+%license /usr/share/doc/copyparty/LICENSE
+%doc /usr/share/doc/copyparty/README.md
+/usr/bin/copyparty
+/usr/bin/partyfuse
+/usr/bin/u2c
+/usr/lib/python3*/site-packages/copyparty*
+ 
+%changelog
+* Mon Jul 28 2025 Riley Loo <dev@zackerthescar.com>
+- Initial package

--- a/anda/tools/copyparty/update.rhai
+++ b/anda/tools/copyparty/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("copyparty"));


### PR DESCRIPTION
[copyparty](https://github.com/9001/copyparty/) is a pretty cool file server. Renders on practically every browser I throw at it and serves files relatively fast. 

Currently does not list any dependencies but it may be a good idea to, since it has the ability to re-encode music files to the target browser's supported codecs with FFmpeg and uses cfssl to autogenerate a cert (It runs without these deps).