### PR TITLE
[f41] fix provides tag (#6673)

### DIFF
--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -7,7 +7,7 @@
 
 Name:			python-%{pypi_name}
 Version:		0~%{commit_date}git.%shortcommit
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Typing stubs for colorama
 License:		Apache-2.0
 URL:			https://github.com/python/typeshed
@@ -23,6 +23,7 @@ Packager:	    Owen Zimmerman <owen@fyralabs.com>
 %package -n     python3-%{pypi_name}
 Summary:        %{summary}
 Provides:       types-colorama
+Provides:       python%{python3_pkgversion}dist(types-colorama)
 %{?python_provide:%python_provide python3-%{pypi_name}}
 
 %description -n python3-%{pypi_name}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix provides tag (#6673)](https://github.com/terrapkg/packages/pull/6673)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)