### PR TITLE
[f42] fix(fluent-icon-theme): manually list out all files? (#6180)

### DIFF
--- a/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
+++ b/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
@@ -2,12 +2,12 @@
 
 Name:           fluent-icon-theme
 Version:        20250821
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Fluent icon theme for linux desktops
 
 License:        GPL-3.0
 URL:            https://github.com/vinceliuice/Fluent-icon-theme/
-Source0:        %{url}/archive/refs/tags/%{tag}.tar.gz
+Source0:        %url/archive/refs/tags/%tag.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  gtk-update-icon-cache fdupes
@@ -17,22 +17,21 @@ Conflicts:      %name
 Fluent icon theme for linux desktops.
 
 %prep
-%autosetup -n Fluent-icon-theme-%{tag}
+%autosetup -n Fluent-icon-theme-%tag
 
 %build
 
 %install
-mkdir -p %{buildroot}%{_datadir}/themes
-./install.sh -a -d %{buildroot}%{_datadir}/icons
+mkdir -p %buildroot%_datadir/themes
+./install.sh -a -d %buildroot%_datadir/icons
 
 %fdupes %buildroot%_datadir/icons/
 
 %files
 %license COPYING
 %doc README.md
-
-%{_datadir}/icons/Fluent*/
-%{_datadir}/icons/.Fluent*
+%_datadir/icons/.Fluent{,-dark,-light}-base/
+%_datadir/icons/Fluent{,-{green,grey,orange,pink,purple,red,teal,yellow}}{,-{dark,light}}/
 
 %changelog
 * Thu Jun 01 2023 Lleyton Gray <lleyton@fyralabs.com> - 20230201-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(fluent-icon-theme): manually list out all files? (#6180)](https://github.com/terrapkg/packages/pull/6180)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)