### PR TITLE
[f41] bump: rpcs3 walker (#6970)

### DIFF
--- a/anda/desktops/waylands/walker/walker.spec
+++ b/anda/desktops/waylands/walker/walker.spec
@@ -4,7 +4,7 @@
 # prevent library files from being installed
 %global cargo_install_lib 0
 
-%global upstream_version v2.3.0
+%global upstream_version v2.7.3
 %global ver %{sub %upstream_version 2}
 
 Name:           walker

--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -11,8 +11,8 @@
 # Need to get rid of everything Clang can't use and undefine -Wunused-command-line-argument where possible due to the project's build flags
 %global build_cflags %(echo %{build_cflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
 %global build_cxxflags %(echo %{build_cxxflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs\=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
-%global commit 9e49b9100fab7293c5f616f6aebc91799461c26c
-%global ver 0.0.38-18185
+%global commit 3a6c71e52395911729b0370442d720b529961e77
+%global ver 0.0.38-18280
 
 Name:           rpcs3
 Version:        %(echo %{ver} | sed 's/-/^/g')


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f41`:
 - [bump: rpcs3 walker (#6970)](https://github.com/terrapkg/packages/pull/6970)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)