### PR TITLE
[f43] fix: rpcc (#6906)

### DIFF
--- a/anda/apps/rpcc/rpcc.spec
+++ b/anda/apps/rpcc/rpcc.spec
@@ -4,7 +4,7 @@
 
 Name:           rpcc
 Version:        0~%commit_date.git~%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Raspberry Pi Control Centre - an extensible settings application for the Raspberry Pi Desktop
 License:        BSD-3-Clause
 URL:            https://github.com/raspberrypi-ui/rpcc
@@ -20,9 +20,6 @@ BuildRequires:  gcc
 
 Requires:       libxml2
 Requires:       gtk3
-
-Provides:       pipanel
-Provides:       rp-appset
 
 %description
 Raspberry Pi Control Centre - an extensible settings application for the Raspberry Pi Desktop


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: rpcc (#6906)](https://github.com/terrapkg/packages/pull/6906)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)