### PR TITLE
[el10] exp: let's play with some azure runners (#5915)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -43,7 +43,7 @@ jobs:
         pkg: ${{ fromJson(needs.manifest.outputs.build_matrix) }}
         version: ["10"]
       fail-fast: false
-    runs-on: ${{ (matrix.pkg.arch == 'aarch64' && matrix.pkg.labels['large']) && 'arm64-lg' || matrix.pkg.arch == 'aarch64' && 'ubuntu-22.04-arm' || matrix.pkg.labels['large'] && 'x86-64-lg' || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.pkg.arch == 'aarch64' && matrix.pkg.labels['large']) && 'arm64-lg' || matrix.pkg.arch == 'aarch64' && 'ubuntu-22.04-arm' || matrix.pkg.labels['large'] && 'cirun-x86-64-lg--${{ github.run_id }}' || 'ubuntu-22.04' }}
     container:
       image: ghcr.io/terrapkg/builder:el${{ matrix.version }}
       options: --cap-add=SYS_ADMIN --privileged

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -15,7 +15,7 @@ jobs:
         pkg: ${{ fromJson(inputs.packages) }}
         version: ["10"]
       fail-fast: false
-    runs-on: ${{ (matrix.pkg.arch == 'aarch64' && matrix.pkg.labels['large']) && 'arm64-lg' || matrix.pkg.arch == 'aarch64' && 'ubuntu-22.04-arm' || matrix.pkg.labels['large'] && 'x86-64-lg' || 'ubuntu-22.04' }}
+    runs-on: ${{ (matrix.pkg.arch == 'aarch64' && matrix.pkg.labels['large']) && 'arm64-lg' || matrix.pkg.arch == 'aarch64' && 'ubuntu-22.04-arm' || matrix.pkg.labels['large'] && 'cirun-x86-64-lg--${{ github.run_id }}"' || 'ubuntu-22.04' }}
     container:
       image: ghcr.io/terrapkg/builder:el${{ matrix.version }}
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [exp: let's play with some azure runners (#5915)](https://github.com/terrapkg/packages/pull/5915)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)