### PR TITLE
[el10] Add: piclone (#6010)

### DIFF
--- a/anda/tools/piclone/anda.hcl
+++ b/anda/tools/piclone/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "piclone.spec"
+  }
+}

--- a/anda/tools/piclone/piclone.spec
+++ b/anda/tools/piclone/piclone.spec
@@ -1,0 +1,60 @@
+%global commit 2d0d97cd76d9e570c14cf18ef3d6369d2513d13a
+%global commit_date 20250327
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           piclone
+Version:        %commit_date.git~%shortcommit
+Release:        1%?dist
+Summary:        Utility to back up Pi to an SD card reader
+License:        BSD-3-Clause
+URL:            https://github.com/raspberrypi-ui/piclone
+Source0:        %url/archive/%commit.tar.gz
+
+BuildRequires: meson
+BuildRequires: ninja-build
+BuildRequires: gtk3-devel
+BuildRequires: glib2-devel
+BuildRequires: intltool
+BuildRequires: vala
+BuildRequires: pkgconfig
+BuildRequires: gcc
+
+Requires: parted dosfstools e2fsprogs coreutils util-linux-core uuid dbus-x11 gtk3
+
+%description
+SD Card backup program for Raspberry Pi.
+This is a GTK application to copy the contents of SD cards and other USB
+drives. It mirrors the partition layout of the source device onto the
+target device, with the exception of the last partition, which is created
+to be the largest which will fit onto the target device.
+Files are then copied between all partitions - the result should be a
+bootable card with an image of the source device.
+
+%prep
+%autosetup -n piclone-%commit
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+%files
+%doc README
+%license debian/copyright
+%{_bindir}/piclone
+%{_datadir}/applications/piclone.desktop
+%{_datadir}/locale/de/LC_MESSAGES/piclone.mo
+%{_datadir}/locale/en_GB/LC_MESSAGES/piclone.mo
+%{_datadir}/locale/hy/LC_MESSAGES/piclone.mo
+%{_datadir}/locale/it/LC_MESSAGES/piclone.mo
+%{_datadir}/locale/ko/LC_MESSAGES/piclone.mo
+%{_datadir}/locale/nb/LC_MESSAGES/piclone.mo
+%{_datadir}/locale/sk/LC_MESSAGES/piclone.mo
+%{_datadir}/locale/zh_CN/LC_MESSAGES/piclone.mo
+%{_datadir}/piclone/piclone.ui
+
+%changelog
+* Thu Aug 07 2025 Owen Zimmerman <owen@fyralabs.com>
+- Package piclone

--- a/anda/tools/piclone/update.rhai
+++ b/anda/tools/piclone/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("raspberrypi-ui/piclone"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Add: piclone (#6010)](https://github.com/terrapkg/packages/pull/6010)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)