### PR TITLE
[el10] fix(readymade-git): bdep glibc-all-langpacks (#6489)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -13,7 +13,12 @@ Source1:        https://github.com/FyraLabs/rdms_proc_macros/archive/HEAD.tar.gz
 BuildRequires:	anda-srpm-macros rust-packaging mold
 BuildRequires:  pkgconfig(libhelium-1)
 BuildRequires:  clang-devel
+BuildRequires:  gcc
 BuildRequires:  cmake
+BuildRequires:  glibc-all-langpacks
+# We'll need cryptsetup to unlock disks for now
+Requires:       cryptsetup
+Recommends:     readymade-config
 Conflicts:      readymade
 Obsoletes:      readymade-nightly < 20250502.4dc78ec-3
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(readymade-git): bdep glibc-all-langpacks (#6489)](https://github.com/terrapkg/packages/pull/6489)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)