### PR TITLE
[f43] fix(katsu): remove dep dracut-config-generic (#6570)

### DIFF
--- a/anda/tools/buildsys/katsu/katsu.spec
+++ b/anda/tools/buildsys/katsu/katsu.spec
@@ -7,7 +7,7 @@
 
 Name:           katsu
 Version:        0.9.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Vicious image builder
 Packager:       madonuko <mado@fyralabs.com>
 
@@ -30,7 +30,7 @@ Source0:		%url/archive/refs/tags/v%version.tar.gz
 
 BuildRequires:  anda-srpm-macros cargo-rpm-macros >= 26
 Requires:		xorriso dracut limine grub2 systemd-devel squashfs-tools parted gdisk
-Requires:		dracut-live dracut-config-generic dracut-config-rescue grub2-tools-extra dracut-squash
+Requires:		dracut-live dracut-config-rescue grub2-tools-extra dracut-squash
 BuildRequires:	cargo rust-packaging pkgconfig(libudev) clang-devel mold
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(katsu): remove dep dracut-config-generic (#6570)](https://github.com/terrapkg/packages/pull/6570)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)