### PR TITLE
[f41] fix?: sbctl again (#6329)

### DIFF
--- a/anda/tools/sbctl/sbctl.spec
+++ b/anda/tools/sbctl/sbctl.spec
@@ -1,6 +1,6 @@
 Name:           sbctl
 Version:        0.17
-Release:        4%?dist
+Release:        5%?dist
 Summary:        Secure Boot key manager
 
 License:        MIT
@@ -51,7 +51,7 @@ if [[ ! -f /run/ostree-booted ]] && grep -q -m 1 -e '\.efi$' -e '/vmlinuz$'; the
     %{_bindir}/sbctl-batch-sign
 fi
 
-%filetriggerpostun -P 1 -- /boot
+%transfiletriggerun -P -10000 -- /boot
 if [[ ! -f /run/ostree-booted ]] && grep -q -m 1 -e '\.efi$' -e '/vmlinuz$'; then
     exec </dev/null
     %{_bindir}/sbctl-batch-sign


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix?: sbctl again (#6329)](https://github.com/terrapkg/packages/pull/6329)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)