### PR TITLE
[el10] Feat: Switch mesa to large runners (#6157)

### DIFF
--- a/anda/lib/mesa/anda.hcl
+++ b/anda/lib/mesa/anda.hcl
@@ -6,5 +6,6 @@ project pkg {
     labels {
         mock = 1
         subrepo = "mesa"
+		large = 1
     }
 }

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -80,7 +80,7 @@ Summary:        Mesa graphics libraries
 # disabled by default, and has to be enabled manually. See `terra/release/terra-mesa.repo` for details.
 Epoch:          1
 Version:        25.2.1
-Release:        3%?dist
+Release:        4%?dist
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [Feat: Switch mesa to large runners (#6157)](https://github.com/terrapkg/packages/pull/6157)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)