### PR TITLE
[el10] bump: netto (#6787)

### DIFF
--- a/anda/langs/nim/netto/netto.spec
+++ b/anda/langs/nim/netto/netto.spec
@@ -1,5 +1,5 @@
 Name:           netto
-Version:        0.1.2
+Version:        0.1.3
 Release:        1%?dist
 Summary:        📡 GUI Network Applet
 License:        GPL-3.0-or-later


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [bump: netto (#6787)](https://github.com/terrapkg/packages/pull/6787)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)