### PR TITLE
[f41] fix(copyparty): don't dep on python3 (#6697)

### DIFF
--- a/anda/tools/copyparty/copyparty.spec
+++ b/anda/tools/copyparty/copyparty.spec
@@ -2,7 +2,7 @@
 
 Name:           %{pypi_name}
 Version:        1.19.16
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Portable, featureful, and fast file server 
 URL:            https://github.com/9001/copyparty
 Source0:        %{pypi_source}
@@ -12,7 +12,6 @@ BuildRequires:  anda-srpm-macros
 BuildRequires:  python3-devel python3-pip pyproject-rpm-macros
 BuildRequires:  python3dist(wheel) python3dist(build) python3dist(jinja2)
 BuildRequires:  python3dist(setuptools) python3dist(installer)
-Requires:       python3
 Requires:       python3-%{name} = %{evr}
 Suggests:       ffmpeg python3dist(fuse)
 BuildArch:		noarch
@@ -20,8 +19,7 @@ Packager:       Riley Loo <dev@zackerthescar.com>
 
 %description
 Portable file server with accelerated resumable uploads, dedup, WebDAV, 
-FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
-(runtime) deps (other than Python itself)
+FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no deps.
 
 %package -n     python3-%{pypi_name}
 Requires:       python3
@@ -29,10 +27,8 @@ Summary:        %{summary}
 Requires:       %{name} = %{evr}
 
 %description -n python3-%{pypi_name}
-
 Portable file server with accelerated resumable uploads, dedup, WebDAV, 
-FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no 
-(runtime) deps (other than Python itself)
+FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no deps.
  
 %prep
 %autosetup -n copyparty-%version
@@ -53,8 +49,6 @@ FTP, TFTP, zeroconf, media indexer, thumbnails++ all in one file, no
 %files -n python3-%{pypi_name}
 %{python3_sitelib}/%{pypi_name}*
 
- 
 %changelog
-
 * Mon Jul 28 2025 Riley Loo <dev@zackerthescar.com>
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(copyparty): don&#x27;t dep on python3 (#6697)](https://github.com/terrapkg/packages/pull/6697)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)