### PR TITLE
[f41] add: bitwarden-cli.bin (#6023)

### DIFF
--- a/anda/apps/bitwarden/cli.bin/anda.hcl
+++ b/anda/apps/bitwarden/cli.bin/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "bitwarden-cli.bin.spec"
+  }
+}

--- a/anda/apps/bitwarden/cli.bin/bitwarden-cli.bin.spec
+++ b/anda/apps/bitwarden/cli.bin/bitwarden-cli.bin.spec
@@ -1,0 +1,25 @@
+Name:           bitwarden-cli.bin
+Version:        2025.7.0
+Release:        1%?dist
+Summary:        Bitwarden command-line client
+License:        GPL-3.0-only
+URL:            https://bitwarden.com
+Source0:        https://github.com/bitwarden/clients/releases/download/cli-v%version/bw-oss-linux-%version.zip
+
+Packager:       madonuko <mado@fyralabs.com>
+Provides:       bw
+ExclusiveArch:  x86_64
+
+BuildRequires:  unzip
+
+%description
+%summary.
+
+%prep
+unzip %{S:0}
+
+%install
+install -Dpm755 bw -t %buildroot%_bindir
+
+%files
+%_bindir/bw

--- a/anda/apps/bitwarden/cli.bin/update.rhai
+++ b/anda/apps/bitwarden/cli.bin/update.rhai
@@ -1,0 +1,5 @@
+let v = gh("bitwarden/clients");
+if v.starts_with("cli-v") {
+    v.crop(5);
+    rpm.version(v);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: bitwarden-cli.bin (#6023)](https://github.com/terrapkg/packages/pull/6023)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)