### PR TITLE
[f42] fix: readymade (#7145)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,7 +1,7 @@
 %global commit 53fe99a00a6778da8402a6870854499bcd5088d1
 %global commit_date 20251031
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-
+%global crate readymade
 Name:           readymade-git
 Version:        %commit_date.%shortcommit
 Release:        1%?dist

--- a/anda/system/readymade/stable/readymade.spec
+++ b/anda/system/readymade/stable/readymade.spec
@@ -1,3 +1,4 @@
+%global crate readymade
 Name:           readymade
 Version:        0.12.6
 Release:        1%?dist


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: readymade (#7145)](https://github.com/terrapkg/packages/pull/7145)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)