### PR TITLE
[f41] add: TDF (#6835)

### DIFF
--- a/anda/multimedia/tdf/anda.hcl
+++ b/anda/multimedia/tdf/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "tdf.spec"
+    }
+}

--- a/anda/multimedia/tdf/tdf.spec
+++ b/anda/multimedia/tdf/tdf.spec
@@ -1,0 +1,42 @@
+Name:           tdf
+Version:        0.4.3
+Release:        1%?dist
+Summary:        A tui-based PDF viewer
+URL:            https://github.com/itsjunetime/tdf
+Source0:        %url/archive/refs/tags/v%{version}.tar.gz
+License:        AGPL-3.0
+BuildRequires:  cargo anda-srpm-macros cargo-rpm-macros mold fontconfig-devel mupdf glib2 libgcc clang python
+
+Packager:       Its-J
+
+%description
+A terminal-based PDF viewer.
+Designed to be performant, very responsive, and work well with even very large PDFs. Built with ratatui.
+
+%prep
+%git_clone
+%cargo_prep_online
+pushd ratatui-image
+%cargo_prep_online
+popd
+pushd ratatui
+%cargo_prep_online
+popd
+
+%build
+%cargo_build
+
+%install
+install -Dm755 target/rpm/tdf %{buildroot}%{_bindir}/tdf
+%cargo_license_summary_online
+%{cargo_license_online -a} > LICENSE.dependencies
+
+%files
+%doc README.md
+%license LICENSE
+%license LICENSE.dependencies
+%{_bindir}/tdf
+
+%changelog
+* Wed Oct 22 2025 Its-J
+- Intial Commit

--- a/anda/multimedia/tdf/update.rhai
+++ b/anda/multimedia/tdf/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("itsjunetime/tdf"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: TDF (#6835)](https://github.com/terrapkg/packages/pull/6835)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)