### PR TITLE
[f43] fix(ghostty-nightly): Update version regex to include '-dev' suffix (#6761)

### DIFF
--- a/anda/devs/ghostty/nightly/update.rhai
+++ b/anda/devs/ghostty/nightly/update.rhai
@@ -6,7 +6,7 @@ if rpm.changed() {
     let date = json.created_at;
     date.truncate(10);
     let html = get(`https://raw.githubusercontent.com/ghostty-org/ghostty/refs/heads/main/build.zig.zon`);
-    let ver = find(".version = \"([\\d.]+)\"", html, 1);
+    let ver = find("\\.version = \"([\\d.]+)-dev\"", html, 1);
     rpm.global("fulldate", date);
     rpm.global("ver", ver);
     rpm.release();


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(ghostty-nightly): Update version regex to include &#x27;-dev&#x27; suffix (#6761)](https://github.com/terrapkg/packages/pull/6761)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)