### PR TITLE
[el10] chore: New srpm-macros file (#5938)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -32,6 +32,7 @@ install -Dpm755 *.sh -t %buildroot%_libexecdir/%name/
 %{_rpmmacrodir}/macros.anda
 %{_rpmmacrodir}/macros.caching
 %{_rpmmacrodir}/macros.cargo_extra
+%{_rpmmacrodir}/macros.electron
 %{_rpmmacrodir}/macros.go_extra
 %{_rpmmacrodir}/macros.nim_extra
 %{_rpmmacrodir}/macros.nodejs_extra


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: New srpm-macros file (#5938)](https://github.com/terrapkg/packages/pull/5938)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)