### PR TITLE
[f42] feat: build crystal from source, split out shards pkg (#7044)

### DIFF
--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -1,57 +1,63 @@
-%define debug_package %nil
+%bcond bootstrap 1
+%global bootstrap_version 1.17.1
 
-Name:			crystal
-Version:		1.18.2
-Release:		1%?dist
-Summary:		The Crystal Programming Language
-License:		Apache-2.0
-URL:			https://crystal-lang.org/
-Source0:		https://github.com/crystal-lang/crystal/releases/download/%version/crystal-%version-1-linux-x86_64-bundled.tar.gz
-ExclusiveArch:	x86_64
-BuildRequires:	rpm_macro(fdupes)
+Name:          crystal
+Version:       1.18.2
+Release:       2%?dist
+Summary:       A general-purpose, object-oriented programming language
+License:       Apache-2.0
+Packager:      Carl Hörberg <carl@84codes.com>
+URL:           https://crystal-lang.org/
+Source0:       https://github.com/crystal-lang/crystal/archive/%version.tar.gz
+%if %{with bootstrap}
+Source1:       https://dev.alpinelinux.org/archive/crystal/crystal-%{bootstrap_version}-%{_arch}-alpine-linux-musl.tar.gz
+%else
+BuildRequires: crystal
+%endif
+BuildRequires: gcc gcc-c++ make gc-devel llvm-devel
+BuildRequires: pcre2-devel libyaml-devel libffi-devel
+Requires:      gcc pkgconfig gc-devel
+Requires:      pcre2-devel openssl-devel zlib-devel
+Requires:      libyaml-devel libxml2-devel gmp-devel
+Suggests:      shards
 
 %description
-%summary.
-
-%package devel
-Summary:	Development files for the crystal package
-
-%description devel
-%summary.
+Crystal is a programming language with the following goals:
+- Have a syntax similar to Ruby (but compatibility with it is not a goal)
+- Statically type-checked but without having to specify the type of variables or method arguments
+- Be able to call C code by writing bindings to it in Crystal
+- Have compile-time evaluation and generation of code, to avoid boilerplate code
+- Compile to efficient native code
 
 %prep
-%autosetup -n crystal-%version-1
+%setup -q
+%if %{with bootstrap}
+%setup -q -b 1
+%endif
 
 %build
+%if %{with bootstrap}
+# Use bootstrap crystal binary
+export PATH="%{_builddir}/crystal-%{bootstrap_version}-%{_arch}-alpine-linux-musl/bin:$PATH"
+%endif
+%make_build release=1 interpreter=1 LDFLAGS="%{build_ldflags}" CRYSTAL_CONFIG_LIBRARY_PATH=%{_libdir}/crystal
 
 %install
-mkdir -p %buildroot/usr/bin
-mkdir -p %buildroot/usr/share
-mkdir -p %buildroot/usr/lib/crystal
-install -Dm755 bin/* %buildroot/usr/bin/
-cp -r share/* %buildroot/usr/share/
-cp -r lib/crystal/* %buildroot/usr/lib/crystal/
-
-%fdupes %buildroot%_datadir/crystal/src/lib_c/
-
+%make_install PREFIX=%{_prefix}
 
 %files
-%license /usr/share/licenses/crystal/LICENSE
-/usr/bin/crystal
-/usr/share/zsh/site-functions/_crystal
-/usr/share/man/man1/crystal.1.gz
-/usr/share/crystal/
-/usr/share/fish/vendor_completions.d/crystal.fish
-/usr/share/bash-completion/completions/crystal
-
-/usr/bin/shards
-/usr/share/man/man1/shards.1.gz
-/usr/share/man/man5/shard.yml.5.gz
-
-%files devel
-/usr/lib/crystal/
+%license %{_datadir}/licenses/crystal/LICENSE
+%{_bindir}/crystal
+%{_datadir}/crystal
+%{_datadir}/zsh/site-functions/_crystal
+%{_datadir}/bash-completion/completions/crystal
+%{_datadir}/fish/vendor_completions.d/crystal.fish
+%{_mandir}/man1/crystal.1.gz
 
 %changelog
+* Mon Nov 03 2025 Carl Hörberg <carl@84codes.com> -  1.18.2-2
+- Build from source, support multiple architectures.
+
 * Sat Jun 17 2023 windowsboy111 <windowsboy111@fyralabs.com> - 1.8.2-2
 - Add devel package.
 

--- a/anda/langs/crystal/crystal/update.rhai
+++ b/anda/langs/crystal/crystal/update.rhai
@@ -1,9 +1,1 @@
-let v = gh("crystal-lang/crystal");
-let url = `crystal-${v}-1-linux-x86_64-bundled.tar.gz`;
-
-if get(`https://github.com/crystal-lang/crystal/releases/expanded_assets/${v}`).contains(url) {
-  rpm.version(v);
-} else {
-  print(`crystal: ${v} (waiting for bundle)`);
-  terminate();
-}
+rpm.version(gh_tag("crystal-lang/crystal"));

--- a/anda/langs/crystal/shards/anda.hcl
+++ b/anda/langs/crystal/shards/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
 	rpm {
-		spec = "crystal.spec"
+		spec = "shards.spec"
 	}
 }

--- a/anda/langs/crystal/shards/shards.spec
+++ b/anda/langs/crystal/shards/shards.spec
@@ -1,0 +1,33 @@
+Name:          shards
+Version:       0.19.1
+Release:       1%?dist
+Summary:       Dependency manager for the Crystal language 
+License:       Apache-2.0
+Packager:      Carl Hörberg <carl@84codes.com>
+URL:           https://crystal-lang.org/
+Source0:       https://github.com/crystal-lang/shards/archive/refs/tags/v%version.tar.gz
+BuildRequires: crystal make
+BuildRequires: gcc gc-devel libyaml-devel pcre-devel
+Suggests:      git make
+Supplements:   crystal
+
+%description
+Shards is a dependency manager for the Crystal programming language. It allows you to easily manage and install external libraries (called "shards") that your Crystal projects depend on.
+
+%prep
+%setup -q
+
+%build
+%make_build release=1 FLAGS="--link-flags=\"%{build_ldflags}\""
+
+%install
+%make_install PREFIX=%{_prefix}
+
+%files
+%{_bindir}/shards
+%{_mandir}/man1/shards.1.gz
+%{_mandir}/man5/shard.yml.5.gz
+
+%changelog
+* Mon Nov 03 2025 Carl Hörberg <carl@84codes.com> - 0.19.1-1
+- Initial package

--- a/anda/langs/crystal/shards/update.rhai
+++ b/anda/langs/crystal/shards/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("crystal-lang/shards"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat: build crystal from source, split out shards pkg (#7044)](https://github.com/terrapkg/packages/pull/7044)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)