### PR TITLE
[f43] fix(flameshot-nightly): include hash (#6240)

### DIFF
--- a/anda/apps/flameshot.qt5/flameshot.qt5.spec
+++ b/anda/apps/flameshot.qt5/flameshot.qt5.spec
@@ -9,7 +9,7 @@
 
 Name:			flameshot.qt5
 Version:		%ver^%{commit_date}git.%shortcommit
-Release:		2%?dist
+Release:		3%?dist
 License:		GPL-3.0-or-later AND ASL-2.0 AND GPL-2.0-only AND LGPL-3.0-only AND FAL-1.3
 Summary:		Powerful yet simple to use screenshot software
 URL:			https://flameshot.org
@@ -71,6 +71,7 @@ Development files for Flameshot.
 %autosetup -p1 -n flameshot-%commit
 
 %build
+export GIT_HASH=%commit
 %cmake -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DUSE_WAYLAND_CLIPBOARD:BOOL=ON \

--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -10,7 +10,7 @@
 
 Name:			flameshot.nightly
 Version:		%ver^%{commit_date}git.%shortcommit
-Release:		1%?dist
+Release:		2%?dist
 License:		GPL-3.0-or-later AND ASL-2.0 AND GPL-2.0-only AND LGPL-3.0-only AND FAL-1.3
 Summary:		Powerful yet simple to use screenshot software
 URL:			https://flameshot.org
@@ -72,9 +72,10 @@ Requires:     %{name} = %{version}
 %autosetup -p1 -n flameshot-%commit
 
 %build
+export GIT_HASH=%commit
 %cmake -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DUSE_WAYLAND_CLIPBOARD:BOOL=ON \
+    -DUSE_WAYLAND_CLIPBOARD:BOOL=ON
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(flameshot-nightly): include hash (#6240)](https://github.com/terrapkg/packages/pull/6240)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)