### PR TITLE
[f42] fix(throne): rename core (#6279)

### DIFF
--- a/anda/apps/throne/throne.spec
+++ b/anda/apps/throne/throne.spec
@@ -2,7 +2,7 @@
 
 Name: throne
 Version: 1.0.5
-Release: 2%?dist
+Release: 3%?dist
 Summary: Qt based cross-platform GUI proxy configuration manager (backend: sing-box)
 URL: https://github.com/throneproj/Throne
 License: GPLv3
@@ -39,7 +39,7 @@ BuildRequires: golang
 BuildRequires: rpm_macro(gobuildflags)
 BuildRequires: protobuf-compiler
 Requires: %{name}-core
-%define core throne_core
+%define core Core
 
 %package core
 Summary: %{summary}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(throne): rename core (#6279)](https://github.com/terrapkg/packages/pull/6279)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)