### PR TITLE
[f43] add: graftcp (#6871)

### DIFF
--- a/anda/tools/graftcp/nightly/anda.hcl
+++ b/anda/tools/graftcp/nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "graftcp-nightly.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/tools/graftcp/nightly/graftcp-nightly.spec
+++ b/anda/tools/graftcp/nightly/graftcp-nightly.spec
@@ -1,0 +1,56 @@
+%global commit ebb5ad865f673ecbde1a628b75c5505bbd2bfd04
+%global commit_date 20250817
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:			graftcp-nightly
+Version:		0~%{commit_date}git.%{shortcommit}
+Release:		1%?dist
+Summary:		A flexible tool for redirecting a given program's TCP traffic to SOCKS5 or HTTP proxy
+URL:			https://github.com/hmgle/graftcp
+License:		GPL-3.0
+Source0:        %url/archive/%commit/graftcp-%commit.tar.gz
+BuildRequires:	gcc mold make golang systemd-rpm-macros
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+Conflicts:      graftcp
+
+%description
+graftcp can redirect the TCP connection made by the given program [application, script, shell, etc.] to SOCKS5 or HTTP proxy.
+
+Compared with tsocks, proxychains or proxychains-ng, graftcp is not using the LD_PRELOAD trick which only work for dynamically
+linked programs, e.g., applications built by Go can not be hook by proxychains-ng. graftcp can trace or modify any given program's
+connect by ptrace(2), so it is workable for any program. The principle will be explained in this paragraph of how does it work.
+
+%prep
+%autosetup -n graftcp-%{commit}
+
+%build
+%make_build
+
+%install
+install -Dm755 graftcp                                      %{buildroot}%{_bindir}/graftcp
+install -Dm755 local/graftcp-local                          %{buildroot}%{_bindir}/graftcp-local
+install -Dm755 local/mgraftcp                               %{buildroot}%{_bindir}/mgraftcp
+install -Dm644 local/contrib/systemd/graftcp-local.service  %{buildroot}%{_unitdir}/graftcp-local.service
+install -Dm644 local/example-graftcp-local.conf             %{buildroot}%{_sysconfdir}/graftcp-local/example-graftcp-local.conf
+
+%post
+%systemd_post graftcp-local.service
+
+%preun
+%systemd_preun graftcp-local.service
+
+%postun
+%systemd_postun_with_restart graftcp-local.service
+
+%files
+%doc README.md README.zh-CN.md
+%license COPYING
+%{_bindir}/graftcp
+%{_bindir}/graftcp-local
+%{_bindir}/mgraftcp
+%{_unitdir}/graftcp-local.service
+%{_sysconfdir}/graftcp-local/example-graftcp-local.conf
+
+%changelog
+* Fri Oct 24 2025 Owen Zimmerman <owen@fyralabs.com>
+- initial commit

--- a/anda/tools/graftcp/nightly/update.rhai
+++ b/anda/tools/graftcp/nightly/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("hmgle/graftcp"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}

--- a/anda/tools/graftcp/stable/anda.hcl
+++ b/anda/tools/graftcp/stable/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "graftcp.spec"
+  }
+}

--- a/anda/tools/graftcp/stable/graftcp.spec
+++ b/anda/tools/graftcp/stable/graftcp.spec
@@ -1,0 +1,52 @@
+Name:			graftcp
+Version:		0.7.1
+Release:		1%?dist
+Summary:		A flexible tool for redirecting a given program's TCP traffic to SOCKS5 or HTTP proxy
+URL:			https://github.com/hmgle/graftcp
+License:		GPL-3.0
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+BuildRequires:	gcc mold make golang systemd-rpm-macros
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+Conflicts:      graftcp-nightly
+
+%description
+graftcp can redirect the TCP connection made by the given program [application, script, shell, etc.] to SOCKS5 or HTTP proxy.
+
+Compared with tsocks, proxychains or proxychains-ng, graftcp is not using the LD_PRELOAD trick which only work for dynamically
+linked programs, e.g., applications built by Go can not be hook by proxychains-ng. graftcp can trace or modify any given program's
+connect by ptrace(2), so it is workable for any program. The principle will be explained in this paragraph of how does it work.
+
+%prep
+%autosetup  -n graftcp-%{version}
+
+%build
+%make_build
+
+%install
+install -Dm755 graftcp                                      %{buildroot}%{_bindir}/graftcp
+install -Dm755 local/graftcp-local                          %{buildroot}%{_bindir}/graftcp-local
+install -Dm755 local/mgraftcp                               %{buildroot}%{_bindir}/mgraftcp
+install -Dm644 local/contrib/systemd/graftcp-local.service  %{buildroot}%{_unitdir}/graftcp-local.service
+install -Dm644 local/example-graftcp-local.conf             %{buildroot}%{_sysconfdir}/graftcp-local/example-graftcp-local.conf
+
+%post
+%systemd_post graftcp-local.service
+
+%preun
+%systemd_preun graftcp-local.service
+
+%postun
+%systemd_postun_with_restart graftcp-local.service
+
+%files
+%doc README.md README.zh-CN.md
+%license COPYING
+%{_bindir}/graftcp
+%{_bindir}/graftcp-local
+%{_bindir}/mgraftcp
+%{_unitdir}/graftcp-local.service
+%{_sysconfdir}/graftcp-local/example-graftcp-local.conf
+
+%changelog
+* Fri Oct 24 2025 Owen Zimmerman <owen@fyralabs.com>
+- initial commit

--- a/anda/tools/graftcp/stable/update.rhai
+++ b/anda/tools/graftcp/stable/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("hmgle/graftcp"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: graftcp (#6871)](https://github.com/terrapkg/packages/pull/6871)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)