### PR TITLE
[el10] chore: Bump nightly packages on <= 43 (#7410)

### DIFF
--- a/anda/apps/envision/envision.spec
+++ b/anda/apps/envision/envision.spec
@@ -1,5 +1,5 @@
-%global commit 5470662f25a0fc9cdb024d2e3dce4108f5cc529a
-%global commit_date 20250917
+%global commit 9615228a515fd77abb0cab5de21528f1f33d26f6
+%global commit_date 20251104
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           envision-nightly

--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,9 +1,9 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
 %global ver 13.3.0
-%global commit 88c951e771fd57bccf6d8f1539a03df47316368d
+%global commit 555d7231efef507f9fc76b21c1333a07916cc792
 %global shortcommit %{sub %{commit} 1 7}
-%global commit_date 20251029
+%global commit_date 20251116
 %global devel_name QtColorWidgets
 %global _distro_extra_cflags -fuse-ld=mold
 %global _distro_extra_cxxflags -fuse-ld=mold

--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,5 +1,5 @@
-%global commit 71a73d9ac15b3c50c80f1a4cffd657f304da79a8
-%global commit_date 20251015
+%global commit 94128d8fbcac0a14af4c529b29e0d91b0b997796
+%global commit_date 20251114
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global debug_package %nil
 %global __strip /bin/true

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,9 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-%global commit 0a606d9e189c749fae199287dccfaea4c68cca4a
+%global commit 701201b13c95d00cc894b4f88551b5add740d409
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251102
+%global commit_date 20251116
 %global ver 0.40.0
 
 Name:           mpv-nightly

--- a/anda/apps/rasputin/rasputin.spec
+++ b/anda/apps/rasputin/rasputin.spec
@@ -1,5 +1,5 @@
-%global commit a445d545c8e1a3339acd53cadf4e9c08698a786d
-%global commit_date 20251028
+%global commit b3f3f1da2fa59a2cbdea73c75b7d67bc312ce2bc
+%global commit_date 20251115
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           rasputin

--- a/anda/apps/rp-appset/rp-appset.spec
+++ b/anda/apps/rp-appset/rp-appset.spec
@@ -1,5 +1,5 @@
-%global commit a445d545c8e1a3339acd53cadf4e9c08698a786d
-%global commit_date 20251024
+%global commit b3f3f1da2fa59a2cbdea73c75b7d67bc312ce2bc
+%global commit_date 20251115
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           appset

--- a/anda/apps/rp-bookshelf/rp-bookshelf.spec
+++ b/anda/apps/rp-bookshelf/rp-bookshelf.spec
@@ -1,5 +1,5 @@
-%global commit 316b2a9787e19352eb22cf8de163d6856a1ea26f
-%global commit_date 20251101
+%global commit d09cc3fdb2071552f18b4564e1c77cb288b580db
+%global commit_date 20251104
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           rp-bookshelf

--- a/anda/apps/winetricks/git/winetricks-git.spec
+++ b/anda/apps/winetricks/git/winetricks-git.spec
@@ -1,9 +1,9 @@
 # Fedora sometimes sources the snapshots under stable versions and just bumps release
 # For user clarity I have separated these into different packages
-%global commit  a5a76f24a5d03697cab0c3192843a4379d6f8ff6
+%global commit  533f41704766765cfb3706fb2aa197acbb05df32
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 20250102
-%global commit_date 20251025
+%global commit_date 20251105
 
 Name:           winetricks-git
 Version:        %{ver}^%{commit_date}git.%{shortcommit}

--- a/anda/desktops/hyprland/hyprgraphics/hyprgraphics.nightly.spec
+++ b/anda/desktops/hyprland/hyprgraphics/hyprgraphics.nightly.spec
@@ -1,9 +1,9 @@
 #? https://src.fedoraproject.org/rpms/hyprgraphics/blob/rawhide/f/hyprgraphics.spec
 
 %global realname hyprgraphics
-%global ver 0.2.0
-%global commit 50fb9f069219f338a11cf0bcccb9e58357d67757
-%global commit_date 20251015
+%global ver 0.3.0
+%global commit ffc999d980c7b3bca85d3ebd0a9fbadf984a8162
+%global commit_date 20251107
 %global shortcommit %{sub %commit 1 7}
 
 %bcond libjxl 1

--- a/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
+++ b/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
@@ -1,10 +1,10 @@
 #? https://src.fedoraproject.org/rpms/hyprutils/blob/rawhide/f/hyprutils.spec
 
 %global realname hyprutils
-%global ver 0.10.0
+%global ver 0.10.2
 
-%global commit 3df7bde01efb3a3e8e678d1155f2aa3f19e177ef
-%global commit_date 20251005
+%global commit e3cae692f6685a4e211d9ea1e7be0001ba8ea7b8
+%global commit_date 20251116
 %global shortcommit %{sub %commit 1 7}
 
 Name:           %realname.nightly

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 765ee6842930f0d6918574b9b87c2ee6583e4727
+%global commit caf5040a6de2aaa326d93f75625a3c9a0e08858c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-10-31
+%global fulldate 2025-11-15
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0

--- a/anda/devs/micro/micro-nightly.spec
+++ b/anda/devs/micro/micro-nightly.spec
@@ -12,8 +12,8 @@
 
 # Naming variable as something other than "commit" is necessary
 # to stop %%gometa from putting commit hash in release
-%global commit_hash fa6831412394ee08e23ef0855c246bbef02bed33
-%global commit_date 20251028
+%global commit_hash 9183fbe64090ee3be147a2b52a74e4516777a0eb
+%global commit_date 20251106
 %global shortcommit %{sub %{commit_hash} 1 7}
 %global ver 2.0.14
 

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,7 @@
-%global commit df15d2d2feada0bd474d814fcd4514e8000be62c
+%global commit 1683052e6ce44d206e947c397917b2ab7617c0fe
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251102
-%global ver 0.212.0
+%global commit_date 20251116
+%global ver 0.214.0
 
 %bcond_with check
 %bcond nightly 1

--- a/anda/games/gamescope-session-steam/gamescope-session-steam.spec
+++ b/anda/games/gamescope-session-steam/gamescope-session-steam.spec
@@ -1,8 +1,8 @@
 %define debug_package %nil
 
-%global commit ba967fd8c5de7dc6c623b614296b3872255996b0
+%global commit 93859eaa6056c24a9a6e9bc7464951793a54d3d3
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250904
+%global commit_date 20251113
 
 Name:           gamescope-session-steam
 Version:        %commit_date.%shortcommit

--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,8 +1,8 @@
 %define debug_package %nil
 
-%global commit 7887b2941dd1ec70bf002e8ea3cd6007859131ec
+%global commit df099b31451531a2bb5a1dc29c93f76bbbab79d0
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251012
+%global commit_date 20251109
 
 Name:           gamescope-session
 Version:        %commit_date.%shortcommit

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -1,10 +1,10 @@
 %global real_name prismlauncher
 %global nice_name PrismLauncher
 
-%global commit f3bc2f0e9fd93b557f6179e55d3616fb3f428a3b
+%global commit 16066c9a15f09f92bb22e44d53e3aafc520f9f70
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20251102
+%global commit_date 20251116
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6

--- a/anda/langs/go/albius/albius.spec
+++ b/anda/langs/go/albius/albius.spec
@@ -1,6 +1,6 @@
 %define debug_package %nil
-%global commit 1cb64ec6df27d70d90b59bb946c6aa4323e4ec63
-%global commit_date 20251029
+%global commit ee04f2624c4fa5875052d2a90f3eae4645966a81
+%global commit_date 20251105
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           albius

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit 5079074b1a86b7b2b80197e079c564d2d5924735
+%global commit 79ddb7d89e4320b448c35b5936ce150706bbf210
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20251101
+%global commit_date 20251116
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/curl_cffi/curl_cffi.spec
+++ b/anda/langs/python/curl_cffi/curl_cffi.spec
@@ -5,7 +5,7 @@
 %global _version 0.14.0b2
 
 Name:			python-%{pypi_name}
-Version:		%{_version}
+Version:		0.13.0
 Release:		1%?dist
 Summary:		Python binding for curl-impersonate fork via cffi..
 License:		MIT

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit 8aaa86f6a4b5f518734973884d14bf4da0f6f399
-%global commit_date 20251102
+%global commit ebce8d766b41fbf4d83cf47c1297563a9508ff60
+%global commit_date 20251116
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/lib/astal/astal/astal.spec
+++ b/anda/lib/astal/astal/astal.spec
@@ -1,7 +1,7 @@
 
-%global commit 20bd8318e4136fbd3d4eb2d64dbabc3acbc915dd
+%global commit 5baeb660214bcafc9ae0b733a1bc84f5fa6078f4
 %global shortcommit %{sub %commit 1 7}
-%global commit_date 20250830
+%global commit_date 20251108
 
 Name:			astal
 Version:		0^%commit_date.%shortcommit

--- a/anda/lib/backtrace/libbacktrace-nightly.spec
+++ b/anda/lib/backtrace/libbacktrace-nightly.spec
@@ -1,8 +1,8 @@
 %global debug_package %nil
 
-%global commit 793921876c981ce49759114d7bb89bb89b2d3a2d
+%global commit b9e40069c0b47a722286b94eb5231f7f05c08713
 %global shortcommit %(c=%commit; echo ${c:0:7})
-%global commit_date 20250411
+%global commit_date 20251107
 
 %global _desc %{expand:
 A C library that may be linked into a C/C++ program to produce symbolic backtraces.

--- a/anda/multimedia/carla/Carla-nightly.spec
+++ b/anda/multimedia/carla/Carla-nightly.spec
@@ -1,8 +1,8 @@
 %global pname   carla
 %global ver     2.5.10
-%global commit  1d8dcb5aab5e0c30352e9f928ce3e40cbc86a439
+%global commit  a406f0044bc8c098475814abc1f379ed7e0545d6
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251010
+%global commit_date 20251111
 
 Name:           Carla-nightly
 Version:        %(echo %ver | tr -d 'v')^%commit_date.git~%shortcommit

--- a/anda/system/ipu6-drivers/kmod-common/intel-ipu6-drivers.spec
+++ b/anda/system/ipu6-drivers/kmod-common/intel-ipu6-drivers.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
-%global commit 69b2fde9edcbc24128b91541fdf2791fbd4bf7a4
+%global commit 9766e218112f4173be9b0f06dfae27cb40c54f40
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20250917
+%global commit_date 20251113
 # Actual "release" version, currently unused as the release versions are back and forth on if on if they use 1.0.0 or 1.0.1
 # Use this if they ever stop doing that I guess
 %global ver 1.0.1

--- a/anda/system/nvidia-patch/nvidia-patch.spec
+++ b/anda/system/nvidia-patch/nvidia-patch.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
-%global commit c28a647b527fbc2761f808fb1695b30cd7d97077
+%global commit a7690e64b5080452596ffd55062c625abe05fa3a
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251024
+%global commit_date 20251108
 
 
 %global patches %{_datadir}/src/nvidia-patch

--- a/anda/system/nvidia/libva-nvidia-driver/libva-nvidia-driver.spec
+++ b/anda/system/nvidia/libva-nvidia-driver/libva-nvidia-driver.spec
@@ -1,5 +1,5 @@
-%global commit0 3d46e26818a9e0eff26a7cd0db581316029d953b
-%global date 20250929
+%global commit0 57a476b0e55f015759d9c50cc1f13159c6cd8f95
+%global date 20251114
 %global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
 
 %global upstream_name nvidia-vaapi-driver

--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,5 +1,5 @@
-%global commit 2a1faf0b607c8ab87fb794d25b8050a8b9117f60
-%global commit_date 20251107
+%global commit 40d07f6d1e34c5ecaf958d01a5ddee8d9e1fefcf
+%global commit_date 20251111
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           readymade-git

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 18cc70b14aa74b270d41016786c45f3f936f86fe
+%global commit 82dacccf33f4ffe0a8e6fbeea2a0e18780b4186b
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251102
-%global ver 1.0.17
+%global commitdate 20251116
+%global ver 1.0.18
 
 Name:           scx-scheds-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}

--- a/anda/tools/glasgow/glasgow.spec
+++ b/anda/tools/glasgow/glasgow.spec
@@ -1,5 +1,5 @@
-%global commit a1f179a51c7d343859ed3fc7babdd4eb62841571
-%global commit_date 20251101
+%global commit 67a8574a9b59af18e36e81411a981e23fe205ff3
+%global commit_date 20251116
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name glasgow

--- a/anda/tools/natscli/natscli.spec
+++ b/anda/tools/natscli/natscli.spec
@@ -1,7 +1,7 @@
 # https://github.com/nats-io/natscli
 %global goipath         github.com/nats-io/natscli
-%global commit          0bfcceedd64a3e9abc85f55bff7b187b28a6b34c
-%global commit_date     20251031
+%global commit          9cebb956791ff8f9f10d35f11af8d471af0cdbd8
+%global commit_date     20251113
 %global shortcommit     %{sub %{commit} 1 7}
 
 %gometa -f

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,5 +1,5 @@
-%global commit de9c99a1f2c74ee722b3216ca28c8f7f76ac206d
-%global commit_date 20251023
+%global commit a2bd8479a2a80a068e749530aa5a78b2918358b8
+%global commit_date 20251108
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           spotx-bash


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [chore: Bump nightly packages on <= 43 (#7410)](https://github.com/terrapkg/packages/pull/7410)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)