### PR TITLE
[el10] chore(dkms-nvidia-open): Make weekly (#6595)

### DIFF
--- a/anda/system/nvidia/dkms-nvidia/open/anda.hcl
+++ b/anda/system/nvidia/dkms-nvidia/open/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		subrepo = "nvidia"
+        weekly = 1
 	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(dkms-nvidia-open): Make weekly (#6595)](https://github.com/terrapkg/packages/pull/6595)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)