### PR TITLE
[f43] bump: ffmpeg (#6939)

### DIFF
--- a/anda/multimedia/ffmpeg/ffmpeg.spec
+++ b/anda/multimedia/ffmpeg/ffmpeg.spec
@@ -13,7 +13,7 @@
 Summary:        A complete solution to record, convert and stream audio and video
 Name:           ffmpeg
 Version:        7.1.2
-Release:        1%?dist
+Release:        2%?dist
 License:        LGPLv3+
 URL:            http://%{name}.org/
 Epoch:          1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [bump: ffmpeg (#6939)](https://github.com/terrapkg/packages/pull/6939)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)