### PR TITLE
[f41] fix(hyprgraphics): bdep pangocairo (#6485)

### DIFF
--- a/anda/desktops/waylands/hyprgraphics/hyprgraphics.nightly.spec
+++ b/anda/desktops/waylands/hyprgraphics/hyprgraphics.nightly.spec
@@ -24,6 +24,7 @@ BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  (pkgconfig(hyprlang) with hyprlang.nightly-devel)
 BuildRequires:  pkgconfig(cairo)
+BuildRequires:  pkgconfig(pangocairo)
 BuildRequires:  (pkgconfig(hyprutils) with hyprutils.nightly-devel)
 BuildRequires:  pkgconfig(libjpeg)
 BuildRequires:  pkgconfig(libwebp)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(hyprgraphics): bdep pangocairo (#6485)](https://github.com/terrapkg/packages/pull/6485)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)