### PR TITLE
[el10] add: asusctl (#7043)

### DIFF
--- a/anda/system/asusctl/anda.hcl
+++ b/anda/system/asusctl/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "asusctl.spec"
+  }
+}

--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -1,0 +1,92 @@
+%global debug_package %{nil}
+
+%global commit c9e76f327376c8bb6ab4e4cc5187954aa8cdc538
+%global commit_date 20251020
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           asusctl
+Version:        %commit_date.%shortcommit
+Release:        1%?dist
+Summary:        A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops
+URL:            https://gitlab.com/asus-linux/asusctl
+Source0:        %url/-/archive/%commit/asusctl-%commit.tar.gz
+License:        MPL-2.0
+Patch0:         fix-makefile.patch
+BuildRequires:  anda-srpm-macros cargo-rpm-macros systemd-rpm-macros mold rust-udev-devel clang-devel 
+BuildRequires:  desktop-file-utils
+BuildRequires:  cmake
+BuildRequires:  rust
+BuildRequires:  rust-std-static
+BuildRequires:  pkgconfig(gbm)
+BuildRequires:  pkgconfig(libinput)
+BuildRequires:  pkgconfig(libseat)
+BuildRequires:  pkgconfig(libudev)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(libzstd)
+ExclusiveArch:  x86_64
+
+Packager:       Metcya <metcya@gmail.com>
+
+%description
+%summary.
+
+%package rog-gui
+Summary:    An experimental gui for %name
+Requires:   %name
+
+%description rog-gui
+A one-stop-shop GUI tool for asusd/asusctl. It aims to provide most controls,
+a notification service, and ability to run in the background.
+
+%prep
+%autosetup -p1 -n asusctl-%commit
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+%make_install
+
+install -D -m 0644 README.md %{buildroot}/%{_docdir}/%{name}/README.md
+install -D -m 0644 rog-anime/README.md %{buildroot}/%{_docdir}/%{name}/README-anime.md
+install -D -m 0644 rog-anime/data/diagonal-template.png %{buildroot}/%{_docdir}/%{name}/diagonal-template.png
+
+desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.desktop
+
+%files
+%license LICENSE
+%{_datadir}/asusctl/LICENSE
+%{_bindir}/asusd
+%{_bindir}/asusd-user
+%{_bindir}/asusctl
+%{_unitdir}/asusd.service
+%{_userunitdir}/asusd-user.service
+%{_udevrulesdir}/99-asusd.rules
+%dnl %{_sysconfdir}/asusd/
+%{_datadir}/asusd/aura_support.ron
+%{_datadir}/dbus-1/system.d/asusd.conf
+%{_datadir}/icons/hicolor/512x512/apps/asus_notif_yellow.png
+%{_datadir}/icons/hicolor/512x512/apps/asus_notif_green.png
+%{_datadir}/icons/hicolor/512x512/apps/asus_notif_red.png
+%{_datadir}/icons/hicolor/512x512/apps/asus_notif_blue.png
+%{_datadir}/icons/hicolor/512x512/apps/asus_notif_orange.png
+%{_datadir}/icons/hicolor/512x512/apps/asus_notif_white.png
+%{_datadir}/icons/hicolor/scalable/status/gpu-compute.svg
+%{_datadir}/icons/hicolor/scalable/status/gpu-hybrid.svg
+%{_datadir}/icons/hicolor/scalable/status/gpu-integrated.svg
+%{_datadir}/icons/hicolor/scalable/status/gpu-nvidia.svg
+%{_datadir}/icons/hicolor/scalable/status/gpu-vfio.svg
+%{_datadir}/icons/hicolor/scalable/status/notification-reboot.svg
+%{_docdir}/%{name}/
+%{_datadir}/asusd/
+
+%files rog-gui
+%{_bindir}/rog-control-center
+%{_datadir}/applications/rog-control-center.desktop
+%{_datadir}/icons/hicolor/512x512/apps/rog-control-center.png
+%{_datadir}/rog-gui
+
+%changelog
+* Sun Oct 26 2025 Metcya <metcya@gmail.com>
+- Package asusctl

--- a/anda/system/asusctl/fix-makefile.patch
+++ b/anda/system/asusctl/fix-makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 6db2b96..232c993 100644
+--- a/Makefile
++++ b/Makefile
+@@ -113,7 +113,7 @@ install-data-asusd_user:
+ 
+ .PHONY: install-data-asusd install-data-asusd_user
+ 
+-install-data: install-data-asusd install-data-rog_gui
++install-data: install-data-asusd install-data-rog_gui install-data-asusd_user
+ 
+ install: install-program install-data
+ 	$(INSTALL_DATA) "./LICENSE" "$(DESTDIR)$(datarootdir)/asusctl/LICENSE"

--- a/anda/system/asusctl/update.rhai
+++ b/anda/system/asusctl/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gitlab("20328305"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: asusctl (#7043)](https://github.com/terrapkg/packages/pull/7043)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)