### PR TITLE
[f43] add: provides tags for signal-desktop (#6518)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -13,7 +13,7 @@
 
 Name:			signal-desktop	
 Version:			7.72.1
-Release:			1%?dist
+Release:			2%?dist
 Summary:		A private messenger for Windows, macOS, and Linux
 URL:			https://signal.org
 Source0:		https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz
@@ -48,6 +48,10 @@ Requires:		mesa-libgbm
 Requires:		at-spi2-atk
 Requires:		expat
 Requires:		alsa-lib
+
+Provides:       signal
+Provides:       Signal
+Provides:       Signal-Desktop
 
 %description
 Signal Desktop links with Signal on Android or iOS and lets you message from your Windows, macOS, and Linux computers.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: provides tags for signal-desktop (#6518)](https://github.com/terrapkg/packages/pull/6518)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)