### PR TITLE
[f43] feat: Add scx-tools, update scx-scheds (#7411)

### DIFF
--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -2,10 +2,11 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commitdate 20251117
 %global ver 1.0.18
+%undefine __brp_mangle_shebangs
 
 Name:           scx-scheds-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Nightly builds of sched_ext schedulers and tools
 SourceLicense:  GPL-2.0-only
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (LGPL-2.1-only OR BSD-2-Clause) AND LGPL-2.1 AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR MIT OR Apache-2.0) AND MPL-2.0-only and MPL-2.0-or-later AND (Unlicense OR MIT) AND Zlib
@@ -32,6 +33,8 @@ BuildRequires:  rust
 BuildRequires:  systemd
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  zlib-ng-compat
+Requires:       (scx-tools or scx-tools-nightly)
+Suggests:       scx-tools-nightly
 Requires:       elfutils-libelf
 Requires:       jq
 Requires:       libseccomp
@@ -70,25 +73,24 @@ License:       GPL-2.0-only
 %cargo_prep_online
 
 %build
-%meson \
- -Dsystemd=enabled \
- -Dopenrc=disabled
-%meson_build
-
+%{cargo_build -a} \
+     --workspace \
+     --exclude scx_rlfifo \
+     --exclude scx_mitosis \
+     --exclude scx_wd40 \
+     --exclude xtask \
+     --exclude scxcash \
+     --exclude vmlinux_docify \
+     --exclude scx_arena_selftests
 
 %install
