### PR TITLE
[f42] chore(zed, zed-preview): Bump on <= 43

### DIFF
--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -1,6 +1,6 @@
 %bcond_with check
 
-%global ver 0.211.4
+%global ver 0.212.6
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -9,7 +9,7 @@
 %global rustflags_debuginfo 0
 
 Name:           zed
-Version:        0.211.6
+Version:        0.212.6
 Release:        1%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
 SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [chore(zed, zed-preview): Bump on &lt;&#x3D; 43](https://github.com/terrapkg/packages/pull/7432)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)