### PR TITLE
[f41] fix(emulationstation-de): Drop patch, update build deps (#6117)

### DIFF
--- a/anda/games/emulationstation-de/emulationstation-de.spec
+++ b/anda/games/emulationstation-de/emulationstation-de.spec
@@ -15,11 +15,9 @@ Packager:       Cappy Ishihara <cappy@fyralabs.com>
 License:        MIT
 URL:            https://es-de.org/
 Source0:        https://gitlab.com/es-de/emulationstation-de/-/archive/v%{version}/emulationstation-de-v%{version}.tar.gz
-# Backport a patch to fix a build issue with libgit2
-# This patch should already be included in the next release
-Patch0:         https://gitlab.com/es-de/emulationstation-de/-/commit/3510a09d83949beb765c140041332583b4e70837.patch
 
 BuildRequires:  gcc-c++
+BuildRequires:  bluez-libs-devel
 BuildRequires:  clang-tools-extra
 BuildRequires:  cmake
 BuildRequires:  gettext
@@ -41,6 +39,7 @@ BuildRequires:  pugixml-devel
 BuildRequires:  alsa-lib-devel
 BuildRequires:  mesa-libGL-devel
 BuildRequires:  poppler-cpp-devel
+BuildRequires:  vulkan-loader-devel
 
 Provides:       es-de = %{version}-%{release}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(emulationstation-de): Drop patch, update build deps (#6117)](https://github.com/terrapkg/packages/pull/6117)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)