### PR TITLE
[f41] bump: readymade-git again (#7164)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,4 +1,4 @@
-%global commit 4cbb97800d3eda85d2d0f245980764fbec1c1079
+%global commit 70554f6bbb6325a9638d73b56d9f49bcbc6441ab
 %global commit_date 20251106
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global crate readymade


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [bump: readymade-git again (#7164)](https://github.com/terrapkg/packages/pull/7164)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)