### PR TITLE
[f43] fix: amaranth _desc (#7091)

### DIFF
--- a/anda/langs/amaranth/amaranth.spec
+++ b/anda/langs/amaranth/amaranth.spec
@@ -1,5 +1,5 @@
 %global pypi_name amaranth
-%global _desc Scots A modern hardware definition language and toolchain based on Python.
+%global _desc A modern hardware definition language and toolchain based on Python.
 
 %define _python_dist_allow_version_zero 1
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: amaranth _desc (#7091)](https://github.com/terrapkg/packages/pull/7091)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)