### PR TITLE
[f41] chore: Bring in latest DXIL changes from Fedora PR discussions (#6376)

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -32,7 +32,7 @@
 %global intel_platform_vulkan %{?with_vulkan_hw:,intel,intel_hasvk}%{!?with_vulkan_hw:%{nil}}
 %if !0%{?rhel}
 %global with_i915   1
-%endif 
+%endif
 %endif
 %ifarch x86_64
 %if !0%{?with_vulkan_hw}
@@ -80,7 +80,7 @@ Summary:        Mesa graphics libraries
 # disabled by default, and has to be enabled manually. See `terra/release/terra-mesa.repo` for details.
 Epoch:          1
 Version:        25.2.3
-Release:        1%?dist
+Release:        2%?dist
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 
@@ -189,7 +189,7 @@ BuildRequires:  pkgconfig(vulkan)
 %endif
 %if 0%{?with_d3d12}
 BuildRequires:  pkgconfig(DirectX-Headers) >= 1.614.1
-%endif 
+%endif
 
 %description
 %{summary}.
@@ -324,29 +324,20 @@ Summary:        Mesa TensorFlow Lite delegate
 %endif
 
 %if 0%{?with_d3d12}
-%package dxil
+%package dxil-devel
 Summary:        Mesa SPIR-V to DXIL binary
 Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Obsoletes:      %{name}-dxil-libs < 1:25.2.3-2
+Obsoletes:      %{name}-dxil < 1:25.2.3-2
 
-%description dxil
-Binary for translating SPIR-V shader code to DXIL for Direct3D 12
-
-%package dxil-libs
-Summary:        Mesa SPIR-V to DXIL libraries
-Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Requires:       %{name}-dxil = %{?epoch:%{epoch}:}%{version}-%{release}
-
-%description dxil-libs
-Libraries for translating SPIR-V shader code to DXIL for Direct3D 12
+%description dxil-devel
+Development tools for translating SPIR-V shader code to DXIL for Direct3D 12
 %endif
 
 %package vulkan-drivers
 Summary:        Mesa Vulkan drivers
 Requires:       vulkan%{_isa}
 Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-%if 0%{?with_d3d12}
-Requires:       %{name}-dxil-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-%endif
 Obsoletes:      mesa-vulkan-devel < %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description vulkan-drivers
@@ -520,7 +511,7 @@ popd
 %{_libdir}/dri/iris_dri.so
 %if 0%{?with_i915}
 %{_libdir}/dri/i915_dri.so
-%endif 
+%endif
 %endif
 %ifarch aarch64 x86_64 %{ix86}
 %if 0%{?with_asahi}
@@ -529,7 +520,7 @@ popd
 %endif
 %if 0%{?with_d3d12}
 %{_libdir}/dri/d3d12_dri.so
-%endif 
+%endif
 %{_libdir}/dri/ingenic-drm_dri.so
 %{_libdir}/dri/imx-drm_dri.so
 %{_libdir}/dri/imx-lcdif_dri.so
@@ -612,7 +603,7 @@ popd
 %endif
 %if 0%{?with_d3d12}
 %{_libdir}/dri/d3d12_drv_video.so
-%endif 
+%endif
 %{_libdir}/dri/virtio_gpu_drv_video.so
 %endif
 
@@ -628,14 +619,13 @@ popd
 %endif
 %if 0%{?with_d3d12}
 %{_libdir}/vdpau/libvdpau_d3d12.so.1*
-%endif 
+%endif
 %{_libdir}/vdpau/libvdpau_virtio_gpu.so.1*
 %endif
 
 %if 0%{?with_d3d12}
-%files dxil
+%files dxil-devel
 %{_bindir}/spirv2dxil
-%files dxil-libs
 %{_libdir}/libspirv_to_dxil.a
 %{_libdir}/libspirv_to_dxil.so
 %endif
@@ -650,7 +640,7 @@ popd
 %if 0%{?with_virtio}
 %{_libdir}/libvulkan_virtio.so
 %{_datadir}/vulkan/icd.d/virtio_icd.*.json
-%endif 
+%endif
 %if 0%{?with_vulkan_hw}
 %{_libdir}/libvulkan_radeon.so
 %{_datadir}/drirc.d/00-radv-defaults.conf


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [chore: Bring in latest DXIL changes from Fedora PR discussions (#6376)](https://github.com/terrapkg/packages/pull/6376)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)