### PR TITLE
[f42] add: copyparty file server (#5968)

### DIFF
--- a/anda/tools/copyparty/anda.hcl
+++ b/anda/tools/copyparty/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "copyparty.spec"
+    }
+}

--- a/anda/tools/copyparty/copyparty.spec
+++ b/anda/tools/copyparty/copyparty.spec
@@ -1,0 +1,55 @@
+%global pypi_name copyparty
+
+Name:           %{pypi_name}
+Version:        1.18.6
+Release:        1%?dist
+Summary:        Portable, featureful, and fast file server 
+URL:            https://github.com/9001/copyparty
+Source0:        %{pypi_source}
+License:        MIT
+BuildRequires:  python3-devel python3-pip pyproject-rpm-macros
+BuildRequires:  python3dist(wheel) python3dist(build) python3dist(jinja2)
+BuildRequires:  python3dist(setuptools) python3dist(installer)
+Requires:       python3
+Suggests:       ffmpeg python3dist(fuse)
+BuildArch:		noarch
+Packager:       Riley Loo <dev@zackerthescar.com>
+
+%description
+Portable file server with accelerated resumable uploads, dedup, WebDAV, 
+FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
+(runtime) deps (other than Python itself)
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+
+%description -n python3-%{pypi_name}
+
+Portable file server with accelerated resumable uploads, dedup, WebDAV, 
+FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
+(runtime) deps (other than Python itself)
+ 
+%prep
+%autosetup -n copyparty-%version
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/copyparty
+%{_bindir}/partyfuse
+%{_bindir}/u2c
+
+%files -n python3-%{pypi_name}
+%{python3_sitelib}/%{pypi_name}*
+
+ 
+%changelog
+
+* Mon Jul 28 2025 Riley Loo <dev@zackerthescar.com>
+- Initial package

--- a/anda/tools/copyparty/update.rhai
+++ b/anda/tools/copyparty/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("copyparty"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: copyparty file server (#5968)](https://github.com/terrapkg/packages/pull/5968)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)