### PR TITLE
[el10] fix(gstreamer1-plugins-ugly): Tracking file path (#7204)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/update.rhai
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/update.rhai
@@ -4,7 +4,7 @@ let vr = bump::bodhi_vr("gstreamer1-plugins-ugly-free", bump::as_bodhi_ver(label
 rpm.version(vr[1]);
 rpm.release(vr[2]);
 
-open_file("anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/update.rhai/VERSION_x264.txt", "w").write(bump::madoguchi("x264", labels.branch));
+open_file("anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/VERSION_x264.txt", "w").write(bump::madoguchi("x264", labels.branch));
 open_file("anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/VERSION_x265.txt", "w").write(bump::madoguchi("x265", labels.branch));
 
 let dir = sub(`/[^/]+$`, "", __script_path);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(gstreamer1-plugins-ugly): Tracking file path (#7204)](https://github.com/terrapkg/packages/pull/7204)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)