### PR TITLE
[el10] bump: x264 (#6935)

### DIFF
--- a/anda/multimedia/x264/x264.spec
+++ b/anda/multimedia/x264/x264.spec
@@ -1,10 +1,10 @@
-%global fusionsrc_commit 91b92ea4846982e5d9eb58744fda70f75d0faf8d
+%global fusionsrc_commit d8f53f1f25ce2c778582e7cff5790ae24408db2e
 
 # globals for x264-0.164-20231001git31e19f92.tar.bz2
-%global api 164
+%global api 165
 %global gitdate 20231001
-%global gitversion 31e19f92
-%global gitlongver 31e19f92f00c7003fa115047ce50978bc98c3a0d
+%global gitlongver b35605ace3ddf7c1a5d67a2eb553f034aef41d55
+%global gitversion %{sub %gitlongver 1 8}
 
 %global snapshot %{gitdate}git%{gitversion}
 %global gver .%{gitdate}git%{gitversion}
@@ -47,8 +47,6 @@ Source2: https://raw.githubusercontent.com/rpmfusion/x264/%fusionsrc_commit/vers
 Patch0: https://raw.githubusercontent.com/rpmfusion/x264/%fusionsrc_commit/x264-nover.patch
 # add 10b suffix to high bit depth build
 Patch1: https://raw.githubusercontent.com/rpmfusion/x264/%fusionsrc_commit/x264-10b.patch
-# fix assignment from incompatible pointer type errors
-Patch2: https://raw.githubusercontent.com/rpmfusion/x264/%fusionsrc_commit/x264-altivec-incompatible-pointer-type.patch
 Patch11: https://raw.githubusercontent.com/rpmfusion/x264/%fusionsrc_commit/x264-opencl.patch
 
 BuildRequires: anda-srpm-macros git-core
@@ -125,7 +123,6 @@ sh version.sh > ./version.h
 cp %{SOURCE2} .
 %patch -P0 -p1 -b .nover
 %patch -P1 -p1 -b .10b
-%patch -P2 -p1 -b .ptr
 %patch -P11 -p1 -b .opencl
 popd
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [bump: x264 (#6935)](https://github.com/terrapkg/packages/pull/6935)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)