### PR TITLE
[el10] chore(nvidia*): Update specs, reblacklist Nouveau (#6291)

### DIFF
--- a/anda/system/nvidia/nvidia-driver/70-nvidia-driver.preset
+++ b/anda/system/nvidia/nvidia-driver/70-nvidia-driver.preset
@@ -4,6 +4,7 @@
 enable nvidia-hibernate.service
 enable nvidia-resume.service
 enable nvidia-suspend.service
+enable nvidia-suspend-then-hibernate.service
 
 # Enable Dynamic Boost. From:
 # file:///usr/share/doc/nvidia-driver/html/dynamicboost.html

--- a/anda/system/nvidia/nvidia-driver/nvidia-driver.spec
+++ b/anda/system/nvidia/nvidia-driver/nvidia-driver.spec
@@ -63,10 +63,11 @@ version %{version}.
 
 %package libs
 Summary:        Libraries for %{name}
-Requires:       egl-gbm%{?_isa} >= 2:1.1.2
-Requires:       egl-wayland%{?_isa} >= 1.1.13.1
-Requires:       egl-x11%{?_isa}
-Requires:       libvdpau%{?_isa} >= 0.5
+Requires:       egl-gbm%{?_isa} >= 2:1.1.2.1
+Requires:       (egl-wayland%{?_isa} >= 1.1.20 or egl-wayland2%{?_isa} >= 1.0.0~20250806gitd4deb7c-3)
+Suggests:       egl-wayland%{?_isa} >= 1.1.20
+Requires:       egl-x11%{?_isa} >= 1.0.3
+Requires:       libvdpau%{?_isa} >= 1.5
 Requires:       libglvnd%{?_isa} >= 1.0
 Requires:       libglvnd-egl%{?_isa} >= 1.0
 Requires:       libglvnd-gles%{?_isa} >= 1.0
@@ -76,7 +77,7 @@ Requires:       libnvidia-ml%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:       vulkan-loader
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       %{name}-libs(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       (%{name}-libs(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
 # dlopened
@@ -102,7 +103,7 @@ Requires:       libnvidia-cfg = %{?epoch:%{epoch}:}%{version}-%{release}
 %endif
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       %{name}-cuda-libs(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       (%{name}-cuda-libs(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
 # dlopened:
@@ -121,7 +122,7 @@ Provides:       nvidia-driver-NvFBCOpenGL = %{?epoch:%{epoch}:}%{version}-%{rele
 Obsoletes:      nvidia-driver-NvFBCOpenGL < %{?epoch:%{epoch}:}%{version}-%{release}
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       libnvidia-fbc(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       (libnvidia-fbc(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
 # dlopened:
@@ -137,7 +138,7 @@ graphics scenarios.
 Summary:        NVIDIA library for shader compilation (nvgpucomp)
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       libnvidia-gpucomp(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       (libnvidia-gpucomp(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
 
@@ -151,7 +152,7 @@ Provides:       cuda-nvml%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 Provides:       nvidia-driver-NVML = %{?epoch:%{epoch}:}%{version}-%{release}
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       libnvidia-ml(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       (libnvidia-ml(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
 Obsoletes:      nvidia-driver-NVML < %{?epoch:%{epoch}:}%{version}-%{release}

--- a/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
+++ b/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
@@ -66,8 +66,8 @@ cp %{SOURCE18} .
 
 # Fallback service. Fall back to Nouveau if NVIDIA drivers fail.
 # This is actually from RPM Fusion.
-install -Dm644 %{SOURCE22} -t %{buildroot}%{_unitdir}
-install -Dm644 %{SOURCE23} -t %{buildroot}%{_udevrulesdir}
+%dnl install -Dm644 %{SOURCE22} -t %{buildroot}%{_unitdir}
+%dnl install -Dm644 %{SOURCE23} -t %{buildroot}%{_udevrulesdir}
 
 %pre
 # Remove the kernel command line adjustments one last time when doing an upgrade
@@ -87,9 +87,9 @@ dracut --regenerate-all --force
 %dir %{_prefix}/lib/firmware/nvidia
 %{_prefix}/lib/firmware/nvidia/%{version}
 %config(noreplace) %{_sysconfdir}/modprobe.d/nvidia-modeset.conf
-%{_udevrulesdir}/10-nvidia-fallback.rules
+%dnl %{_udevrulesdir}/10-nvidia-fallback.rules
 %{_udevrulesdir}/60-nvidia.rules
-%{_unitdir}/nvidia-fallback.service
+%dnl %{_unitdir}/nvidia-fallback.service
 
 %changelog
 %autochangelog

--- a/anda/system/nvidia/nvidia-kmod-common/nvidia.conf
+++ b/anda/system/nvidia/nvidia-kmod-common/nvidia.conf
@@ -1,5 +1,8 @@
-# NOVA must be blacklisted as it conflicts with both these drivers and Nouveau.
+# Nouvea/Nova must be blacklisted here as well beside from the initrd to avoid a
+# delayed loading (for example on Optimus laptops where the Nvidia card is not
+# driving the main display).
 
+blacklist nouveau
 blacklist nova-core
 
 # Make a soft dependency for nvidia-uvm as adding the module loading to


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(nvidia*): Update specs, reblacklist Nouveau (#6291)](https://github.com/terrapkg/packages/pull/6291)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)