### PR TITLE
[f43] fix(scrcpy): specify OpenCL-ICD-Loader manually (#6466)

### DIFF
--- a/anda/apps/scrcpy/scrcpy.spec
+++ b/anda/apps/scrcpy/scrcpy.spec
@@ -17,7 +17,8 @@ BuildRequires:	pkgconfig(libusb)
 BuildRequires:	pkgconfig(libv4l2)
 BuildRequires:	cmake(VulkanHeaders)
 BuildRequires:	vulkan-loader
-BuildRequires:	%_libdir/libOpenCL.so.1
+BuildRequires:	OpenCL-ICD-Loader
+BuildConflicts:	dkms-nvidia akmod-nvidia
 
 %description
 This application mirrors Android devices (video and audio) connected via USB or TCP/IP and allows control using the computer's keyboard and mouse. It does not require root access or an app installed on the device. It works on Linux, Windows, and macOS.


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f43`:
 - [fix(scrcpy): specify OpenCL-ICD-Loader manually (#6466)](https://github.com/terrapkg/packages/pull/6466)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)