### PR TITLE
[el10] bump: python-yt-dlp-ejs

### DIFF
--- a/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
+++ b/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
@@ -1,6 +1,6 @@
 Name:           python-yt-dlp-ejs
-Version:        0.3.0
-Release:        %autorelease
+Version:        0.3.1
+Release:        1%?dist
 Summary:        External JavaScript for yt-dlp supporting many runtimes
 
 License:        Unlicense AND MIT AND ISC


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - bump: python-yt-dlp-ejs (96fa448f)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)