### PR TITLE
[f42] chore(metainfo): bun (#7347)

### DIFF
--- a/anda/devs/bun/bun-bin.spec
+++ b/anda/devs/bun/bun-bin.spec
@@ -7,11 +7,12 @@
 
 Name:			bun-bin
 Version:		1.3.2
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one
 License:		MIT
 URL:			https://bun.sh
 Source0:		https://github.com/oven-sh/bun/releases/download/bun-v%version/bun-linux-%a.zip
+Source1:        sh.oven.bun.metainfo.xml
 BuildRequires:	unzip
 
 %description
@@ -57,7 +58,10 @@ install -Dm644 bun.bash -t %buildroot%bash_completions_dir
 install -Dm644 bun.fish -t %buildroot%fish_completions_dir
 ln -s bun %buildroot%_bindir/bunx
 
+install -Dm644 %{SOURCE1} %buildroot%{_datadir}/metainfo/sh.oven.bun.metainfo.xml
+
 %files
 %license LICENSE
 %_bindir/bun
 %_bindir/bunx
+%{_datadir}/metainfo/sh.oven.bun.metainfo.xml

--- a/anda/devs/bun/sh.oven.bun.metainfo.xml
+++ b/anda/devs/bun/sh.oven.bun.metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="runtime">
+  <id>sh.oven.bun</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <name>Bun</name>
+  <summary
+    >Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one</summary>
+
+  <description>
+    <p>
+    Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one
+    </p>
+  </description>
+  <url type="homepage">https://bun.sh</url>
+  <provides>
+      <mediatype>text/javascript</mediatype>
+      <mediatype>text/typescript</mediatype>
+  </provides>
+
+
+  <releases>
+    <release version="1.3.2" />
+  </releases>
+</component>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(metainfo): bun (#7347)](https://github.com/terrapkg/packages/pull/7347)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)