### PR TITLE
[f41] fix(signal-desktop): build sticker-creator (#6092)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -1,3 +1,4 @@
+#? https://gitlab.archlinux.org/archlinux/packaging/packages/signal-desktop/-/blob/main/PKGBUILD
 %define	debug_package %{nil}
 
 # Exclude private libraries
@@ -10,55 +11,54 @@
 %define arch arm64-
 %endif
 
-Name:			        signal-desktop	
-Version:		      7.67.0
-Release:		      1%?dist
-Summary:		      A private messenger for Windows, macOS, and Linux
-URL:			        https://signal.org
-Source0:		      https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz
+Name:			signal-desktop	
+Version:			7.67.0
+Release:			1%?dist
+Summary:		A private messenger for Windows, macOS, and Linux
+URL:			https://signal.org
+Source0:		https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz
 # signal.desktop from https://github.com/signalflatpak/signal/blob/master/org.signal.Signal.desktop
-Source1:		      signal.desktop
-License:		      AGPL-3.0 AND %electron_licenses
-ExclusiveArch:    x86_64 aarch64
-BuildRequires:		pulseaudio-libs-devel libX11-devel pnpm make gcc g++ python3 
-Requires:		      pulseaudio-libs 
-Requires:         glib2
-Requires:         gtk3
-Requires:         libwayland-cursor
-Requires:         libwayland-client 
-Requires:         libxkbcommon
-Requires:         glibc 
-Requires:         gdk-pixbuf2
-Requires:         libthai
-Requires:         nettle
-Requires:         avahi-libs
-Requires:         libXfixes
-Requires:         libX11
-Requires:         libjpeg-turbo
-Requires:         sqlite-libs
-Requires:         json-glib
-Requires:         libdatrie
-Requires:         libxml2
-Requires:         libbrotli
-Requires:         cairo
-Requires:         xz-libs
-Requires:         libxcb
-Requires:         nss-util
-Requires:         nss
-Requires:         dbus-libs
-Requires:         mesa-libgbm
-Requires:         at-spi2-atk
-Requires:         expat
-Requires:         alsa-lib
+Source1:		signal.desktop
+License:		AGPL-3.0 AND %electron_licenses
+ExclusiveArch:	x86_64 aarch64
+BuildRequires:	pulseaudio-libs-devel libX11-devel pnpm make gcc g++ python3 
+BuildRequires:	git-lfs
+Requires:		gtk3
+Requires:		libwayland-cursor
+Requires:		libwayland-client 
+Requires:		libxkbcommon
+Requires:		gdk-pixbuf2
+Requires:		libthai
+Requires:		nettle
+Requires:		avahi-libs
+Requires:		libXfixes
+Requires:		libjpeg-turbo
+Requires:		sqlite-libs
+Requires:		json-glib
+Requires:		libdatrie
+Requires:		libxml2
+Requires:		libbrotli
+Requires:		cairo
+Requires:		xz-libs
+Requires:		libxcb
+Requires:		nss-util
+Requires:		nss
+Requires:		dbus-libs
+Requires:		mesa-libgbm
+Requires:		at-spi2-atk
+Requires:		expat
+Requires:		alsa-lib
 
 %description
 Signal Desktop links with Signal on Android or iOS and lets you message from your Windows, macOS, and Linux computers.
 
 %prep
-%autosetup -n Signal-Desktop-%{version}
+%autosetup -n Signal-Desktop-%{version} -p1
 
 %build
-pnpm install
+pnpm install --frozen-lockfile
+pnpm --prefix sticker-creator install
+pnpm --prefix sticker-creator build
 pnpm run build-linux --dir
 
 %install
@@ -95,7 +95,7 @@ install -Dm644 build/icons/png/512x512.png %{buildroot}%{_iconsdir}/hicolor/512x
 install -Dm644 build/icons/png/64x64.png %{buildroot}%{_iconsdir}/hicolor/64x64/apps/signal.png
 
 install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/applications/signal.desktop
-
+mkdir -p %buildroot%_bindir
 ln -s %_libdir/signal-desktop/signal-desktop %buildroot%_bindir/signal-desktop
 
 %files


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(signal-desktop): build sticker-creator (#6092)](https://github.com/terrapkg/packages/pull/6092)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)