### PR TITLE
[f43] fix(udev-joystick-blacklist): Drop release from Obsoletes (#7104)

### DIFF
--- a/anda/games/udev-joystick-blacklist/udev-joystick-blacklist.spec
+++ b/anda/games/udev-joystick-blacklist/udev-joystick-blacklist.spec
@@ -4,14 +4,14 @@
 
 Name:          udev-joystick-blacklist
 Version:       0^%{commit_date}git%{shortcommit}
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       Fix for keyboard/mouse/tablet being detected as joysticks in Linux
 License:       Public Domain
 URL:           https://github.com/denilsonsa/udev-joystick-blacklist
 Source0:       %{url}/archive/%{commit}.tar.gz
 BuildRequires: systemd-rpm-macros
 Conflicts:     %{name}-rm
-Conflicts:     steam-device-rules <= 1.0.0.85-1
+Conflicts:     steam-device-rules <= 1.0.0.85
 BuildArch:     noarch
 Packager:      Gilver E. <rockgrub@disroot.org>
 
@@ -23,8 +23,8 @@ This package contains rules which will prevent those devices from being recogniz
 %package       rm
 Summary:       Fix for keyboard/mouse/tablet being detected as joysticks in Linux
 Conflicts:     %{name}
-Conflicts:     steam-device-rules <= 1.0.0.85-1
-Obsoletes:     steam-device-rules <= 1.0.0.85-1
+Conflicts:     steam-device-rules <= 1.0.0.85
+Obsoletes:     steam-device-rules <= 1.0.0.85
 
 %description   rm
 There are several devices that, although recognized by kernel as joysticks, are not joysticks.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(udev-joystick-blacklist): Drop release from Obsoletes (#7104)](https://github.com/terrapkg/packages/pull/7104)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)