### PR TITLE
[f41] add: types-colorama (#6613)

### DIFF
--- a/anda/langs/python/types-colorama/anda.hcl
+++ b/anda/langs/python/types-colorama/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "types-colorama.spec"
+  }
+}

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,0 +1,50 @@
+%global commit 91055c730ffcda6311654cf32d663858ece69bad
+%global commit_date 20250930
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global pypi_name types-colorama
+%global _desc Typing stubs for colorama.
+
+Name:			python-%{pypi_name}
+Version:		0~%{commit_date}git.%shortcommit
+Release:		1%?dist
+Summary:		Typing stubs for colorama
+License:		Apache-2.0
+URL:			https://github.com/python/typeshed
+Source0:		%url/archive/%commit/typeshed-%commit.tar.gz
+BuildArch:      noarch
+BuildRequires:  python3-devel
+Requires:       python3-colorama
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       types-colorama
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n typeshed-%{commit}
+
+%build
+# Not needed for stub file package
+
+%install
+mkdir -p %{buildroot}%{python3_sitelib}/colorama-stubs
+install -Dm755 stubs/colorama/colorama/*.pyi          %{buildroot}%{python3_sitelib}/colorama-stubs/
+install -Dm755 stubs/colorama/METADATA.toml         %{buildroot}%{python3_sitelib}/colorama-stubs/METADATA.toml
+
+%files -n python3-%{pypi_name}
+%doc README.md MAINTAINERS.md CONTRIBUTING.md
+%license LICENSE
+%python3_sitelib/colorama-stubs/METADATA.toml
+%{python3_sitelib}/colorama-stubs/*.pyi
+
+%changelog
+* Tue Sep 30 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/types-colorama/update.rhai
+++ b/anda/langs/python/types-colorama/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("python/typeshed"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: types-colorama (#6613)](https://github.com/terrapkg/packages/pull/6613)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)