### PR TITLE
[f41] fix: readymade commit date (#7182)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,5 +1,5 @@
 %global commit 2a1faf0b607c8ab87fb794d25b8050a8b9117f60
-%global commit_date 20251106
+%global commit_date 20251107
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global crate readymade
 Name:           readymade-git


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f41`:
 - [fix: readymade commit date (#7182)](https://github.com/terrapkg/packages/pull/7182)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)