### PR TITLE
[f41] add: Honkers Launcher (#6886)

### DIFF
--- a/anda/games/launcher.moe/honkers-launcher/anda.hcl
+++ b/anda/games/launcher.moe/honkers-launcher/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "honkers-launcher.spec"
+    }
+}

--- a/anda/games/launcher.moe/honkers-launcher/honkers-launcher.spec
+++ b/anda/games/launcher.moe/honkers-launcher/honkers-launcher.spec
@@ -1,0 +1,75 @@
+%global cargo_install_lib 0
+%global crate honkers-launcher
+%global appid moe.launcher.honkers-launcher
+Name:           %{crate}
+Version:        1.12.0
+Release:        1%?dist
+Summary:        Honkers Launcher for Linux with automatic patching and telemetry disabling 
+
+License:        GPL-3.0-or-later
+URL:            https://github.com/an-anime-team/honkers-launcher
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+
+# Allow migrate path from Maroxy's OBS repo
+Provides: honkers-launcher = %{version}-%{release}
+
+Requires: unzip
+Requires: cabextract
+Requires: tar
+Requires: git
+Requires: p7zip
+Requires: curl
+Requires: xdelta
+BuildRequires: gtk4
+BuildRequires: git
+BuildRequires: rust
+BuildRequires: cargo
+BuildRequires: gtk4-devel
+BuildRequires: openssl-devel
+BuildRequires: python3
+BuildRequires: python3-gobject
+BuildRequires: libadwaita-devel
+BuildRequires: cmake
+BuildRequires: gcc clang-devel mold
+BuildRequires: rust-packaging
+BuildRequires: desktop-file-utils
+BuildRequires: anda-srpm-macros
+BuildRequires: cargo-rpm-macros
+
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n honkers-launcher-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+%crate_install_bin
+
+install -Dm644 assets/images/icon.png %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%{appid}.png
+desktop-file-install \
+    --set-icon="%{appid}" \
+    --set-key="Exec" --set-value="%{name}" \
+    --dir=%{buildroot}%{_datadir}/applications \
+    assets/honkers-launcher.desktop
+
+%check
+desktop-file-validate %{buildroot}/%{_datadir}/applications/honkers-launcher.desktop
+
+
+%files
+%license LICENSE
+%doc README.md CHANGELOG.md
+%{_datadir}/applications/honkers-launcher.desktop
+%{_bindir}/%{crate}
+%{_datadir}/icons/hicolor/512x512/apps/%{appid}.png
+
+%changelog
+* Sat Sep 20 2025 Cappy Ishihara <cappy@cappuchino.xyz>
+- Initial package

--- a/anda/games/launcher.moe/honkers-launcher/update.rhai
+++ b/anda/games/launcher.moe/honkers-launcher/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("an-anime-team/honkers-launcher"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: Honkers Launcher (#6886)](https://github.com/terrapkg/packages/pull/6886)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)