### PR TITLE
[el10] fix: coreboot utils fix (#6052)

### DIFF
--- a/anda/tools/coreboot-utils/coreboot-utils.spec
+++ b/anda/tools/coreboot-utils/coreboot-utils.spec
@@ -739,6 +739,8 @@ cp Documentation/util/smmstoretool/index.md %{buildroot}%{_docdir}/coreboot-util
 %files abuild
 %{_bindir}/abuild
 
+%files all
+
 %files amdfwtool
 %{_bindir}/amdfwtool
 %{_bindir}/amdfwread


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: coreboot utils fix (#6052)](https://github.com/terrapkg/packages/pull/6052)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)