### PR TITLE
[f42] fix(vesktop): Install the correct icon to the correct path (#6825)

### DIFF
--- a/anda/apps/vesktop/vesktop.spec
+++ b/anda/apps/vesktop/vesktop.spec
@@ -7,7 +7,7 @@
 Name:		vesktop
 Obsoletes:  VencordDesktop < 1.5.8-1
 Obsoletes:  vencord-desktop < 1.5.8-1
-Version:	1.5.8
+Version:	1.6.0
 Release:	2%?dist
 License:	GPL-3.0
 Summary:	Vesktop is a cross platform desktop app aiming to give you a snappier Discord experience with Vencord pre-installed
@@ -58,17 +58,17 @@ cp -r dist/*-unpacked/. %buildroot/usr/share/vesktop/.
 install -Dm755 dist/*-unpacked/vesktop %buildroot/usr/bin/vesktop
 ln -sf /usr/share/vesktop/vesktop %buildroot/usr/bin/vesktop
 ln -sf /usr/bin/vesktop %buildroot/usr/bin/vencorddesktop
-install -Dm644 vesktop.desktop %buildroot/usr/share/applications/vesktop.desktop
-install -Dm644 build/icon.png %buildroot/usr/share/pixmaps/vesktop.png
+install -Dm644 vesktop.desktop %{buildroot}%{_datadir}/applications/vesktop.desktop
+install -Dm644 build/icon.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/vesktop.svg
 
 %files
 %doc README.md
 %license LICENSE
-/usr/bin/vesktop
-/usr/bin/vencorddesktop
-/usr/share/applications/vesktop.desktop
-/usr/share/pixmaps/vesktop.png
-/usr/share/vesktop/*
+%{_bindir}/vesktop
+%{_bindir}/vencorddesktop
+%{_datadir}/applications/vesktop.desktop
+%{_iconsdir}/hicolor/scalable/apps/vesktop.svg
+%{_datadir}/vesktop/*
 
 %changelog
 * Thu Jul 24 2025 Atmois <info@atmois.com> - 1.5.8-2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(vesktop): Install the correct icon to the correct path (#6825)](https://github.com/terrapkg/packages/pull/6825)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)