### PR TITLE
[f42] Bump commit date on gamescope-session packages (#6321)

### DIFF
--- a/anda/games/gamescope-session-steam/gamescope-session-steam.spec
+++ b/anda/games/gamescope-session-steam/gamescope-session-steam.spec
@@ -2,7 +2,7 @@
 
 %global commit ba967fd8c5de7dc6c623b614296b3872255996b0
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20241206
+%global commit_date 20250904
 
 Name:           gamescope-session-steam
 Version:        %commit_date.%shortcommit

--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -2,7 +2,7 @@
 
 %global commit c65fbffa7306167989e4dd6fe76d6bab3c9d8c30
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250802
+%global commit_date 20250904
 
 Name:           gamescope-session
 Version:        %commit_date.%shortcommit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Bump commit date on gamescope-session packages (#6321)](https://github.com/terrapkg/packages/pull/6321)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)