### PR TITLE
[el10] fix: limine (#6249)

### DIFF
--- a/anda/system/limine/.gitignore
+++ b/anda/system/limine/.gitignore
@@ -1,0 +1,1 @@
+README.md

--- a/anda/system/limine/limine.spec
+++ b/anda/system/limine/limine.spec
@@ -1,11 +1,11 @@
 Name:		limine
-Version:	moved.to.codeberg
+Version:	9.6.5
 Release:	1%?dist
 Summary:	Modern, advanced, portable, multiprotocol bootloader
 License:	BSD-2-Clause
 URL:		https://limine-bootloader.org
-Source0:	https://github.com/limine-bootloader/limine/releases/download/v%version/limine-%version.tar.gz
-Source1:	https://raw.githubusercontent.com/limine-bootloader/limine/v%version/README.md
+Source0:	https://codeberg.org/Limine/Limine/releases/download/v%version/limine-%version.tar.gz
+Source1:	https://codeberg.org/Limine/Limine/raw/tag/v%version/README.md
 Packager:	madonuko <mado@fyralabs.com>
 BuildRequires:	nasm mtools llvm lld clang make
 
@@ -15,10 +15,10 @@ the reference implementation for the Limine boot protocol.
 
 %prep
 %autosetup
-cp %SOURCE1 .
+cp %{S:1} .
 
 %build
-%configure --enable-all TOOLCHAIN_FOR_TARGET=llvm
+%configure --enable-all CC_FOR_TARGET=clang LD_FOR_TARGET=ld.lld
 %make_build
 
 %install
@@ -27,7 +27,7 @@ cp %SOURCE1 .
 
 %files
 %doc README.md 3RDPARTY.md FAQ.md CONFIG.md PROTOCOL.md COPYING USAGE.md
-%doc %_datadir/doc/limine/LICENSES/LicenseRef-scancode-bsd-no-disclaimer-unmodified.txt
+%license %_datadir/doc/limine/LICENSES/LicenseRef-scancode-bsd-no-disclaimer-unmodified.txt
 %license COPYING
 %_bindir/limine
 %_includedir/limine.h

--- a/anda/system/limine/update.rhai
+++ b/anda/system/limine/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh("limine-bootloader/limine"));
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::codeberg("Limine/Limine"));

--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -2,6 +2,10 @@ fn codeberg_commit(repo) {
     return get(`https://codeberg.org/api/v1/repos/${repo}/commits?stat=false&verification=false&files=false&limit=1`).json_arr()[0].sha;
 }
 
+fn codeberg(repo) {
+    return get(`https://codeberg.org/api/v1/repos/${repo}/releases/latest`).json().tag_name;
+}
+
 fn as_bodhi_ver(branch) {
     if branch.starts_with("el") {
         branch.crop(2);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: limine (#6249)](https://github.com/terrapkg/packages/pull/6249)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)