### PR TITLE
[f42] fix(fluent-icon-theme): try using symlinks (#6255)

### DIFF
--- a/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
+++ b/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
@@ -2,7 +2,7 @@
 
 Name:           fluent-icon-theme
 Version:        20250821
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Fluent icon theme for linux desktops
 
 License:        GPL-3.0
@@ -25,7 +25,7 @@ Fluent icon theme for linux desktops.
 mkdir -p %buildroot%_datadir/themes
 ./install.sh -a -d %buildroot%_datadir/icons
 
-%fdupes %buildroot%_datadir/icons/
+%fdupes -s %buildroot%_datadir/icons/
 
 %files
 %license COPYING


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(fluent-icon-theme): try using symlinks (#6255)](https://github.com/terrapkg/packages/pull/6255)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)