### PR TITLE
[f42] backport: bump: readymade-git yet again (#7177)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,4 +1,4 @@
-%global commit 70554f6bbb6325a9638d73b56d9f49bcbc6441ab
+%global commit 2a1faf0b607c8ab87fb794d25b8050a8b9117f60
 %global commit_date 20251106
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global crate readymade


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [backport: bump: readymade-git yet again (#7177)](https://github.com/terrapkg/packages/pull/7177)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)