### PR TITLE
[f43] fix(android-studio): Don't overide libedit library (#6141)

### DIFF
--- a/anda/devs/android-studio/stable/android-studio.spec
+++ b/anda/devs/android-studio/stable/android-studio.spec
@@ -1,11 +1,11 @@
 %global debug_package %{nil}
 %define __requires_exclude ^/usr/libexec/android-studio/.*$
-%define __provides_exclude ^/usr/libexec/android-studio/.*$
+%define __provides_exclude ^/usr/libexec/android-studio/.*|libedit\\so.*$
 %global __requires_exclude ^libaaudio\\.so.*|^libandroid\\.so.*|^libmediandk\\.so.*|^liblog\\.so.*|^libc\\.so.*|^libm\\.so.*|^libdl\\.so.*|^libcrypt\\.so.*|^libstdc\\+\\+\\.so.*|^libncursesw\\.so.*|^libtinfo\\.so.*|^libnsl\\.so.*|^libpanelw\\.so.*$
 
 Name:           android-studio
 Version:        2025.1.2.12
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Official IDE for Android development
 License:        Apache-2.0
 Packager:       like-engels <higashikataengels@icloud.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(android-studio): Don&#x27;t overide libedit library (#6141)](https://github.com/terrapkg/packages/pull/6141)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)