### PR TITLE
[f42] feat(release): terra-multimedia (#7327)

### DIFF
--- a/anda/terra/release/terra-multimedia.repo
+++ b/anda/terra/release/terra-multimedia.repo
@@ -1,0 +1,26 @@
+[terra-multimedia]
+name=Terra $releasever (Multimedia)
+#baseurl=https://repos.fyralabs.com/terra$releasever-multimedia
+metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-multimedia&arch=$basearch
+metadata_expire=6h
+type=rpm
+gpgcheck=1
+gpgkey=https://repos.fyralabs.com/terra$releasever-multimedia/key.asc
+repo_gpgcheck=1
+enabled=0
+enabled_metadata=1
+countme=1
+priority=80
+
+[terra-multimedia-source]
+name=Terra $releasever (Multimedia) - Source
+#baseurl=https://repos.fyralabs.com/terra$releasever-multimedia-source
+metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-multimedia-source&arch=$basearch
+metadata_expire=6h
+type=rpm
+gpgcheck=1
+gpgkey=https://repos.fyralabs.com/terra$releasever-multimedia-source/key.asc
+repo_gpgcheck=1
+enabled=0
+enabled_metadata=0
+priority=80

--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -1,6 +1,6 @@
 Name:           terra-release
-Version:        42
-Release:        4
+Version:        43
+Release:        1
 Summary:        Release package for Terra
 
 License:        MIT
@@ -9,6 +9,7 @@ Source0:        terra.repo
 Source1:        terra-extras.repo
 Source2:        terra-nvidia.repo
 Source3:        terra-mesa.repo
+Source4:        terra-multimedia.repo
 BuildArch:      noarch
 
 %dnl We probably shouldn't do this in Rawhide!
@@ -35,6 +36,7 @@ install -D -p -m 0644 -t %{buildroot}%{_sysconfdir}/yum.repos.d %{SOURCE0}
 install -Dpm644 -t %buildroot%_sysconfdir/yum.repos.d %SOURCE1
 install -Dpm644 -t %buildroot%_sysconfdir/yum.repos.d %SOURCE2
 install -Dpm644 -t %buildroot%_sysconfdir/yum.repos.d %SOURCE3
+install -Dpm644 -t %buildroot%_sysconfdir/yum.repos.d %SOURCE4
 
 %files
 %config(noreplace) %{_sysconfdir}/yum.repos.d/terra.repo
@@ -43,8 +45,12 @@ install -Dpm644 -t %buildroot%_sysconfdir/yum.repos.d %SOURCE3
 %config(noreplace) %{_sysconfdir}/yum.repos.d/terra-extras.repo
 %config(noreplace) %{_sysconfdir}/yum.repos.d/terra-nvidia.repo
 %config(noreplace) %{_sysconfdir}/yum.repos.d/terra-mesa.repo
+%config(noreplace) %{_sysconfdir}/yum.repos.d/terra-multimedia.repo
 
 %changelog
+* Thu Nov 13 2025 madonuko <mado@fyralabs.com> - 44-1
+- Add terra-multimedia
+
 * Sun Jan 12 2025 Cappy Ishihara <cappy@cappuchino.xyz> - 42-4
 - Add NVIDIA and Mesa repository streams
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(release): terra-multimedia (#7327)](https://github.com/terrapkg/packages/pull/7327)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)