### PR TITLE
[f43] fix: hyprutils (#7250)

### DIFF
--- a/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
+++ b/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
@@ -22,6 +22,7 @@ ExcludeArch:    %{ix86}
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  pkgconfig(pixman-1)
+BuildRequires:  cmake(GTest)
 
 Provides:		%realname = %evr
 Conflicts:		%realname


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: hyprutils (#7250)](https://github.com/terrapkg/packages/pull/7250)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)