### PR TITLE
[el10] backport: add: shitpost (#7293)

### DIFF
--- a/anda/misc/shitpost/anda.hcl
+++ b/anda/misc/shitpost/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "shitpost.spec"
+    }
+}

--- a/anda/misc/shitpost/shitpost.spec
+++ b/anda/misc/shitpost/shitpost.spec
@@ -1,0 +1,28 @@
+Name:           shitpost
+Version:        1
+Release:        1%?dist
+Summary:        A tool to create memes using CLI
+License:        WTFPL
+URL:            https://redd.it/5ezk1f
+Source0:        https://raw.githubusercontent.com/magnus-ISU/aur-scripts/master/shitpost
+Requires:       bash
+BuildArch:      noarch
+
+Packager:       Its-J
+
+%description
+%{summary}.
+
+%prep
+
+%build
+
+%install
+install -Dm 755 %{SOURCE0} %{buildroot}%{_bindir}/shitpost
+
+%files
+%{_bindir}/shitpost
+
+%changelog
+* Sun Nov 09 2025 Its-J
+- Package shitpost


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [backport: add: shitpost (#7293)](https://github.com/terrapkg/packages/pull/7293)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)