### PR TITLE
[el10] fix(nodejs-backport): files (#6185)

### DIFF
--- a/anda/devs/backport/nodejs-backport.spec
+++ b/anda/devs/backport/nodejs-backport.spec
@@ -49,7 +49,6 @@ NODE_ENV=test %{builddir}/bin/%{module} -R tests
 %endif
 
 %files
-%doc CHANGELOG.md
 %doc README.md
 %license LICENSE.txt
 %license LICENSE.modules


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [fix(nodejs-backport): files (#6185)](https://github.com/terrapkg/packages/pull/6185)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)