### PR TITLE
[f43] fix(throne): desktop file (#6257)

### DIFF
--- a/anda/apps/throne/throne.desktop
+++ b/anda/apps/throne/throne.desktop
@@ -2,10 +2,10 @@
 Version=1.0
 Terminal=false
 Type=Application
-Name=nekoray
+Name=Throne
 Categories=Network;
 Comment=Qt based cross-platform GUI proxy configuration manager (backend: sing-box)
 Comment[zh_CN]=基于 Qt 的跨平台代理配置管理器 (后端 sing-box)
-Keywords=Internet;VPN;Proxy;sing-box;
-Exec=/bin/nekoray
-Icon=/usr/share/icons/nekoray.ico
+Keywords=Internet;VPN;Proxy;sing-box;nekoray;
+Exec=/usr/bin/throne
+Icon=/usr/share/icons/Throne.ico

--- a/anda/apps/throne/throne.sh
+++ b/anda/apps/throne/throne.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-/lib64/nekoray/nekoray -appdata "${@}"
+/usr/lib64/throne/throne -appdata "${@}"

--- a/anda/apps/throne/throne.spec
+++ b/anda/apps/throne/throne.spec
@@ -2,7 +2,7 @@
 
 Name: throne
 Version: 1.0.5
-Release: 1%?dist
+Release: 2%?dist
 Summary: Qt based cross-platform GUI proxy configuration manager (backend: sing-box)
 URL: https://github.com/throneproj/Throne
 License: GPLv3
@@ -84,8 +84,6 @@ install -Dm755 %__cmake_builddir/Throne %buildroot%_libdir/%name/%name
 install -Dm755 %__cmake_builddir/%core %buildroot%_libdir/%name/%core
 install -Dpm755 %{SOURCE4} %{buildroot}%{_bindir}/%{name}
 install -Dpm644 %{SOURCE3} %{buildroot}%{_datadir}/applications/%{name}.desktop
-sed -i 's~/bin~%{_bindir}~g' %{buildroot}%{_datadir}/applications/%{name}.desktop
-sed -i 's~/bin~%{_bindir}~g;s~/lib64~%{_libdir}~g' %{buildroot}%{_bindir}/%{name}
 install -Dpm644 res/Throne.ico -t %buildroot%_iconsdir/
 install -Dpm644 res/public/Throne.png -t %buildroot%_datadir/pixmaps/
 patchelf --remove-rpath %{buildroot}%{_libdir}/%{name}/%{name}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(throne): desktop file (#6257)](https://github.com/terrapkg/packages/pull/6257)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)