### PR TITLE
[el10] fix(hyprgraphics): librsvg-2.0 (#6649)

### DIFF
--- a/anda/desktops/waylands/hyprgraphics/hyprgraphics.nightly.spec
+++ b/anda/desktops/waylands/hyprgraphics/hyprgraphics.nightly.spec
@@ -30,6 +30,7 @@ BuildRequires:  pkgconfig(libjpeg)
 BuildRequires:  pkgconfig(libwebp)
 BuildRequires:  pkgconfig(libmagic)
 BuildRequires:  pkgconfig(spng)
+BuildRequires:  pkgconfig(librsvg-2.0)
 
 %if %{with libjxl}
 BuildRequires:  pkgconfig(libjxl)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(hyprgraphics): librsvg-2.0 (#6649)](https://github.com/terrapkg/packages/pull/6649)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)