### PR TITLE
[f41] add: imageio-ffmpeg (#7258)

### DIFF
--- a/anda/langs/python/imageio-ffmpeg/anda.hcl
+++ b/anda/langs/python/imageio-ffmpeg/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "imageio-ffmpeg.spec"
+  }
+}

--- a/anda/langs/python/imageio-ffmpeg/imageio-ffmpeg.spec
+++ b/anda/langs/python/imageio-ffmpeg/imageio-ffmpeg.spec
@@ -1,0 +1,49 @@
+%global pypi_name imageio-ffmpeg
+%global _desc FFMPEG wrapper for Python.
+
+Name:			python-%{pypi_name}
+Version:		0.6.0
+Release:		1%?dist
+Summary:		FFMPEG wrapper for Python
+License:		BSD-2-Clause
+URL:			https://github.com/imageio/imageio-ffmpeg
+Source0:		%url/archive/refs/tags/v%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-setuptools_scm
+BuildRequires:  python3-pip
+BuildRequires:  python3-poetry-core
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       imageio-ffmpeg
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n imageio-ffmpeg-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files imageio_ffmpeg
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Sun Nov 09 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/imageio-ffmpeg/update.rhai
+++ b/anda/langs/python/imageio-ffmpeg/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("imageio-ffmpeg"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: imageio-ffmpeg (#7258)](https://github.com/terrapkg/packages/pull/7258)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)