### PR TITLE
[f42] add: raindrop (#6011)

### DIFF
--- a/anda/tools/raindrop/anda.hcl
+++ b/anda/tools/raindrop/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "raindrop.spec"
+	}
+}

--- a/anda/tools/raindrop/desktop-file-call-pkexec.patch
+++ b/anda/tools/raindrop/desktop-file-call-pkexec.patch
@@ -1,0 +1,13 @@
+diff --git a/data/raindrop.desktop.in b/data/raindrop.desktop.in
+index 69e66f7..a042659 100644
+--- data/raindrop.desktop.in
++++ data/raindrop.desktop.in
+@@ -3,7 +3,7 @@ Type=Application
+ Name=Screen Configuration
+ Comment=Configure monitor arrangement, scaling and orientation
+ Icon=computer
+-Exec=raindrop
++Exec=sh -c 'pkexec /usr/bin/raindrop'
+ Terminal=false
+ Categories=Settings;
+ StartupNotify=true

--- a/anda/tools/raindrop/org.raspberrypi.raindrop.configure-display.policy
+++ b/anda/tools/raindrop/org.raspberrypi.raindrop.configure-display.policy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+ <policyconfig>
+
+  <action id="org.raspberrypi.raindrop.configure-display">
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <description>GTK screen configuration tool for labwc and openbox environments.</description>
+    <message>Authentication is required to configure the system's display settings.</message>
+    <icon_name>computer</icon_name>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/raindrop</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+</policyconfig>

--- a/anda/tools/raindrop/raindrop.spec
+++ b/anda/tools/raindrop/raindrop.spec
@@ -1,0 +1,53 @@
+%global commit 66271d1eea4740131bae3aaec499a7ce06441ace
+%global commit_date 20250530
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           raindrop
+Version:        0~%commit_date.git~%shortcommit
+Release:        1%?dist
+Summary:        Desktop front-end for arandr and wlrandr
+License:        BSD-3-Clause
+URL:            https://github.com/raspberrypi-ui/raindrop
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+Source0:        %url/archive/%commit.tar.gz
+Source1:        org.raspberrypi.raindrop.configure-display.policy
+Patch0:         desktop-file-call-pkexec.patch
+
+BuildRequires: meson
+BuildRequires: ninja-build
+BuildRequires: gtk3-devel
+BuildRequires: libxml2-devel
+BuildRequires: intltool
+BuildRequires: pkgconfig
+BuildRequires: gcc
+BuildRequires: gtk-layer-shell-devel
+BuildRequires: polkit
+
+Requires: libxml2 libinput wlr-randr gtk3 polkit
+
+%description
+Screen configuration tool for Raspberry Pi Desktop,
+GTK screen configuration tool for labwc and openbox environments.
+
+%prep
+%autosetup -n raindrop-%commit -p0
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+install -Dm644 %{SOURCE1} %{buildroot}/%{_datadir}/polkit-1/actions/org.raspberrypi.raindrop.configure-display.policy
+%find_lang %{name}
+
+%files -f %{name}.lang
+%license debian/copyright
+%{_bindir}/raindrop
+%{_datadir}/polkit-1/actions/org.raspberrypi.raindrop.configure-display.policy
+%{_datadir}/applications/raindrop.desktop
+%{_datadir}/raindrop/ui/raindrop.ui
+
+%changelog
+* Thu Aug 07 2025 Owen Zimmerman <owen@fyralabs.com>
+- Package raindrop

--- a/anda/tools/raindrop/update.rhai
+++ b/anda/tools/raindrop/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("raspberrypi-ui/raindrop"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: raindrop (#6011)](https://github.com/terrapkg/packages/pull/6011)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)