### PR TITLE
[f42] add: natscli (#6467)

### DIFF
--- a/anda/tools/natscli/anda.hcl
+++ b/anda/tools/natscli/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "natscli.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/tools/natscli/natscli.spec
+++ b/anda/tools/natscli/natscli.spec
@@ -1,0 +1,46 @@
+# https://github.com/nats-io/natscli
+%global goipath         github.com/nats-io/natscli
+%global commit          607ceaac6bb542dacadb52573fb20bedc5b6228b
+%global commit_date     20250919
+%global shortcommit     %{sub %{commit} 1 7}
+
+%gometa -f
+
+Name:           natscli
+Version:        0~%{commit_date}git.%shortcommit
+Release:        1%{?dist}
+Summary:        The NATS Command Line Interface
+
+License:        Apache-2.0
+URL:            %{gourl}
+Source0:        %{gosource}
+
+Packager:       Ruka <pkgs@ruka.red>
+
+BuildRequires:  go
+BuildRequires:  git
+BuildRequires:  anda-srpm-macros
+
+%description
+A command line utility to interact with and manage NATS.
+
+%prep
+%goprep -A
+
+%build
+%define currentgoldflags -X main.version=%{version} -X main.commit=%{commit} -X main.date=%{commit_date}
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/nats %{goipath}/nats
+
+%install
+install -m 0755 -vd                     %{buildroot}%{_bindir}
+install -m 0755 -vp %{gobuilddir}/bin/* %{buildroot}%{_bindir}/
+
+%files
+%license LICENSE
+%doc README.md AUTH.md LOCAL_DEVELOPMENT.md cli/cheats/*
+%{_bindir}/nats
+
+%changelog
+* Fri Sep 19 2025 Ruka <pkgs@ruka.red> - 0~20250919git.607ceaa-1
+- Initial packaging for Terra PKG

--- a/anda/tools/natscli/update.rhai
+++ b/anda/tools/natscli/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("nats-io/natscli"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: natscli (#6467)](https://github.com/terrapkg/packages/pull/6467)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)