### PR TITLE
[f42] add: monita (#6740)

### DIFF
--- a/anda/tools/monita/anda.hcl
+++ b/anda/tools/monita/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "monita.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/tools/monita/monita.spec
+++ b/anda/tools/monita/monita.spec
@@ -1,0 +1,38 @@
+%global commit      ac498cd3b228c5218dd91ab6876459a7790b3c8a
+%global shortcommit %{sub %commit 1 7}
+%global commit_date 20251012
+
+Name:           monita
+Version:        0~%{commit_date}git.%shortcommit
+Release:        1%?dist
+Summary:        A modern, beautiful system monitor
+License:        GPL-3.0-only
+URL:            https://github.com/tau-OS/monita
+Source0:        %url/archive/%commit.tar.gz
+Packager:       madonuko <mado@fyralabs.com>
+BuildRequires:  meson vala
+BuildRequires:  pkgconfig(gtk4)
+BuildRequires:  pkgconfig(libhelium-1)
+BuildRequires:  pkgconfig(gee-0.8)
+BuildRequires:  pkgconfig(libgtop-2.0)
+BuildRequires:  %_bindir/update-desktop-database
+
+%description
+A modern, beautiful system monitor for Linux built with GTK4 and libhelium.
+
+%prep
+%autosetup -n %name-%commit
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+%files
+%doc README.md
+%license COPYING
+%_bindir/com.fyralabs.Monita
+%_datadir/applications/com.fyralabs.Monita.desktop
+%_iconsdir/hicolor/*/apps/com.fyralabs.Monita.svg

--- a/anda/tools/monita/update.rhai
+++ b/anda/tools/monita/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("tau-OS/monita"));
+if rpm.changed() {
+	rpm.release();
+	rpm.global("date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: monita (#6740)](https://github.com/terrapkg/packages/pull/6740)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)