### PR TITLE
[f42] fix: coreboot-utils, use %configure macro (#6920)

### DIFF
--- a/anda/tools/coreboot-utils/coreboot-utils.spec
+++ b/anda/tools/coreboot-utils/coreboot-utils.spec
@@ -559,7 +559,7 @@ popd
 
 %ifarch x86_64
 pushd msrtool
-./configure
+%configure
 %make_build
 popd
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: coreboot-utils, use %configure macro (#6920)](https://github.com/terrapkg/packages/pull/6920)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)