### PR TITLE
[f41] fix(yt-dlp): files (#7009)

### DIFF
--- a/anda/tools/yt-dlp-ejs/anda.hcl
+++ b/anda/tools/yt-dlp-ejs/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "python-yt-dlp-ejs.spec"
+	}
+}

--- a/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
+++ b/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
@@ -1,0 +1,51 @@
+Name:           python-yt-dlp-ejs
+Version:        0.3.0
+Release:        %autorelease
+Summary:        External JavaScript for yt-dlp supporting many runtimes
+
+License:        Unlicense AND MIT AND ISC
+URL:            https://github.com/yt-dlp/ejs
+Source:         %{pypi_source yt_dlp_ejs}
+Packager:		madonuko <mado@fyralabs.com>
+
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(hatch-vcs)
+BuildRequires:  (deno or bun or nodejs-npm)
+
+
+%global _description %{expand:
+%summary.}
+
+%description %_description
+
+%package -n     python3-yt-dlp-ejs
+Summary:        %{summary}
+Provides:		yt-dlp-ejs = %evr
+
+%description -n python3-yt-dlp-ejs %_description
+
+
+%prep
+%autosetup -p1 -n yt_dlp_ejs-%{version}
+
+
+#generate_buildrequires
+#pyproject_buildrequires
+
+
+%build
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+%pyproject_save_files -l yt_dlp_ejs
+
+
+%check
+%pyproject_check_import
+
+
+%files -n python3-yt-dlp-ejs -f %{pyproject_files}

--- a/anda/tools/yt-dlp-ejs/update.rhai
+++ b/anda/tools/yt-dlp-ejs/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("yt-dlp-ejs"));

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -8,10 +8,9 @@ Summary:        A command-line program to download videos from online video plat
 
 License:        Unlicense
 URL:            https://github.com/yt-dlp/yt-dlp
-# License of the specfile
-Source:         https://src.fedoraproject.org/rpms/yt-dlp/raw/rawhide/f/yt-dlp.spec.license
-
 BuildArch:      noarch
+Packager:       madonuko <mado@fyralabs.com>
+Requires:       deno
 
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(hatchling)
@@ -31,6 +30,7 @@ BuildRequires:  anda-srpm-macros
 # ffmpeg-free is now available in Fedora.
 Recommends:     /usr/bin/ffmpeg
 Recommends:     /usr/bin/ffprobe
+Recommends:     yt-dlp-ejs
 
 Conflicts:      yt-dlp
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(yt-dlp): files (#7009)](https://github.com/terrapkg/packages/pull/7009)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)