### PR TITLE
[el10] add: android-studio package (#6097)

### DIFF
--- a/anda/devs/android-studio/stable/anda.hcl
+++ b/anda/devs/android-studio/stable/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "android-studio.spec"
+  }
+}

--- a/anda/devs/android-studio/stable/android-studio.spec
+++ b/anda/devs/android-studio/stable/android-studio.spec
@@ -1,0 +1,66 @@
+%global debug_package %{nil}
+%define __requires_exclude ^/usr/libexec/android-studio/.*$
+%define __provides_exclude ^/usr/libexec/android-studio/.*$
+%global __requires_exclude ^libaaudio\\.so.*|^libandroid\\.so.*|^libmediandk\\.so.*|^liblog\\.so.*|^libc\\.so.*|^libm\\.so.*|^libdl\\.so.*|^libcrypt\\.so.*|^libstdc\\+\\+\\.so.*|^libncursesw\\.so.*|^libtinfo\\.so.*|^libnsl\\.so.*|^libpanelw\\.so.*$
+
+Name:           android-studio
+Version:        2025.1.2.12
+Release:        1%{?dist}
+Summary:        Official IDE for Android development
+License:        Apache-2.0
+Packager:       like-engels <higashikataengels@icloud.com>
+URL:            https://developer.android.com/studio
+Source0:        https://dl.google.com/dl/android/studio/ide-zips/%{version}/android-studio-%{version}-linux.tar.gz
+
+Requires:       alsa-lib
+Requires:       freetype
+Requires:       which
+Requires:       libXrender
+Requires:       libXtst
+Requires:       glibc
+Requires:       libsecret
+
+%description
+Android Studio is the official IDE for Android development, and includes everything you need to build Android apps.
+
+%prep
+%setup -q -n android-studio
+
+%install
+mkdir -p %{buildroot}%{_libexecdir}/%{name}
+
+cp -a * %{buildroot}%{_libexecdir}/%{name}
+
+mkdir -p %{buildroot}%{_bindir}
+ln -s %{_libexecdir}/%{name}/bin/studio %{buildroot}%{_bindir}/%{name}
+
+mkdir -p %{buildroot}%{_licensedir}/%{name}
+install -Dm644 LICENSE.txt %{buildroot}%{_licensedir}/%{name}/LICENSE.txt
+
+install -Dm644 bin/studio.png %{buildroot}%{_datadir}/pixmaps/%{name}.png
+
+mkdir -p %{buildroot}%{_datadir}/applications
+cat > %{buildroot}%{_datadir}/applications/%{name}.desktop << 'EOF'
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Android Studio
+Exec=android-studio %f
+Icon=android-studio
+Comment=The official Android IDE
+Categories=Development;IDE;
+Terminal=false
+StartupNotify=true
+StartupWMClass=jetbrains-studio
+MimeType=application/x-extension-iml;
+EOF
+
+%files
+%license %{_licensedir}/%{name}/LICENSE.txt
+%{_libexecdir}/%{name}
+%{_bindir}/%{name}
+%{_datadir}/pixmaps/%{name}.png
+%{_datadir}/applications/%{name}.desktop
+
+%changelog
+%autochangelog

--- a/anda/devs/android-studio/stable/update.rhai
+++ b/anda/devs/android-studio/stable/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(find(`https://redirector.gvt1.com/edgedl/android/studio/ide-zips/([\d.]+)/android-studio-[\d.]+-linux.tar.gz`, get("https://developer.android.com/studio"), 1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: android-studio package (#6097)](https://github.com/terrapkg/packages/pull/6097)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)