### PR TITLE
[f41] feat(kf6-kio): track ecm too in update (#5990)

### DIFF
--- a/anda/desktops/kde/kf6-kio/kf6-kio.spec
+++ b/anda/desktops/kde/kf6-kio/kf6-kio.spec
@@ -1,7 +1,9 @@
 %global framework kio
 
 %global stable_kf6 stable
-%global majmin_ver_kf6 6.16
+%global majmin_ver_kf6 6.17
+%global ecm_ver 6.17.0
+%global ecm_rel 1
 
 Name:    kf6-%{framework}
 Version: %{majmin_ver_kf6}.0
@@ -175,7 +177,7 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 Summary:        Developer Documentation files for %{name}
 BuildArch:      noarch
 %description    html
-Developer Documentation files for %{name} in HTML format 
+Developer Documentation files for %{name} in HTML format
 
 
 %prep
@@ -236,15 +238,15 @@ Developer Documentation files for %{name} in HTML format
 %{_kf6_datadir}/kdevappwizard/templates/kioworker6.tar.bz2
 %{_kf6_qtplugindir}/designer/kio6widgets.so
 %{_qt6_docdir}/*/*.tags
-%{_qt6_docdir}/*/*.index 
- 
+%{_qt6_docdir}/*/*.index
+
 %files qch-doc
 %{_qt6_docdir}/*.qch
 
 %files html
 %{_qt6_docdir}/*/*
 %exclude %{_qt6_docdir}/*/*.tags
-%exclude %{_qt6_docdir}/*/*.index 
+%exclude %{_qt6_docdir}/*/*.index
 
 %changelog
 * Fri Feb 07 2025 Marc Deop i Argemí <marcdeop@fedoraproject.org> - 6.11.0-1
@@ -307,7 +309,7 @@ Developer Documentation files for %{name} in HTML format
 
 * Fri Mar 15 2024 Marie Loise Nolden <loise@kde.org> - 6.0.0-5
 - add 6e7775d315f389df0a440ed62b842ce83dc9a27e.patch
-[kterminallauncherjob] Inherit default process environment from parent 
+[kterminallauncherjob] Inherit default process environment from parent
 
 * Mon Mar 11 2024 Yaakov Selkowitz <yselkowi@redhat.com> - 6.0.0-4
 - Soften switcheroo-control dependency

--- a/anda/desktops/kde/kf6-kio/update.rhai
+++ b/anda/desktops/kde/kf6-kio/update.rhai
@@ -14,3 +14,7 @@ for entry in get(url).json().updates[0].title.split(' ') {
   }
   break;
 }
+
+let vr = bump::bodhi_vr("extra-cmake-modules", branch);
+rpm.global("ecm_ver", vr[1]);
+rpm.global("ecm_rel", vr[2]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(kf6-kio): track ecm too in update (#5990)](https://github.com/terrapkg/packages/pull/5990)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)