### PR TITLE
[f41] add: sway-audio-idle-inhibit (#6318)

### DIFF
--- a/anda/desktops/waylands/sway-audio-idle-inhibit/anda.hcl
+++ b/anda/desktops/waylands/sway-audio-idle-inhibit/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "sway-audio-idle-inhibit.spec"
+	}
+}

--- a/anda/desktops/waylands/sway-audio-idle-inhibit/sway-audio-idle-inhibit.spec
+++ b/anda/desktops/waylands/sway-audio-idle-inhibit/sway-audio-idle-inhibit.spec
@@ -1,0 +1,28 @@
+Name:			sway-audio-idle-inhibit
+Version:		0.2.0
+Release:		1%?dist
+Summary:		Prevents swayidle/hypridle from sleeping while any application is outputting or receiving audio
+License:		GPL-3.0-only
+URL:			https://github.com/ErikReider/SwayAudioIdleInhibit
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildRequires:	meson gcc-c++
+BuildRequires:	pkgconfig(libpulse)
+BuildRequires:	pkgconfig(libsystemd)
+
+%description
+%summary.
+
+%prep
+%autosetup -n SwayAudioIdleInhibit-%version
+
+%build
+%meson -Dlogind-provider=systemd
+%meson_build
+
+%install
+%meson_install
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/sway-audio-idle-inhibit

--- a/anda/desktops/waylands/sway-audio-idle-inhibit/update.rhai
+++ b/anda/desktops/waylands/sway-audio-idle-inhibit/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("ErikReider/SwayAudioIdleInhibit"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: sway-audio-idle-inhibit (#6318)](https://github.com/terrapkg/packages/pull/6318)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)