### PR TITLE
[f41] fix: Update bazzite.patch and mesa.spec for 25.2.0 (#6008)

### DIFF
--- a/anda/lib/mesa/bazzite.patch
+++ b/anda/lib/mesa/bazzite.patch
@@ -1,256 +1,16 @@
-From 27e5ca5e9f32a3dab5d9f22e53c34133a98fc1ef Mon Sep 17 00:00:00 2001
-From: Antheas Kapenekakis <git@antheas.dev>
-Date: Sat, 15 Mar 2025 16:38:53 +0100
-Subject: [PATCH 01/11] [NA] Developer files, readme, etc
-
----
- Containerfile | 117 ++++++++++++++++++++++++++++++++++++++++++++++++++
- sync.sh       |  94 ++++++++++++++++++++++++++++++++++++++++
- 2 files changed, 211 insertions(+)
- create mode 100644 Containerfile
- create mode 100755 sync.sh
-
-diff --git a/Containerfile b/Containerfile
-new file mode 100644
-index 00000000000..ba4ecf6c172
---- /dev/null
-+++ b/Containerfile
-@@ -0,0 +1,117 @@
-+ARG FEDORA_VERSION=41
-+
-+FROM fedora:${FEDORA_VERSION}
-+
-+# noarch
-+RUN dnf5 install -y \
-+    meson \
-+    python3-mako \
-+    python3-ply \
-+    python3-pycparser \
-+    rust-paste-devel \
-+    rust-proc-macro2-devel \
-+    rust-quote-devel \
-+    cargo-rpm-macros \
-+    rust-syn+clone-impls-devel \
-+    rust-unicode-ident-devel \
-+    vulkan-headers \
-+    wayland-protocols-devel \
-+    xorg-x11-proto-devel \
-+    && dnf5 clean all
-+
-+# x86_64
-+RUN dnf5 install -y \
-+    bindgen-cli \
-+    bison \
-+    cbindgen \
-+    clang-devel \
-+    elfutils-libelf-devel \
-+    expat-devel \
-+    flex \
-+    gcc \
-+    gettext \
-+    glslang \
-+    kernel-headers \
-+    libX11-devel \
-+    libXdamage-devel \
-+    libXext-devel \
-+    libXfixes-devel \
-+    libXrandr-devel \
-+    libXxf86vm-devel \
-+    libclc-devel \
-+    libdrm-devel \
-+    libglvnd-core-devel \
-+    libselinux-devel \
-+    libunwind-devel \
-+    libva-devel \
-+    libvdpau-devel \
-+    libxcb-devel \
-+    libxshmfence-devel \
-+    libzstd-devel \
-+    python3-devel \
-+    lm_sensors-devel \
-+    python3-pyyaml \
-+    valgrind-devel \
-+    spirv-llvm-translator-devel \
-+    spirv-tools-devel \
-+    vulkan-loader-devel \
-+    wayland-devel \
-+    zlib-ng-compat-devel
-+
-+# x86
-+RUN dnf5 install -y \
-+    clang-devel.i686 \
-+    elfutils-libelf-devel.i686 \
-+    expat-devel.i686 \
-+    glslang.i686 \
-+    kernel-headers.i686 \
-+    libX11-devel.i686 \
-+    libXdamage-devel.i686 \
-+    libXext-devel.i686 \
-+    libXfixes-devel.i686 \
-+    libXrandr-devel.i686 \
-+    libXxf86vm-devel.i686 \
-+    libclc-devel.i686 \
-+    libdrm-devel.i686 \
-+    libglvnd-core-devel.i686 \
-+    libselinux-devel.i686 \
-+    libunwind-devel.i686 \
-+    libva-devel.i686 \
-+    libvdpau-devel.i686 \
-+    libxcb-devel.i686 \
-+    libxshmfence-devel.i686 \
-+    libzstd-devel.i686 \
-+    python3-devel.i686 \
-+    lm_sensors-devel.i686 \
-+    valgrind-devel.i686 \
-+    spirv-llvm-translator-devel.i686 \
-+    spirv-tools-devel.i686 \
-+    vulkan-loader-devel.i686 \
-+    wayland-devel.i686 \
-+    zlib-ng-compat-devel.i686 \
-+    pkgconf-pkg-config.i686
-+
-+# these do not have an i686 version
-+# bindgen-cli.i686 \
-+# bison.i686 \
-+# cbindgen.i686 \
-+# flex.i686 \
-+# gcc.i686 \
-+# gettext.i686 \
-+# python3-pyyaml.i686 \
-+
-+RUN dnf install -y ccache
-+
-+ARG UID=1000
-+ARG GID=1000
-+
-+RUN groupadd -g $GID -o builder && \
-+    useradd -m -u $UID -g $GID -o -s /bin/bash builder && \
-+    echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder && \
-+    chmod 0440 /etc/sudoers.d/builder
-+
-+USER builder
-+
-+ENV PATH="/usr/lib64/ccache/:$PATH"
-+
-+WORKDIR /workspace
-\ No newline at end of file
-diff --git a/sync.sh b/sync.sh
-new file mode 100755
-index 00000000000..f0fa113f876
---- /dev/null
-+++ b/sync.sh
-@@ -0,0 +1,94 @@
-+if [ -z "$1" ]; then
-+    echo "Usage: $0 <host>"
-+    exit 1
-+fi
-+
-+# https://gist.github.com/Venemo/a9483106565df3a83fc67a411191edbd
-+
-+RHOST=$1
-+RSYNC="rsync -rv --exclude .git --exclude venv --exclude __pycache__ --links"
-+DEVUSER=${DEVUSER:-bazzite}
-+
-+# If RHOST=claw, set driver name to intel
-+if [ "$RHOST" = "claw" ]; then
-+    echo "Using Intel driver"
-+    DRIVER_NAME=intel
-+    VKICD_NAME=intel
-+    GALLIUM_DRIVER=iris
-+else
-+    echo "Using AMD driver"
-+    DRIVER_NAME=amd
-+    VKICD_NAME=radeon
-+    GALLIUM_DRIVER=radeonsi
-+fi
-+
-+set -e -x
-+
-+sudo podman build . --tag mesa_builder \
-+    --build-arg UID=$(id -u) --build-arg GID=$(id -g)
-+
-+PODMAN_RUN="sudo podman run --rm -v $(pwd):/workspace \
-+  --env CCACHE_DIR=/workspace/.cache \
-+  --env CCACHE_MAXSIZE=5G \
-+  --env CCACHE_COMPRESS=1 \
-+    -it mesa_builder"
-+
-+$PODMAN_RUN rm -rf build64 build32
-+
-+$PODMAN_RUN meson setup build64 --libdir lib64 --prefix /workspace/.out \
-+    -Dgallium-drivers=swrast,zink,$GALLIUM_DRIVER -Dvulkan-drivers=$DRIVER_NAME \
-+    -Dgallium-nine=true -Dbuildtype=release \
-+    -Dvideo-codecs=h264dec,h264enc,h265dec,h265enc,vc1dec
-+
-+# Cross-file for arch: lib32, fedora: ./gcc-i686
-+$PODMAN_RUN meson setup build32 --libdir lib --prefix /workspace/.out \
-+    -Dgallium-drivers=swrast,zink,$GALLIUM_DRIVER -Dvulkan-drivers=$DRIVER_NAME \
-+    -Dgallium-nine=true -Dbuildtype=release \
-+    -Dvideo-codecs=h264dec,h264enc,h265dec,h265enc,vc1dec
-+
-+time $PODMAN_RUN ninja -C build64 install
-+
-+time $PODMAN_RUN ninja -C build32 install
-+
-+RUNCONFIG=$(cat << EOF
-+
-+
-+MESA=/home/$DEVUSER/.out
-+
-+export LD_LIBRARY_PATH=\$MESA/lib64:\$MESA/lib:\$LD_LIBRARY_PATH
-+export LIBGL_DRIVERS_PATH=\$MESA/lib64/dri:\$MESA/lib/dri
-+export EGL_DRIVERS_PATH=\$MESA/lib64/dri:\$MESA/lib/dri
-+export VK_ICD_FILENAMES=\$MESA/share/vulkan/icd.d/${VKICD_NAME}_icd.x86_64.json:\$MESA/share/vulkan/icd.d/${VKICD_NAME}_icd.i686.json
-+export LIBVA_DRIVERS_PATH=\$MESA/lib64/dri:\$MESA/lib/dri
-+export VDPAU_DRIVER_PATH=\$MESA/lib64/vdpau
-+export D3D_MODULE_PATH=\$MESA/lib64/d3d/d3dadapter9.so.1:\$MESA/lib/d3d/d3dadapter9.so.1
-+# export ENABLE_GAMESCOPE_WSI=0
-+
-+EOF
-+)
-+
-+ssh $RHOST /bin/bash << EOF
-+    rm -rf .out
-+    mkdir -p .out
-+EOF
-+
-+echo "$RUNCONFIG" > .out/runconfig
-+
-+# Fixup vunkan_icd install dir
-+sed -i "s|/workspace/.out|/home/$DEVUSER/.out|g" .out/share/vulkan/icd.d/*.json
-+
-+$RSYNC .out/ $RHOST:.out/
-+
-+ssh $RHOST /bin/bash << EOF
-+    sudo rpm-ostree usroverlay --hotfix
-+
-+    # check if session does not have D3D_MODULE_PATH
-+    if ! grep -q D3D_MODULE_PATH /usr/share/gamescope-session-plus/device-quirks; then
-+        cat ~/.out/runconfig | sudo tee -a /usr/share/gamescope-session-plus/device-quirks
-+    fi
-+
-+    # sudo rsync -r -v ~/.out/* /usr/
-+    
-+    bazzite-session-select gamescope
-+    # sudo reboot
-+EOF
--- 
-2.49.0
-
-
-From 2f02ad01e44eddb1d78e6e2a336bb21b7c3c93af Mon Sep 17 00:00:00 2001
+From cc3cc28e7b1e76d3640be7a497271475fdcfc550 Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Sat, 15 Mar 2025 16:39:08 +0100
-Subject: [PATCH 02/11] [BEGIN] SteamOS Changes
+Subject: [PATCH 1/8] [BEGIN] SteamOS Changes
 
 -- 
-2.49.0
+2.50.1
 
 
-From d446cc1258a6c6fd042e9a3d651a799a033a2d8c Mon Sep 17 00:00:00 2001
+From 21b062a757a202dcb737d40442b6145c34bb1e48 Mon Sep 17 00:00:00 2001
 From: Bas Nieuwenhuizen <bas@basnieuwenhuizen.nl>
 Date: Fri, 14 Jan 2022 15:58:45 +0100
-Subject: [PATCH 03/11] STEAMOS: radv: min image count override for FH5
+Subject: [PATCH 2/8] STEAMOS: radv: min image count override for FH5
 
 Otherwise in combination with the vblank time reservation in
 gamescope the game could get stuck in low power states.
@@ -259,10 +19,10 @@ gamescope the game could get stuck in low power states.
  1 file changed, 4 insertions(+)
 
 diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
-index e0e5b34dc87..5e931f61760 100644
+index b82e8d4da4d..c8d059571ad 100644
 --- a/src/util/00-radv-defaults.conf
 +++ b/src/util/00-radv-defaults.conf
-@@ -238,5 +238,9 @@ Application bugs worked around in this file:
+@@ -234,5 +234,9 @@ Application bugs worked around in this file:
          <application name="Total War: WARHAMMER III" application_name_match="TotalWarhammer3">
              <option name="radv_disable_depth_storage" value="true"/>
          </application>
@@ -273,14 +33,14 @@ index e0e5b34dc87..5e931f61760 100644
      </device>
  </driconf>
 -- 
-2.49.0
+2.50.1
 
 
-From 016b60d32de3cd99e10207e7f0fa2c6fce91476c Mon Sep 17 00:00:00 2001
+From e837814b4f33e48eaf6a79975cb738da39ed0fd2 Mon Sep 17 00:00:00 2001
 From: Samuel Pitoiset <samuel.pitoiset@gmail.com>
 Date: Thu, 22 Feb 2024 22:32:45 +0100
-Subject: [PATCH 04/11] STEAMOS: Dynamic swapchain override for gamescope
- limiter for DRI3 only
+Subject: [PATCH 3/8] STEAMOS: Dynamic swapchain override for gamescope limiter
+ for DRI3 only
 
 The original patch (from Bas) contained WSI VK support too but it's
 been removed because the Gamescope WSI layer already handles that.
@@ -292,7 +52,7 @@ Signed-off-by: Samuel Pitoiset <samuel.pitoiset@gmail.com>
  2 files changed, 41 insertions(+), 2 deletions(-)
 
 diff --git a/src/gallium/frontends/dri/loader_dri3_helper.c b/src/gallium/frontends/dri/loader_dri3_helper.c
-index 37970f4fa33..f200f2063a2 100644
+index a795d45ce29..435ea2405a8 100644
 --- a/src/gallium/frontends/dri/loader_dri3_helper.c
 +++ b/src/gallium/frontends/dri/loader_dri3_helper.c
 @@ -297,6 +297,30 @@ dri3_update_max_num_back(struct loader_dri3_drawable *draw)
@@ -368,10 +128,10 @@ index 37970f4fa33..f200f2063a2 100644
         * successful MSC and adding in a swap interval for each outstanding swap
         * request. target_msc=divisor=remainder=0 means "Use glXSwapBuffers()
 diff --git a/src/gallium/frontends/dri/loader_dri3_helper.h b/src/gallium/frontends/dri/loader_dri3_helper.h
-index 4da19d73090..819a0e548fc 100644
+index 26f138d1b83..3f0f3f66fac 100644
 --- a/src/gallium/frontends/dri/loader_dri3_helper.h
 +++ b/src/gallium/frontends/dri/loader_dri3_helper.h
-@@ -170,6 +170,7 @@ struct loader_dri3_drawable {
+@@ -169,6 +169,7 @@ struct loader_dri3_drawable {
     bool block_on_depleted_buffers;
     bool queries_buffer_age;
     int swap_interval;
@@ -380,69 +140,31 @@ index 4da19d73090..819a0e548fc 100644
     const struct loader_dri3_vtable *vtable;
  
 -- 
-2.49.0
+2.50.1
 
 
-From 23db9ff0bf721f2c9080955c8c5dcf1f187d7adc Mon Sep 17 00:00:00 2001
+From 354cf8783e49b082c97982f2e5be305ad6e4ab50 Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Sat, 15 Mar 2025 16:39:25 +0100
-Subject: [PATCH 05/11] [BEGIN] SteamOS Backports
+Subject: [PATCH 4/8] [BEGIN] SteamOS Backports
 
 -- 
-2.49.0
+2.50.1
 
 
-From 69160c86a0d01b1c8482277faca1f6f7fa24cfce Mon Sep 17 00:00:00 2001
+From c5a4eab20075dfa2f2bdfb87e55ecec262ef00f6 Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Sat, 15 Mar 2025 16:39:33 +0100
-Subject: [PATCH 06/11] [BEGIN] Our Mesa backports
+Subject: [PATCH 5/8] [BEGIN] Our Mesa backports
 
 -- 
-2.49.0
+2.50.1
 
 
-From 59e3d359a4f4f78112ee965bb790dec2208ea480 Mon Sep 17 00:00:00 2001
-From: Maarten Lankhorst <maarten.lankhorst@intel.com>
-Date: Mon, 17 Feb 2025 14:55:29 -0800
-Subject: [PATCH 07/11] anv: Mark images with format modifiers set as scanout.
-
-We currently use the presence of struct WSI_IMAGE_CREATE_INFO_MESA.scanout to mark the BO as scanout,
-but this only handles the linear case, and fails when drm format modifiers are used.
-
-Also handle the case of exportable BO with tiling set to VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT.
-This fixes the gamescope handling of using vulkan allocated images for scanout.
-
-Link: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12633
-Signed-off-by: Maarten Lankhorst <dev@lankhorst.se>
-Signed-off-by: Matthew Schwartz <matthew.schwartz@linux.dev>
-
-Normalspeak: fixes battlemage iGPUs in gamescope
----
- src/intel/vulkan/anv_device.c | 3 +++
- 1 file changed, 3 insertions(+)
-
-diff --git a/src/intel/vulkan/anv_device.c b/src/intel/vulkan/anv_device.c
-index 0fb86e9d846..de37994d324 100644
---- a/src/intel/vulkan/anv_device.c
-+++ b/src/intel/vulkan/anv_device.c
-@@ -1566,6 +1566,9 @@ VkResult anv_AllocateMemory(
-           dedicated_info->image != VK_NULL_HANDLE) {
-          ANV_FROM_HANDLE(anv_image, image, dedicated_info->image);
- 
-+         if (image->vk.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)
-+            alloc_flags |= ANV_BO_ALLOC_SCANOUT;
-+
-          /* Apply implicit sync to be compatible with clients relying on
-           * implicit fencing. This matches the behavior in iris i915_batch
-           * submit. An example client is VA-API (iHD), so only dedicated
--- 
-2.49.0
-
-
-From 8c17b9dd7ad7f565080bd3623cfb820efb729444 Mon Sep 17 00:00:00 2001
+From 221b11df6d9cd7b66c8502fa51d8d72cfc377e5e Mon Sep 17 00:00:00 2001
 From: Antheas Kapenekakis <git@antheas.dev>
 Date: Mon, 24 Mar 2025 19:50:51 +0100
-Subject: [PATCH 08/11] Revert "winsys/amdgpu: use VM_ALWAYS_VALID for all VRAM
+Subject: [PATCH 6/8] Revert "winsys/amdgpu: use VM_ALWAYS_VALID for all VRAM
  and GTT allocations"
 
 This reverts commit 8c91624614c1f939974fe0d2d1a3baf83335cecb.
@@ -453,14 +175,14 @@ Messes with AutoVRAM, who would have thought?
  1 file changed, 5 deletions(-)
 
 diff --git a/src/gallium/winsys/amdgpu/drm/amdgpu_bo.c b/src/gallium/winsys/amdgpu/drm/amdgpu_bo.c
-index dfefc468bca..cc0719a1898 100644
+index d5646e9660b..a51348b44a8 100644
 --- a/src/gallium/winsys/amdgpu/drm/amdgpu_bo.c
 +++ b/src/gallium/winsys/amdgpu/drm/amdgpu_bo.c
-@@ -618,11 +618,6 @@ static struct amdgpu_winsys_bo *amdgpu_create_bo(struct amdgpu_winsys *aws,
+@@ -624,11 +624,6 @@ static struct amdgpu_winsys_bo *amdgpu_create_bo(struct amdgpu_winsys *aws,
     if (flags & RADEON_FLAG_GTT_WC)
        request.flags |= AMDGPU_GEM_CREATE_CPU_GTT_USWC;
  
--   if (aws->info.has_local_buffers &&
+-   if (aws->info.has_vm_always_valid &&
 -       initial_domain & (RADEON_DOMAIN_VRAM_GTT | RADEON_DOMAIN_DOORBELL) &&
 -       flags & RADEON_FLAG_NO_INTERPROCESS_SHARING)
 -      request.flags |= AMDGPU_GEM_CREATE_VM_ALWAYS_VALID;
@@ -469,22 +191,22 @@ index dfefc468bca..cc0719a1898 100644
         aws->info.drm_minor >= 47)
        request.flags |= AMDGPU_GEM_CREATE_DISCARDABLE;
 -- 
-2.49.0
+2.50.1
 
 
-From 816dec380bba16f65d7c65ddf9960a0ff79a8923 Mon Sep 17 00:00:00 2001
+From 21c90507cdbb7c2ca23b5d59421b28ac8081051f Mon Sep 17 00:00:00 2001
 From: Kyle Gospodnetich <me@kylegospodneti.ch>
 Date: Sun, 18 May 2025 09:40:01 -0700
-Subject: [PATCH 09/11] [BEGIN] Proton-GE Patches
+Subject: [PATCH 7/8] [BEGIN] Proton-GE Patches
 
 -- 
-2.49.0
+2.50.1
 
 
-From e768b0cf066c73e9c379d59d380462c15f050a03 Mon Sep 17 00:00:00 2001
+From 942ac03422d32e31102e3bff506f28ab6aeca18f Mon Sep 17 00:00:00 2001
 From: Kyle Gospodnetich <me@kylegospodneti.ch>
 Date: Sun, 18 May 2025 09:42:23 -0700
-Subject: [PATCH 10/11] radv: min image count patch for Wine Wayland/Path of
+Subject: [PATCH 8/8] radv: min image count patch for Wine Wayland/Path of
  Exile 2 Credit to Glorious Eggroll.
 
 ---
@@ -506,10 +228,10 @@ Subject: [PATCH 10/11] radv: min image count patch for Wine Wayland/Path of
  15 files changed, 42 insertions(+), 22 deletions(-)
 
 diff --git a/src/amd/vulkan/radv_instance.c b/src/amd/vulkan/radv_instance.c
-index d03b311fa07..910d3989451 100644
+index 6bcf18847bd..2773003911b 100644
 --- a/src/amd/vulkan/radv_instance.c
 +++ b/src/amd/vulkan/radv_instance.c
-@@ -148,7 +148,7 @@ static const struct debug_control trace_options[] = {
+@@ -151,7 +151,7 @@ static const struct debug_control trace_options[] = {
  static const driOptionDescription radv_dri_options[] = {
     DRI_CONF_SECTION_PERFORMANCE
        DRI_CONF_ADAPTIVE_SYNC(true)
@@ -519,7 +241,7 @@ index d03b311fa07..910d3989451 100644
        DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
        DRI_CONF_VK_KHR_PRESENT_WAIT(false)
 diff --git a/src/asahi/vulkan/hk_instance.c b/src/asahi/vulkan/hk_instance.c
-index 4be7a763da7..f1171053e0b 100644
+index 69e315ff979..b0361133793 100644
 --- a/src/asahi/vulkan/hk_instance.c
 +++ b/src/asahi/vulkan/hk_instance.c
 @@ -80,7 +80,7 @@ hk_EnumerateInstanceExtensionProperties(const char *pLayerName,
@@ -532,10 +254,10 @@ index 4be7a763da7..f1171053e0b 100644
        DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
        DRI_CONF_VK_KHR_PRESENT_WAIT(false)
 diff --git a/src/freedreno/vulkan/tu_device.cc b/src/freedreno/vulkan/tu_device.cc
-index dd79caf6927..a86a2e31017 100644
+index 2c72aff780d..f9d95c63bbe 100644
 --- a/src/freedreno/vulkan/tu_device.cc
 +++ b/src/freedreno/vulkan/tu_device.cc
-@@ -1623,7 +1623,7 @@ tu_destroy_physical_device(struct vk_physical_device *device)
+@@ -1671,7 +1671,7 @@ tu_destroy_physical_device(struct vk_physical_device *device)
  
  static const driOptionDescription tu_dri_options[] = {
     DRI_CONF_SECTION_PERFORMANCE
@@ -545,7 +267,7 @@ index dd79caf6927..a86a2e31017 100644
        DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
        DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
 diff --git a/src/intel/vulkan/anv_instance.c b/src/intel/vulkan/anv_instance.c
-index d478c2d52cd..e4ee0aa51ca 100644
+index 268a5f3425b..0ab889654ae 100644
 --- a/src/intel/vulkan/anv_instance.c
 +++ b/src/intel/vulkan/anv_instance.c
 @@ -10,7 +10,7 @@
@@ -558,7 +280,7 @@ index d478c2d52cd..e4ee0aa51ca 100644
        DRI_CONF_VK_KHR_PRESENT_WAIT(false)
        DRI_CONF_VK_XWAYLAND_WAIT_READY(false)
 diff --git a/src/intel/vulkan_hasvk/anv_device.c b/src/intel/vulkan_hasvk/anv_device.c
-index fd4f4c73a33..3cba9ac23ef 100644
+index 81f08e50e5d..7e9d43df7ce 100644
 --- a/src/intel/vulkan_hasvk/anv_device.c
 +++ b/src/intel/vulkan_hasvk/anv_device.c
 @@ -65,7 +65,7 @@
@@ -571,10 +293,10 @@ index fd4f4c73a33..3cba9ac23ef 100644
        DRI_CONF_VK_KHR_PRESENT_WAIT(false)
        DRI_CONF_VK_XWAYLAND_WAIT_READY(true)
 diff --git a/src/nouveau/vulkan/nvk_instance.c b/src/nouveau/vulkan/nvk_instance.c
-index 8c7d9050063..3966dab52c5 100644
+index 37e7abe1584..29da7e3a0b3 100644
 --- a/src/nouveau/vulkan/nvk_instance.c
 +++ b/src/nouveau/vulkan/nvk_instance.c
-@@ -103,7 +103,7 @@ nvk_init_debug_flags(struct nvk_instance *instance)
+@@ -98,7 +98,7 @@ nvk_init_debug_flags(struct nvk_instance *instance)
  static const driOptionDescription nvk_dri_options[] = {
     DRI_CONF_SECTION_PERFORMANCE
        DRI_CONF_ADAPTIVE_SYNC(true)
@@ -584,7 +306,7 @@ index 8c7d9050063..3966dab52c5 100644
        DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
        DRI_CONF_VK_KHR_PRESENT_WAIT(false)
 diff --git a/src/panfrost/vulkan/panvk_instance.c b/src/panfrost/vulkan/panvk_instance.c
-index f6cbe8de4b7..7d3e3c71acf 100644
+index 31abc8f4369..8c8f7a8ca0c 100644
 --- a/src/panfrost/vulkan/panvk_instance.c
 +++ b/src/panfrost/vulkan/panvk_instance.c
 @@ -151,7 +151,7 @@ panvk_kmod_free(const struct pan_kmod_allocator *allocator, void *data)
@@ -597,10 +319,10 @@ index f6cbe8de4b7..7d3e3c71acf 100644
        DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
        DRI_CONF_VK_KHR_PRESENT_WAIT(false)
 diff --git a/src/util/00-mesa-defaults.conf b/src/util/00-mesa-defaults.conf
-index 5f6034061c2..ca7511877ee 100644
+index d42526732fa..eaab8afc3e9 100644
 --- a/src/util/00-mesa-defaults.conf
 +++ b/src/util/00-mesa-defaults.conf
-@@ -625,24 +625,24 @@ TODO: document the other workarounds.
+@@ -634,24 +634,24 @@ TODO: document the other workarounds.
  
          <application name="gfxbench" executable="testfw_app">
              <option name="mesa_glthread_app_profile" value="0" />
@@ -629,7 +351,7 @@ index 5f6034061c2..ca7511877ee 100644
              <option name="vk_x11_strict_image_count" value="true" />
          </application>
  
-@@ -703,10 +703,12 @@ TODO: document the other workarounds.
+@@ -712,10 +712,12 @@ TODO: document the other workarounds.
  
          <application name="Path of Exile" executable="PathOfExile_x64Steam.exe">
              <option name="vk_zero_vram" value="true" />
@@ -643,10 +365,10 @@ index 5f6034061c2..ca7511877ee 100644
  
          <application name="X4 Foundations" executable="X4">
 diff --git a/src/util/driconf.h b/src/util/driconf.h
-index 86e00d6edd6..a00c4c0e9a5 100644
+index 8faa15fb560..c94de3f45fe 100644
 --- a/src/util/driconf.h
 +++ b/src/util/driconf.h
-@@ -448,8 +448,8 @@
+@@ -449,8 +449,8 @@
     DRI_CONF_OPT_B(vk_wsi_force_swapchain_to_current_extent, def, \
                    "Force VkSwapchainCreateInfoKHR::imageExtent to be VkSurfaceCapabilities2KHR::currentExtent")
  
@@ -658,7 +380,7 @@ index 86e00d6edd6..a00c4c0e9a5 100644
  
  #define DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(def) \
 diff --git a/src/virtio/vulkan/vn_instance.c b/src/virtio/vulkan/vn_instance.c
-index a843b463e84..4de75ceb8af 100644
+index 1942d77f67c..23c8e19188c 100644
 --- a/src/virtio/vulkan/vn_instance.c
 +++ b/src/virtio/vulkan/vn_instance.c
 @@ -70,8 +70,8 @@ static const struct vk_instance_extension_table
@@ -672,10 +394,10 @@ index a843b463e84..4de75ceb8af 100644
        DRI_CONF_VK_XWAYLAND_WAIT_READY(true)
        DRI_CONF_VENUS_IMPLICIT_FENCING(false)
 diff --git a/src/vulkan/wsi/wsi_common.c b/src/vulkan/wsi/wsi_common.c
-index 528605856d5..d0ffd475b8f 100644
+index f78e4baa22a..047d5dcdeaf 100644
 --- a/src/vulkan/wsi/wsi_common.c
 +++ b/src/vulkan/wsi/wsi_common.c
-@@ -219,7 +219,7 @@ wsi_device_init(struct wsi_device *wsi,
+@@ -220,7 +220,7 @@ wsi_device_init(struct wsi_device *wsi,
  #endif
  
  #ifdef VK_USE_PLATFORM_WAYLAND_KHR
@@ -685,7 +407,7 @@ index 528605856d5..d0ffd475b8f 100644
        goto fail;
  #endif
 diff --git a/src/vulkan/wsi/wsi_common.h b/src/vulkan/wsi/wsi_common.h
-index 08c1438cb1f..f12f57e70e0 100644
+index 44c81ccddf0..a97e7c2a948 100644
 --- a/src/vulkan/wsi/wsi_common.h
 +++ b/src/vulkan/wsi/wsi_common.h
 @@ -209,6 +209,10 @@ struct wsi_device {
@@ -700,10 +422,10 @@ index 08c1438cb1f..f12f57e70e0 100644
  
     /*
 diff --git a/src/vulkan/wsi/wsi_common_private.h b/src/vulkan/wsi/wsi_common_private.h
-index 51bfa77d4b2..593743c8b0e 100644
+index f138fee5519..1d1b55ac7e5 100644
 --- a/src/vulkan/wsi/wsi_common_private.h
 +++ b/src/vulkan/wsi/wsi_common_private.h
-@@ -413,7 +413,8 @@ void wsi_x11_finish_wsi(struct wsi_device *wsi_device,
+@@ -420,7 +420,8 @@ void wsi_x11_finish_wsi(struct wsi_device *wsi_device,
                          const VkAllocationCallbacks *alloc);
  VkResult wsi_wl_init_wsi(struct wsi_device *wsi_device,
                           const VkAllocationCallbacks *alloc,
@@ -714,7 +436,7 @@ index 51bfa77d4b2..593743c8b0e 100644
                         const VkAllocationCallbacks *alloc);
  VkResult wsi_win32_init_wsi(struct wsi_device *wsi_device,
 diff --git a/src/vulkan/wsi/wsi_common_wayland.c b/src/vulkan/wsi/wsi_common_wayland.c
-index d592aa59401..4c1bbed855e 100644
+index dd15d03846b..df68d2ea006 100644
 --- a/src/vulkan/wsi/wsi_common_wayland.c
 +++ b/src/vulkan/wsi/wsi_common_wayland.c
 @@ -58,6 +58,7 @@
@@ -725,7 +447,7 @@ index d592aa59401..4c1bbed855e 100644
  
  #include <loader/loader_wayland_helper.h>
  
-@@ -1684,9 +1685,12 @@ wsi_wl_surface_get_support(VkIcdSurfaceBase *surface,
+@@ -1668,9 +1669,12 @@ wsi_wl_surface_get_support(VkIcdSurfaceBase *surface,
  #define WSI_WL_DEFAULT_NUM_IMAGES 3
  
  static uint32_t
@@ -739,7 +461,7 @@ index d592aa59401..4c1bbed855e 100644
     if (present_mode) {
        return present_mode->presentMode == VK_PRESENT_MODE_MAILBOX_KHR ?
               WSI_WL_BUMPED_NUM_IMAGES : WSI_WL_DEFAULT_NUM_IMAGES;
-@@ -1735,7 +1739,7 @@ wsi_wl_surface_get_capabilities(VkIcdSurfaceBase *icd_surface,
+@@ -1719,7 +1723,7 @@ wsi_wl_surface_get_capabilities(VkIcdSurfaceBase *icd_surface,
        display = &temp_display;
     }
  
@@ -748,7 +470,7 @@ index d592aa59401..4c1bbed855e 100644
  
     if (!wsi_wl_surface->display)
        wsi_wl_display_finish(&temp_display);
-@@ -3497,7 +3501,7 @@ wsi_wl_surface_create_swapchain(VkIcdSurfaceBase *icd_surface,
+@@ -3481,7 +3485,7 @@ wsi_wl_surface_create_swapchain(VkIcdSurfaceBase *icd_surface,
        const VkSurfacePresentModeEXT mode =
              { VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_EXT, NULL, pCreateInfo->presentMode };
  
@@ -757,7 +479,7 @@ index d592aa59401..4c1bbed855e 100644
        bool requires_image_count_bump = min_images == WSI_WL_BUMPED_NUM_IMAGES;
        if (requires_image_count_bump)
           num_images = MAX2(min_images, num_images);
-@@ -3685,7 +3689,8 @@ fail:
+@@ -3676,7 +3680,8 @@ fail:
  VkResult
  wsi_wl_init_wsi(struct wsi_device *wsi_device,
                  const VkAllocationCallbacks *alloc,
@@ -767,7 +489,7 @@ index d592aa59401..4c1bbed855e 100644
  {
     struct wsi_wayland *wsi;
     VkResult result;
-@@ -3711,6 +3716,14 @@ wsi_wl_init_wsi(struct wsi_device *wsi_device,
+@@ -3702,6 +3707,14 @@ wsi_wl_init_wsi(struct wsi_device *wsi_device,
  
     wsi_device->wsi[VK_ICD_WSI_PLATFORM_WAYLAND] = &wsi->base;
  
@@ -783,10 +505,10 @@ index d592aa59401..4c1bbed855e 100644
  
  fail:
 diff --git a/src/vulkan/wsi/wsi_common_x11.c b/src/vulkan/wsi/wsi_common_x11.c
-index 65b7fdf7212..ea5d3750f46 100644
+index 2edb7bf2bf3..0f9e2a422c0 100644
 --- a/src/vulkan/wsi/wsi_common_x11.c
 +++ b/src/vulkan/wsi/wsi_common_x11.c
-@@ -2876,9 +2876,9 @@ wsi_x11_init_wsi(struct wsi_device *wsi_device,
+@@ -2924,9 +2924,9 @@ wsi_x11_init_wsi(struct wsi_device *wsi_device,
     }
  
     if (dri_options) {
@@ -799,211 +521,5 @@ index 65b7fdf7212..ea5d3750f46 100644
        if (driCheckOption(dri_options, "vk_x11_strict_image_count", DRI_BOOL)) {
           wsi_device->x11.strict_imageCount =
 -- 
-2.49.0
-
-
-From a1be005decba7afccc3f9ef36d7b8913d3e53952 Mon Sep 17 00:00:00 2001
-From: Kyle Gospodnetich <me@kylegospodneti.ch>
-Date: Sun, 18 May 2025 09:59:41 -0700
-Subject: [PATCH 11/11] vulkan/wsi/wayland: Move drm syncobj to swapchain
-
----
- src/vulkan/wsi/wsi_common_wayland.c | 84 +++++++++++++++--------------
- 1 file changed, 44 insertions(+), 40 deletions(-)
-
-diff --git a/src/vulkan/wsi/wsi_common_wayland.c b/src/vulkan/wsi/wsi_common_wayland.c
-index 4c1bbed855e..c4da2626a31 100644
---- a/src/vulkan/wsi/wsi_common_wayland.c
-+++ b/src/vulkan/wsi/wsi_common_wayland.c
-@@ -194,13 +194,9 @@ struct wsi_wl_surface {
-    struct zwp_linux_dmabuf_feedback_v1 *wl_dmabuf_feedback;
-    struct dmabuf_feedback dmabuf_feedback, pending_dmabuf_feedback;
- 
--   struct wp_linux_drm_syncobj_surface_v1 *wl_syncobj_surface;
--
-    struct vk_instance *instance;
- 
-    struct {
--      struct wp_color_management_surface_v1 *color_surface;
--      int color_surface_refcount;
-       VkColorSpaceKHR colorspace;
-       VkHdrMetadataEXT hdr_metadata;
-       bool has_hdr_metadata;
-@@ -214,6 +210,7 @@ struct wsi_wl_swapchain {
-    struct wp_tearing_control_v1 *tearing_control;
-    struct wp_fifo_v1 *fifo;
-    struct wp_commit_timer_v1 *commit_timer;
-+   struct wp_linux_drm_syncobj_surface_v1 *wl_syncobj_surface;
- 
-    struct wl_callback *frame;
- 
-@@ -256,6 +253,8 @@ struct wsi_wl_swapchain {
-    } present_ids;
- 
-    struct {
-+      struct wp_color_management_surface_v1 *color_surface;
-+      int color_surface_refcount;
-       VkColorSpaceKHR colorspace;
-       VkHdrMetadataEXT hdr_metadata;
-       bool has_hdr_metadata;
-@@ -1154,22 +1153,23 @@ needs_color_surface(struct wsi_wl_display *display, VkColorSpaceKHR colorspace)
- }
- 
- static void
--wsi_wl_surface_add_color_refcount(struct wsi_wl_surface *wsi_surface)
-+wsi_wl_swapchain_add_color_refcount(struct wsi_wl_swapchain *wsi_swapchain)
- {
--   wsi_surface->color.color_surface_refcount++;
--   if (wsi_surface->color.color_surface_refcount == 1) {
--      wsi_surface->color.color_surface =
-+   const struct wsi_wl_surface *wsi_surface = wsi_swapchain->wsi_wl_surface;
-+   wsi_swapchain->color.color_surface_refcount++;
-+   if (wsi_swapchain->color.color_surface_refcount == 1) {
-+      wsi_swapchain->color.color_surface =
-          wp_color_manager_v1_get_surface(wsi_surface->display->color_manager, wsi_surface->surface);
-    }
- }
- 
- static void
--wsi_wl_surface_remove_color_refcount(struct wsi_wl_surface *wsi_surface)
-+wsi_wl_swapchain_remove_color_refcount(struct wsi_wl_swapchain *wsi_swapchain)
- {
--   wsi_surface->color.color_surface_refcount--;
--   if (wsi_surface->color.color_surface_refcount == 0) {
--      wp_color_management_surface_v1_destroy(wsi_surface->color.color_surface);
--      wsi_surface->color.color_surface = NULL;
-+   wsi_swapchain->color.color_surface_refcount--;
-+   if (wsi_swapchain->color.color_surface_refcount == 0) {
-+      wp_color_management_surface_v1_destroy(wsi_swapchain->color.color_surface);
-+      wsi_swapchain->color.color_surface = NULL;
-    }
- }
- 
-@@ -1237,14 +1237,14 @@ wsi_wl_swapchain_update_colorspace(struct wsi_wl_swapchain *chain)
-       }
-    }
- 
--   bool new_color_surface = !surface->color.color_surface;
-+   bool new_color_surface = !chain->color.color_surface;
-    bool needs_color_surface_new = needs_color_surface(display, chain->color.colorspace);
--   bool needs_color_surface_old = surface->color.color_surface &&
--      needs_color_surface(display, surface->color.colorspace);
--   if (!needs_color_surface_old && needs_color_surface_new) {
--      wsi_wl_surface_add_color_refcount(surface);
-+   bool needs_color_surface_old = chain->color.color_surface &&
-+      needs_color_surface(display, chain->color.colorspace);
-+   if ((new_color_surface || !needs_color_surface_old) && needs_color_surface_new) {
-+      wsi_wl_swapchain_add_color_refcount(chain);
-    } else if (needs_color_surface_old && !needs_color_surface_new) {
--      wsi_wl_surface_remove_color_refcount(surface);
-+      wsi_wl_swapchain_remove_color_refcount(chain);
-    }
- 
-    struct wayland_hdr_metadata wayland_hdr_metadata = {
-@@ -1350,7 +1350,7 @@ wsi_wl_swapchain_update_colorspace(struct wsi_wl_swapchain *chain)
-       }
-    }
- 
--   wp_color_management_surface_v1_set_image_description(chain->wsi_wl_surface->color.color_surface,
-+   wp_color_management_surface_v1_set_image_description(chain->color.color_surface,
-                                                         image_desc,
-                                                         WP_COLOR_MANAGER_V1_RENDER_INTENT_PERCEPTUAL);
-    wp_image_description_v1_destroy(image_desc);
-@@ -2026,18 +2026,12 @@ wsi_wl_surface_destroy(VkIcdSurfaceBase *icd_surface, VkInstance _instance,
-    struct wsi_wl_surface *wsi_wl_surface =
-       wl_container_of((VkIcdSurfaceWayland *)icd_surface, wsi_wl_surface, base);
- 
--   if (wsi_wl_surface->wl_syncobj_surface)
--      wp_linux_drm_syncobj_surface_v1_destroy(wsi_wl_surface->wl_syncobj_surface);
--
-    if (wsi_wl_surface->wl_dmabuf_feedback) {
-       zwp_linux_dmabuf_feedback_v1_destroy(wsi_wl_surface->wl_dmabuf_feedback);
-       dmabuf_feedback_fini(&wsi_wl_surface->dmabuf_feedback);
-       dmabuf_feedback_fini(&wsi_wl_surface->pending_dmabuf_feedback);
-    }
- 
--   if (wsi_wl_surface->color.color_surface)
--      wp_color_management_surface_v1_destroy(wsi_wl_surface->color.color_surface);
--
-    if (wsi_wl_surface->surface)
-       wl_proxy_wrapper_destroy(wsi_wl_surface->surface);
- 
-@@ -2315,15 +2309,6 @@ static VkResult wsi_wl_surface_init(struct wsi_wl_surface *wsi_wl_surface,
-                                  wsi_wl_surface->display->queue);
-    }
- 
--   if (wsi_wl_use_explicit_sync(wsi_wl_surface->display, wsi_device)) {
--      wsi_wl_surface->wl_syncobj_surface =
--         wp_linux_drm_syncobj_manager_v1_get_surface(wsi_wl_surface->display->wl_syncobj,
--                                                     wsi_wl_surface->surface);
--
--      if (!wsi_wl_surface->wl_syncobj_surface)
--         goto fail;
--   }
--
-    wsi_wl_surface_analytics_init(wsi_wl_surface, pAllocator);
- 
-    return VK_SUCCESS;
-@@ -3005,11 +2990,11 @@ wsi_wl_swapchain_queue_present(struct wsi_swapchain *wsi_chain,
-       /* Incremented by signal in base queue_present. */
-       uint64_t acquire_point = image->base.explicit_sync[WSI_ES_ACQUIRE].timeline;
-       uint64_t release_point = image->base.explicit_sync[WSI_ES_RELEASE].timeline;
--      wp_linux_drm_syncobj_surface_v1_set_acquire_point(wsi_wl_surface->wl_syncobj_surface,
-+      wp_linux_drm_syncobj_surface_v1_set_acquire_point(chain->wl_syncobj_surface,
-                                                         image->wl_syncobj_timeline[WSI_ES_ACQUIRE],
-                                                         (uint32_t)(acquire_point >> 32),
-                                                         (uint32_t)(acquire_point & 0xffffffff));
--      wp_linux_drm_syncobj_surface_v1_set_release_point(wsi_wl_surface->wl_syncobj_surface,
-+      wp_linux_drm_syncobj_surface_v1_set_release_point(chain->wl_syncobj_surface,
-                                                         image->wl_syncobj_timeline[WSI_ES_RELEASE],
-                                                         (uint32_t)(release_point >> 32),
-                                                         (uint32_t)(release_point & 0xffffffff));
-@@ -3352,9 +3337,10 @@ wsi_wl_swapchain_chain_free(struct wsi_wl_swapchain *chain,
-       wl_callback_destroy(chain->frame);
-    if (chain->tearing_control)
-       wp_tearing_control_v1_destroy(chain->tearing_control);
--   if (needs_color_surface(wsi_wl_surface->display, chain->color.colorspace) &&
--       wsi_wl_surface->color.color_surface) {
--      wsi_wl_surface_remove_color_refcount(wsi_wl_surface);
-+   if (chain->wl_syncobj_surface)
-+      wp_linux_drm_syncobj_surface_v1_destroy(chain->wl_syncobj_surface);
-+   if (chain->color.color_surface) {
-+      wp_color_management_surface_v1_destroy(chain->color.color_surface);
-    }
- 
-    /* Only unregister if we are the non-retired swapchain, or
-@@ -3472,6 +3458,15 @@ wsi_wl_surface_create_swapchain(VkIcdSurfaceBase *icd_surface,
-          wp_commit_timer_v1_destroy(old_chain->commit_timer);
-          old_chain->commit_timer = NULL;
-       }
-+      if (old_chain->wl_syncobj_surface) {
-+         wp_linux_drm_syncobj_surface_v1_destroy(old_chain->wl_syncobj_surface);
-+         old_chain->wl_syncobj_surface = NULL;
-+      }
-+      if (old_chain->color.color_surface) {
-+         wp_color_management_surface_v1_destroy(old_chain->color.color_surface);
-+         old_chain->color.color_surface_refcount = 0;
-+         old_chain->color.color_surface = NULL;
-+      }
-    }
- 
-    /* Take ownership of the wsi_wl_surface */
-@@ -3520,6 +3515,15 @@ wsi_wl_surface_create_swapchain(VkIcdSurfaceBase *icd_surface,
-                                                           WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC);
-    }
- 
-+   if (wsi_wl_use_explicit_sync(wsi_wl_surface->display, wsi_device)) {
-+      chain->wl_syncobj_surface =
-+         wp_linux_drm_syncobj_manager_v1_get_surface(wsi_wl_surface->display->wl_syncobj,
-+                                                     wsi_wl_surface->surface);
-+
-+      if (!chain->wl_syncobj_surface)
-+         goto fail;
-+   }
-+
-    chain->color.colorspace = pCreateInfo->imageColorSpace;
- 
-    enum wsi_wl_buffer_type buffer_type;
--- 
-2.49.0
+2.50.1
 

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -12,7 +12,6 @@
 %if !0%{?rhel}
 %global with_r300 1
 %global with_r600 1
-%global with_nine 1
 %if 0%{?with_vulkan_hw}
 %global with_nvk %{with_vulkan_hw}
 %endif
@@ -30,7 +29,6 @@
 %ifarch %{ix86} x86_64
 %global with_crocus 1
 %global with_iris   1
-%global with_xa     1
 %global with_intel_clc 1
 %global intel_platform_vulkan %{?with_vulkan_hw:,intel,intel_hasvk}%{!?with_vulkan_hw:%{nil}}
 %if !0%{?rhel}
@@ -56,7 +54,6 @@
 %global with_freedreno 1
 %global with_kmsro     1
 %global with_panfrost  1
-%global with_xa        1
 %if 0%{?with_asahi}
 %global asahi_platform_vulkan %{?with_vulkan_hw:,asahi}%{!?with_vulkan_hw:%{nil}}
 %endif
@@ -176,6 +173,7 @@ BuildRequires:  (crate(proc-macro2) >= 1.0.56 with crate(proc-macro2) < 2)
 BuildRequires:  (crate(quote) >= 1.0.25 with crate(quote) < 2)
 BuildRequires:  (crate(syn/clone-impls) >= 2.0.15 with crate(syn/clone-impls) < 3)
 BuildRequires:  (crate(unicode-ident) >= 1.0.6 with crate(unicode-ident) < 2)
+BuildRequires:  (crate(rustc-hash) >= 2.1.1 with crate(rustc-hash) < 3)
 %endif
 %if %{with valgrind}
 BuildRequires:  pkgconfig(valgrind)
@@ -301,25 +299,6 @@ Provides:       libgbm-devel%{?_isa}
 %description libgbm-devel
 %{summary}.
 
-%if 0%{?with_xa}
-%package libxatracker
-Summary:        Mesa XA state tracker
-Provides:       libxatracker
-Provides:       libxatracker%{?_isa}
-
-%description libxatracker
-%{summary}.
-
-%package libxatracker-devel
-Summary:        Mesa XA state tracker development package
-Requires:       %{name}-libxatracker%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Provides:       libxatracker-devel
-Provides:       libxatracker-devel%{?_isa}
-
-%description libxatracker-devel
-%{summary}.
-%endif
-
 %if 0%{?with_opencl}
 %package libOpenCL
 Summary:        Mesa OpenCL runtime library
@@ -344,21 +323,6 @@ Requires:       %{name}-libOpenCL%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{rele
 Summary:        Mesa TensorFlow Lite delegate
 
 %description libTeflon
-%{summary}.
-%endif
-
-%if 0%{?with_nine}
-%package libd3d
-Summary:        Mesa Direct3D9 state tracker
-
-%description libd3d
-%{summary}.
-
-%package libd3d-devel
-Summary:        Mesa Direct3D9 state tracker development package
-Requires:       %{name}-libd3d%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-
-%description libd3d-devel
 %{summary}.
 %endif
 
@@ -399,7 +363,7 @@ export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
 
 %meson \
   -Dplatforms=x11,wayland \
-  -Dosmesa=true \
+  -Dgallium-mediafoundation=disabled \
 %if 0%{?with_hardware}
   -Dgallium-drivers=llvmpipe,virgl,nouveau%{?with_r300:,r300}%{?with_crocus:,crocus}%{?with_i915:,i915}%{?with_iris:,iris}%{?with_vmware:,svga}%{?with_radeonsi:,radeonsi}%{?with_r600:,r600}%{?with_asahi:,asahi}%{?with_freedreno:,freedreno}%{?with_etnaviv:,etnaviv}%{?with_tegra:,tegra}%{?with_vc4:,vc4}%{?with_v3d:,v3d}%{?with_lima:,lima}%{?with_panfrost:,panfrost}%{?with_vulkan_hw:,zink}%{?with_d3d12:,d3d12} \
 %else
@@ -407,12 +371,9 @@ export MESON_PACKAGE_CACHE_DIR="%{cargo_registry}/"
 %endif
   -Dgallium-vdpau=%{?with_vdpau:enabled}%{!?with_vdpau:disabled} \
   -Dgallium-va=%{?with_va:enabled}%{!?with_va:disabled} \
-  -Dgallium-xa=%{?with_xa:enabled}%{!?with_xa:disabled} \
-  -Dgallium-nine=%{?with_nine:true}%{!?with_nine:false} \
   -Dteflon=%{?with_teflon:true}%{!?with_teflon:false} \
 %if 0%{?with_opencl}
   -Dgallium-rusticl=true \
-  -Dgallium-opencl=disabled \
 %endif
   -Dvulkan-drivers=%{?vulkan_drivers} \
   -Dvulkan-layers=device-select \
@@ -507,23 +468,6 @@ popd
 %{_includedir}/gbm_backend_abi.h
 %{_libdir}/pkgconfig/gbm.pc
 
-%if 0%{?with_xa}
-%files libxatracker
-%if 0%{?with_hardware}
-%{_libdir}/libxatracker.so.2
-%{_libdir}/libxatracker.so.2.*
-%endif
-
-%files libxatracker-devel
-%if 0%{?with_hardware}
-%{_libdir}/libxatracker.so
-%{_includedir}/xa_tracker.h
-%{_includedir}/xa_composite.h
-%{_includedir}/xa_context.h
-%{_libdir}/pkgconfig/xatracker.pc
-%endif
-%endif
-
 %if 0%{?with_teflon}
 %files libTeflon
 %{_libdir}/libteflon.so
@@ -536,17 +480,6 @@ popd
 
 %files libOpenCL-devel
 %{_libdir}/libRusticlOpenCL.so
-%endif
-
-%if 0%{?with_nine}
-%files libd3d
-%dir %{_libdir}/d3d/
-%{_libdir}/d3d/*.so.*
-
-%files libd3d-devel
-%{_libdir}/pkgconfig/d3d.pc
-%{_includedir}/d3dadapter/
-%{_libdir}/d3d/*.so
 %endif
 
 %files dri-drivers


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix: Update bazzite.patch and mesa.spec for 25.2.0 (#6008)](https://github.com/terrapkg/packages/pull/6008)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)