### PR TITLE
[f41] fix: fluent-icon-theme (#6106)

### DIFF
--- a/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
+++ b/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
@@ -32,6 +32,7 @@ mkdir -p %{buildroot}%{_datadir}/themes
 %doc README.md
 
 %{_datadir}/icons/Fluent*/
+%{_datadir}/icons/.Fluent*
 
 %changelog
 * Thu Jun 01 2023 Lleyton Gray <lleyton@fyralabs.com> - 20230201-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: fluent-icon-theme (#6106)](https://github.com/terrapkg/packages/pull/6106)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)