### PR TITLE
[f42] fix: add needed nightly tags (#6799)

### DIFF
--- a/anda/apps/mpv/anda.hcl
+++ b/anda/apps/mpv/anda.hcl
@@ -3,6 +3,6 @@ project pkg {
 	  spec = "mpv-nightly.spec"
   }
   labels {
-    nightly = "1"
+    nightly = 1
   }
 }

--- a/anda/apps/rp-appset/anda.hcl
+++ b/anda/apps/rp-appset/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "rp-appset.spec"
   }
+  labels {
+    nightly = 1
+  }
 }

--- a/anda/apps/rp-bookshelf/anda.hcl
+++ b/anda/apps/rp-bookshelf/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "rp-bookshelf.spec"
   }
+  labels {
+    nightly = 1
+  }
 }

--- a/anda/games/prismlauncher-nightly/anda.hcl
+++ b/anda/games/prismlauncher-nightly/anda.hcl
@@ -4,7 +4,7 @@ project pkg {
         extra_repos = ["https://packages.adoptium.net/artifactory/rpm/fedora/\\$releasever/\\$basearch"]
 	}
 	labels {
-		nightly = "1"
+		nightly = 1
 		mock = 1
 	}
 }

--- a/anda/langs/nim/nim-nightly/anda.hcl
+++ b/anda/langs/nim/nim-nightly/anda.hcl
@@ -3,6 +3,6 @@ project pkg {
 		spec = "nim-nightly.spec"
 	}
 	labels {
-		nightly = "1"
+		nightly = 1
 	}
 }

--- a/anda/langs/python/types-colorama/anda.hcl
+++ b/anda/langs/python/types-colorama/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
   rpm {
 	spec = "types-colorama.spec"
   }
+  labels {
+    nightly = 1
+  }
 }

--- a/anda/langs/vala/vala-language-server-nightly/anda.hcl
+++ b/anda/langs/vala/vala-language-server-nightly/anda.hcl
@@ -3,6 +3,6 @@ project pkg {
 		spec = "vala-language-server-nightly.spec"
 	}
 	labels {
-		nightly = "1"
+		nightly = 1
 	}
 }

--- a/anda/langs/vala/vala-lint-nightly/anda.hcl
+++ b/anda/langs/vala/vala-lint-nightly/anda.hcl
@@ -3,6 +3,6 @@ project pkg {
 		spec = "vala-lint-nightly.spec"
 	}
 	labels {
-		nightly = "1"
+		nightly = 1
 	}
 }

--- a/anda/misc/pokemon-colorscripts/anda.hcl
+++ b/anda/misc/pokemon-colorscripts/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
 	rpm {
 		spec = "pokemon-colorscripts.spec"
 	}
+ labels {
+    nightly = 1
+  }
 }

--- a/anda/system/nvidia-patch/anda.hcl
+++ b/anda/system/nvidia-patch/anda.hcl
@@ -3,7 +3,7 @@ project "pkg" {
         spec = "nvidia-patch.spec"
     }
    	labels {
-		nightly = "1"
+		nightly = 1
                 subrepo = "nvidia"
 	}
 }

--- a/anda/system/readymade/git/anda.hcl
+++ b/anda/system/readymade/git/anda.hcl
@@ -3,5 +3,6 @@ project pkg {
     spec = "readymade-git.spec"
   }
   labels {
+    nightly = 1
   }
 }

--- a/anda/system/rtl8821cu/kmod-common/anda.hcl
+++ b/anda/system/rtl8821cu/kmod-common/anda.hcl
@@ -4,6 +4,6 @@ project pkg {
         spec = "rtl8821cu-kmod-common.spec"
     }
    	labels {
-		nightly = "1"
+		nightly = 1
 	}
 }

--- a/anda/tools/crossystem/anda.hcl
+++ b/anda/tools/crossystem/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "crossystem.spec"
 	}
+ labels {
+    nightly = 1
+  }
 }

--- a/anda/tools/glasgow/anda.hcl
+++ b/anda/tools/glasgow/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
 	rpm {
 		spec = "glasgow.spec"
 	}
+ labels {
+    nightly = 1
+  }
 }

--- a/anda/tools/piclone/anda.hcl
+++ b/anda/tools/piclone/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "piclone.spec"
   }
+  labels {
+    nightly = 1
+  }
 }

--- a/anda/tools/raindrop/anda.hcl
+++ b/anda/tools/raindrop/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "raindrop.spec"
 	}
+ labels {
+    nightly = 1
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: add needed nightly tags (#6799)](https://github.com/terrapkg/packages/pull/6799)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)