### PR TITLE
[el10] chore: Bump LCEVdec on <= 42 (#6003)

### DIFF
--- a/anda/multimedia/lcevcdec/LCEVCdec.spec
+++ b/anda/multimedia/lcevcdec/LCEVCdec.spec
@@ -9,8 +9,8 @@
 %bcond docs 0
 
 Name:           LCEVCdec
-Version:        3.3.7
-Release:        1%{?dist}
+Version:        4.0.1
+Release:        1%?dist
 Summary:        MPEG-5 LCEVC Decoder
 License:        BSD-3-Clause-Clear
 URL:            https://docs.v-nova.com/v-nova/lcevc/lcevc-sdk-overview


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [chore: Bump LCEVdec on &lt;&#x3D; 42 (#6003)](https://github.com/terrapkg/packages/pull/6003)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)