### PR TITLE
[el10] add: dotty-dict (#6615)

### DIFF
--- a/anda/langs/python/dotty-dict/anda.hcl
+++ b/anda/langs/python/dotty-dict/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "dotty-dict.spec"
+    }
+}

--- a/anda/langs/python/dotty-dict/dotty-dict.spec
+++ b/anda/langs/python/dotty-dict/dotty-dict.spec
@@ -1,0 +1,53 @@
+%global pypi_name dotty_dict
+%global _desc Dictionary wrapper for quick access to deeply nested keys.
+
+Name:			python-%{pypi_name}
+Version:		1.3.1
+Release:		1%?dist
+Summary:		Dictionary wrapper for quick access to deeply nested keys
+License:		MIT
+URL:			https://github.com/pawelzny/dotty_dict
+Source0:		%url/archive/refs/tags/v%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-build
+BuildRequires:  python3-installer
+BuildRequires:  python3-wheel
+BuildRequires:  python3-poetry-core
+BuildRequires:  python3-pip
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       dotty_dict
+Provides:       dotty-dict
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n dotty_dict-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files dotty_dict
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst AUTHORS.rst CONTRIBUTING.rst
+%license LICENSE
+%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
+%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
+%python3_sitelib/dotty_dict-%version.dist-info/*
+
+%changelog
+* Tue Sep 30 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/dotty-dict/update.rhai
+++ b/anda/langs/python/dotty-dict/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("pawelzny/dotty_dict"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: dotty-dict (#6615)](https://github.com/terrapkg/packages/pull/6615)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)