### PR TITLE
[frawhide] Feat: Switch mesa to large runners (#6157)

### DIFF
--- a/anda/lib/mesa/anda.hcl
+++ b/anda/lib/mesa/anda.hcl
@@ -6,5 +6,6 @@ project pkg {
     labels {
         mock = 1
         subrepo = "mesa"
+		large = 1
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [Feat: Switch mesa to large runners (#6157)](https://github.com/terrapkg/packages/pull/6157)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)