### PR TITLE
[el10] fix(libva-nvidia-driver): Should be nightly (#6600)

### DIFF
--- a/anda/system/nvidia/libva-nvidia-driver/anda.hcl
+++ b/anda/system/nvidia/libva-nvidia-driver/anda.hcl
@@ -6,6 +6,6 @@ project "pkg" {
     labels = {
         subrepo = "nvidia"
         mock = 1
-        weekly = 1
+        nightly = 1
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(libva-nvidia-driver): Should be nightly (#6600)](https://github.com/terrapkg/packages/pull/6600)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)