### PR TITLE
[el10] add: rasputin (#6911)

### DIFF
--- a/anda/apps/rasputin/anda.hcl
+++ b/anda/apps/rasputin/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "rasputin.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/apps/rasputin/rasputin.spec
+++ b/anda/apps/rasputin/rasputin.spec
@@ -1,0 +1,45 @@
+%global commit be92ea86af35aa1ecee28b12cd4401aac82cadb0
+%global commit_date 20251023
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           rasputin
+Version:        0~%commit_date.git~%shortcommit
+Release:        1%?dist
+Summary:        Mouse and keyboard settings for Raspberry Pi Desktop
+License:        BSD-3-Clause
+URL:            https://github.com/raspberrypi-ui/rasputin
+Source0:        %url/archive/%commit.tar.gz
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  meson
+BuildRequires:  ninja-build
+BuildRequires:  gtk3-devel
+BuildRequires:  libxml2-devel
+BuildRequires:  intltool
+BuildRequires:  gcc
+
+Requires:       libxml2
+
+%description
+%summary.
+
+%prep
+%autosetup -n rasputin-%{commit}
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+%find_lang rpcc_rasputin
+
+%files -f rpcc_rasputin.lang
+%license debian/copyright
+%{_datadir}/rpcc/ui/rasputin.ui
+%{_libdir}/rpcc/librpcc_rasputin.so
+
+%changelog
+* Sun Oct 26 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/apps/rasputin/update.rhai
+++ b/anda/apps/rasputin/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("raspberrypi-ui/appset"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: rasputin (#6911)](https://github.com/terrapkg/packages/pull/6911)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)