### PR TITLE
[f42] feat(nvidia*): Better update scripts, adjust weekly trigger (#7269)

### DIFF
--- a/anda/system/nvidia/compat-nvidia-repo/anda.hcl
+++ b/anda/system/nvidia/compat-nvidia-repo/anda.hcl
@@ -5,6 +5,6 @@ project pkg {
 	}
 	labels {
 	   subrepo = "nvidia"
-	   weekly = 1
+	   weekly = 3
     }
 }

--- a/anda/system/nvidia/dkms-nvidia/closed/anda.hcl
+++ b/anda/system/nvidia/dkms-nvidia/closed/anda.hcl
@@ -4,6 +4,6 @@ project pkg {
 	}
 	labels {
 		subrepo = "nvidia"
-		weekly = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/nvidia/dkms-nvidia/closed/update.rhai
+++ b/anda/system/nvidia/dkms-nvidia/closed/update.rhai
@@ -1,3 +1,3 @@
-import "andax/nvidia.rhai" as nvidia;
+import "andax/bump_extras.rhai" as bump;
 
-rpm.version(nvidia::nvidia_driver_version());
+rpm.version(bump::madoguchi("nvidia-kmod-common", labels.branch));

--- a/anda/system/nvidia/dkms-nvidia/open/anda.hcl
+++ b/anda/system/nvidia/dkms-nvidia/open/anda.hcl
@@ -4,6 +4,6 @@ project pkg {
 	}
 	labels {
 		subrepo = "nvidia"
-        weekly = 1
+		updbranch = 1
 	}
 }

--- a/anda/system/nvidia/dkms-nvidia/open/update.rhai
+++ b/anda/system/nvidia/dkms-nvidia/open/update.rhai
@@ -1,3 +1,3 @@
-import "andax/nvidia.rhai" as nvidia;
+import "andax/bump_extras.rhai" as bump;
 
-rpm.version(nvidia::nvidia_driver_version());
+rpm.version(bump::madoguchi("nvidia-kmod-common", labels.branch));

--- a/anda/system/nvidia/nvidia-driver/anda.hcl
+++ b/anda/system/nvidia/nvidia-driver/anda.hcl
@@ -9,6 +9,6 @@ project "pkg" {
     labels = {
         subrepo = "nvidia"
         mock = 1
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-kmod-common/anda.hcl
+++ b/anda/system/nvidia/nvidia-kmod-common/anda.hcl
@@ -5,6 +5,6 @@ project "pkg" {
     arches = ["x86_64"]
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-kmod/closed/anda.hcl
+++ b/anda/system/nvidia/nvidia-kmod/closed/anda.hcl
@@ -5,6 +5,6 @@ project "pkg" {
     labels {
         mock = 1
         subrepo = "nvidia"
-        weekly =1
+        updbranch = 1
     }
 }

--- a/anda/system/nvidia/nvidia-kmod/closed/update.rhai
+++ b/anda/system/nvidia/nvidia-kmod/closed/update.rhai
@@ -1,3 +1,3 @@
-import "andax/nvidia.rhai" as nvidia;
+import "andax/bump_extras.rhai" as bump;
 
-rpm.version(nvidia::nvidia_driver_version());
+rpm.version(bump::madoguchi("nvidia-kmod-common", labels.branch));

--- a/anda/system/nvidia/nvidia-kmod/open/anda.hcl
+++ b/anda/system/nvidia/nvidia-kmod/open/anda.hcl
@@ -5,6 +5,6 @@ project "pkg" {
     labels {
         mock = 1
         subrepo = "nvidia"
-        weekly = 1
+        updbranch = 1
     }
 }

--- a/anda/system/nvidia/nvidia-kmod/open/update.rhai
+++ b/anda/system/nvidia/nvidia-kmod/open/update.rhai
@@ -1,3 +1,3 @@
-import "andax/nvidia.rhai" as nvidia;
+import "andax/bump_extras.rhai" as bump;
 
-rpm.version(nvidia::nvidia_driver_version());
+rpm.version(bump::madoguchi("nvidia-kmod-common", labels.branch));

--- a/anda/system/nvidia/nvidia-modprobe/anda.hcl
+++ b/anda/system/nvidia/nvidia-modprobe/anda.hcl
@@ -4,6 +4,6 @@ project "pkg" {
     }
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-persistenced/anda.hcl
+++ b/anda/system/nvidia/nvidia-persistenced/anda.hcl
@@ -4,6 +4,6 @@ project "pkg" {
     }
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-settings/anda.hcl
+++ b/anda/system/nvidia/nvidia-settings/anda.hcl
@@ -4,6 +4,6 @@ project "pkg" {
     }
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }

--- a/anda/system/nvidia/nvidia-xconfig/anda.hcl
+++ b/anda/system/nvidia/nvidia-xconfig/anda.hcl
@@ -4,6 +4,6 @@ project "pkg" {
     }
     labels = {
         subrepo = "nvidia"
-        weekly = 1
+        weekly = 3
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(nvidia*): Better update scripts, adjust weekly trigger (#7269)](https://github.com/terrapkg/packages/pull/7269)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)