### PR TITLE
[el10] add: rustypaste (#7375)

### DIFF
--- a/anda/tools/rustypaste/anda.hcl
+++ b/anda/tools/rustypaste/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "rustypaste.spec"
+	}
+}

--- a/anda/tools/rustypaste/rustypaste.spec
+++ b/anda/tools/rustypaste/rustypaste.spec
@@ -1,0 +1,62 @@
+%define __brp_mangle_shebangs %{nil}
+
+Name:          rustypaste
+Version:       0.16.1
+Release:       1%?dist
+Summary:       A minimal file upload/pastebin service
+License:       MIT
+URL:           https://github.com/orhun/rustypaste
+Source0:       %url/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires: anda-srpm-macros
+BuildRequires: cargo-rpm-macros
+BuildRequires: gcc
+BuildRequires: cargo
+BuildRequires: mold
+BuildRequires: systemd-rpm-macros
+
+Packager:      Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+install -Dm755 target/rpm/rustypaste %{buildroot}%{_bindir}/rustypaste
+install -Dm644 config.toml %{buildroot}%{_sysconfdir}/rustypaste/config.toml
+install -Dm644 extra/systemd/rustypaste.env %{buildroot}%{_sysconfdir}/rustypaste/rustypaste.env
+install -Dm644 extra/systemd/rustypaste.service %{buildroot}/usr/lib/systemd/system/rustypaste.service
+install -Dm644 extra/systemd257+/rustypaste.sysusers %{buildroot}/usr/lib/sysusers.d/rustypaste.conf
+install -Dm644 extra/systemd/rustypaste.tmpfiles %{buildroot}/usr/lib/tmpfiles.d/rustypaste.conf
+%cargo_license_summary_online
+%{cargo_license_online -a} > LICENSE.dependencies
+
+%post
+%systemd_post swayosd-libinput-backend.service
+
+%preun
+%systemd_preun swayosd-libinput-backend.service
+
+%postun
+%systemd_postun_with_restart swayosd-libinput-backend.service
+
+%files
+%doc README.md CHANGELOG.md RELEASE.md
+%license LICENSE
+%license LICENSE.dependencies
+%{_bindir}/rustypaste
+%{_sysconfdir}/rustypaste/config.toml
+%{_sysconfdir}/rustypaste/rustypaste.env
+%{_unitdir}/rustypaste.service
+%{_sysusersdir}/rustypaste.conf
+%{_tmpfilesdir}/rustypaste.conf
+
+%changelog
+* Thu Nov 13 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/rustypaste/update.rhai
+++ b/anda/tools/rustypaste/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("orhun/rustypaste"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: rustypaste (#7375)](https://github.com/terrapkg/packages/pull/7375)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)