### PR TITLE
[f43] add: lily (#6993)

### DIFF
--- a/anda/langs/lily/anda.hcl
+++ b/anda/langs/lily/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "lily.spec"
+	}
+}

--- a/anda/langs/lily/lily.spec
+++ b/anda/langs/lily/lily.spec
@@ -1,0 +1,45 @@
+Name:           lily
+Summary:        Interpreted language focused on expressiveness and type safety
+Version:        2.2
+Release:        1%?dist
+License:        MIT
+URL:            https://github.com/fascinatedbox/lily
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  cmake
+BuildRequires:  gcc
+BuildRequires:  g++
+
+%description
+%{summary}.
+
+%package       devel
+Summary:       Development files for lily
+Requires:      %{name}
+%pkg_devel_files
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%cmake
+%cmake_build
+
+%install
+install -Dm644 redhat-linux-build/lib/liblily.so %{buildroot}/usr/lib64/liblily.so
+%cmake_install
+
+%files
+%doc README.md RELEASES.md
+%license LICENSE.txt
+%{_bindir}/lily
+
+%files devel
+/usr/lib64/liblily.so
+%ghost /usr/lib/liblily.so
+%{_includedir}/lily/lily.h
+
+%changelog
+* Thu Oct 30 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial package

--- a/anda/langs/lily/update.rhai
+++ b/anda/langs/lily/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("fascinatedbox/lily"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: lily (#6993)](https://github.com/terrapkg/packages/pull/6993)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)