### PR TITLE
[el10] fix(signal-desktop): create symlink during %install, not %post (#6073)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -12,7 +12,7 @@
 
 Name:			        signal-desktop	
 Version:		      7.66.0
-Release:		      1%?dist
+Release:		      2%?dist
 Summary:		      A private messenger for Windows, macOS, and Linux
 URL:			        https://signal.org
 Source0:		      https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz
@@ -96,15 +96,14 @@ install -Dm644 build/icons/png/64x64.png %{buildroot}%{_iconsdir}/hicolor/64x64/
 
 install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/applications/signal.desktop
 
-%post
-ln -s %_libdir/signal-desktop/signal-desktop %_bindir/signal-desktop
+ln -s %_libdir/signal-desktop/signal-desktop %buildroot%_bindir/signal-desktop
 
 %files
 %license LICENSE
 %doc README.md CONTRIBUTING.md ACKNOWLEDGMENTS.md
 %license release/linux-%{arch}unpacked/LICENSE.electron.txt
 %license release/linux-%{arch}unpacked/LICENSES.chromium.html
-%ghost %{_bindir}/signal-desktop
+%{_bindir}/signal-desktop
 %{_libdir}/signal-desktop/
 %{_datadir}/polkit-1/rules.d/org.signalapp.view-aep.policy
 %{_datadir}/polkit-1/rules.d/org.signalapp.enable-backups.policy


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(signal-desktop): create symlink during %install, not %post (#6073)](https://github.com/terrapkg/packages/pull/6073)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)