### PR TITLE
[f43] add: rust-motd (#6837)

### DIFF
--- a/anda/misc/rust-motd/anda.hcl
+++ b/anda/misc/rust-motd/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "rust-motd.spec"
+    }
+}

--- a/anda/misc/rust-motd/rust-motd.spec
+++ b/anda/misc/rust-motd/rust-motd.spec
@@ -1,0 +1,35 @@
+Name:           rust-motd
+Version:        2.1.0
+Release:        1%?dist
+Summary:        Beautiful, useful, configurable MOTD generation with zero runtime dependencies
+URL:            https://github.com/rust-motd/rust-motd
+Source0:        %url/archive/refs/tags/v%{version}.tar.gz
+License:        MIT
+BuildRequires:  cargo anda-srpm-macros cargo-rpm-macros mold perl
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary.
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+%cargo_install
+%cargo_license_summary_online
+%{cargo_license_online -a} > LICENSE.dependencies
+
+%files
+%doc README.md DEVELOPING.md CHANGELOG.md example_config.toml example_config.kdl
+%license LICENSE
+%license LICENSE.dependencies
+%{_bindir}/rust-motd
+
+%changelog
+* Thu Oct 23 2025 Owen Zimmerman <owen@fyralabs.com>
+- Intial Commit

--- a/anda/misc/rust-motd/update.rhai
+++ b/anda/misc/rust-motd/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("rust-motd/rust-motd"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: rust-motd (#6837)](https://github.com/terrapkg/packages/pull/6837)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)