### PR TITLE
[f42] add: chdig (#7386)

### DIFF
--- a/anda/apps/chdig/anda.hcl
+++ b/anda/apps/chdig/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "chdig.spec"
+  }
+}

--- a/anda/apps/chdig/chdig.spec
+++ b/anda/apps/chdig/chdig.spec
@@ -1,0 +1,35 @@
+%undefine __brp_mangle_shebangs
+
+Name:           chdig
+Version:        25.11.1
+Release:        1%?dist
+Summary:        Dig into ClickHouse with TUI interface
+URL:            https://github.com/azat/chdig
+Source0:        %url/archive/refs/tags/v%{version}.tar.gz
+License:        MIT
+BuildRequires:  cargo anda-srpm-macros cargo-rpm-macros mold clang fontconfig-devel glib2 libgcc
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+install -Dm755 target/rpm/chdig %{buildroot}%{_bindir}/chdig
+%cargo_license_summary_online
+%{cargo_license_online -a} > LICENSE.dependencies
+
+%files
+%doc README.md
+%license LICENSE
+%license LICENSE.dependencies
+%{_bindir}/chdig
+
+%changelog
+* Fri Nov 14 2025 Owen Zimmerman <owen@fyralabs.com>
+- Intial Commit

--- a/anda/apps/chdig/update.rhai
+++ b/anda/apps/chdig/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("azat/chdig"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: chdig (#7386)](https://github.com/terrapkg/packages/pull/7386)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)