### PR TITLE
[f42] fix(mock-configs): add terra-rawhide.tpl (#6454)

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,6 +1,6 @@
 Name:           terra-mock-configs
 Version:        2.1.1
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        Mock configs for Terra repos
 
@@ -21,19 +21,14 @@ Obsoletes: anda-mock-configs < 3-2%{?dist}
 %prep
 %autosetup -n mock-configs-%version
 
-%build
-
 %install
-mkdir -p %{buildroot}%{_sysusersdir}
-mkdir -p %{buildroot}%{_sysconfdir}/mock/templates
-
-# not copying terra-el-dev.tpl as we aren't using dev
-cp -v -t %{buildroot}%{_sysconfdir}/mock/templates/ terra.tpl terra-el.tpl
-cp -v *.cfg %{buildroot}%{_sysconfdir}/mock/
+install -Dpm644 *.tpl -t %{buildroot}%{_sysconfdir}/mock/templates/
+install -Dpm644 *.cfg -t %{buildroot}%{_sysconfdir}/mock/
 
 %files
 %config %{_sysconfdir}/mock/templates/terra.tpl
 %config %{_sysconfdir}/mock/templates/terra-el.tpl
+%config %{_sysconfdir}/mock/templates/terra-rawhide.tpl
 %config %{_sysconfdir}/mock/terra-*-x86_64.cfg
 %config %{_sysconfdir}/mock/terra-*-aarch64.cfg
 %config %{_sysconfdir}/mock/terra-*-i386.cfg


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(mock-configs): add terra-rawhide.tpl (#6454)](https://github.com/terrapkg/packages/pull/6454)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)