### PR TITLE
[f43] bump: xeve yt-dlp-git

### DIFF
--- a/anda/multimedia/xeve/xeve.spec
+++ b/anda/multimedia/xeve/xeve.spec
@@ -1,7 +1,7 @@
 Name:           xeve
 Epoch:          1
-Version:        0.5.1
-Release:        2%{?dist}
+Version:        0.5.0
+Release:        1%?dist
 Summary:        eXtra-fast Essential Video Encoder, MPEG-5 EVC (Essential Video Coding)
 License:        BSD-3-Clause
 URL:            https://github.com/mpeg5/xeve

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,7 +2,7 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2025.11.08.095138
+Version:        2025.11.08.104132
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,7 +2,7 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2025.11.08.053059
+Version:        2025.11.08.095138
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - bump: xeve yt-dlp-git (31c9e5fd)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)