### PR TITLE
[el10] fix(signal-desktop): exclude provs (#6486)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -2,8 +2,7 @@
 %define	debug_package %{nil}
 
 # Exclude private libraries
-%global __requires_exclude libffmpeg.so
-%global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
+%global __provides_exclude ^lib.*\\.so.*$
 
 %ifarch x86_64
 %define arch %{nil}
@@ -13,7 +12,7 @@
 
 Name:			signal-desktop	
 Version:			7.71.0
-Release:			1%?dist
+Release:			2%?dist
 Summary:		A private messenger for Windows, macOS, and Linux
 URL:			https://signal.org
 Source0:		https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(signal-desktop): exclude provs (#6486)](https://github.com/terrapkg/packages/pull/6486)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)