### PR TITLE
[f42] fix(signal-desktop): also exclude reqs (#6512)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -2,6 +2,7 @@
 %define	debug_package %{nil}
 
 # Exclude private libraries
+%global __requires_exclude libffmpeg.so
 %global __provides_exclude ^lib.*\\.so.*$
 
 %ifarch x86_64
@@ -12,7 +13,7 @@
 
 Name:			signal-desktop	
 Version:			7.72.0
-Release:			1%?dist
+Release:			2%?dist
 Summary:		A private messenger for Windows, macOS, and Linux
 URL:			https://signal.org
 Source0:		https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(signal-desktop): also exclude reqs (#6512)](https://github.com/terrapkg/packages/pull/6512)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)