### PR TITLE
feat: add terra-surface-dtx-daemon to terra-obsoletes

### DIFF
--- a/anda/terra/obsolete/terra-obsolete.spec
+++ b/anda/terra/obsolete/terra-obsolete.spec
@@ -146,7 +146,7 @@ BuildArch:  noarch
 %obsolete switchboard-plug-useraccounts 8.0.0-2
 %obsolete switchboard-plug-wacom 8.0.0-2
 
-%obsoletes terra-surface-dtx-daemon 0.3.10-1
+%obsolete terra-surface-dtx-daemon 0.3.10-1
 
 %description
 Currently obsoleted packages:

--- a/anda/terra/obsolete/terra-obsolete.spec
+++ b/anda/terra/obsolete/terra-obsolete.spec
@@ -146,6 +146,8 @@ BuildArch:  noarch
 %obsolete switchboard-plug-useraccounts 8.0.0-2
 %obsolete switchboard-plug-wacom 8.0.0-2
 
+%obsoletes terra-surface-dtx-daemon 0.3.10-1
+
 %description
 Currently obsoleted packages:
 
@@ -157,4 +159,3 @@ Currently obsoleted packages:
 
 %changelog
 %autochangelog
-


### PR DESCRIPTION
Not sure about:

If this needs backporting to all branches
If the version should still be on 42 (even on frawhide?)
If I need a `%obsolete_ticket` attached