### PR TITLE
[el10] bump: ghostty (#6792)

### DIFF
--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -3,7 +3,7 @@
 %global appid com.mitchellh.ghostty
 
 Name:           ghostty
-Version:        1.2.1
+Version:        1.2.2
 Release:        1%?dist
 Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump: ghostty (#6792)](https://github.com/terrapkg/packages/pull/6792)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)