### PR TITLE
Bump commit date on gamescope-session packages

### DIFF
--- a/anda/games/gamescope-session-steam/gamescope-session-steam.spec
+++ b/anda/games/gamescope-session-steam/gamescope-session-steam.spec
@@ -2,7 +2,7 @@
 
 %global commit ba967fd8c5de7dc6c623b614296b3872255996b0
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20241206
+%global commit_date 20250904
 
 Name:           gamescope-session-steam
 Version:        %commit_date.%shortcommit

--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -2,7 +2,7 @@
 
 %global commit c65fbffa7306167989e4dd6fe76d6bab3c9d8c30
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250802
+%global commit_date 20250904
 
 Name:           gamescope-session
 Version:        %commit_date.%shortcommit


### PR DESCRIPTION
Fixes an issue where Terra still prefers older versions of gamescope-session, my bad

forgot to bump the time so it pulls the older package