### PR TITLE
[f43] add: mangowc (#7336)

### DIFF
--- a/anda/desktops/mangowc/anda.hcl
+++ b/anda/desktops/mangowc/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "mangowc.spec"
+  }
+}

--- a/anda/desktops/mangowc/mangowc.spec
+++ b/anda/desktops/mangowc/mangowc.spec
@@ -1,0 +1,52 @@
+Name:           mangowc
+Version:        0.10.5
+Release:        1%?dist
+Summary:        wayland compositor base wlroots and scenefx (dwm but wayland)
+License:        GPL-3.0
+Packager:       metcya <metcya@gmail.com>
+URL:            https://github.com/DreamMaoMao/mangowc
+Source:         %{url}/archive/%{version}.tar.gz
+
+BuildRequires:  meson
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  pkgconfig(xcb)
+BuildRequires:  pkgconfig(xcb-icccm)
+BuildRequires:  pkgconfig(wayland-protocols)
+BuildRequires:  pkgconfig(wayland-server)
+BuildRequires:  pkgconfig(wlroots-0.19)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(libinput)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(libpcre2-8)
+BuildRequires:  pkgconfig(scenefx-0.4)
+
+%description
+MangoWC is a lightweight, high-performance Wayland compositor built on dwl, designed for speed, flexibility, and a modern, customizable desktop experience.
+
+%prep
+%autosetup
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+%files
+%doc README.md
+%license LICENSE
+%license LICENSE.wlroots
+%license LICENSE.tinywl 
+%license LICENSE.sway 
+%license LICENSE.dwm 
+%license LICENSE.dwl 
+%{_bindir}/mango
+%{_bindir}/mmsg
+%{_sysconfdir}/mango/config.conf
+%{_datadir}/wayland-sessions/mango.desktop
+
+%changelog
+* Wed Nov 12 2025 metcya <metcya@gmail.com>
+- Package mangowc

--- a/anda/desktops/mangowc/update.rhai
+++ b/anda/desktops/mangowc/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("DreamMaoMao/mangowc"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: mangowc (#7336)](https://github.com/terrapkg/packages/pull/7336)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)