### PR TITLE
[f42] docs(readme): add pkgs.org instead (#6796)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Terra Sources
 
-[![Repository status](https://repology.org/badge/repository-big/terra_40.svg?header=Terra+40)](https://repology.org/repository/terra_40)
-[![Repository status](https://repology.org/badge/repository-big/terra_41.svg?header=Terra+41)](https://repology.org/repository/terra_41)
-[![Repository status](https://repology.org/badge/repository-big/terra_rawhide.svg?header=Terra+Rawhide)](https://repology.org/repository/terra_rawhide)
-
 Terra is a rolling-release Fedora repository for all the software you need.
 With Terra, you can install the latest packages knowing that quality and security are assured.
 
@@ -12,6 +8,8 @@ See the introduction at [our website](https://terra.fyralabs.com).
 This monorepo contains the package manifests for all packages in Terra.
 
 ## Installation
+
+The latest detailed instructions are available in our Devdocs: https://developer.fyralabs.com/terra/installing
 
 ### Fedora
 
@@ -47,6 +45,10 @@ sudo dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/t
 ## Documentation
 
 Our documentation can be found on our [Devdocs](https://developer.fyralabs.com/terra/).
+
+## pkgs.org
+
+pkgs.org provides a list of the packages available in the main stream: https://fedora.pkgs.org/rawhide/terra/
 
 ## Questions?
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [docs(readme): add pkgs.org instead (#6796)](https://github.com/terrapkg/packages/pull/6796)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)