### PR TITLE
[el10] fix(F-Sy-H): use zsh_completions_dir macro (#7311)

### DIFF
--- a/anda/misc/F-Sy-H/F-Sy-H.spec
+++ b/anda/misc/F-Sy-H/F-Sy-H.spec
@@ -1,8 +1,6 @@
-%define _zshfuncdir %{_datadir}/zsh/site-functions
-
 Name:           F-Sy-H
 Version:        1.67
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Feature-rich Syntax Highlighting for Zsh
 License:        BSD-3-Clause
 URL:            https://github.com/z-shell/F-Sy-H
@@ -24,28 +22,28 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %install
 
-mkdir -p %{buildroot}%{_zshfuncdir}/chroma
-mkdir -p %{buildroot}%{_zshfuncdir}/functions
-mkdir -p %{buildroot}%{_zshfuncdir}/share
-mkdir -p %{buildroot}%{_zshfuncdir}/share/parse
-mkdir -p %{buildroot}%{_zshfuncdir}/themes
+mkdir -p %{buildroot}%{zsh_completions_dir}/chroma
+mkdir -p %{buildroot}%{zsh_completions_dir}/functions
+mkdir -p %{buildroot}%{zsh_completions_dir}/share
+mkdir -p %{buildroot}%{zsh_completions_dir}/share/parse
+mkdir -p %{buildroot}%{zsh_completions_dir}/themes
 
-install -Dm644 F-Sy-H.plugin.zsh %{buildroot}%{_zshfuncdir}/F-Sy-H.plugin.zsh
-install -Dm644 chroma/*          %{buildroot}%{_zshfuncdir}/chroma/
-install -Dm644 functions/*       %{buildroot}%{_zshfuncdir}/functions/
-install -Dm644 share/*.zsh       %{buildroot}%{_zshfuncdir}/share/
-install -Dm644 share/parse/*     %{buildroot}%{_zshfuncdir}/share/parse/
-install -Dm644 themes/*          %{buildroot}%{_zshfuncdir}/themes/
+install -Dm644 F-Sy-H.plugin.zsh %{buildroot}%{zsh_completions_dir}/F-Sy-H.plugin.zsh
+install -Dm644 chroma/*          %{buildroot}%{zsh_completions_dir}/chroma/
+install -Dm644 functions/*       %{buildroot}%{zsh_completions_dir}/functions/
+install -Dm644 share/*.zsh       %{buildroot}%{zsh_completions_dir}/share/
+install -Dm644 share/parse/*     %{buildroot}%{zsh_completions_dir}/share/parse/
+install -Dm644 themes/*          %{buildroot}%{zsh_completions_dir}/themes/
 
 %files
 %doc docs/*.md
 %license LICENSE
-%{_zshfuncdir}/F-Sy-H.plugin.zsh
-%{_zshfuncdir}/chroma/*
-%{_zshfuncdir}/functions/*
-%{_zshfuncdir}/share/*.zsh
-%{_zshfuncdir}/share/parse/*
-%{_zshfuncdir}/themes/*
+%{zsh_completions_dir}/F-Sy-H.plugin.zsh
+%{zsh_completions_dir}/chroma/*
+%{zsh_completions_dir}/functions/*
+%{zsh_completions_dir}/share/*.zsh
+%{zsh_completions_dir}/share/parse/*
+%{zsh_completions_dir}/themes/*
 
 %changelog
 * Tue Oct 07 2025 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(F-Sy-H): use zsh_completions_dir macro (#7311)](https://github.com/terrapkg/packages/pull/7311)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)