### PR TITLE
[f42] chore: Bump yt-dlp on <= 43 (#7407)

### DIFF
--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,7 +2,7 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2025.11.14.191745
+Version:        2025.11.16.190803
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [chore: Bump yt-dlp on &lt;&#x3D; 43 (#7407)](https://github.com/terrapkg/packages/pull/7407)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)