### PR TITLE
[f43] add: screeninfo (#7256)

### DIFF
--- a/anda/langs/python/screeninfo/anda.hcl
+++ b/anda/langs/python/screeninfo/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "screeninfo.spec"
+  }
+}

--- a/anda/langs/python/screeninfo/screeninfo.spec
+++ b/anda/langs/python/screeninfo/screeninfo.spec
@@ -1,0 +1,49 @@
+%global pypi_name screeninfo
+%global _desc Fetch location and size of physical screens.
+
+Name:			python-%{pypi_name}
+Version:		0.8.1
+Release:		1%?dist
+Summary:		Fetch location and size of physical screens
+License:		MIT
+URL:			https://github.com/rr-/screeninfo
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-setuptools_scm
+BuildRequires:  python3-pip
+BuildRequires:  python3-poetry-core
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       screeninfo
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n screeninfo-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files screeninfo
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE.md
+
+%changelog
+* Sun Nov 09 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/screeninfo/update.rhai
+++ b/anda/langs/python/screeninfo/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("screeninfo"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: screeninfo (#7256)](https://github.com/terrapkg/packages/pull/7256)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)