### PR TITLE
[el10] fix(scrcpy): builddep on libOpenCL.so.1 (#6432)

### DIFF
--- a/anda/apps/scrcpy/scrcpy.spec
+++ b/anda/apps/scrcpy/scrcpy.spec
@@ -17,6 +17,7 @@ BuildRequires:	pkgconfig(libusb)
 BuildRequires:	pkgconfig(libv4l2)
 BuildRequires:	cmake(VulkanHeaders)
 BuildRequires:	vulkan-loader
+BuildRequires:	%_libdir/libOpenCL.so.1
 
 %description
 This application mirrors Android devices (video and audio) connected via USB or TCP/IP and allows control using the computer's keyboard and mouse. It does not require root access or an app installed on the device. It works on Linux, Windows, and macOS.


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [fix(scrcpy): builddep on libOpenCL.so.1 (#6432)](https://github.com/terrapkg/packages/pull/6432)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)