### PR TITLE
[f42] fix(types-colorama): add other provides tag (#6679)

### DIFF
--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -7,7 +7,7 @@
 
 Name:			python-%{pypi_name}
 Version:		0~%{commit_date}git.%shortcommit
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Typing stubs for colorama
 License:		Apache-2.0
 URL:			https://github.com/python/typeshed
@@ -24,6 +24,7 @@ Packager:	    Owen Zimmerman <owen@fyralabs.com>
 Summary:        %{summary}
 Provides:       types-colorama
 Provides:       python%{python3_pkgversion}dist(types-colorama)
+Provides:       python3.13dist(types-colorama)
 %{?python_provide:%python_provide python3-%{pypi_name}}
 
 %description -n python3-%{pypi_name}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(types-colorama): add other provides tag (#6679)](https://github.com/terrapkg/packages/pull/6679)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)