### PR TITLE
[f42] fix(elephant): remove some docs files (#7031)

### DIFF
--- a/anda/langs/go/elephant/golang-github-abenz1267-elephant.spec
+++ b/anda/langs/go/elephant/golang-github-abenz1267-elephant.spec
@@ -23,7 +23,7 @@ Elephant - cuz it's phat - is a powerful data provider service and backend for b
 }
 
 %global golicenses      LICENSE
-%global godocs          BREAKING.md README.md cmd/elephant/version.txt
+%global godocs          README.md
 
 Name:           elephant
 Release:        1%?dist
@@ -89,7 +89,7 @@ install -Dm755 internal/providers/*/*.so -t %buildroot/etc/xdg/elephant/provider
 %if %{without bootstrap}
 %files
 %license LICENSE
-%doc BREAKING.md README.md cmd/elephant/version.txt
+%doc README.md
 %{_bindir}/elephant
 %ghost /etc/xdg/elephant/
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(elephant): remove some docs files (#7031)](https://github.com/terrapkg/packages/pull/7031)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)