### PR TITLE
[f42] feat(dracut-strip-trigger): use config files instead (#6549)

### DIFF
--- a/anda/system/dracut-strip-trigger/01-aggressive-strip.conf
+++ b/anda/system/dracut-strip-trigger/01-aggressive-strip.conf
@@ -1,0 +1,3 @@
+do_strip=yes
+aggressive_strip=yes
+hostonly=yes

--- a/anda/system/dracut-strip-trigger/dracut-strip-trigger.spec
+++ b/anda/system/dracut-strip-trigger/dracut-strip-trigger.spec
@@ -1,10 +1,12 @@
 Name:		dracut-strip-trigger
 Version:	0
-Release:	4%?dist
+Release:	5%?dist
 Summary:	Strip initramfs aggressively
 License:	GPL-3.0-only
 Requires:	dracut installonlypkg(kernel)
+Conflicts:  dracut-config-generic
 Source0:	LICENSE
+Source1:    01-aggressive-strip.conf
 
 %global _desc %{expand:
 Strip initramfs automatically for each kernel update using --hostonly --aggressive-strip.
@@ -19,19 +21,21 @@ cat<<EOF > README
 EOF
 cp %{S:0} .
 
+%install
+mkdir -p %{buildroot}/usr/lib/dracut/dracut.conf.d/
+cp %{S:1} %{buildroot}/usr/lib/dracut/dracut.conf.d/
+
 %files
+/usr/lib/dracut/dracut.conf.d/01-aggressive-strip.conf
 %doc README
 %license LICENSE
 
 %post
 echo 'Regenerating all initramfs…'
-dracut --force --parallel --regenerate-all --hostonly --strip --aggressive-strip
+dracut --force --parallel --regenerate-all
 echo 'All non-rescue initramfs have been regenerated.'
 echo 'If you have problems booting up, use the rescue image, then uninstall `%name`.'
 
-%transfiletriggerin -P 1 -- /boot
-dracut --force --hostonly --strip --aggressive-strip $(stat --format '%Y %y $%n' /boot/initramfs* | sort -nr | cut -d$ -f2- | head -n1)
-
 %postun
 [ $1 = 0 ] && echo 'Regenerating all initramfs…'
-[ $1 = 0 ] && dracut --force --parallel --regenerate-all --no-hostonly --strip
+[ $1 = 0 ] && dracut --force --parallel --regenerate-all


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(dracut-strip-trigger): use config files instead (#6549)](https://github.com/terrapkg/packages/pull/6549)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)