### PR TITLE
[el10] add: zenergy (#7322)

### DIFF
--- a/anda/system/zenergy/akmod/anda.hcl
+++ b/anda/system/zenergy/akmod/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "zenergy-kmod.spec"
+	}
+	labels {
+		mock = 1
+		nightly = 1
+	}
+}

--- a/anda/system/zenergy/akmod/update.rhai
+++ b/anda/system/zenergy/akmod/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("BoukeHaarsma23/zenergy"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+}

--- a/anda/system/zenergy/akmod/zenergy-kmod.spec
+++ b/anda/system/zenergy/akmod/zenergy-kmod.spec
@@ -1,0 +1,72 @@
+# The reason why this package is a separate from the main one despite using the same sources
+# is because akmods use the srpm to build the kmod package, and if the kmod package is included
+# in the main package, akmods will reinstall the userspace package every time the kernel is updated.
+
+%if 0%{?fedora}
+%global buildforkernels akmod
+%global debug_package %{nil}
+%endif
+
+%global commit 58f2fda7184fbde95033f492f7c54990552ef86f
+%global commitdate 20250831
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global modulename zenergy
+
+Name:           %{modulename}-kmod
+Version:        1.0^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) via the hardware monitor (HWMON) sysfs interface.
+License:        GPL-2.0
+URL:            https://github.com/BoukeHaarsma23/zenergy
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
+# AMD only makes x86_64 CPUs, They literally invented x86_64.
+BuildArch:      x86_64
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  kmodtool
+
+Requires:       akmods
+Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
+Requires:       %{modulename}-akmod-modules = %{?epoch:%{epoch}:}%{version}
+Requires:       help2man
+Requires:       kernel-devel
+Conflicts:      dkms-%{modulename}
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Based on AMD_ENERGY driver, but with some jiffies added so non-root users can read it safely.
+Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs)
+via the hardware monitor (HWMON) sysfs interface.
+
+%prep
+# error out if there was something wrong with kmodtool
+%{?kmodtool_check}
+
+# print kmodtool output for debugging purposes:
+kmodtool --target %{_target_cpu} --repo terra --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%setup -q -c -n %{modulename}-%{commit}
+
+find . -type f -name '*.c' -exec sed -i "s/#VERSION#/%{version}/" {} \+
+
+for kernel_version  in %{?kernel_versions} ; do
+  cp -a %{modulename}-%{commit} _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version  in %{?kernel_versions} ; do
+  make V=1 %{?_smp_mflags} -C ${kernel_version##*___} M=${PWD}/_kmod_build_${kernel_version%%___*} VERSION=v%{version} modules
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+ mkdir -p %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ install -D -m 755 _kmod_build_${kernel_version%%___*}/zenergy.ko %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ chmod a+x %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/zenergy.ko
+done
+%{?akmod_install}
+
+%changelog
+%autochangelog

--- a/anda/system/zenergy/dkms/anda.hcl
+++ b/anda/system/zenergy/dkms/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "dkms-zenergy.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/system/zenergy/dkms/dkms-zenergy.spec
+++ b/anda/system/zenergy/dkms/dkms-zenergy.spec
@@ -1,0 +1,61 @@
+%global commit 58f2fda7184fbde95033f492f7c54990552ef86f
+%global debug_package %{nil}
+%global modulename zenergy
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20250831
+
+Name:           dkms-%{modulename}
+Version:        1.0^%{commitdate}git.%{shortcommit}
+Release:        1%?dist
+Summary:        Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) via the hardware monitor (HWMON) sysfs interface.
+License:        GPL-2.0
+URL:            https://github.com/BoukeHaarsma23/zenergy
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
+Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+BuildArch:      x86_64
+Requires:       dkms
+Requires:       help2man
+Conflicts:      akmod-%{modulename}
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+%description
+Based on AMD_ENERGY driver, but with some jiffies added so non-root users can read it safely.
+Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs)
+via the hardware monitor (HWMON) sysfs interface.
+
+
+%package       akmod-modules
+Summary:       Modules for Akmods
+Requires:      akmod-%{name}
+BuildArch:     noarch
+
+%description   akmod-modules
+Akmods modules for the akmod-%{name} package.
+ 
+%prep
+%autosetup -p1 -n %{modulename}-%{commit}
+# Zenergy has no concrete version, but upstream says "1.0" in their documentation
+/usr/bin/sed -i 's/@VERSION@/%{version}/g' dkms.conf
+
+%install
+mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}
+cp -fr ./ %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+
+%post
+dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{modulename} -v %{version} -q || :
+dkms install -m %{modulename} -v %{version} -q --force || :
+
+
+%files
+%{_usrsrc}/%{modulename}-%{version}
+%license LICENSE
+%doc README.md
+
+
+%changelog
+%autochangelog

