### PR TITLE
[f42] fix(LCEVCdec): Update BuildRequires (#6354)

### DIFF
--- a/anda/multimedia/lcevcdec/LCEVCdec.spec
+++ b/anda/multimedia/lcevcdec/LCEVCdec.spec
@@ -23,6 +23,7 @@ BuildRequires:  cmake(nlohmann_json)
 BuildRequires:  cmake(range-v3)
 BuildRequires:  gcc-c++
 BuildRequires:  git
+BuildRequires:  vulkan-loader
 BuildRequires:  pkgconfig(libavcodec)
 BuildRequires:  pkgconfig(libavdevice)
 BuildRequires:  pkgconfig(libxxhash)


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [fix(LCEVCdec): Update BuildRequires (#6354)](https://github.com/terrapkg/packages/pull/6354)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)