### PR TITLE
[f42] fix: mise (#6461)

### DIFF
--- a/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
+++ b/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- mise-2025.6.6/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ mise-2025.6.6/Cargo.toml	2025-06-23T09:18:21.561501+00:00
-@@ -475,26 +475,6 @@
+--- mise-2025.9.15/Cargo.toml	1970-01-01T00:00:01+00:00
++++ mise-2025.9.15/Cargo.toml	2025-09-22T01:33:34.763933+00:00
+@@ -507,27 +507,6 @@
  optional = true
  default-features = false
  
@@ -10,6 +10,7 @@
 -    "archive-zip",
 -    "compression-zip-deflate",
 -    "signatures",
+-    "rustls",
 -]
 -optional = true
 -default-features = false
@@ -27,7 +28,7 @@
  [lints.clippy]
  borrowed_box = "allow"
  
-@@ -509,3 +489,4 @@
+@@ -544,3 +523,4 @@
  [profile.serious]
  lto = true
  inherits = "release"

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -29,9 +29,10 @@ The front-end to your dev env.}
 %description %{_description}
 
 %package     -n %{crate}
-Summary:        %{summary}
-License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CDLA-Permissive-2.0 AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
 URL:            https://mise.jdx.dev/
+Summary:        %{summary}
+License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CDLA-Permissive-2.0 AND ISC AND (ISC AND (Apache-2.0 OR ISC)) AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT) AND bzip2-1.0.6
+# LICENSE.dependencies contains a full license breakdown
 
 %description -n %{crate} %{_description}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: mise (#6461)](https://github.com/terrapkg/packages/pull/6461)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)