### PR TITLE
[f42] fix(gamescope-session): files (#5989)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -33,6 +33,7 @@ cp -r usr %buildroot/
 %_userunitdir/gamescope-session-plus@.service
 %_datadir/gamescope-session-plus/device-quirks
 %_datadir/gamescope-session-plus/gamescope-session-plus
+%_datadir/gamescope/scripts/50-custom/50-disable-explicit-sync.lua
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(gamescope-session): files (#5989)](https://github.com/terrapkg/packages/pull/5989)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)