### PR TITLE
[frawhide] add: gay (#6969)

### DIFF
--- a/anda/langs/python/gay/anda.hcl
+++ b/anda/langs/python/gay/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "gay.spec"
+    }
+   	labels {
+      nightly = 1
+	}
+}

--- a/anda/langs/python/gay/gay.spec
+++ b/anda/langs/python/gay/gay.spec
@@ -1,0 +1,53 @@
+%global commit af18bcf210659b8b5a40624ffab791d49e831017
+%global commit_date 20241015
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global pypi_name gay
+%global _desc Colour your text / terminal to be more gay.
+
+Name:			python-%{pypi_name}
+Version:		%commit_date.%shortcommit
+Release:		1%?dist
+Summary:		Colour your text / terminal to be more gay
+License:		MIT
+URL:			https://github.com/ms-jpq/gay
+Source0:		%url/archive/%commit/gay-%commit.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       gay
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n gay-%{commit}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+
+%files -n python3-%{pypi_name}
+%doc README.md
+%license LICENSE
+%{_bindir}/gay
+%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
+%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
+%python3_sitelib/gay-1.3.4.dist-info/*
+
+%changelog
+* Tue Sep 30 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/gay/update.rhai
+++ b/anda/langs/python/gay/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("ms-jpq/gay"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [add: gay (#6969)](https://github.com/terrapkg/packages/pull/6969)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)