### PR TITLE
[el10] feat(kf6-kio): track ecm too in update (#5990)

### DIFF
--- a/anda/desktops/kde/kf6-kio/kf6-kio.spec
+++ b/anda/desktops/kde/kf6-kio/kf6-kio.spec
@@ -1,20 +1,22 @@
 %global framework kio
 
 %global stable_kf6 stable
-%global majmin_ver_kf6 6.12
+%global majmin_ver_kf6 6.17
+%global ecm_ver 6.17.0
+%global ecm_rel 1
 
 Name:    kf6-%{framework}
 Version: %{majmin_ver_kf6}.0
 Release: 1%{?dist}.switcheroo
 Summary: KDE Frameworks 6 Tier 3 solution for filesystem abstraction
 
-Provides: kf6-%{framework}.switcheroo = %version-%release
-Obsoletes: kf6-%{framework}.switcheroo < 6.13.0-2
+Obsoletes: kf6-%{framework}.switcheroo < 6.14.0-4
 
 License: BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-only AND GPL-2.0-or-later AND GPL-3.0-only AND LGPL-2.0-only AND LGPL-2.0-or-later AND LGPL-2.1-only AND LGPL-2.1-or-later AND LGPL-3.0-only AND (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only) AND MIT
 URL:     https://invent.kde.org/frameworks/%{framework}
 
 Source0: https://download.kde.org/%{stable_kf6}/frameworks/%{majmin_ver_kf6}/%{framework}-%{version}.tar.xz
+Source1: https://download.kde.org/%{stable_kf6}/frameworks/%{majmin_ver_kf6}/%{framework}-%{version}.tar.xz.sig
 
 # https://invent.kde.org/frameworks/kio/-/issues/26
 # I'm not sending this upstream because I'm not sure it's really
@@ -99,7 +101,7 @@ Requires:       cmake(KF6Solid)
 Requires:       cmake(KF6XmlGui)
 Requires:       cmake(KF6WindowSystem)
 Requires:       qt6-qtbase-devel
-Provides:       kf6-kio-devel = %version-%release
+Obsoletes:      kf6-kio.switcheroo-devel < 6.14.0-4
 %description    devel
 The %{name}-devel package contains libraries and header files for
 developing applications that use %{name}.
@@ -108,8 +110,7 @@ developing applications that use %{name}.
 Summary:        Documentation files for %{name}
 Requires:       %{name}-core = %{version}-%{release}
 BuildArch:      noarch
-Provides:       kf6-kio-doc = %version-%release
-Obsoletes:      kf6-kio-doc <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-doc < 6.14.0-4
 %description    doc
 Documentation for %{name}.
 
@@ -120,16 +121,14 @@ Requires:       %{name}-core-libs%{?_isa} = %{version}-%{release}
 Requires:       %{name}-doc = %{version}-%{release}
 Requires:       kf6-filesystem
 Recommends:     switcheroo-control
-Provides:       kf6-kio-core = %version-%release
-Obsoletes:      kf6-kio-core <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-core < 6.14.0-4
 %description    core
 KIOCore library provides core non-GUI components for working with KIO.
 
 %package        core-libs
 Summary:        Runtime libraries for KIO Core
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
-Provides:       kf6-kio-core-libs = %version-%release
-Obsoletes:      kf6-kio-core-libs <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-core-libs < 6.14.0-4
 %description    core-libs
 %{summary}.
 
@@ -139,8 +138,7 @@ Summary:        Widgets for KIO Framework
 ## included here for completeness, even those -core already has a dependency.
 %{?kf6_kinit_requires}
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
-Provides:       kf6-kio-widgets = %version-%release
-Obsoletes:      kf6-kio-widgets <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-widgets < 6.14.0-4
 %description    widgets
 KIOWidgets contains classes that provide generic job control, progress
 reporting, etc.
@@ -148,16 +146,14 @@ reporting, etc.
 %package        widgets-libs
 Summary:        Runtime libraries for KIO Widgets library
 Requires:       %{name}-widgets%{?_isa} = %{version}-%{release}
-Provides:       kf6-kio-widgets-libs = %version-%release
-Obsoletes:      kf6-kio-widgets-libs <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-widgets-libs < 6.14.0-4
 %description    widgets-libs
 %{summary}.
 
 %package        file-widgets
 Summary:        Widgets for file-handling for KIO Framework
 Requires:       %{name}-widgets%{?_isa} = %{version}-%{release}
-Provides:       kf6-kio-file-widgets = %version-%release
-Obsoletes:      kf6-kio-file-widgets <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-file-widgets < 6.14.0-4
 %description    file-widgets
 The KIOFileWidgets library provides the file selection dialog and
 its components.
@@ -166,17 +162,22 @@ its components.
 Summary:        Gui components for the KIO Framework
 Requires:       %{name}-core%{?_isa} = %{version}-%{release}
 Provides:       kf6-kio-gui = %version-%release
-Obsoletes:      kf6-kio-gui <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-gui < 6.14.0-4
 %description    gui
 %{summary}.
 
 %package        qch-doc
 Summary:        Developer Documentation files for %{name}
 BuildArch:      noarch
-Provides:       kf6-kio-qch-doc = %version-%release
-Obsoletes:      kf6-kio-qch-doc <= %version-%release
+Obsoletes:      kf6-kio.switcheroo-qch-doc < 6.14.0-4
 %description    qch-doc
 Developer Documentation files for %{name} for use with KDevelop or QtCreator.
+
+%package        html
+Summary:        Developer Documentation files for %{name}
+BuildArch:      noarch
+%description    html
+Developer Documentation files for %{name} in HTML format
 
 
 %prep
@@ -185,11 +186,11 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 
 %build
 %cmake_kf6
-%cmake_build
+%cmake_build_kf6
 
 
 %install
-%cmake_install
+%cmake_install_kf6
 %find_lang kf6-kio --all-name --with-man --with-html
 
 %files
@@ -236,10 +237,16 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 %{_kf6_libdir}/cmake/KF6KIO/
 %{_kf6_datadir}/kdevappwizard/templates/kioworker6.tar.bz2
 %{_kf6_qtplugindir}/designer/kio6widgets.so
-%{_qt6_docdir}/*.tags
- 
+%{_qt6_docdir}/*/*.tags
+%{_qt6_docdir}/*/*.index
+
 %files qch-doc
 %{_qt6_docdir}/*.qch
+
+%files html
+%{_qt6_docdir}/*/*
+%exclude %{_qt6_docdir}/*/*.tags
+%exclude %{_qt6_docdir}/*/*.index
 
 %changelog
 * Fri Feb 07 2025 Marc Deop i Argemí <marcdeop@fedoraproject.org> - 6.11.0-1
@@ -302,7 +309,7 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 
 * Fri Mar 15 2024 Marie Loise Nolden <loise@kde.org> - 6.0.0-5
 - add 6e7775d315f389df0a440ed62b842ce83dc9a27e.patch
-[kterminallauncherjob] Inherit default process environment from parent 
+[kterminallauncherjob] Inherit default process environment from parent
 
 * Mon Mar 11 2024 Yaakov Selkowitz <yselkowi@redhat.com> - 6.0.0-4
 - Soften switcheroo-control dependency

--- a/anda/desktops/kde/kf6-kio/update.rhai
+++ b/anda/desktops/kde/kf6-kio/update.rhai
@@ -14,3 +14,7 @@ for entry in get(url).json().updates[0].title.split(' ') {
   }
   break;
 }
+
+let vr = bump::bodhi_vr("extra-cmake-modules", branch);
+rpm.global("ecm_ver", vr[1]);
+rpm.global("ecm_rel", vr[2]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(kf6-kio): track ecm too in update (#5990)](https://github.com/terrapkg/packages/pull/5990)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)