### PR TITLE
[el10] fix(scx-scheds-nightly): New file (#6523)

### DIFF
--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -97,6 +97,7 @@ License:       GPL-2.0-only
 %license LICENSE.dependencies
 %{_bindir}/scx*
 %{_bindir}/vmlinux_docify
+%{_bindir}/xtask
 %{_unitdir}/scx_loader.service
 %{_datadir}/dbus-1/system.d/org.scx.Loader.conf
 %{_datadir}/dbus-1/system-services/org.scx.Loader.service


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(scx-scheds-nightly): New file (#6523)](https://github.com/terrapkg/packages/pull/6523)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)