### PR TITLE
[el10] chore(modern-colorthief): Disable docs for now so we can rebuild it for Python 3.14 (#5543)

### DIFF
--- a/anda/tools/modern-colorthief/modern-colorthief.spec
+++ b/anda/tools/modern-colorthief/modern-colorthief.spec
@@ -1,6 +1,7 @@
 %global pypi_name modern_colorthief
-%bcond docs 1
-%bcond test 1
+%bcond bootstrap 1
+%bcond docs %{without bootstrap}
+%bcond test %{without bootstrap}
 
 # The srcrpm is not prefixed with Python because the source is mostly Rust
 Name:          modern-colorthief
@@ -11,6 +12,22 @@ SourceLicense: MIT
 License:       (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:           https://modern-colorthief.readthedocs.io
 Source0:       %{pypi_source}
+%if 0%{?fedora} >= 43
+Patch0:        https://github.com/baseplate-admin/modern_colorthief/commit/6b1f631af1e690741646d9432ed971cdf5b627e3.patch
+Patch1:        https://github.com/baseplate-admin/modern_colorthief/commit/c8beb56ff742fa43dc37ecc31f086f767406d3d1.patch
+Patch2:        https://github.com/baseplate-admin/modern_colorthief/commit/08ea71c82ff5b160e5f9aa0a38f58cf87a22861d.patch
+Patch3:        https://github.com/baseplate-admin/modern_colorthief/commit/0abc0147d574bb962e17a244fca413448848e7e0.patch
+Patch4:        https://github.com/baseplate-admin/modern_colorthief/commit/6b67d731414317a4cc58c67732bf3ddddf4dea68.patch
+Patch5:        https://github.com/baseplate-admin/modern_colorthief/commit/1192273984074c6cf17735ce677a6092bd223fa5.patch
+Patch6:        https://github.com/baseplate-admin/modern_colorthief/commit/9cc135bcb85f93645cf62328adda64e92acafacb.patch
+Patch7:        https://github.com/baseplate-admin/modern_colorthief/commit/07a62bbbc1ad389d1df19052db82f6bb7f63b5d5.patch
+Patch8:        https://github.com/baseplate-admin/modern_colorthief/commit/47c5d08576f98b06733d997d9f05e227b150858c.patch
+Patch9:        https://github.com/baseplate-admin/modern_colorthief/commit/5e1ae7a597d2fc2e56e1e4b1aae22257dd8b7624.patch
+Patch10:       https://github.com/baseplate-admin/modern_colorthief/commit/cbc10285ba3afe0c62636f3a39ce54226a139846.patch
+Patch11:       https://github.com/baseplate-admin/modern_colorthief/commit/4ce6437b9cf14002eb388bde7a49dc9c1448d7b3.patch
+Patch12:       https://github.com/baseplate-admin/modern_colorthief/commit/8c9a8ff0db2b1ed2fcc3465dba4e5848dbd5128e.patch
+Patch13:       https://github.com/baseplate-admin/modern_colorthief/commit/1ae82aa8e695820224721d18069ec75ad73543a0.patch
+%endif
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo
 BuildRequires: cargo-rpm-macros
@@ -57,7 +74,7 @@ Documentation for Modern Colorthief.
 %endif
 
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -p1 -n %{pypi_name}-%{version}
 %cargo_prep_online
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(modern-colorthief): Disable docs for now so we can rebuild it for Python 3.14 (#5543)](https://github.com/terrapkg/packages/pull/5543)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)