### PR TITLE
[el10] add: udev-joystick-blacklist, split from Steam package (#7054)

### DIFF
--- a/anda/games/udev-joystick-blacklist/anda.hcl
+++ b/anda/games/udev-joystick-blacklist/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "udev-joystick-blacklist.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/games/udev-joystick-blacklist/udev-joystick-blacklist.spec
+++ b/anda/games/udev-joystick-blacklist/udev-joystick-blacklist.spec
@@ -1,0 +1,52 @@
+%global commit a1ace571823be5979c135e9cb8e9ae103c7641ac
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20250715
+
+Name:          udev-joystick-blacklist
+Version:       0^%{commit_date}git%{shortcommit}
+Release:       1%{?dist}
+Summary:       Fix for keyboard/mouse/tablet being detected as joysticks in Linux
+License:       Public Domain
+URL:           https://github.com/denilsonsa/udev-joystick-blacklist
+Source0:       %{url}/archive/%{commit}.tar.gz
+BuildRequires: systemd-rpm-macros
+Conflicts:     %{name}-rm
+BuildArch:     noarch
+Packager:      Gilver E. <rockgrub@disroot.org>
+
+%description
+There are several devices that, although recognized by kernel as joysticks, are not joysticks.
+
+This package contains rules which will prevent those devices from being recognized as joysticks.
+
+%package       rm
+Summary:       Fix for keyboard/mouse/tablet being detected as joysticks in Linux
+Conflicts:     %{name}
+Obsoletes:     steam-device-rules <= 1.0.0.85-1
+
+%description   rm
+There are several devices that, although recognized by kernel as joysticks, are not joysticks.
+
+This package contains rules which will prevent those devices from being recognized as joysticks by removing the devices.
+
+%prep
+%autosetup -n %{name}-%{commit}
+
+%build
+# Empty.
+
+%install
+install -Dpm644 after_kernel_4_9/51-these-are-not-joysticks.rules -t %{buildroot}%{_udevrulesdir}
+install -Dpm644 after_kernel_4_9/51-these-are-not-joysticks-rm.rules -t %{buildroot}%{_udevrulesdir}
+
+%files
+%doc README.md
+%{_udevrulesdir}/51-these-are-not-joysticks.rules
+
+%files rm
+%doc README.md
+%{_udevrulesdir}/51-these-are-not-joysticks-rm.rules
+
+%changelog
+* Mon Nov 03 2025 Gilver E. <rockgrub@disroot.org> - 0^20250715gita1ace57-1
+- Initial package

--- a/anda/games/udev-joystick-blacklist/update.rhai
+++ b/anda/games/udev-joystick-blacklist/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("denilsonsa/udev-joystick-blacklist"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: udev-joystick-blacklist, split from Steam package (#7054)](https://github.com/terrapkg/packages/pull/7054)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)