### PR TITLE
[f41] fix (swayosd): forgot space (#7366)

### DIFF
--- a/anda/desktops/sway/swayosd/swayosd.spec
+++ b/anda/desktops/sway/swayosd/swayosd.spec
@@ -1,6 +1,6 @@
 Name:           SwayOSD
 Version:        0.2.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A GTK based on screen display for keyboard shortcuts like caps-lock and volume
 License:        GPL-3.0-only
 URL:            https://github.com/ErikReider/SwayOSD
@@ -58,7 +58,7 @@ Provides:       swayosd
 
 %preun
 %systemd_preun swayosd-libinput-backend.service
-%systemd_preunorg.erikreider.swayosd.service
+%systemd_preun org.erikreider.swayosd.service
 
 %postun
 %systemd_postun_with_restart swayosd-libinput-backend.service


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix (swayosd): forgot space (#7366)](https://github.com/terrapkg/packages/pull/7366)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)