--- a/anda/system/zenergy/dkms/update.rhai
+++ b/anda/system/zenergy/dkms/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("BoukeHaarsma23/zenergy"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+}

--- a/anda/system/zenergy/kmod-common/anda.hcl
+++ b/anda/system/zenergy/kmod-common/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "zenergy.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/system/zenergy/kmod-common/com.github.zenergy.metainfo.xml
+++ b/anda/system/zenergy/kmod-common/com.github.zenergy.metainfo.xml
@@ -1,0 +1,30 @@
+<component type="driver">
+  <id>com.github.zenergy</id>
+  <name>zenergy</name>
+  <pkgname>zenergy</pkgname>
+  <summary>Exposes the energy counters that are reported via the Running Average Power Limit (RAPL)</summary>
+  <description>
+    <p>
+    Based on AMD_ENERGY driver, but with some jiffies added so non-root users can read it safely.
+    Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs)
+    via the hardware monitor (HWMON) sysfs interface.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/BoukeHaarsma23/zenergy</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <!-- gplv2 -->
+  <project_license>GPL-2.0</project_license>
+
+  <developer id="com.github.zenergy">
+    <name>BoukeHaarsma23</name>
+  </developer>
+  
+
+  <provides>
+  <!-- /class/hwmon/hwmon*/energy* -->
+    <modalias>platform:zenergy</modalias>
+    <modalias>cpu:type:x86,ven0002fam0017mod*:feature:*</modalias>
+    <modalias>cpu:type:x86,ven0002fam0019mod*:feature:*</modalias>
+    <modalias>cpu:type:x86,ven0002fam001Amod*:feature:*</modalias>
+  </provides>
+</component>

--- a/anda/system/zenergy/kmod-common/update.rhai
+++ b/anda/system/zenergy/kmod-common/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("BoukeHaarsma23/zenergy"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+}

--- a/anda/system/zenergy/kmod-common/zenergy.spec
+++ b/anda/system/zenergy/kmod-common/zenergy.spec
@@ -1,0 +1,56 @@
+%global commit 58f2fda7184fbde95033f492f7c54990552ef86f
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20250831
+
+Name:           zenergy
+Version:        1.0^%{commitdate}git.%{shortcommit}
+Release:        1%?dist
+Summary:        Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) via the hardware monitor (HWMON) sysfs interface.
+License:        GPL-2.0
+URL:            https://github.com/BoukeHaarsma23/zenergy
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
+Source1:        com.github.zenergy.metainfo.xml
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       (akmod-%{name} = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = %{?epoch:%{epoch}:}%{version})
+Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+BuildArch:      noarch
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+%description
+Based on AMD_ENERGY driver, but with some jiffies added so non-root users can read it safely.
+Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs)
+via the hardware monitor (HWMON) sysfs interface.
+
+
+%package       akmod-modules
+Summary:       Modules for Akmods
+Requires:      akmod-%{name}
+BuildArch:     noarch
+
+%description   akmod-modules
+Akmods modules for the akmod-%{name} package.
+ 
+%prep
+%autosetup -p1 -n %{name}-%{commit}
+
+# Zenergy has no concrete version, but upstream says "1.0" in their documentation
+/usr/bin/sed -nE 's/@VERSION@/%{version}/g' dkms.conf > %{name}.conf
+
+%install
+install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/metainfo/com.github.zenergy.metainfo.xml
+
+# Akmods modules
+install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
+
+
+%files
+%license LICENSE
+%doc README.md
+%{_datadir}/metainfo/com.github.zenergy.metainfo.xml
+
+%files akmod-modules
+%{_modulesloaddir}/%{name}.conf
+
+%changelog
+%autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: zenergy (#7322)](https://github.com/terrapkg/packages/pull/7322)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)