### PR TITLE
[f41] Add: rp-bookshelf (#6025)

### DIFF
--- a/anda/apps/rp-bookshelf/anda.hcl
+++ b/anda/apps/rp-bookshelf/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "rp-bookshelf.spec"
+  }
+}

--- a/anda/apps/rp-bookshelf/rp-bookshelf.spec
+++ b/anda/apps/rp-bookshelf/rp-bookshelf.spec
@@ -1,0 +1,50 @@
+%global commit 53102fb6f4b0324cc89635f0ef58966c6b847a74
+%global commit_date 20250327
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           rp-bookshelf
+Version:        0~%commit_date.git~%shortcommit
+Release:        1%?dist
+Summary:        Browser for Raspberry Pi Press publications in PDF format
+License:        BSD-3-Clause
+URL:            https://github.com/raspberrypi-ui/bookshelf
+Source0:        %url/archive/%commit.tar.gz
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires: meson
+BuildRequires: ninja-build
+BuildRequires: gtk3-devel
+BuildRequires: libcurl-devel
+BuildRequires: intltool
+BuildRequires: gcc
+
+Requires: libcurl gtk3
+
+%description
+%summary.
+
+%prep
+%autosetup -n bookshelf-%commit
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+%find_lang %{name}
+
+%files -f %{name}.lang
+%doc README
+%license debian/copyright
+%{_bindir}/rp-bookshelf
+%{_datadir}/icons/hicolor/16x16/apps/bookshelf.png
+%{_datadir}/icons/hicolor/24x24/apps/bookshelf.png
+%{_datadir}/icons/hicolor/32x32/apps/bookshelf.png
+%{_datadir}/icons/hicolor/48x48/apps/bookshelf.png
+%{_datadir}/applications/rp-bookshelf.desktop
+%{_datadir}/rp-bookshelf/*
+
+%changelog
+* Fri Aug 08 2025 Owen Zimmerman <owen@fyralabs.com>
+- Package bookshelf

--- a/anda/apps/rp-bookshelf/update.rhai
+++ b/anda/apps/rp-bookshelf/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("raspberrypi-ui/bookshelf"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Add: rp-bookshelf (#6025)](https://github.com/terrapkg/packages/pull/6025)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)