### PR TITLE
[f42] add: magic-wormhole (#7080)

### DIFF
--- a/anda/langs/python/magic-wormhole/anda.hcl
+++ b/anda/langs/python/magic-wormhole/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "magic-wormhole.spec"
+  }
+}

--- a/anda/langs/python/magic-wormhole/magic-wormhole.spec
+++ b/anda/langs/python/magic-wormhole/magic-wormhole.spec
@@ -1,0 +1,96 @@
+%define _unpackaged_files_terminate_build 0
+
+%global pypi_name magic-wormhole
+%global _desc get things from one computer to another, safely.
+
+Name:			python-%{pypi_name}
+Version:		0.21.1
+Release:		1%?dist
+Summary:		get things from one computer to another, safely
+License:		MIT
+URL:			https://github.com/magic-wormhole/magic-wormhole
+Source0:		%url/archive/refs/tags/%version.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+BuildRequires:  python3-versioneer
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       magic-wormhole
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%package        bash-completion
+Summary:        magic-wormhole Bash completion
+Requires:       python3-%{pypi_name}
+Requires:       bash-completion
+BuildArch:      noarch
+
+%description    bash-completion
+Bash shell completion for magic-wormhole.
+
+%package        fish-completion
+Summary:        magic-wormhole Fish completion
+Requires:       python3-%{pypi_name}
+Requires:       fish
+BuildArch:      noarch
+
+%description    fish-completion
+Fish shell completion for magic-wormhole.
+
+%package        zsh-completion
+Summary:        magic-wormhole Zsh completion
+Requires:       python3-%{pypi_name}
+Requires:       zsh
+BuildArch:      noarch
+
+%description    zsh-completion
+Zsh shell completion for magic-wormhole.
+
+%prep
+%autosetup -n magic-wormhole-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+install -Dm644 wormhole_complete.bash %{buildroot}%{bash_completions_dir}/wormhole_complete.bash
+install -Dm644 wormhole_complete.bash %{buildroot}%{fish_completions_dir}/wormhole_complete.fish
+install -Dm644 wormhole_complete.bash %{buildroot}%{zsh_completions_dir}/wormhole_complete.zsh
+install -Dm644 docs/wormhole.1 %{buildroot}%{_mandir}/man1/wormhole.1
+%pyproject_install
+%pyproject_save_files wormhole
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md docs/*.rst
+%license LICENSE
+%{_bindir}/magic-wormhole
+%{_bindir}/wormhole
+%{_mandir}/man1/wormhole.1.gz
+%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
+%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
+%python3_sitelib/magic_wormhole-%version.dist-info/*
+
+%files bash-completion
+%{bash_completions_dir}/wormhole_complete.bash
+
+%files fish-completion
+%{fish_completions_dir}/wormhole_complete.fish
+
+%files zsh-completion
+%{zsh_completions_dir}/wormhole_complete.zsh
+
+%changelog
+* Mon Nov 03 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/magic-wormhole/update.rhai
+++ b/anda/langs/python/magic-wormhole/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("magic-wormhole/magic-wormhole"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: magic-wormhole (#7080)](https://github.com/terrapkg/packages/pull/7080)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)