### PR TITLE
[el10] fix(elephant): Update file path in update.rhai (#6960)

### DIFF
--- a/anda/langs/go/elephant/update.rhai
+++ b/anda/langs/go/elephant/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_rawfile("abenz1267/elephant", "master", "cmd/version.txt"));
+rpm.version(gh_rawfile("abenz1267/elephant", "master", "cmd/elephant/version.txt"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(elephant): Update file path in update.rhai (#6960)](https://github.com/terrapkg/packages/pull/6960)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)