### PR TITLE
[f43] bump: readymade-git (#7155)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,5 +1,5 @@
-%global commit a292282b53e79490491abe31bd489cd8c019a464
-%global commit_date 20251105
+%global commit 4cbb97800d3eda85d2d0f245980764fbec1c1079
+%global commit_date 20251106
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global crate readymade
 Name:           readymade-git


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [bump: readymade-git (#7155)](https://github.com/terrapkg/packages/pull/7155)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)