### PR TITLE
[f43] fix(lomiri-indicator-network): files (#6374)

### DIFF
--- a/anda/desktops/lomiri-unity/lomiri-indicator-network/lomiri-indicator-network.spec
+++ b/anda/desktops/lomiri-unity/lomiri-indicator-network/lomiri-indicator-network.spec
@@ -65,7 +65,7 @@ The %{name}-doc package contains documentation files for %{name}.
 %files -f %{name}.lang
 %doc README.md
 %license COPYING COPYING.LGPL
-%config /usr/etc/xdg/autostart/lomiri-indicator-network.desktop
+%config /etc/xdg/autostart/lomiri-indicator-network.desktop
 %{_userunitdir}/*.service
 %{_libdir}/liblomiri-connectivity-qt1.so.*
 %dir %{_qt5_qmldir}/Lomiri/Connectivity


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(lomiri-indicator-network): files (#6374)](https://github.com/terrapkg/packages/pull/6374)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)