### PR TITLE
[f42] add: vgmstream (#6490)

### DIFF
--- a/anda/multimedia/vgmstream/anda.hcl
+++ b/anda/multimedia/vgmstream/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "vgmstream.spec"
+	}
+}

--- a/anda/multimedia/vgmstream/update.rhai
+++ b/anda/multimedia/vgmstream/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("vgmstream/vgmstream"));
+if rpm.changed() {
+	rpm.global("commit_date", date());
+	rpm.release();
+}

--- a/anda/multimedia/vgmstream/vgmstream.spec
+++ b/anda/multimedia/vgmstream/vgmstream.spec
@@ -1,0 +1,55 @@
+%global commit      9db666eb0c2275334ac68a2537a6a689aee792f2
+%global shortcommit %{sub %{commit} 1 7}
+%global commit_date 20250924
+
+Name:			vgmstream
+Version:		0~%{commit_date}git.%shortcommit
+Release:		1%?dist
+Summary:		A library for playback of various streamed audio formats used in video games
+License:		ISC
+URL:			https://vgmstream.org
+Packager:		madonuko <mado@fyralabs.com>
+Source0:		https://github.com/vgmstream/vgmstream/archive/%commit.tar.gz
+# https://github.com/vgmstream/vgmstream/blob/master/make-build-cmake.sh
+BuildRequires:	gcc gcc-c++ cmake git-core
+BuildRequires:	pkgconfig(libmpg123) pkgconfig(vorbis) pkgconfig(speex)
+BuildRequires:	pkgconfig(libavformat) pkgconfig(libavcodec) pkgconfig(libavutil) pkgconfig(libswresample)
+BuildRequires:	yasm pkgconfig(opus) pkgconfig(ao) pkgconfig(audacious)
+
+%description
+%summary.
+
+%package devel
+%pkg_devel_files
+%license COPYING
+%_libdir/cmake/vgmstream
+
+%package -n audacious-plugins-vgmstream
+Summary:		Audacious input plugin for vgmstream
+Supplements:	(vgmstream and audacious)
+%description -n audacious-plugins-vgmstream
+Audacious input plugin for vgmstream.
+For more information, see the main vgmstream package.
+
+%files -n audacious-plugins-vgmstream
+%license COPYING
+%_libdir/audacious/Input/vgmstream.so
+
+%prep
+%autosetup -n %name-%commit
+
+sed 's/VERSION=""/VERSION="%shortcommit"/g' -i version-make.sh
+
+%build
+# https://github.com/vgmstream/vgmstream/issues/1780
+%cmake -DCMAKE_BUILD_TYPE=Release -DUSE_G719=0 %["%_arch" == "x86_64" ? "" : "-DUSE_CELT=0"]
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%doc README.md SECURITY.md doc/*.md
+%license COPYING
+%_bindir/vgmstream-cli
+%_bindir/vgmstream123


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: vgmstream (#6490)](https://github.com/terrapkg/packages/pull/6490)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)