### PR TITLE
[f41] add: activate-linux (#7048)

### DIFF
--- a/anda/misc/activate-linux/activate-linux.spec
+++ b/anda/misc/activate-linux/activate-linux.spec
@@ -1,0 +1,52 @@
+%global commit d55b639e251cf921541be11e0c32530b0364f7bb
+%global date 20251019
+%global short %(c=%{commit}; echo ${c:0:7})
+%global ver 1.1.0
+
+Name:           activate-linux
+Summary:        The "Activate Windows" watermark ported to Linux
+Version:        %{ver}^%{date}git.%{short}
+License:        GPL-3.0-only
+Release:        1%?dist
+URL:            https://github.com/MrGlockenspiel/activate-linux
+Source0:        %{url}/archive/%{commit}.tar.gz
+BuildRequires:  clang 
+BuildRequires:  pkgconfig(pango)
+BuildRequires:  libconfig-devel
+BuildRequires:  libXinerama-devel
+BuildRequires:  libXext-devel
+BuildRequires:  libXt-devel
+BuildRequires:  libXrandr-devel
+BuildRequires:  libX11-devel
+BuildRequires:  libXi-devel
+BuildRequires:  wayland-devel
+BuildRequires:  wayland-protocols-devel
+Packager:       Metcya <metcya@gmail.com>
+
+%description
+The "Activate Windows" watermark ported to Linux with Xlib and cairo in C
+
+"Science isn't about WHY. It's about WHY NOT. Why is so much of our science dangerous? Why not marry safe science if you love it so much. In fact, why not invent a special safety door that won't hit you on the butt on the way out, because you are fired."
+
+Maintained by MrGlockenspiel.
+
+%prep
+%autosetup -n activate-linux-%{commit}
+
+%build
+%make_build
+
+%install
+# ewwww
+export PREFIX=""
+export BINDIR=%{_bindir}
+%make_install
+
+%files
+%{_bindir}/activate-linux
+%license LICENSE.md
+%doc ARGS.md README.md
+
+%changelog
+* Sun Nov 2 2025 Metcya <metcya@gmail.com>
+- Package activate-linux

--- a/anda/misc/activate-linux/anda.hcl
+++ b/anda/misc/activate-linux/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "activate-linux.spec"
+  }
+}

--- a/anda/misc/activate-linux/update.rhai
+++ b/anda/misc/activate-linux/update.rhai
@@ -1,0 +1,8 @@
+rpm.global("commit", gh_commit("MrGlockenspiel/activate-linux"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("date", date());
+    let ver = gh_tag("MrGlockenspiel/activate-linux");
+    ver.crop(1);
+    rpm.global("ver", ver);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: activate-linux (#7048)](https://github.com/terrapkg/packages/pull/7048)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)