### PR TITLE
[f42] fix(croskbd): rhai script tracking versions (#6707)

### DIFF
--- a/anda/system/croskbd/update.rhai
+++ b/anda/system/croskbd/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("WeirdTreeThing/croskbd"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(gh("WeirdTreeThing/croskbd"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(croskbd): rhai script tracking versions (#6707)](https://github.com/terrapkg/packages/pull/6707)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)