### PR TITLE
[el10] chore(vvenc): Update spec (#7206)

### DIFF
--- a/anda/multimedia/vvenc/vvenc.spec
+++ b/anda/multimedia/vvenc/vvenc.spec
@@ -1,17 +1,13 @@
-%global build_cxxflags %{__build_flags_lang_cxx} %{?_distro_extra_cxxflags} -Wno-error=maybe-uninitialized -Wno-error=uninitialized
-
 Name:           vvenc
 Version:        1.13.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        VVenC, the Fraunhofer Versatile Video Encoder
 License:        BSD-3-Clause
 URL:            https://github.com/fraunhoferhhi/%{name}
 
 Source0:        %{url}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-# Fixes for i386/ARM32 builds
 Patch0:         %{url}/commit/ebce395254d9d7be7dc00cec7b49c7ed1d9eebec.patch
-Patch1:         %{url}/commit/bfd55ee783bfe30fc73f6f314b066b84bb1e5b60.patch
-Patch2:         %{url}/commit/982fcaac22488415899ae6c6ef7977a728a88e94.patch
+Patch1:         %{url}/commit/982fcaac22488415899ae6c6ef7977a728a88e94.patch
 
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
@@ -49,6 +45,7 @@ developing applications that use %{name}.
 %autosetup -p1
 
 %build
+export CXXFLAGS="%{optflags} -Wno-error=maybe-uninitialized -Wno-error=uninitialized"
 %cmake \
     -DCMAKE_SKIP_INSTALL_RPATH=OFF \
     -DVVENC_INSTALL_FULLFEATURE_APP=ON


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(vvenc): Update spec (#7206)](https://github.com/terrapkg/packages/pull/7206)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)