### PR TITLE
[el10] fix(nvidia-patch): Update update.rhai (#6808)

### DIFF
--- a/anda/system/nvidia-patch/update.rhai
+++ b/anda/system/nvidia-patch/update.rhai
@@ -1,7 +1,5 @@
-if filters.contains("nightly") {
-	rpm.global("commit", gh_commit("keylase/nvidia-patch"));
-	if rpm.changed() {
-		rpm.global("commit_date", date());
-		rpm.release();
-	}
+rpm.global("commit", gh_commit("keylase/nvidia-patch"));
+if rpm.changed() {
+	rpm.global("commit_date", date());
+	rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(nvidia-patch): Update update.rhai (#6808)](https://github.com/terrapkg/packages/pull/6808)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)