### PR TITLE
[f43] add: sleepy launcher (#6885)

### DIFF
--- a/anda/games/launcher.moe/sleepy-launcher/anda.hcl
+++ b/anda/games/launcher.moe/sleepy-launcher/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "sleepy-launcher.spec"
+    }
+}

--- a/anda/games/launcher.moe/sleepy-launcher/sleepy-launcher.spec
+++ b/anda/games/launcher.moe/sleepy-launcher/sleepy-launcher.spec
@@ -1,0 +1,75 @@
+%global cargo_install_lib 0
+%global crate sleepy-launcher
+%global appid moe.launcher.sleepy-launcher
+Name:           %{crate}
+Version:        1.5.0
+Release:        1%?dist
+Summary:        Sleepy Game Launcher for Linux with automatic patching and telemetry disabling 
+
+License:        GPL-3.0-or-later
+URL:            https://github.com/an-anime-team/sleepy-launcher
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+
+# Allow migrate path from Maroxy's OBS repo
+Provides: sleepy-launcher = %{version}-%{release}
+
+Requires: unzip
+Requires: cabextract
+Requires: tar
+Requires: git
+Requires: p7zip
+Requires: curl
+Requires: xdelta
+BuildRequires: gtk4
+BuildRequires: git
+BuildRequires: rust
+BuildRequires: cargo
+BuildRequires: gtk4-devel
+BuildRequires: openssl-devel
+BuildRequires: python3
+BuildRequires: python3-gobject
+BuildRequires: libadwaita-devel
+BuildRequires: cmake
+BuildRequires: gcc clang-devel mold
+BuildRequires: rust-packaging
+BuildRequires: desktop-file-utils
+BuildRequires: anda-srpm-macros
+BuildRequires: cargo-rpm-macros
+
+
+%description
+%{summary}
+
+%prep
+%autosetup -n sleepy-launcher-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+%crate_install_bin
+
+install -Dm644 assets/images/icon.png %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%{appid}.png
+desktop-file-install \
+    --set-icon="%{appid}" \
+    --set-key="Exec" --set-value="%{name}" \
+    --dir=%{buildroot}%{_datadir}/applications \
+    assets/sleepy-launcher.desktop
+
+%check
+desktop-file-validate %{buildroot}/%{_datadir}/applications/sleepy-launcher.desktop
+
+
+%files
+%license LICENSE
+%doc README.md CHANGELOG.md
+%{_datadir}/applications/sleepy-launcher.desktop
+%{_bindir}/%{crate}
+%{_datadir}/icons/hicolor/512x512/apps/%{appid}.png
+
+%changelog
+* Sat Sep 20 2025 Cappy Ishihara <cappy@cappuchino.xyz>
+- Initial package

--- a/anda/games/launcher.moe/sleepy-launcher/update.rhai
+++ b/anda/games/launcher.moe/sleepy-launcher/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("an-anime-team/sleepy-launcher"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: sleepy launcher (#6885)](https://github.com/terrapkg/packages/pull/6885)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)