### PR TITLE
[f42] add: bitwarden-cli (#6022)

### DIFF
--- a/anda/apps/bitwarden/cli/anda.hcl
+++ b/anda/apps/bitwarden/cli/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "bitwarden-cli.spec"
+  }
+  labels {
+    updbranch = 1
+  }
+}

--- a/anda/apps/bitwarden/cli/bitwarden-cli.spec
+++ b/anda/apps/bitwarden/cli/bitwarden-cli.spec
@@ -1,0 +1,40 @@
+%define debug_package %nil
+%global __strip /bin/true
+
+%ifarch aarch64
+%global armsuffix -arm64
+%endif
+
+Name:           bitwarden-cli
+Version:        2025.7.0
+Release:        1%?dist
+Summary:        Bitwarden command-line client
+License:        GPL-3.0-only
+URL:            https://bitwarden.com
+Source0:        https://github.com/bitwarden/clients/archive/refs/tags/cli-v%version.tar.gz
+
+Packager:       madonuko <mado@fyralabs.com>
+Provides:       bw
+
+BuildRequires:  nodejs-npm
+BuildRequires:  gcc-c++ gcc make
+
+%description
+%summary.
+
+%prep
+%autosetup -n clients-cli-v%version
+npm i
+
+%build
+pushd apps/cli
+npm i
+npm run dist:oss:lin%?armsuffix
+
+%install
+install -Dm755 apps/cli/dist/oss/linux%?armsuffix/bw -t %buildroot%_bindir
+
+%files
+%doc README.md SECURITY.md CONTRIBUTING.md
+%license LICENSE.txt LICENSE_GPL.txt LICENSE_BITWARDEN.txt
+%_bindir/bw

--- a/anda/apps/bitwarden/cli/update.rhai
+++ b/anda/apps/bitwarden/cli/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::madoguchi("bitwarden-cli.bin", labels.branch));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: bitwarden-cli (#6022)](https://github.com/terrapkg/packages/pull/6022)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)