### PR TITLE
[f42] fix: deno (#7032)

### DIFF
--- a/anda/devs/deno/deno-fix-metadata-auto.diff
+++ b/anda/devs/deno/deno-fix-metadata-auto.diff
@@ -1,11 +1,11 @@
---- deno-2.5.2/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ deno-2.5.2/Cargo.toml	2025-09-25T08:45:18.476444+00:00
-@@ -650,24 +650,3 @@
+--- deno-2.5.6/Cargo.toml	1970-01-01T00:00:01+00:00
++++ deno-2.5.6/Cargo.toml	2025-11-02T08:06:51.091942+00:00
+@@ -654,24 +654,3 @@
  [target."cfg(unix)".dependencies.shell-escape]
  version = "=0.1.5"
  
 -[target."cfg(windows)".dependencies.deno_subprocess_windows]
--version = "0.12.0"
+-version = "0.16.0"
 -
 -[target."cfg(windows)".dependencies.winapi]
 -version = "=0.3.9"


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: deno (#7032)](https://github.com/terrapkg/packages/pull/7032)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)