### PR TITLE
[el10] chore(x264, x265): Move to Extras (#6954)

### DIFF
--- a/anda/multimedia/x264-bootstrap/anda.hcl
+++ b/anda/multimedia/x264-bootstrap/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels {
         mock = 1
+        subrepo = "extras"
     }
 }

--- a/anda/multimedia/x264/anda.hcl
+++ b/anda/multimedia/x264/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels { 
         mock = 1
+        subrepo = "extras"
     }
 }

--- a/anda/multimedia/x265/anda.hcl
+++ b/anda/multimedia/x265/anda.hcl
@@ -4,6 +4,7 @@ project pkg {
         spec = "x265.spec"
     }
     labels {
-        mock =1
+        mock = 1
+        subrepo = "extras"
    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(x264, x265): Move to Extras (#6954)](https://github.com/terrapkg/packages/pull/6954)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)