### PR TITLE
[f43] add: udev rules for 8Bitdo controllers (#6335)

### DIFF
--- a/anda/games/8bitdo-udev-rules/71-8bitdo.rules
+++ b/anda/games/8bitdo-udev-rules/71-8bitdo.rules
@@ -1,0 +1,4 @@
+# 2.4GHz/Dongle
+KERNEL=="hidraw*", ATTRS{idVendor}=="2dc8", MODE="0660", TAG+="uaccess"
+# Bluetooth
+KERNEL=="hidraw*", KERNELS=="*2DC8:*", MODE="0660", TAG+="uaccess"

--- a/anda/games/8bitdo-udev-rules/8bitdo-udev-rules.spec
+++ b/anda/games/8bitdo-udev-rules/8bitdo-udev-rules.spec
@@ -1,0 +1,39 @@
+
+Name:           8bitdo-udev-rules
+Version:        1.0
+Release:        1%{?dist}
+Summary:        Udev rules for 8Bitdo controllers
+Provides: 8bitdo-udev = %{version}-%{release}
+License:        Unlicense
+Source0:        71-8bitdo.rules
+BuildArch:      noarch
+BuildRequires:  systemd
+Requires:       systemd-udev
+
+%global udev_order 71
+
+%description
+Udev rules for 8Bitdo controllers, for use with Steam Input
+and generic gamepad support in Linux.
+
+%prep
+
+%build
+
+%install
+install -D -p -m 644 %SOURCE0 %{buildroot}%{_udevrulesdir}/%{udev_order}-8bitdo.rules
+
+%post
+%udev_rules_update
+
+%postun
+%udev_rules_update
+
+%files
+%_udevrulesdir/%{udev_order}-8bitdo.rules
+
+
+
+%changelog
+* Thu Sep 04 2025 Cappy Ishihara <cappy@cappuchino.xyz>
+- Initial release

--- a/anda/games/8bitdo-udev-rules/anda.hcl
+++ b/anda/games/8bitdo-udev-rules/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	rpm {
+		spec = "8bitdo-udev-rules.spec"
+	}
+	arches = ["x86_64"]
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: udev rules for 8Bitdo controllers (#6335)](https://github.com/terrapkg/packages/pull/6335)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)