### PR TITLE
chore(dkms-nvidia-open): Make weekly

### DIFF
--- a/anda/system/nvidia/dkms-nvidia/open/anda.hcl
+++ b/anda/system/nvidia/dkms-nvidia/open/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		subrepo = "nvidia"
+        weekly = 1
 	}
 }


### PR DESCRIPTION
Same reason as everything else, the garbo NVIDIA servers.