### PR TITLE
[el10] fix(wine-dxvk): Fix Mesa repo in anda.hcl (#7416)

### DIFF
--- a/anda/system/wine-dxvk/anda.hcl
+++ b/anda/system/wine-dxvk/anda.hcl
@@ -2,7 +2,7 @@ project pkg {
         arches = ["x86_64", "i386"]
 	rpm {
 		spec = "wine-dxvk.spec"
-		extra_repos = ["https://repos.fyralabs.com/terrarawhide-mesa"]
+		extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-mesa"]
 	}
 	labels {
 	    mock = 1


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [fix(wine-dxvk): Fix Mesa repo in anda.hcl (#7416)](https://github.com/terrapkg/packages/pull/7416)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)