### PR TITLE
fix(zed,zed-preview,zed-nightly): Don't fail on warnings

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -108,7 +108,7 @@ export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed Nightly from Terra."
 echo "nightly" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
-script/generate-licenses
+ALLOW_MISSING_LICENSES=1 script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -97,7 +97,7 @@ export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed Preview from Terra."
 echo "preview" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
-script/generate-licenses
+ALLOW_MISSING_LICENSES=1 script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -97,7 +97,7 @@ export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed from Terra."
 echo "stable" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
-script/generate-licenses
+ALLOW_MISSING_LICENSES=1 script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor


### PR DESCRIPTION
Fedora has a hacky trick to override Cargo config. However, it results in the following warning:

```
warning: both `/builddir/build/BUILD/zed-0.195.5-build/zed-0.195.5/.cargo/config` and `/builddir/build/BUILD/zed-0.195.5-build/zed-0.195.5/.cargo/config.toml` exist. Using `/builddir/build/BUILD/zed-0.195.5-build/zed-0.195.5/.cargo/config
```

[This commit](https://github.com/zed-industries/zed/commit/2a6ef006f4ea35ee0e611aa26640aed8b655022a) made it so the Zed license script fails on Cargo warnings. Meaning it will *inherently* fail with Fedora's build macros.

However, it appears per [this line](https://github.com/zed-industries/zed/blob/e5269212ade866d33866af5dc008d0710058e0ec/script/generate-licenses#L38) that passing this env var *should* make the script ignore Cargo warnings.