### PR TITLE
[f43] fix(ffmpeg): Missing ) in update.rhai (#6389)

### DIFF
--- a/anda/multimedia/ffmpeg/update.rhai
+++ b/anda/multimedia/ffmpeg/update.rhai
@@ -2,7 +2,7 @@ import "andax/bump_extras.rhai" as bump;
 import "andax/spec.rhai" as spec;
 
 // rpm.version(find(`<small>ffmpeg-([\d.]+?)\.tar\.xz</small>`, get("https://ffmpeg.org/download.html"), 1));
-rpm.version(bump::bodhi("ffmpeg-free", bump::as_bodhi_ver(labels.branch));
+rpm.version(bump::bodhi("ffmpeg", bump::as_bodhi_ver(labels.branch)));
 
 open_file("anda/multimedia/ffmpeg/VERSION_x265.txt", "w").write(bump::madoguchi("x265", labels.branch));
 open_file("anda/multimedia/ffmpeg/VERSION_tesseract.txt", "w").write(bump::bodhi("tesseract", bump::as_bodhi_ver(labels.branch)));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(ffmpeg): Missing ) in update.rhai (#6389)](https://github.com/terrapkg/packages/pull/6389)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)