### PR TITLE
[f41] fix(rio): bdep alsa (#6573)

### DIFF
--- a/anda/devs/rio/rio.spec
+++ b/anda/devs/rio/rio.spec
@@ -21,6 +21,7 @@ BuildRequires: libxcb-devel
 BuildRequires: libxkbcommon-devel
 BuildRequires: mold
 BuildRequires: sed
+BuildRequires: pkgconfig(alsa)
 Requires:      freetype
 Requires:      fontconfig
 Requires:      hicolor-icon-theme


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(rio): bdep alsa (#6573)](https://github.com/terrapkg/packages/pull/6573)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)