### PR TITLE
[el10] bump(throne): 1.0.6 (#6766)

### DIFF
--- a/anda/apps/throne/throne.spec
+++ b/anda/apps/throne/throne.spec
@@ -1,8 +1,8 @@
 #? https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=throne-git
 
 Name: throne
-Version: 1.0.5
-Release: 3%?dist
+Version: 1.0.6
+Release: 1%?dist
 Summary: Qt based cross-platform GUI proxy configuration manager (backend: sing-box)
 URL: https://github.com/throneproj/Throne
 License: GPLv3
@@ -17,6 +17,7 @@ Source2: Sagernet.SingBox.Version.txt
 
 Source3: %{name}.desktop
 Source4: %{name}.sh
+Source5: https://raw.githubusercontent.com/throneproj/routeprofiles/rule-set/srslist.h
 
 BuildRequires: rpm_macro(cmake)
 BuildRequires: rpm_macro(cmake_build)
@@ -65,6 +66,8 @@ cd gen
 protoc -I . --go_out=. --protorpc_out=. libcore.proto
 
 %build
+mkdir -p %__cmake_builddir
+cp %{S:5} %__cmake_builddir/
 %cmake
 %cmake_build
 DEST=$PWD/%{__cmake_builddir}/%{core}

--- a/anda/apps/throne/update.rhai
+++ b/anda/apps/throne/update.rhai
@@ -1,3 +1,2 @@
-rpm.version(find(`([\d.]+)-\d+-\d+-\d+`, gh_rawfile("throneproj/Throne", "dev", "throne_version.txt"), 1));
-
+rpm.version(gh("throneproj/Throne"));
 open_file("anda/apps/throne/Sagernet.SingBox.Version.txt", "w").write(gh("sagernet/sing-box"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [bump(throne): 1.0.6 (#6766)](https://github.com/terrapkg/packages/pull/6766)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)