### PR TITLE
[f41] fix(flameshot-nightly): unpin (#6234)

### DIFF
--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,15 +1,16 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
-%global ver 12.1.0
-%global commit 4edfb2ac1d71e7f75fcdcb850ff6bce5fb148a7b
+%global ver 13.1.0
+%global commit 06f41a86cc91d53d68871fcdc67053239ff1e87b
 %global shortcommit %{sub %{commit} 1 7}
-#global commit_date 20250608
-%global commit_date 20250618
+%global commit_date 20250830
 %global devel_name QtColorWidgets
+%global _distro_extra_cflags -fuse-ld=mold
+%global _distro_extra_cxxflags -fuse-ld=mold
 
 Name:			flameshot.nightly
 Version:		%ver^%{commit_date}git.%shortcommit
-Release:		2%?dist
+Release:		1%?dist
 License:		GPL-3.0-or-later AND ASL-2.0 AND GPL-2.0-only AND LGPL-3.0-only AND FAL-1.3
 Summary:		Powerful yet simple to use screenshot software
 URL:			https://flameshot.org
@@ -22,24 +23,22 @@ BuildRequires:	fdupes
 BuildRequires:	libappstream-glib
 BuildRequires:	ninja-build
 BuildRequires:	desktop-file-utils
+BuildRequires:	mold
 
-BuildRequires:	cmake(Qt5Core) >= 5.9.0
-BuildRequires:	cmake(KF5GuiAddons) >= 5.89.0
-BuildRequires:	cmake(Qt5DBus) >= 5.9.0
-BuildRequires:	cmake(Qt5Gui) >= 5.9.0
-BuildRequires:	cmake(Qt5LinguistTools) >= 5.9.0
-BuildRequires:	cmake(Qt5Network) >= 5.9.0
-BuildRequires:	cmake(Qt5Svg) >= 5.9.0
-BuildRequires:	cmake(Qt5Widgets) >= 5.9.0
+BuildRequires:	cmake(Qt6Core) >= 6.0.0
+BuildRequires:	cmake(KF6GuiAddons) >= 6.7.0
+BuildRequires:	cmake(Qt6DBus) >= 6.0.0
+BuildRequires:	cmake(Qt6Gui) >= 6.0.0
+BuildRequires:	cmake(Qt6LinguistTools) >= 6.0.0
+BuildRequires:	cmake(Qt6Network) >= 6.0.0
+BuildRequires:	cmake(Qt6Svg) >= 6.0.0
+BuildRequires:	cmake(Qt6Widgets) >= 6.0.0
 
 Requires:		hicolor-icon-theme
-Requires:		qt5-qtbase >= 5.9.0
-Requires:		qt5-qttools >= 5.9.0
-Requires:		qt5-qtsvg%{?_isa} >= 5.9.0
 
-%dnl Provides:		flameshot = %version-%release
 Conflicts:		flameshot
 
+Recommends:		qt6-qtimageformats
 Recommends:		xdg-desktop-portal%{?_isa}
 Recommends:		(xdg-desktop-portal-gnome%{?_isa} if gnome-shell%{?_isa})
 Recommends:		(xdg-desktop-portal-kde%{?_isa} if plasma-workspace-wayland%{?_isa})
@@ -55,17 +54,19 @@ Features:
  * Easy to use.
  * In-app screenshot edition.
  * DBus interface.
- * Upload to Imgur
-
 
 %pkg_completion -Bfz flameshot
 
 %package devel
-Summary:      Flameshot development files
 Requires:     %{name} = %{version}
+%pkg_devel_files
+%_libdir/cmake/*/
 
-%description devel
-Development files for Flameshot.
+%package libs
+%pkg_libs_files
+
+%package static
+%pkg_static_files
 
 %prep
 %autosetup -p1 -n flameshot-%commit
@@ -78,7 +79,6 @@ Development files for Flameshot.
 
 %install
 %cmake_install
-# https://fedoraproject.org/wiki/PackagingDrafts/find_lang
 %find_lang Internationalization --with-qt
 %fdupes %{buildroot}%{_datadir}/icons
 
@@ -87,13 +87,11 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.metainfo.xml
 desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 
 %files -f Internationalization.lang
-%{_datadir}/flameshot/translations/Internationalization_grc.qm
 %doc README.md
 %license LICENSE
 %dir %{_datadir}/flameshot
 %dir %{_datadir}/flameshot/translations
 %{_bindir}/flameshot
-%{_libdir}/lib%{devel_name}.so.*
 %{_datadir}/applications/org.flameshot.Flameshot.desktop
 %{_metainfodir}/org.flameshot.Flameshot.metainfo.xml
 %{_datadir}/dbus-1/interfaces/org.flameshot.Flameshot.xml
@@ -101,9 +99,3 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/*.desktop
 %{_datadir}/icons/hicolor/*/apps/*.png
 %{_datadir}/icons/hicolor/scalable/apps/*.svg
 %{_mandir}/man1/flameshot.1*
-
-%files devel
-%{_libdir}/lib%{devel_name}.so
-%{_libdir}/cmake/%{devel_name}/
-%{_libdir}/pkgconfig/%{devel_name}.pc
-%{_includedir}/%{devel_name}/

--- a/anda/apps/flameshot/update.rhai
+++ b/anda/apps/flameshot/update.rhai
@@ -1,4 +1,3 @@
-terminate();
 rpm.global("commit", gh_commit("flameshot-org/flameshot"));
 if rpm.changed() {
     let v = gh("flameshot-org/flameshot");


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(flameshot-nightly): unpin (#6234)](https://github.com/terrapkg/packages/pull/6234)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)