### PR TITLE
[f41] fix: micro (#6105)

### DIFF
--- a/anda/devs/micro/micro-nightly.spec
+++ b/anda/devs/micro/micro-nightly.spec
@@ -60,7 +60,6 @@ Conflicts:      micro
 git clone --recurse-submodules -q %{gourl} micro-%{version}
 cd %{builddir}/micro-%{version} && git checkout -q %{commit_hash}
 %gomkdir
-%go_prep_online
 
 %build
 %if %{without bootstrap}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: micro (#6105)](https://github.com/terrapkg/packages/pull/6105)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)