### PR TITLE
[f42] gamescope-session-*: Rebase to Bazzite fork (#6284)

### DIFF
--- a/anda/games/gamescope-session-steam/gamescope-session-steam.spec
+++ b/anda/games/gamescope-session-steam/gamescope-session-steam.spec
@@ -1,6 +1,6 @@
 %define debug_package %nil
 
-%global commit 1a3fdb7fa15a4bba7204bef69702b7a10a297828
+%global commit ba967fd8c5de7dc6c623b614296b3872255996b0
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20241206
 
@@ -9,7 +9,7 @@ Version:        %commit_date.%shortcommit
 Release:        1%?dist
 Summary:        gamescope-session-steam
 License:        MIT
-URL:            https://github.com/ChimeraOS/gamescope-session-steam
+URL:            https://github.com/bazzite-org/gamescope-session-steam
 Source0:        %url/archive/%commit.tar.gz
 
 %description
@@ -21,20 +21,25 @@ Source0:        %url/archive/%commit.tar.gz
 %build
 
 %install
-mkdir -p %buildroot
-cp -r usr %buildroot/
+mkdir -p %{buildroot}%{_bindir}/
+mkdir -p %{buildroot}%{_datadir}/
+cp -rv usr/bin/* %{buildroot}%{_bindir}
+cp -rv usr/share/* %{buildroot}%{_datadir}
+rm -rf %{buildroot}%{_bindir}/steamos-polkit-helpers
+rm %{buildroot}%{_bindir}/jupiter-biosupdate
+# We want to actually keep this for drop-in scripts
+# rm %{buildroot}%{_bindir}/steamos-session-select
+rm %{buildroot}%{_bindir}/steamos-update
+
 
 %files
 %license LICENSE
-%_bindir/steamos-polkit-helpers/
-%_bindir/jupiter-biosupdate
-%_bindir/steam-http-loader
-%_bindir/steamos-select-branch
-%_bindir/steamos-session-select
-%_bindir/steamos-update
-%_datadir/applications/gamescope-mimeapps.list
-%_datadir/applications/steam_http_loader.desktop
-%_datadir/gamescope-session-plus/sessions.d/steam
-%_datadir/polkit-1/actions/org.chimeraos.update.policy
-%_datadir/wayland-sessions/gamescope-session-steam.desktop
-%_datadir/wayland-sessions/gamescope-session.desktop
+%{_bindir}/steam-http-loader
+%{_bindir}/steamos-select-branch
+%{_bindir}/steamos-session-select
+%{_datadir}/applications/gamescope-mimeapps.list
+%{_datadir}/applications/steam_http_loader.desktop
+%{_datadir}/gamescope-session-plus/sessions.d/steam
+%{_datadir}/polkit-1/actions/org.chimeraos.update.policy
+%{_datadir}/wayland-sessions/gamescope-session-steam.desktop
+%{_datadir}/wayland-sessions/gamescope-session.desktop

--- a/anda/games/gamescope-session-steam/update.rhai
+++ b/anda/games/gamescope-session-steam/update.rhai
@@ -1,5 +1,5 @@
 if filters.contains("nightly") {
-    rpm.global("commit", gh_commit("ChimeraOS/gamescope-session-steam"));
+    rpm.global("commit", gh_commit("bazzite-org/gamescope-session-steam"));
     if rpm.changed() {
         rpm.release();
         rpm.global("commit_date", date());

--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,15 +1,15 @@
 %define debug_package %nil
 
-%global commit 1c14e09d2cf75c9716fb8ca808d243ea9f5e9154
+%global commit c65fbffa7306167989e4dd6fe76d6bab3c9d8c30
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20250802
 
 Name:           gamescope-session
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        ChimeraOS session on Gamescope
+Summary:        Gamescope session based on Valve's gamescope
 License:        MIT
-URL:            https://github.com/ChimeraOS/gamescope-session
+URL:            https://github.com/bazzite-org/gamescope-session
 Source0:        %url/archive/%commit.tar.gz
 BuildRequires:  systemd-rpm-macros
 
@@ -28,12 +28,13 @@ cp -r usr %buildroot/
 %files
 %doc README.md
 %license LICENSE
-%_bindir/export-gpu
-%_bindir/gamescope-session-plus
-%_userunitdir/gamescope-session-plus@.service
-%_datadir/gamescope-session-plus/device-quirks
-%_datadir/gamescope-session-plus/gamescope-session-plus
-%_datadir/gamescope/scripts/50-custom/50-disable-explicit-sync.lua
+%{_bindir}/export-gpu
+%{_bindir}/gamescope-session-plus
+%{_datadir}/gamescope-session-plus/device-quirks
+%{_datadir}/gamescope-session-plus/gamescope-session-plus
+%{_userunitdir}/gamescope-session-plus@.service
+%{_userunitdir}/gamescope-session.target
+
 
 %changelog
 %autochangelog

--- a/anda/games/gamescope-session/update.rhai
+++ b/anda/games/gamescope-session/update.rhai
@@ -1,5 +1,5 @@
 if filters.contains("nightly") {
-    rpm.global("commit", gh_commit("ChimeraOS/gamescope-session"));
+    rpm.global("commit", gh_commit("bazzite-org/gamescope-session"));
     if rpm.changed() {
         rpm.release();
         rpm.global("commit_date", date());


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [gamescope-session-*: Rebase to Bazzite fork (#6284)](https://github.com/terrapkg/packages/pull/6284)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)