### PR TITLE
[f41] Add: qmk (#6358)

### DIFF
--- a/anda/tools/qmk_cli/anda.hcl
+++ b/anda/tools/qmk_cli/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "qmk_cli.spec"
+	}
+}

--- a/anda/tools/qmk_cli/nonexistant-deps.patch
+++ b/anda/tools/qmk_cli/nonexistant-deps.patch
@@ -1,0 +1,17 @@
+diff --git a/setup.cfg b/setup.cfg
+index c3da40d..e031621 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -37,10 +37,10 @@ classifiers =
+ [options]
+ install_requires =
+ 	hid
+-	milc>=1.9.0
++#	milc>=1.9.0
+ 	pyusb
+ 	# qmk_firmware packages
+-	dotty-dict
++#	dotty-dict
+ 	hjson
+ 	jsonschema>=4
+ 	pillow

--- a/anda/tools/qmk_cli/qmk_cli.spec
+++ b/anda/tools/qmk_cli/qmk_cli.spec
@@ -1,0 +1,80 @@
+%define debug_package %nil
+%global pypi_name qmk_cli
+%global _desc The QMK CLI (command line interface) makes building and working with QMK keyboards easier. We have provided a number of commands to simplify and streamline tasks such as obtaining and compiling the QMK firmware, creating keymaps, and more.
+
+
+Name:			python-%{pypi_name}
+Version:		1.1.8
+Release:		1%?dist
+Summary:		A program to help users work with QMK
+License:		MIT
+URL:			https://github.com/qmk/qmk_cli
+Source0:		%url/archive/refs/tags/%version.tar.gz
+Patch0:         nonexistant-deps.patch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  git
+BuildRequires:  python3-devel
+
+Requires:       python3
+Requires:       python3-platformdirs
+Requires:       python3-argcomplete
+Requires:       python3-colorama
+Requires:       python3-jsonschema
+Requires:       git
+Requires:       avr-gcc
+Requires:       arm-none-eabi-gcc
+Requires:       avr-libc
+Requires:       arm-none-eabi-binutils
+Requires:       arm-none-eabi-newlib
+Requires:       avr-binutils
+Requires:       dfu-programmer
+Requires:       dfu-util
+Requires:       avrdude
+Requires:       python3-hjson
+Requires:       python3-pygments
+Requires:       python3-hid
+Requires:       python3-pyusb
+Requires:       python3-pyserial
+Requires:       python3-pillow
+
+Provides:       qmk
+Provides:       qmk_cli
+Provides:       qmk-cli
+Provides:       python3-qmk_cli
+
+Packager:	      Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -p1 -n qmk_cli-%version
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files qmk_cli
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md SECURITY.md
+%license LICENSE
+%{_bindir}/qmk
+%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
+%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
+%python3_sitelib/qmk-%version.dist-info/*
+
+%changelog
+* Thu Sep 04 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/qmk_cli/update.rhai
+++ b/anda/tools/qmk_cli/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("qmk/qmk_cli"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [Add: qmk (#6358)](https://github.com/terrapkg/packages/pull/6358)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)