### PR TITLE
[f41] fix: mpv-nightly (#6424)

### DIFF
--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -82,6 +82,10 @@ BuildRequires:  pkgconfig(xscrnsaver)
 BuildRequires:  pkgconfig(xv)
 %endif
 
+%ifarch x86_64
+BuildRequires:  libOpenCL.so.1
+%endif
+
 Requires:       hicolor-icon-theme
 Provides:       mplayer-backend
 Recommends:     (yt-dlp or youtube-dl)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: mpv-nightly (#6424)](https://github.com/terrapkg/packages/pull/6424)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)