### PR TITLE
[f42] fix(astal-gtk): add commit (#6204)

### DIFF
--- a/anda/lib/astal/astal-gtk/astal-gtk.spec
+++ b/anda/lib/astal/astal-gtk/astal-gtk.spec
@@ -1,4 +1,5 @@
-%global commit 20bd831
+%global commit 20bd8318e4136fbd3d4eb2d64dbabc3acbc915dd
+%global shortcommit 20bd831
 %global commit_date 20250830
 
 Name:			astal

--- a/anda/lib/astal/astal-gtk/update.rhai
+++ b/anda/lib/astal/astal-gtk/update.rhai
@@ -1,8 +1,12 @@
 import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
 
 let mg = bump::madoguchi_json("astal", labels.branch);
 rpm.global("commit_date", `0\^(\d+)\.([[:xdigit:]]+)`.find(mg.ver, 1));
-rpm.global("commit", `0\^(\d+)\.([[:xdigit:]]+)`.find(mg.ver, 2));
+rpm.global("shortcommit", `0\^(\d+)\.([[:xdigit:]]+)`.find(mg.ver, 2));
 if rpm.changed() {
 	rpm.release(`^(\d+)\.`.find(mg.rel, 1));
+	rpm.global("commit", spec::get_global(#{
+		f: open_file("anda/lib/astal/astal/astal.spec").read_string()
+	}, "commit"));
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(astal-gtk): add commit (#6204)](https://github.com/terrapkg/packages/pull/6204)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)