### PR TITLE
[el10] add: senpai (#6994)

### DIFF
--- a/anda/misc/senpai/anda.hcl
+++ b/anda/misc/senpai/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "senpai.spec"
+	}
+}

--- a/anda/misc/senpai/senpai.spec
+++ b/anda/misc/senpai/senpai.spec
@@ -1,0 +1,47 @@
+Name:			senpai
+Version:		0.4.1
+Release:		1%?dist
+Summary:		Your everyday IRC student
+License:		ISC
+URL:			https://github.com/delthas/senpai
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildRequires:	golang scdoc gcc
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+senpai is an IRC client that works best with bouncers:
+
+    - no logs are kept,
+    - history is fetched from the server via CHATHISTORY,
+    - networks are fetched from the server via bouncer-networks,
+    - messages can be searched in logs via SEARCH,
+    - files can be uploaded via FILEHOST (with drag & drop!)
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%make_build
+
+%install
+install -Dm755 senpai                   %{buildroot}%{_bindir}/senpai
+install -Dm644 doc/senpai.1             %{buildroot}%{_mandir}/man1/senpai.1
+install -Dm644 doc/senpai.5             %{buildroot}%{_mandir}/man5/senpai.5
+install -Dm644 contrib/senpai.desktop   %{buildroot}%{_datadir}/applications/senpai.desktop
+install -Dm644 res/icon.48.png          %{buildroot}%{_iconsdir}/hicolor/48x48/apps/senpai.png
+install -Dm644 res/icon.svg             %{buildroot}%{_iconsdir}/hicolor/scalable/apps/senpai.svg
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/senpai
+%{_mandir}/man1/senpai.1.gz
+%{_mandir}/man5/senpai.5.gz
+%{_datadir}/applications/senpai.desktop
+%{_iconsdir}/hicolor/48x48/apps/senpai.png
+%{_iconsdir}/hicolor/scalable/apps/senpai.svg
+
+%changelog
+* Fri Oct 31 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/misc/senpai/update.rhai
+++ b/anda/misc/senpai/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("delthas/senpai"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: senpai (#6994)](https://github.com/terrapkg/packages/pull/6994)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)