### PR TITLE
[f41] bump(libhelium): 1.8.65 (#6737)

### DIFF
--- a/anda/lib/libhelium/libhelium.spec
+++ b/anda/lib/libhelium/libhelium.spec
@@ -1,4 +1,4 @@
-%global ver 1.8.64
+%global ver 1.8.65
 %global sanitized_ver %(echo %{ver} | sed -E 's/-/~/g')
 Summary:        The Application Framework for tauOS apps
 Name:           libhelium


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [bump(libhelium): 1.8.65 (#6737)](https://github.com/terrapkg/packages/pull/6737)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)