### PR TITLE
fix(yt-dlp-ejs): Fix tracked -ejs version and package deps

### DIFF
--- a/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
+++ b/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
@@ -1,6 +1,6 @@
 Name:           python-yt-dlp-ejs
 Version:        0.3.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        External JavaScript for yt-dlp supporting many runtimes
 
 License:        Unlicense AND MIT AND ISC

--- a/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
+++ b/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
@@ -8,8 +8,6 @@ URL:            https://github.com/yt-dlp/ejs
 Source:         %{pypi_source yt_dlp_ejs}
 Packager:		madonuko <mado@fyralabs.com>
 
-Requires:       (deno or bun or nodejs-npm)
-
 BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(pip)
@@ -25,6 +23,7 @@ BuildRequires:  (deno or bun or nodejs-npm)
 %package -n     python3-yt-dlp-ejs
 Summary:        %{summary}
 Provides:		yt-dlp-ejs = %evr
+Requires:       (deno or bun or nodejs-npm)
 
 %description -n python3-yt-dlp-ejs %_description
 

--- a/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
+++ b/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
@@ -8,6 +8,8 @@ URL:            https://github.com/yt-dlp/ejs
 Source:         %{pypi_source yt_dlp_ejs}
 Packager:		madonuko <mado@fyralabs.com>
 
+Requires:       (deno or bun or nodejs-npm)
+
 BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(pip)

--- a/anda/tools/yt-dlp-ejs/update.rhai
+++ b/anda/tools/yt-dlp-ejs/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(pypi("yt-dlp-ejs"));
+rpm.version(find("yt-dlp-ejs==([\\d.]+)", gh_rawfile("yt-dlp/yt-dlp", "master", "pyproject.toml"), 1));

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -10,7 +10,7 @@ License:        Unlicense
 URL:            https://github.com/yt-dlp/yt-dlp
 BuildArch:      noarch
 Packager:       madonuko <mado@fyralabs.com>
-Requires:       deno
+Recommends:     (deno or bun or nodejs-npm)
 
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(hatchling)

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -3,7 +3,7 @@
 
 Name:           yt-dlp-git
 Version:        2025.11.12.004747
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A command-line program to download videos from online video platforms
 
 License:        Unlicense


### PR DESCRIPTION
1. `yt-dlp` is fixed to a specific `yt-dlp-ejs` version and will reject all others
2. `yt-dlp` itself does not *require* JS runtimes to work, but `yt-dlp-ejs` *does.*