### PR TITLE
[f41] add: zipstream-ng (#7057)

### DIFF
--- a/anda/langs/python/zipstream-ng/anda.hcl
+++ b/anda/langs/python/zipstream-ng/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "zipstream-ng.spec"
+  }
+}

--- a/anda/langs/python/zipstream-ng/update.rhai
+++ b/anda/langs/python/zipstream-ng/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("pR0Ps/zipstream-ng"));

--- a/anda/langs/python/zipstream-ng/zipstream-ng.spec
+++ b/anda/langs/python/zipstream-ng/zipstream-ng.spec
@@ -1,0 +1,51 @@
+%global pypi_name zipstream-ng
+%global _desc 🔉 A modern and easy to use streamable zip file generator
+
+Name:			python-%{pypi_name}
+Version:		1.9.0
+Release:		1%?dist
+Summary:		A modern and easy to use streamable zip file generator
+License:		LGPL-3.0-only
+URL:			https://github.com/pR0Ps/zipstream-ng
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       zipstream-ng
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n zipstream-ng-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files zipstream
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md CHANGELOG.md docs/zipserver.rst
+%license LICENSE
+%{_bindir}/zipserver
+%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
+%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
+%python3_sitelib/zipstream_ng-%version.dist-info/*
+
+%changelog
+* Mon Nov 03 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: zipstream-ng (#7057)](https://github.com/terrapkg/packages/pull/7057)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)