### PR TITLE
[f41] add: terra-appstream-helper (#7401)

### DIFF
--- a/anda/terra/appstream-helper/anda.hcl
+++ b/anda/terra/appstream-helper/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "terra-appstream-helper.spec"
+	}
+}

--- a/anda/terra/appstream-helper/terra-appstream-helper.spec
+++ b/anda/terra/appstream-helper/terra-appstream-helper.spec
@@ -1,0 +1,52 @@
+Name:           terra-appstream-helper
+Version:        0.1.1
+Release:        1%?dist
+Summary:        Scripts and RPM macros to help with AppStream metadata generation for Terra
+License:        GPL-3.0-or-Later
+URL:            https://github.com/terrapkg/appstream-helper
+Source:         %{url}/archive/refs/tags/v%version.tar.gz
+BuildArch:      noarch
+Requires:       python3-%{name} = %{evr}
+BuildRequires:  anda-srpm-macros python3-devel python3-installer pyproject-rpm-macros python3dist(pip) python3dist(setuptools) python3dist(wheel)
+
+%description
+%{summary}.
+
+%package -n     python3-%{name}
+Summary:        Python files for %{name}
+Requires:       %{name} = %{evr}
+BuildArch:      noarch
+
+%description -n python3-%{name}
+Python files needed for %{name}.
+
+%prep
+%autosetup -n appstream-helper-%{version}
+
+%generate_buildrequires
+%pyproject_buildrequires
+
+
+%build
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+%pyproject_save_files -l terra_appstream_helper
+install -Dpm644 terra-appstream.macros %buildroot%_rpmmacrodir/macros.terra-appstream
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/terra-appstream-helper
+%{_rpmmacrodir}/macros.terra-appstream
+
+
+
+%files -n python3-%{name} -f %{pyproject_files}
+
+
+
+%changelog
+%autochangelog

--- a/anda/terra/appstream-helper/update.rhai
+++ b/anda/terra/appstream-helper/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("terrapkg/appstream-helper"));

--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -1,6 +1,6 @@
 Name:           anda-srpm-macros
 Version:        0.2.21
-Release:        1%?dist
+Release:        2%?dist
 Summary:        SRPM macros for extra Fedora packages
 
 License:        MIT
@@ -9,6 +9,7 @@ Source0:        %url/archive/refs/tags/v%{version}.tar.gz
 
 Recommends:     rust-packaging
 Requires:       git-core
+Requires:       terra-appstream-helper
 Obsoletes:      fyra-srpm-macros < 0.1.1-1
 Provides:       fyra-srpm-macros = %{version}-%{release}
 BuildArch:      noarch


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: terra-appstream-helper (#7401)](https://github.com/terrapkg/packages/pull/7401)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)