### PR TITLE
[f41] add: pyvcd (#6532)

### DIFF
--- a/anda/langs/python/pyvcd/anda.hcl
+++ b/anda/langs/python/pyvcd/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "pyvcd.spec"
+  }
+}

--- a/anda/langs/python/pyvcd/pyvcd.spec
+++ b/anda/langs/python/pyvcd/pyvcd.spec
@@ -1,0 +1,61 @@
+%global pypi_name pyvcd
+%global _desc Python package for writing Value Change Dump (VCD) files.
+
+Name:			python-%{pypi_name}
+Version:		0.4.0
+Release:		1%?dist
+Summary:		Python package for writing Value Change Dump (VCD) files
+License:		MIT
+URL:			https://github.com/SanDisk-Open-Source/pyvcd
+Source0:		%url/releases/download/%version/pyvcd-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3
+BuildRequires:  python3.10
+BuildRequires:  python3-build
+BuildRequires:  python3-installer
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-setuptools_scm
+BuildRequires:  python3-pip
+BuildRequires:  python3-devel
+BuildRequires:  python3-installer
+BuildRequires:  git
+
+Requires:       python3
+
+Provides:       pyvcd
+Provides:       python3-pyvcd
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n pyvcd-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files vcd
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst CODE_OF_CONDUCT.md CHANGELOG.rst
+%license LICENSE.txt
+%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
+%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
+%python3_sitelib/pyvcd-%version.dist-info/*
+
+%changelog
+* Sat Sep 27 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/pyvcd/update.rhai
+++ b/anda/langs/python/pyvcd/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("SanDisk-Open-Source/pyvcd"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: pyvcd (#6532)](https://github.com/terrapkg/packages/pull/6532)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)