### PR TITLE
[f41] fix: osu-lazer (#6214)

### DIFF
--- a/anda/games/osu-lazer/osu-lazer.spec
+++ b/anda/games/osu-lazer/osu-lazer.spec
@@ -3,15 +3,15 @@
 %define __strip /bin/true
 
 Name:			osu-lazer
-Version:		2025.816.0.lazer
+Version:		2025.816.0
 Release:		1%?dist
 Summary:		The future of osu! and the beginning of an open era! Commonly known by the codename osu!lazer. Pew pew.
 ExclusiveArch:	x86_64
 URL:			https://osu.ppy.sh/
 License:		MIT AND CC-BY-NC-4.0
 Requires:		osu-mime fuse
-Source0:		https://github.com/ppy/osu/releases/download/%{version}/osu.AppImage
-Source1:		https://raw.githubusercontent.com/ppy/osu/%{version}/assets/lazer.png
+Source0:		https://github.com/ppy/osu/releases/download/%{version}-lazer/osu.AppImage
+Source1:		https://raw.githubusercontent.com/ppy/osu/%{version}-lazer/assets/lazer.png
 Source2:		https://raw.githubusercontent.com/ppy/osu-resources/%{osuresver}/LICENCE.md
 Source3:		osu-lazer.desktop
 Source4:		osu-lazer-uri-handler.desktop

--- a/anda/games/osu-lazer/update.rhai
+++ b/anda/games/osu-lazer/update.rhai
@@ -1,2 +1,8 @@
-rpm.version(gh("ppy/osu"));
-rpm.define("osuresver", gh("ppy/osu-resources"));
+let v = gh("ppy/osu");
+if v.ends_with("-lazer") {
+    v.pop(6);
+    rpm.version(v);
+    if rpm.changed() {
+        rpm.define("osuresver", gh("ppy/osu-resources"));
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: osu-lazer (#6214)](https://github.com/terrapkg/packages/pull/6214)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)