### PR TITLE
[el10] chore(ffmpeg, wine*): Add releasever for extra repos on branches under Rawhide (#6953)

### DIFF
--- a/anda/multimedia/ffmpeg/anda.hcl
+++ b/anda/multimedia/ffmpeg/anda.hcl
@@ -2,7 +2,7 @@ project pkg {
     arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "ffmpeg.spec"
-        extra_repos = ["https://repos.fyralabs.com/terrarawhide-nvidia"]
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-nvidia"]
     }
     labels {
         updbranch = 1

--- a/anda/system/wine/dev/anda.hcl
+++ b/anda/system/wine/dev/anda.hcl
@@ -2,7 +2,7 @@ project pkg {
         arches = ["x86_64", "aarch64", "i386"]
 	rpm {
 		spec = "wine-dev.spec"
-		extra_repos = ["https://repos.fyralabs.com/terrarawhide-mesa"]
+		extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-mesa"]
 	}
 	labels {
 	    mock = 1

--- a/anda/system/wine/stable/anda.hcl
+++ b/anda/system/wine/stable/anda.hcl
@@ -2,7 +2,7 @@ project pkg {
         arches = ["x86_64", "aarch64", "i386"]
 	rpm {
 		spec = "wine-stable.spec"
-		extra_repos = ["https://repos.fyralabs.com/terrarawhide-mesa"]
+		extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-mesa"]
 	}
 	labels {
 	    mock = 1

--- a/anda/system/wine/staging/anda.hcl
+++ b/anda/system/wine/staging/anda.hcl
@@ -2,7 +2,7 @@ project pkg {
         arches = ["x86_64", "aarch64", "i386"]
 	rpm {
 		spec = "wine-staging.spec"
-		extra_repos = ["https://repos.fyralabs.com/terrarawhide-mesa"]
+		extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-mesa"]
 	}
 	labels {
 	    mock = 1


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [chore(ffmpeg, wine*): Add releasever for extra repos on branches under Rawhide (#6953)](https://github.com/terrapkg/packages/pull/6953)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)