### PR TITLE
[frawhide] chore(LCEVCdec): Update spec (#7188)

### DIFF
--- a/anda/multimedia/lcevcdec/LCEVCdec.spec
+++ b/anda/multimedia/lcevcdec/LCEVCdec.spec
@@ -10,7 +10,7 @@
 
 Name:           LCEVCdec
 Version:        4.0.3
-Release:        1%?dist
+Release:        1%{?dist}
 Summary:        MPEG-5 LCEVC Decoder
 License:        BSD-3-Clause-Clear
 URL:            https://docs.v-nova.com/v-nova/lcevc/lcevc-sdk-overview
@@ -23,7 +23,7 @@ BuildRequires:  cmake(nlohmann_json)
 BuildRequires:  cmake(range-v3)
 BuildRequires:  gcc-c++
 BuildRequires:  git
-BuildRequires:  vulkan-loader
+BuildRequires:  gmock-devel
 BuildRequires:  pkgconfig(libavcodec)
 BuildRequires:  pkgconfig(libavdevice)
 BuildRequires:  pkgconfig(libxxhash)
@@ -64,7 +64,7 @@ Summary:        Development files for %{name}
 Provides:       %{name}-static = %{version}-%{release}
 Obsoletes:      %{name}-static < %{version}-%{release}
 Requires:       %{name}%{?_isa} = %{version}-%{release}
-Requires:       plutovg-devel%{?_isa}       
+Requires:       plutovg-devel%{?_isa}
 
 %description    devel
 The %{name}-devel package contains libraries and header files for
@@ -118,7 +118,6 @@ rm -fr %{buildroot}%{_docdir} %{buildroot}%{_prefix}/licenses
 python3 src/func_tests/run_tests.py
 %endif
 
-
 %files
 %license LICENSE.md COPYING
 %doc README.md
@@ -129,8 +128,6 @@ python3 src/func_tests/run_tests.py
 %{_libdir}/liblcevc_dec_pipeline_legacy.so.1
 
 %files devel
-%license LICENSE.md COPYING
-%doc README.md
 %{_includedir}/LCEVC
 %{_libdir}/liblcevc_dec_api.so
 %{_libdir}/liblcevc_dec_legacy.so


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `frawhide`:
 - [chore(LCEVCdec): Update spec (#7188)](https://github.com/terrapkg/packages/pull/7188)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)