### PR TITLE
[f43] fix(xeve): Switch to gh_tag for updates (#7234)

### DIFF
--- a/anda/multimedia/xeve/update.rhai
+++ b/anda/multimedia/xeve/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("mpeg5/xeve"));
+rpm.version(gh_tag("mpeg5/xeve"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(xeve): Switch to gh_tag for updates (#7234)](https://github.com/terrapkg/packages/pull/7234)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)