### PR TITLE
[f42] add: fyra-labs-natrium-fonts (#6574)

### DIFF
--- a/anda/fonts/natrium/anda.hcl
+++ b/anda/fonts/natrium/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "natrium-fonts.spec"
+	}
+}

--- a/anda/fonts/natrium/natrium-fonts.spec
+++ b/anda/fonts/natrium/natrium-fonts.spec
@@ -1,0 +1,47 @@
+%global orgprefix fyralabs
+%global fontcontact security@fyralabs.com
+%global fontorg co.tauos
+%global foundry           Fyra Labs
+%global fontlicense       OFL-1.1
+%global fontlicenses      LICENSE.md
+%global fontdocs          README.md
+
+Version:        1.0.0
+Release:        1%{?dist}
+%global fontfamily        Natrium
+%global fontsummary       Natrium - The tauOS UI font
+%global fonts             Natrium/otf/*.otf
+%global fontdescription   %fontsummary
+
+URL:            https://github.com/tau-OS/natrium
+Provides:       natrium-fonts = %{version}-%{release}
+Source0:        %url/releases/download/v%{version}/natrium-fonts.zip
+
+BuildRequires:	fontforge
+BuildRequires:  rpm_macro(fontpkg)
+
+
+%global fonts2             NatriumMono/otf/*.otf
+%global fontfamily2        Natrium Mono
+%global fontsummary2       Natrium Mono - The tauOS monospace font
+%global fontdescription2   %fontsummary2
+
+%fontpkg -a
+%fontmetapkg
+
+
+%prep
+%autosetup -c
+
+%build
+%fontbuild
+
+%install
+%fontinstall -a
+
+
+
+%check
+%fontcheck -a
+
+%fontfiles -a

--- a/anda/fonts/natrium/update.rhai
+++ b/anda/fonts/natrium/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("tau-OS/natrium"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: fyra-labs-natrium-fonts (#6574)](https://github.com/terrapkg/packages/pull/6574)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)