### PR TITLE
[f41] fix(komikku): add missing dependency on modern_colorthief (#6148)

### DIFF
--- a/anda/apps/komikku/komikku.spec
+++ b/anda/apps/komikku/komikku.spec
@@ -8,7 +8,7 @@
 Name:           komikku
 Version:        1.86.0
 %forgemeta
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A manga reader for GNOME
 
 BuildArch:      noarch
@@ -36,7 +36,7 @@ Requires:       libnotify
 Requires:       webkitgtk6.0
 Requires:       python3-beautifulsoup4
 Requires:       python3-brotli
-Requires:       python3-colorthief
+Requires:       python3-modern-colorthief
 Requires:       python3-dateparser  %dnl >= 1.1.4 | https://bugzilla.redhat.com/show_bug.cgi?id=2115204
 Requires:       python3-emoji
 Requires:       python3-gobject


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(komikku): add missing dependency on modern_colorthief (#6148)](https://github.com/terrapkg/packages/pull/6148)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)