### PR TITLE
[f43] add: flameshot.qt5 (#6087)

### DIFF
--- a/anda/apps/flameshot.qt5/anda.hcl
+++ b/anda/apps/flameshot.qt5/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "flameshot.qt5.spec"
+  }
+}

--- a/anda/apps/flameshot.qt5/flameshot.qt5.spec
+++ b/anda/apps/flameshot.qt5/flameshot.qt5.spec
@@ -1,0 +1,109 @@
+#? https://github.com/terrapkg/packages/pull/5554
+#? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
+
+%global ver 12.1.0
+%global commit 4edfb2ac1d71e7f75fcdcb850ff6bce5fb148a7b
+%global shortcommit %{sub %{commit} 1 7}
+%global commit_date 20250618
+%global devel_name QtColorWidgets
+
+Name:			flameshot.qt5
+Version:		%ver^%{commit_date}git.%shortcommit
+Release:		2%?dist
+License:		GPL-3.0-or-later AND ASL-2.0 AND GPL-2.0-only AND LGPL-3.0-only AND FAL-1.3
+Summary:		Powerful yet simple to use screenshot software
+URL:			https://flameshot.org
+Source0:		https://github.com/flameshot-org/flameshot/archive/%commit/flameshot-%commit.tar.gz
+Packager:  madonuko <mado@fyralabs.com>
+
+BuildRequires:	cmake >= 3.13.0
+BuildRequires:	gcc-c++ >= 7
+BuildRequires:	fdupes
+BuildRequires:	libappstream-glib
+BuildRequires:	ninja-build
+BuildRequires:	desktop-file-utils
+
+BuildRequires:	cmake(Qt5Core) >= 5.9.0
+BuildRequires:	cmake(KF5GuiAddons) >= 5.89.0
+BuildRequires:	cmake(Qt5DBus) >= 5.9.0
+BuildRequires:	cmake(Qt5Gui) >= 5.9.0
+BuildRequires:	cmake(Qt5LinguistTools) >= 5.9.0
+BuildRequires:	cmake(Qt5Network) >= 5.9.0
+BuildRequires:	cmake(Qt5Svg) >= 5.9.0
+BuildRequires:	cmake(Qt5Widgets) >= 5.9.0
+
+Requires:		hicolor-icon-theme
+Requires:		qt5-qtbase >= 5.9.0
+Requires:		qt5-qttools >= 5.9.0
+Requires:		qt5-qtsvg%{?_isa} >= 5.9.0
+
+%dnl Provides:		flameshot = %version-%release
+Conflicts:		flameshot
+
+Recommends:		xdg-desktop-portal%{?_isa}
+Recommends:		(xdg-desktop-portal-gnome%{?_isa} if gnome-shell%{?_isa})
+Recommends:		(xdg-desktop-portal-kde%{?_isa} if plasma-workspace-wayland%{?_isa})
+Recommends:		(xdg-desktop-portal-wlr%{?_isa} if wlroots%{?_isa})
+
+%description
+Powerful and simple to use screenshot software with built-in
+editor with advanced features.
+
+Features:
+
+ * Customizable appearance.
+ * Easy to use.
+ * In-app screenshot edition.
+ * DBus interface.
+ * Upload to Imgur
+
+
+%pkg_completion -Bfz flameshot
+
+%package devel
+Summary:      Flameshot development files
+Requires:     %{name} = %{version}
+
+%description devel
+Development files for Flameshot.
+
+%prep
+%autosetup -p1 -n flameshot-%commit
+
+%build
+%cmake -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DUSE_WAYLAND_CLIPBOARD:BOOL=ON \
+%cmake_build
+
+%install
+%cmake_install
+# https://fedoraproject.org/wiki/PackagingDrafts/find_lang
+%find_lang Internationalization --with-qt
+%fdupes %{buildroot}%{_datadir}/icons
+
+%check
+appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.metainfo.xml
+desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
+
+%files -f Internationalization.lang
+%{_datadir}/flameshot/translations/Internationalization_grc.qm
+%doc README.md
+%license LICENSE
+%dir %{_datadir}/flameshot
+%dir %{_datadir}/flameshot/translations
+%{_bindir}/flameshot
+%{_libdir}/lib%{devel_name}.so.*
+%{_datadir}/applications/org.flameshot.Flameshot.desktop
+%{_metainfodir}/org.flameshot.Flameshot.metainfo.xml
+%{_datadir}/dbus-1/interfaces/org.flameshot.Flameshot.xml
+%{_datadir}/dbus-1/services/org.flameshot.Flameshot.service
+%{_datadir}/icons/hicolor/*/apps/*.png
+%{_datadir}/icons/hicolor/scalable/apps/*.svg
+%{_mandir}/man1/flameshot.1*
+
+%files devel
+%{_libdir}/lib%{devel_name}.so
+%{_libdir}/cmake/%{devel_name}/
+%{_libdir}/pkgconfig/%{devel_name}.pc
+%{_includedir}/%{devel_name}/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: flameshot.qt5 (#6087)](https://github.com/terrapkg/packages/pull/6087)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)