### PR TITLE
[f43] add: croskbd (#6698)

### DIFF
--- a/anda/system/croskbd/anda.hcl
+++ b/anda/system/croskbd/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "croskbd.spec"
+	}
+}

--- a/anda/system/croskbd/croskbd.spec
+++ b/anda/system/croskbd/croskbd.spec
@@ -1,0 +1,43 @@
+Name:           croskbd
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        Chromebook Keyboard Daemon
+
+License:        BSD-3-Clause
+URL:            https://github.com/WeirdTreeThing/croskbd
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  make gcc systemd-rpm-macros
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%make_build
+
+%install
+%make_install DESTDIR=%{buildroot} PREFIX=%{_prefix} install install_systemd
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+
+%changelog
+* Tue Oct 07 2025 Owen-sz <owen@fyralabs.com>
+- Initial commit

--- a/anda/system/croskbd/update.rhai
+++ b/anda/system/croskbd/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("WeirdTreeThing/croskbd"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: croskbd (#6698)](https://github.com/terrapkg/packages/pull/6698)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)