### PR TITLE
[f41] fix(metainfo): zed (#7384)

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -71,6 +71,7 @@ This package provides the /usr/bin/zed binary. If you use zfs, install %name-ren
 %files cli
 %_bindir/zed
 %{_datadir}/applications/%app_id.desktop
+%{_metainfodir}/%app_id.metainfo.xml
 
 %package rename-zeditor
 Summary: Rename zed to zeditor to prevent collision with zfs
@@ -84,6 +85,7 @@ The normal package is %name-cli.
 %files rename-zeditor
 %_bindir/zeditor
 %_datadir/applications/%app_id.desktop.zeditor
+%{_metainfodir}/%app_id.metainfo.xml
 
 
 %prep
@@ -171,7 +173,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
 %license assets/licenses.md
 %{_libexecdir}/zed-editor
 %{_datadir}/pixmaps/%app_id.png
-%{_metainfodir}/%app_id.metainfo.xml
 
 %changelog
 %autochangelog

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -63,6 +63,7 @@ This package provides the /usr/bin/zed binary. If you use zfs, install %name-ren
 %files cli
 %_bindir/zed
 %{_datadir}/applications/%app_id.desktop
+%{_metainfodir}/%app_id.metainfo.xml
 
 %package rename-zeditor
 Summary: Rename zed to zeditor to prevent collision with zfs
@@ -76,6 +77,7 @@ The normal package is %name-cli.
 %files rename-zeditor
 %_bindir/zeditor
 %_datadir/applications/%app_id.desktop.zeditor
+%{_metainfodir}/%app_id.metainfo.xml
 
 
 %prep
@@ -160,7 +162,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
 %license assets/licenses.md
 %{_libexecdir}/zed-editor
 %{_datadir}/pixmaps/%app_id.png
-%{_metainfodir}/%app_id.metainfo.xml
 
 %changelog
 %autochangelog

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -63,6 +63,7 @@ This package provides the /usr/bin/zed binary. If you use zfs, install %name-ren
 %files cli
 %_bindir/zed
 %{_datadir}/applications/%app_id.desktop
+%{_metainfodir}/%app_id.metainfo.xml
 
 %package rename-zeditor
 Summary: Rename zed to zeditor to prevent collision with zfs
@@ -76,6 +77,7 @@ The normal package is %name-cli.
 %files rename-zeditor
 %_bindir/zeditor
 %_datadir/applications/%app_id.desktop.zeditor
+%{_metainfodir}/%app_id.metainfo.xml
 
 
 %prep
@@ -160,7 +162,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
 %license assets/licenses.md
 %{_libexecdir}/zed-editor
 %{_datadir}/pixmaps/%app_id.png
-%{_metainfodir}/%app_id.metainfo.xml
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(metainfo): zed (#7384)](https://github.com/terrapkg/packages/pull/7384)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)