### PR TITLE
[f43] fix(yt-dlp-ejs): Fix tracked -ejs version and package deps (#7380)

### DIFF
--- a/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
+++ b/anda/tools/yt-dlp-ejs/python-yt-dlp-ejs.spec
@@ -1,6 +1,6 @@
 Name:           python-yt-dlp-ejs
 Version:        0.3.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        External JavaScript for yt-dlp supporting many runtimes
 
 License:        Unlicense AND MIT AND ISC
@@ -23,6 +23,7 @@ BuildRequires:  (deno or bun or nodejs-npm)
 %package -n     python3-yt-dlp-ejs
 Summary:        %{summary}
 Provides:		yt-dlp-ejs = %evr
+Requires:       (deno or bun or nodejs-npm)
 
 %description -n python3-yt-dlp-ejs %_description
 

--- a/anda/tools/yt-dlp-ejs/update.rhai
+++ b/anda/tools/yt-dlp-ejs/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(pypi("yt-dlp-ejs"));
+rpm.version(find("yt-dlp-ejs==([\\d.]+)", gh_rawfile("yt-dlp/yt-dlp", "master", "pyproject.toml"), 1));

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -3,14 +3,14 @@
 
 Name:           yt-dlp-git
 Version:        2025.11.12.004747
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A command-line program to download videos from online video platforms
 
 License:        Unlicense
 URL:            https://github.com/yt-dlp/yt-dlp
 BuildArch:      noarch
 Packager:       madonuko <mado@fyralabs.com>
-Requires:       deno
+Recommends:     (deno or bun or nodejs-npm)
 
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(hatchling)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(yt-dlp-ejs): Fix tracked -ejs version and package deps (#7380)](https://github.com/terrapkg/packages/pull/7380)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)