-%meson_install
+find target/rpm \
+    -maxdepth 1 -type f -executable ! -name '*.so' \
+    -exec install -Dm755 -t %{buildroot}%{_bindir} {} +
+
+install -Dm755 target/rpm/*.so -t %{buildroot}%{_libdir}
 
 %{cargo_license_online} > LICENSE.dependencies
-
-%post
-%systemd_post scx_loader.service
-
-%preun
-%systemd_preun scx_loader.service
-
-%postun
-%systemd_postun_with_restart scx_loader.service
 
 %files
 %doc OVERVIEW.md
@@ -96,12 +98,6 @@ License:       GPL-2.0-only
 %license LICENSE
 %license LICENSE.dependencies
 %{_bindir}/scx*
-%{_bindir}/vmlinux_docify
-%{_bindir}/xtask
-%{_unitdir}/scx_loader.service
-%{_datadir}/dbus-1/system.d/org.scx.Loader.conf
-%{_datadir}/dbus-1/system-services/org.scx.Loader.service
-%config(noreplace) %{_datadir}/scx_loader/config.toml
 
 %changelog
 * Sun Jun 15 2025 Gilver E. <rockgrub@disroot.org> - 1.0.13^20250612.git.c1507b0-1

--- a/anda/system/scx-scheds/stable/scx-scheds.spec
+++ b/anda/system/scx-scheds/stable/scx-scheds.spec
@@ -1,7 +1,9 @@
+%undefine __brp_mangle_shebangs
+
 Name:           scx-scheds
 Version:        1.0.18
-Release:        1%?dist
-Summary:        sched_ext schedulers and tools
+Release:        2%?dist
+Summary:        sched_ext schedulers
 SourceLicense:  GPL-2.0-only
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (LGPL-2.1-only OR BSD-2-Clause) AND LGPL-2.1 AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR MIT OR Apache-2.0) AND MPL-2.0-only and MPL-2.0-or-later AND (Unlicense OR MIT) AND Zlib
 URL:            https://github.com/sched-ext/scx
@@ -27,6 +29,8 @@ BuildRequires:  rust
 BuildRequires:  systemd
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  zlib-ng-compat
+Requires:       (scx-tools or scx-tools-nightly)
+Suggests:       scx-tools
 Requires:       elfutils-libelf
 Requires:       jq
 Requires:       libseccomp
@@ -38,6 +42,7 @@ Conflicts:      scx_layered
 Conflicts:      scx_rustland
 Conflicts:      scx_rusty
 Conflicts:      scx-scheds-git
+Conflicts:      scx-scheds-nightly
 Provides:       rust-scx_utils-devel
 Provides:       scx_c_schedulers
 Provides:       scxctl = %{version}
@@ -62,40 +67,31 @@ License:       GPL-2.0-only
 %cargo_prep_online
 
 %build
-%meson \
- -Dsystemd=enabled \
- -Dopenrc=disabled
-%meson_build
+%{cargo_build -a} \
+     --workspace \
+     --exclude scx_rlfifo \
+     --exclude scx_mitosis \
+     --exclude scx_wd40 \
+     --exclude xtask \
+     --exclude scxcash \
+     --exclude vmlinux_docify \
+     --exclude scx_arena_selftests
 
 %install
-%meson_install
+find target/rpm \
+    -maxdepth 1 -type f -executable ! -name '*.so' \
+    -exec install -Dm755 -t %{buildroot}%{_bindir} {} +
 
-mv services/systemd/README.md SERVICE_MIGRATION.md
+install -Dm755 target/rpm/*.so -t %{buildroot}%{_libdir}
 
 %{cargo_license_online} > LICENSE.dependencies
-
-%post
-%systemd_post scx_loader.service
-
-%preun
-%systemd_preun scx_loader.service
-
-%postun
-%systemd_postun_with_restart scx_loader.service
 
 %files
 %doc OVERVIEW.md
 %doc README.md
-%doc SERVICE_MIGRATION.md
 %license LICENSE
 %license LICENSE.dependencies
 %{_bindir}/scx*
-%{_bindir}/vmlinux_docify
-%{_bindir}/xtask
-%{_unitdir}/scx_loader.service
-%{_datadir}/dbus-1/system.d/org.scx.Loader.conf
-%{_datadir}/dbus-1/system-services/org.scx.Loader.service
-%config(noreplace) %{_datadir}/scx_loader/config.toml
 
 %changelog
 * Sun Jun 15 2025 Gilver E. <rockgrub@disroot.org> - 1.0.13-1

--- a/anda/system/scx-tools/nightly/anda.hcl
+++ b/anda/system/scx-tools/nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+	spec = "scx-tools-nightly.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/system/scx-tools/nightly/scx-tools-nightly.spec
+++ b/anda/system/scx-tools/nightly/scx-tools-nightly.spec
@@ -1,0 +1,87 @@
+%global commit d830ef7cae6b6e937dc01455a4c59607189d4db7
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20251114
+%global ver 1.0.18
+%global appid com.sched_ext.scx
+%global developer "sched-ext Contributors"
+%global org "com.sched_ext"
+
+Name:           scx-tools-nightly
+Version:        %{ver}^%{commitdate}.git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Sched_ext Tools
+License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND GPL-2.0-only AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
+SourceLicense:  GPL-2.0-only
+URL:            https://github.com/sched-ext/scx-loader
+Source0:        %{url}/archive/%{commit}/%{commit}.tar.gz
+BuildRequires:  anda-srpm-macros
+BuildRequires:  bpftool
+BuildRequires:  cargo
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  clang >= 17
+BuildRequires:  gcc
+BuildRequires:  git
+BuildRequires:  libseccomp-devel
+BuildRequires:  lld >= 17
+BuildRequires:  llvm >= 17
+BuildRequires:  mold
+BuildRequires:  python3
+BuildRequires:  rust
+BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
+Requires:       (scx-scheds or scx-scheds-nightly)
+Suggests:       scx-scheds-nightly
+Obsoletes:      scxctl <= 0.3.4
+Provides:       scxctl = %{evr}
+Conflicts:      scx-tools
+Packager:       Gilver E. <rockgrub@disroot.org>
+
+%description
+scx_loader: A D-Bus interface for managing sched_ext schedulers
+
+%prep
+%autosetup -n scx-loader-%{commit}
+%cargo_prep_online
+
+%build
+%{cargo_build -a} \
+     --workspace
+
+%install
+find target/rpm \
+    -maxdepth 1 -type f -executable ! -name '*.so' ! -name 'xtask' \
+    -exec install -Dm755 -t %{buildroot}%{_bindir} {} +
+
+# Install runtime assets via xtask
+./target/rpm/xtask install --destdir %{buildroot}
+
+install -Dm755 target/rpm/*.so -t %{buildroot}%{_libdir} || :
+
+%{cargo_license_online} > LICENSE.dependencies
+
+%terra_appstream
+
+%post
+%systemd_post scx_loader.service
+
+%preun
+%systemd_preun scx_loader.service
+
+%postun
+%systemd_postun_with_restart scx_loader.service
+
+%files
+%license LICENSE
+%license LICENSE.dependencies
+%doc README.md
+%{_bindir}/scx*
+%{_unitdir}/scx_loader.service
+%{_datadir}/dbus-1/system-services/org.scx.Loader.service
+%{_datadir}/dbus-1/system.d/org.scx.Loader.conf
+%{_datadir}/polkit-1/actions/org.scx.Loader.policy
+%config(noreplace) %{_datadir}/scx_loader/config.toml
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%changelog
+* Sun Nov 16 2025 Gilver E. <rockgrub@disroot.org> - 1.0.18^20251114.git.d830ef7-1
+- Initial package

--- a/anda/system/scx-tools/nightly/update.rhai
+++ b/anda/system/scx-tools/nightly/update.rhai
@@ -1,0 +1,8 @@
+rpm.global("commit", gh_commit("sched-ext/scx-loader"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+    let v = gh("sched-ext/scx-loader");
+    v.crop(1);
+    rpm.global("ver", v);
+}

--- a/anda/system/scx-tools/stable/anda.hcl
+++ b/anda/system/scx-tools/stable/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+	spec = "scx-tools.spec"
+  }
+}

--- a/anda/system/scx-tools/stable/scx-tools.spec
+++ b/anda/system/scx-tools/stable/scx-tools.spec
@@ -1,0 +1,84 @@
+%global appid com.sched_ext.scx
+%global developer "sched-ext Contributors"
+%global org "com.sched_ext"
+
+Name:           scx-tools
+Version:        1.0.18
+Release:        1%{?dist}
+Summary:        Sched_ext Tools
+License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND GPL-2.0-only AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
+SourceLicense:  GPL-2.0-only
+URL:            https://github.com/sched-ext/scx-loader
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires:  anda-srpm-macros
+BuildRequires:  bpftool
+BuildRequires:  cargo
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  clang >= 17
+BuildRequires:  gcc
+BuildRequires:  git
+BuildRequires:  libseccomp-devel
+BuildRequires:  lld >= 17
+BuildRequires:  llvm >= 17
+BuildRequires:  mold
+BuildRequires:  python3
+BuildRequires:  rust
+BuildRequires:  systemd
+BuildRequires:  systemd-rpm-macros
+Requires:       (scx-scheds or scx-scheds-nightly)
+Suggests:       scx-scheds
+Obsoletes:      scxctl <= 0.3.4
+Provides:       scxctl = %{evr}
+Conflicts:      scx-tools-git
+Conflicts:      scx-tools-nightly
+Packager:       Gilver E. <rockgrub@disroot.org>
+
+%description
+scx_loader: A D-Bus interface for managing sched_ext schedulers
+
+%prep
+%autosetup -n scx-loader-%{version}
+%cargo_prep_online
+
+%build
+%{cargo_build -a} \
+     --workspace
+
+%install
+find target/rpm \
+    -maxdepth 1 -type f -executable ! -name '*.so' ! -name 'xtask' \
+    -exec install -Dm755 -t %{buildroot}%{_bindir} {} +
+
+# Install runtime assets via xtask
+./target/rpm/xtask install --destdir %{buildroot}
+
+install -Dm755 target/rpm/*.so -t %{buildroot}%{_libdir} || :
+
+%{cargo_license_online} > LICENSE.dependencies
+
+%terra_appstream
+
+%post
+%systemd_post scx_loader.service
+
+%preun
+%systemd_preun scx_loader.service
+
+%postun
+%systemd_postun_with_restart scx_loader.service
+
+%files
+%license LICENSE
+%license LICENSE.dependencies
+%doc README.md
+%{_bindir}/scx*
+%{_unitdir}/scx_loader.service
+%{_datadir}/dbus-1/system-services/org.scx.Loader.service
+%{_datadir}/dbus-1/system.d/org.scx.Loader.conf
+%{_datadir}/polkit-1/actions/org.scx.Loader.policy
+%config(noreplace) %{_datadir}/scx_loader/config.toml
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%changelog
+* Sun Nov 16 2025 Gilver E. <rockgrub@disroot.org> - 1.0.18-1
+- Initial package

--- a/anda/system/scx-tools/stable/update.rhai
+++ b/anda/system/scx-tools/stable/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("sched-ext/scx-loader"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Add scx-tools, update scx-scheds (#7411)](https://github.com/terrapkg/packages/pull/7411)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)