### PR TITLE
[f42] fix(zed,zed-preview,zed-nightly): Don't fail on warnings (#5972)

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -108,7 +108,7 @@ export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed Nightly from Terra."
 echo "nightly" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
-script/generate-licenses
+ALLOW_MISSING_LICENSES=1 script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -97,7 +97,7 @@ export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed Preview from Terra."
 echo "preview" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
-script/generate-licenses
+ALLOW_MISSING_LICENSES=1 script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -97,7 +97,7 @@ export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed from Terra."
 echo "stable" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
-script/generate-licenses
+ALLOW_MISSING_LICENSES=1 script/generate-licenses
 
 %install
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(zed,zed-preview,zed-nightly): Don&#x27;t fail on warnings (#5972)](https://github.com/terrapkg/packages/pull/5972)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)