### PR TITLE
[f42] initial package for gnome-shell-extension-gpu-switcher-supergfxctl (#6917)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/anda.hcl
+++ b/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+    rpm {
+        spec = "gnome-shell-extension-gpu-supergfxctl-switch.spec"
+    }
+}

--- a/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/gnome-shell-extension-gpu-supergfxctl-switch.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/gnome-shell-extension-gpu-supergfxctl-switch.spec
@@ -1,0 +1,39 @@
+%global commit 1de26db2ea4166fdca85306300b12bdc24f2c955
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20250925
+%global ver 11
+%global extension   gpu-switcher-supergfxctl
+%global uuid        %{extension}@chikobara.github.io
+
+Name:           gnome-shell-extension-%{extension}
+Version:        %ver^%commit_date.%shortcommit
+Release:        1%?dist
+Summary:        GPU Profile switcher Gnome-Shell-Extension for ASUS laptops using Supergfxctl
+License:        GPL-3.0-only
+URL:            https://github.com/chikobara/GPU-Switcher-Supergfxctl
+
+Source0:        %url/archive/%commit.tar.gz
+
+Requires:       (gnome-shell >= 48~ with gnome-shell < 50~) asusctl supergfxctl
+Recommends:     gnome-extensions-app
+
+BuildArch:	noarch
+
+%description
+GPU Profile switcher Gnome-Shell-Extension for ASUS laptops using Supergfxctl
+
+%prep
+%autosetup -n GPU-Switcher-Supergfxctl-%{commit} -p1
+
+%install
+install -Dm644 metadata.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/metadata.json
+install -Dm644 extension.js %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/extension.js
+
+%files
+%license LICENSE
+%doc README.md
+%{_datadir}/gnome-shell/extensions/%{uuid}
+
+%changelog
+* Mon Oct 27 2025 june-fish <june@fyralabs.com> - 11
+- Initial Package

--- a/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/update.rhai
+++ b/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/update.rhai
@@ -1,0 +1,9 @@
+if filters.contains("nightly") {
+  rpm.global("commit", gh_commit("chikobara/GPU-Switcher-Supergfxctl"));
+  if rpm.changed() {
+    let v = find("\"version\": ([.\\d]+)\n", gh_rawfile("chikobara/GPU-Switcher-Supergfxctl", "main", "metadata.json"), 1);
+    rpm.global("ver", v);
+    rpm.global("commit_date", date());
+    rpm.release();
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [initial package for gnome-shell-extension-gpu-switcher-supergfxctl (#6917)](https://github.com/terrapkg/packages/pull/6917)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)