### PR TITLE
[f42] fix (amaranth): don't require python3 (#7251)

### DIFF
--- a/anda/langs/amaranth/amaranth.spec
+++ b/anda/langs/amaranth/amaranth.spec
@@ -5,7 +5,7 @@
 
 Name:			python-%{pypi_name}
 Version:		0.5.8
-Release:		1%?dist
+Release:		2%?dist
 Summary:		A modern hardware definition language and toolchain based on Python
 License:		BSD-2-Clause
 URL:			https://github.com/amaranth-lang/amaranth
@@ -19,7 +19,6 @@ BuildRequires:  python3-setuptools_scm
 BuildRequires:  python3-packaging
 BuildRequires:  python3-pip
 
-Requires:       python3
 Requires:       python3-jinja2
 Requires:       python3-jschon
 Requires:       python3-pyvcd


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (amaranth): don&#x27;t require python3 (#7251)](https://github.com/terrapkg/packages/pull/7251)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)