### PR TITLE
feat(nvidia*): Better update scripts, adjust weekly trigger

### DIFF
--- a/anda/system/nvidia/compat-nvidia-repo/anda.hcl
+++ b/anda/system/nvidia/compat-nvidia-repo/anda.hcl
@@ -5,6 +5,6 @@ project pkg {
 	}
 	labels {
 	   subrepo = "nvidia"
-	   weekly = 1
+	   weekly = 3
     }
 }

--- a/anda/system/nvidia/dkms-nvidia/closed/anda.hcl
+++ b/anda/system/nvidia/dkms-nvidia/closed/anda.hcl
@@ -4,6 +4,6 @@ project pkg {
 	}
 	labels {
 		subrepo = "nvidia"
-		weekly = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/nvidia/dkms-nvidia/closed/update.rhai
+++ b/anda/system/nvidia/dkms-nvidia/closed/update.rhai
@@ -1,3 +1,3 @@
-import "andax/nvidia.rhai" as nvidia;
+import "andax/bump_extras.rhai" as bump;
 
-rpm.version(nvidia::nvidia_driver_version());
+rpm.version(bump::madoguchi("nvidia-kmod-common", labels.branch));

--- a/anda/system/nvidia/dkms-nvidia/open/anda.hcl
+++ b/anda/system/nvidia/dkms-nvidia/open/anda.hcl
@@ -4,6 +4,6 @@ project pkg {
 	}
 	labels {
 		subrepo = "nvidia"
-        weekly = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/nvidia/dkms-nvidia/open/update.rhai
+++ b/anda/system/nvidia/dkms-nvidia/open/update.rhai
@@ -1,3 +1,3 @@
-import "andax/nvidia.rhai" as nvidia;
+import "andax/bump_extras.rhai" as bump;
 
-rpm.version(nvidia::nvidia_driver_version());
+rpm.version(bump::madoguchi("nvidia-kmod-common", labels.branch));

--- a/anda/system/nvidia/nvidia-driver/anda.hcl
+++ b/anda/system/nvidia/nvidia-driver/anda.hcl
@@ -9,6 +9,6 @@ project "pkg" {
     labels = {
         subrepo = "nvidia"
         mock = 1
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-kmod-common/anda.hcl
+++ b/anda/system/nvidia/nvidia-kmod-common/anda.hcl
@@ -5,6 +5,6 @@ project "pkg" {
     arches = ["x86_64"]
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-kmod/closed/anda.hcl
+++ b/anda/system/nvidia/nvidia-kmod/closed/anda.hcl
@@ -5,6 +5,6 @@ project "pkg" {
     labels {
         mock = 1
         subrepo = "nvidia"
-        weekly =1
+        updbranch = 1
     }
 }

--- a/anda/system/nvidia/nvidia-kmod/closed/update.rhai
+++ b/anda/system/nvidia/nvidia-kmod/closed/update.rhai
@@ -1,3 +1,3 @@
-import "andax/nvidia.rhai" as nvidia;
+import "andax/bump_extras.rhai" as bump;
 
-rpm.version(nvidia::nvidia_driver_version());
+rpm.version(bump::madoguchi("nvidia-kmod-common", labels.branch));

--- a/anda/system/nvidia/nvidia-kmod/open/anda.hcl
+++ b/anda/system/nvidia/nvidia-kmod/open/anda.hcl
@@ -5,6 +5,6 @@ project "pkg" {
     labels {
         mock = 1
         subrepo = "nvidia"
-        weekly = 1
+        updbranch = 1
     }
 }

--- a/anda/system/nvidia/nvidia-kmod/open/update.rhai
+++ b/anda/system/nvidia/nvidia-kmod/open/update.rhai
@@ -1,3 +1,3 @@
-import "andax/nvidia.rhai" as nvidia;
+import "andax/bump_extras.rhai" as bump;
 
-rpm.version(nvidia::nvidia_driver_version());
+rpm.version(bump::madoguchi("nvidia-kmod-common", labels.branch));

--- a/anda/system/nvidia/nvidia-modprobe/anda.hcl
+++ b/anda/system/nvidia/nvidia-modprobe/anda.hcl
@@ -4,6 +4,6 @@ project "pkg" {
     }
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-persistenced/anda.hcl
+++ b/anda/system/nvidia/nvidia-persistenced/anda.hcl
@@ -4,6 +4,6 @@ project "pkg" {
     }
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-settings/anda.hcl
+++ b/anda/system/nvidia/nvidia-settings/anda.hcl
@@ -4,6 +4,6 @@ project "pkg" {
     }
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-xconfig/anda.hcl
+++ b/anda/system/nvidia/nvidia-xconfig/anda.hcl
@@ -4,6 +4,6 @@ project "pkg" {
     }
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }


### PR DESCRIPTION
1. Adjust weekly update trigger again because NVIDIA's servers are cursed
2. Make the DKMS and Akmod packages track the version of the driver actually available in our repos
3. Serves as a rebuild for the failed packages because of the aforementioned cursed servers