### PR TITLE
[f42] bump: golang-github-abenz1267-elephant (#6985)

### DIFF
--- a/anda/langs/go/elephant/golang-github-abenz1267-elephant.spec
+++ b/anda/langs/go/elephant/golang-github-abenz1267-elephant.spec
@@ -14,7 +14,7 @@
 
 # https://github.com/abenz1267/elephant
 %global goipath         github.com/abenz1267/elephant
-Version:                2.9.0
+Version:                2.9.1
 
 %gometa -f
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [bump: golang-github-abenz1267-elephant (#6985)](https://github.com/terrapkg/packages/pull/6985)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)