### PR TITLE
[el10] add: glasgow (#6590)

### DIFF
--- a/anda/tools/glasgow/anda.hcl
+++ b/anda/tools/glasgow/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+	rpm {
+		spec = "glasgow.spec"
+	}
+}

--- a/anda/tools/glasgow/glasgow.spec
+++ b/anda/tools/glasgow/glasgow.spec
@@ -1,0 +1,71 @@
+%global commit b8a7635d0479c9b4af574fb9c28d9c6036e0a14a
+%global commit_date 20250927
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global pypi_name glasgow
+%global _desc Scots Army Knife for electronics.
+
+# Errors without setting this for some reason
+%global _udevrulesdir /usr/lib/udev/rules.d
+
+Name:			python-%{pypi_name}
+Version:		%commit_date.%shortcommit
+Release:		1%?dist
+Summary:		Scots Army Knife for electronics
+License:		0BSD AND Apache-2.0
+URL:			https://github.com/GlasgowEmbedded/glasgow
+Source0:		%url/archive/%commit/glasgow-%commit.tar.gz
+Patch0:         remove-dep-versions.patch
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-build
+BuildRequires:  python3-pdm-backend
+BuildRequires:  git
+
+Requires:       yosys
+Requires:       nextpnr
+Requires:       icestorm
+
+Recommends:     python3-aiohttp
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package     -n python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       glasgow
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -p1 -n glasgow-%commit
+
+%build
+export PDM_BUILD_SCM_VERSION=0.1.0
+pushd software
+%pyproject_wheel
+popd
+
+%install
+%pyproject_install
+%pyproject_save_files glasgow
+install -Dm644 config/70-glasgow.rules %{buildroot}%{_udevrulesdir}/70-glasgow.rules
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md CODEOWNERS CODE_OF_CONDUCT.md CONTRIBUTING.md
+%license LICENSE-0BSD.txt LICENSE-Apache-2.0.txt
+%{_bindir}/glasgow
+%{_udevrulesdir}/70-glasgow.rules
+%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
+%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
+%python3_sitelib/glasgow-*.dist-info/*
+
+%changelog
+* Mon Sep 29 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/glasgow/remove-dep-versions.patch
+++ b/anda/tools/glasgow/remove-dep-versions.patch
@@ -1,0 +1,44 @@
+diff --git a/software/pyproject.toml b/software/pyproject.toml
+index c1151748..c3302e60 100644
+--- a/software/pyproject.toml
++++ b/software/pyproject.toml
+@@ -29,30 +29,30 @@ requires-python = ">=3.11, <4"
+ dependencies = [
+   # We use `typing` features not available in the lowest Python version we support. The library
+   # `typing_extensions` provides shims for such features. It uses SemVer.
+-  "typing_extensions>=4.8,<5",
++  "typing_extensions",
+   # Amaranth is the core of the Glasgow software/gateware interoperability layer. It uses SemVer.
+-  "amaranth>=0.5.7,<0.6",
++  "amaranth",
+   # `packaging` is used in the plugin system, `support.plugin`. It uses CalVer: the major version
+   # is the two last digits of the year and the minor version is the release within that year.
+-  "packaging>=23.0",
++  "packaging",
+   # `platformdirs` is used in the bitstream builder to use platform-appropriate cache directories.
+   # It uses SemVer.
+-  "platformdirs>=3.0.0,<5",
++  "platformdirs",
+   # `fx2` is effectively maintained together with Glasgow. It uses SemVer, and keeps backward
+   # compatibility within the 0.x release series.
+-  "fx2>=0.11,<1",
++  "fx2",
+   # `libusb1` is used to communicate with the device, and its API mirrors the stable API/ABI of
+   # of the native `libusb1` library. It increases major version when dropping support for older
+   # Python versions.
+-  "libusb1>=3.3.0; sys_platform!='emscripten'",
++  "libusb1; sys_platform!='emscripten'",
+   # `cobs` is used to multiplex communication streams in applets. It uses an ad-hoc versioning
+   # system.
+-  "cobs>=1.2.1",
++  "cobs",
+   # `pyvcd` is used in the applet analyzer to dump waveform files. It is also a dependency of
+   # Amaranth, and the version range here must be compatible with Amaranth's.
+-  "pyvcd>=0.4.1,<0.5",
++  "pyvcd",
+   # `importlib_resources` is used to shim over Python API incompatibilities. It uses SemVer.
+-  "importlib_resources~=6.5.2",
++  "importlib_resources",
+ ]
+ 
+ [project.optional-dependencies]

--- a/anda/tools/glasgow/update.rhai
+++ b/anda/tools/glasgow/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("GlasgowEmbedded/glasgow"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: glasgow (#6590)](https://github.com/terrapkg/packages/pull/6590)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)