### PR TITLE
[f42] fix(qmk_cli): remove duplicate build dep (#6531)

### DIFF
--- a/anda/tools/qmk_cli/qmk_cli.spec
+++ b/anda/tools/qmk_cli/qmk_cli.spec
@@ -16,7 +16,6 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  git
-BuildRequires:  python3-devel
 
 Requires:       python3
 Requires:       python3-platformdirs


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(qmk_cli): remove duplicate build dep (#6531)](https://github.com/terrapkg/packages/pull/6531)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)