### PR TITLE
[el10] fix(zed, zed-nightly, zed-preview): Make compatible with ZFS (#5570)

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -16,7 +16,7 @@
 
 Name:           zed-nightly
 Version:        %ver^%commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
 SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
@@ -52,9 +52,32 @@ BuildRequires:  perl-lib
 BuildRequires:  rustup
 %endif
 BuildRequires:  vulkan-loader
+Requires: (%name-rename-zeditor if zfs else %name-cli)
+Suggests: %name-cli
 
 %description
 Code at the speed of thought - Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
+
+%package cli
+Summary: Provides the /usr/bin/zed binary
+Conflicts: zfs
+Supplements: (%name unless zfs)
+%description cli
+This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
+%files cli
+%_bindir/zed
+
+%package rename-zeditor
+Summary: Rename zed to zeditor to prevent collision with zfs
+Provides: %name-cli
+Conflicts: %name-cli
+Supplements: (%name and zfs)
+%description rename-zeditor
+This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
+The normal package is %name-cli.
+%files rename-zeditor
+%_bindir/zeditor
+
 
 %prep
 %autosetup -n %{crate}-%{commit} -p1
@@ -89,6 +112,7 @@ script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
+install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zeditor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
 %__cargo clean
@@ -133,7 +157,6 @@ mv assets/fonts/plex-mono/license.txt LICENSE.fonts
 %license LICENSE.themes
 %license assets/licenses.md
 %{_libexecdir}/zed-editor
-%{_bindir}/zed
 %{_datadir}/applications/%app_id.desktop
 %{_datadir}/pixmaps/%app_id.png
 %{_metainfodir}/%app_id.metainfo.xml

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -11,7 +11,7 @@
 
 Name:           zed-preview
 Version:        %(echo %ver | sed 's/-/~/')
-Release:        pre2%?dist
+Release:        3%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
 SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
@@ -44,9 +44,32 @@ BuildRequires:  perl-File-Compare
 BuildRequires:  perl-File-Copy
 BuildRequires:  perl-lib
 BuildRequires:  vulkan-loader
+Requires: (%name-rename-zeditor if zfs else %name-cli)
+Suggests: %name-cli
 
 %description
 Code at the speed of thought - Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
+
+%package cli
+Summary: Provides the /usr/bin/zed binary
+Conflicts: zfs
+Supplements: (%name unless zfs)
+%description cli
+This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
+%files cli
+%_bindir/zed
+
+%package rename-zeditor
+Summary: Rename zed to zeditor to prevent collision with zfs
+Provides: %name-cli
+Conflicts: %name-cli
+Supplements: (%name and zfs)
+%description rename-zeditor
+This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
+The normal package is %name-cli.
+%files rename-zeditor
+%_bindir/zeditor
+
 
 %prep
 %autosetup -n %{crate}-%{ver} -p1
@@ -78,6 +101,7 @@ script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
+install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zeditor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
 %__cargo clean
@@ -122,7 +146,6 @@ mv assets/fonts/plex-mono/license.txt LICENSE.fonts
 %license LICENSE.themes
 %license assets/licenses.md
 %{_libexecdir}/zed-editor
-%{_bindir}/zed
 %{_datadir}/applications/%app_id.desktop
 %{_datadir}/pixmaps/%app_id.png
 %{_metainfodir}/%app_id.metainfo.xml

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -10,7 +10,7 @@
 
 Name:           zed
 Version:        0.196.6
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
 SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
@@ -44,9 +44,32 @@ BuildRequires:  perl-File-Copy
 BuildRequires:  perl-lib
 BuildRequires:  vulkan-loader
 BuildRequires:  libcurl-devel
+Requires: (%name-rename-zeditor if zfs else %name-cli)
+Suggests: %name-cli
 
 %description
 Code at the speed of thought - Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
+
+%package cli
+Summary: Provides the /usr/bin/zed binary
+Conflicts: zfs
+Supplements: (%name unless zfs)
+%description cli
+This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
+%files cli
+%_bindir/zed
+
+%package rename-zeditor
+Summary: Rename zed to zeditor to prevent collision with zfs
+Provides: %name-cli
+Conflicts: %name-cli
+Supplements: (%name and zfs)
+%description rename-zeditor
+This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
+The normal package is %name-cli.
+%files rename-zeditor
+%_bindir/zeditor
+
 
 %prep
 %autosetup -n %{crate}-%{version} -p1
@@ -78,6 +101,7 @@ script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
+install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zeditor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
 %__cargo clean
@@ -122,7 +146,6 @@ mv assets/fonts/plex-mono/license.txt LICENSE.fonts
 %license LICENSE.themes
 %license assets/licenses.md
 %{_libexecdir}/zed-editor
-%{_bindir}/zed
 %{_datadir}/applications/%app_id.desktop
 %{_datadir}/pixmaps/%app_id.png
 %{_metainfodir}/%app_id.metainfo.xml


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(zed, zed-nightly, zed-preview): Make compatible with ZFS (#5570)](https://github.com/terrapkg/packages/pull/5570)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)