### PR TITLE
[el10] fix: minor stardust stuff (#6585)

### DIFF
--- a/anda/stardust/armillary/stardust-armillary.spec
+++ b/anda/stardust/armillary/stardust-armillary.spec
@@ -7,7 +7,7 @@
 Name:           stardust-xr-armillary
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Model viewer for Stardust XR.
+Summary:        Model viewer for Stardust XR
 URL:            https://github.com/StardustXR/armillary
 Source0:        %url/archive/%commit/armillary-%commit.tar.gz
 License:        MIT

--- a/anda/stardust/atmosphere/stardust-atmosphere.spec
+++ b/anda/stardust/atmosphere/stardust-atmosphere.spec
@@ -7,7 +7,7 @@
 Name:           stardust-xr-atmosphere
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Environment, homespace, and setup client for Stardust XR.
+Summary:        Environment, homespace, and setup client for Stardust XR
 URL:            https://github.com/StardustXR/atmosphere
 Source0:        %url/archive/%commit/atmosphere-%commit.tar.gz
 License:        MIT
@@ -17,7 +17,7 @@ Provides:       atmosphere stardust-atmosphere
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n atmosphere-%commit

--- a/anda/stardust/black-hole/stardust-black-hole.spec
+++ b/anda/stardust/black-hole/stardust-black-hole.spec
@@ -2,12 +2,12 @@
 %global commit_date 20241230
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
-%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$ 
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-black-hole
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Spatial storage for Stardust XR.
+Summary:        Spatial storage for Stardust XR
 URL:            https://github.com/StardustXR/black-hole
 Source0:        %url/archive/%commit/black-hole-%commit.tar.gz
 License:        MIT
@@ -17,7 +17,7 @@ Provides:       black-hole stardust-black-hole
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n black-hole-%commit

--- a/anda/stardust/comet/stardust-comet.spec
+++ b/anda/stardust/comet/stardust-comet.spec
@@ -7,7 +7,7 @@
 Name:           stardust-xr-comet
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Annotate things in Stardust XR.
+Summary:        Annotate things in Stardust XR
 URL:            https://github.com/StardustXR/comet
 Source0:        %url/archive/%commit/comet-%commit.tar.gz
 License:        MIT
@@ -17,7 +17,7 @@ Provides:       comet stardust-comet
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n comet-%commit

--- a/anda/stardust/flatland/stardust-flatland.spec
+++ b/anda/stardust/flatland/stardust-flatland.spec
@@ -7,7 +7,7 @@
 Name:           stardust-xr-flatland
 Version:        %commit_date.%shortcommit
 Release:        2%?dist
-Summary:        Flatland for Stardust XR.
+Summary:        Flatland for Stardust XR
 URL:            https://github.com/StardustXR/flatland
 Source0:        %url/archive/%commit/flatland-%commit.tar.gz
 License:        MIT
@@ -17,7 +17,7 @@ Provides:       flatland stardust-flatland
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n flatland-%commit

--- a/anda/stardust/gravity/stardust-gravity.spec
+++ b/anda/stardust/gravity/stardust-gravity.spec
@@ -7,17 +7,17 @@
 Name:           stardust-xr-gravity
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Utility to launch apps and Stardust XR clients spatially.
+Summary:        Utility to launch apps and Stardust XR clients spatially
 URL:            https://github.com/StardustXR/gravity
 Source0:        %url/archive/%commit/gravity-%commit.tar.gz
 License:        MIT
-BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold  
+BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
-Provides:       stardust-gravity
+Provides:       gravity stardust-gravity
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n gravity-%commit

--- a/anda/stardust/magnetar/stardust-magnetar.spec
+++ b/anda/stardust/magnetar/stardust-magnetar.spec
@@ -7,7 +7,7 @@
 Name:           stardust-xr-magnetar
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Workspaces client for Stardust XR.
+Summary:        Workspaces client for Stardust XR
 URL:            https://github.com/StardustXR/magnetar
 Source0:        %url/archive/%commit/magnetar-%commit.tar.gz
 License:        MIT
@@ -17,7 +17,7 @@ Provides:       magnetar stardust-magnetar
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n magnetar-%commit
@@ -38,4 +38,3 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %changelog
 * Wed Sep 11 2024 Owen-sz <owen@fyralabs.com>
 - Package StardustXR magnetar
-

--- a/anda/stardust/non-spatial-input/stardust-non-spatial-input.spec
+++ b/anda/stardust/non-spatial-input/stardust-non-spatial-input.spec
@@ -7,7 +7,7 @@
 Name:           stardust-xr-non-spatial-input
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Tools you can easily snap together to get non-spatial input into Stardust XR.
+Summary:        Tools you can easily snap together to get non-spatial input into Stardust XR
 URL:            https://github.com/StardustXR/non-spatial-input
 Source0:        %url/archive/%commit/non-spatial-input-%commit.tar.gz
 License:        MIT
@@ -17,7 +17,7 @@ Provides:       non-spatial-input stardust-non-spatial-input
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n non-spatial-input-%commit

--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -7,7 +7,7 @@
 Name:           stardust-xr-protostar
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Prototype application launcher for Stardust XR.
+Summary:        Prototype application launcher for Stardust XR
 URL:            https://github.com/StardustXR/protostar
 Source0:        %url/archive/%commit/protostar-%commit.tar.gz
 License:        MIT

--- a/anda/stardust/server/stardust-server.spec
+++ b/anda/stardust/server/stardust-server.spec
@@ -7,7 +7,7 @@
 Name:           stardust-xr-server
 Version:        %commit_date.%shortcommit
 Release:        1%?dist
-Summary:        Usable Linux display server that reinvents human-computer interaction for all kinds of XR.
+Summary:        Usable Linux display server that reinvents human-computer interaction for all kinds of XR
 URL:            https://github.com/StardustXR/server
 Source0:        %url/archive/%commit/server-%commit.tar.gz
 License:        GPL-2.0-only

--- a/anda/stardust/telescope/stardust-telescope.spec
+++ b/anda/stardust/telescope/stardust-telescope.spec
@@ -6,17 +6,25 @@
 
 Name:           stardust-xr-telescope
 Version:        %commit_date.git~%shortcommit
-Release:        1%?dist
-Summary:        See the stars! Easy stardust setups to run on your computer. 
+Release:        2%?dist
+Summary:        See the stars! Easy stardust setups to run on your computer
 License:        MIT
 URL:            https://github.com/StardustXR/telescope
 Source0:        %url/archive/%commit.tar.gz
+
 Requires:       bash
-Requires:       stardust-xr-server
-Requires:       stardust-xr-gravity
-Requires:       stardust-xr-black-hole
-Requires:       stardust-xr-protostar
 Requires:       xwayland-satellite
+Requires:       stardust-xr-armillary
+Requires:       stardust-xr-atmosphere
+Requires:       stardust-xr-black-hole
+Requires:       stardust-xr-comet
+Requires:       stardust-xr-flatland
+Requires:       stardust-xr-gravity
+Requires:       stardust-xr-magnetar
+Requires:       stardust-xr-non-spatial-input
+Requires:       stardust-xr-protostar
+Requires:       stardust-xr-server
+
 BuildArch:      noarch
 Provides:       telescope stardust-telescope
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: minor stardust stuff (#6585)](https://github.com/terrapkg/packages/pull/6585)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)