### PR TITLE
[f42] [f43] chore: Move packages to multimedia repo (#7417)

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -3,7 +3,7 @@ project pkg {
     spec = "fdk-aac.spec"
   }
   labels {
-        subrepo = "extras"
+        subrepo = "multimedia"
         weekly = 1
     }
 }

--- a/anda/lib/libde265/anda.hcl
+++ b/anda/lib/libde265/anda.hcl
@@ -2,8 +2,10 @@ project pkg {
   arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "libde265.spec"
+    extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
   }
   labels {
     mock = 1
+    subrepo = "multimedia"
   }
 }

--- a/anda/lib/libfreeaptx/anda.hcl
+++ b/anda/lib/libfreeaptx/anda.hcl
@@ -6,5 +6,6 @@ project pkg {
   labels {
         weekly = 1
         mock = 1
+        subrepo = "multimedia"
     }
 }

--- a/anda/lib/openh264/anda.hcl
+++ b/anda/lib/openh264/anda.hcl
@@ -3,6 +3,6 @@ project pkg {
         spec = "openh264.spec"
     }
     labels {
-        subrepo = "extras"
+        subrepo = "multimedia"
     }
 }

--- a/anda/lib/rtmpdump/anda.hcl
+++ b/anda/lib/rtmpdump/anda.hcl
@@ -4,6 +4,7 @@ project pkg {
     spec = "rtmpdump.spec"
   }
   labels {
-    mock =1
+    mock = 1
+    subrepo = "multimedia"
   }
 }

--- a/anda/multimedia/ffmpeg/anda.hcl
+++ b/anda/multimedia/ffmpeg/anda.hcl
@@ -2,11 +2,11 @@ project pkg {
     arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "ffmpeg.spec"
-        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-nvidia"]
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-nvidia", "https://repos.fyralabs.com/terra\\$releasever-multimedia"]
     }
     labels {
         updbranch = 1
         mock = 1
-        subrepo = "extras"
+        subrepo = "multimedia"
     }
 }

--- a/anda/multimedia/gstreamer1/gstreamer1-plugin-libav/anda.hcl
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugin-libav/anda.hcl
@@ -2,9 +2,10 @@ project pkg {
     arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "gstreamer1-plugin-libav.spec"
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
     }
     labels {
-        subrepo = "extras"
+        subrepo = "multimedia"
         mock = 1
         updbranch = 1
     }

--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/anda.hcl
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/anda.hcl
@@ -2,9 +2,10 @@ project pkg {
 	arches = ["x86_64", "aarch64", "i386"]
 	rpm {
 		spec = "gstreamer1-plugins-bad.spec"
+		extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
 	}
 	labels {
-		subrepo = "extras"
+		subrepo = "multimedia"
 		mock = 1
 		updbranch = 1
 	}

--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/anda.hcl
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/anda.hcl
@@ -2,9 +2,10 @@ project pkg {
   arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "gstreamer1-plugins-ugly.spec"
+    extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
   }
   labels {
-    subrepo = "extras"
+    subrepo = "multimedia"
     mock = 1
     updbranch = 1
   }

--- a/anda/multimedia/gstreamer1/gstreamer1-vaapi/anda.hcl
+++ b/anda/multimedia/gstreamer1/gstreamer1-vaapi/anda.hcl
@@ -2,9 +2,10 @@ project pkg {
   arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "gstreamer1-vaapi.spec"
+    extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
   }
   labels {
-        subrepo = "extras"
+        subrepo = "multimedia"
         mock = 1
         updbranch = 1
     }

--- a/anda/multimedia/kvazaar/anda.hcl
+++ b/anda/multimedia/kvazaar/anda.hcl
@@ -4,6 +4,6 @@ project pkg {
         spec = "kvazaar.spec"
     }
     labels {
-       mock =1
+       mock = 1
     }
 }

--- a/anda/multimedia/lcevcdec/anda.hcl
+++ b/anda/multimedia/lcevcdec/anda.hcl
@@ -2,8 +2,10 @@ project pkg {
     arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "LCEVCdec.spec"
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
     }
     labels {
         mock = 1
+        subrepo = "multimedia"
    }
 }

--- a/anda/multimedia/mjpegtools/anda.hcl
+++ b/anda/multimedia/mjpegtools/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels {
         mock = 1
+        subrepo = "multimedia"
     }
 }

--- a/anda/multimedia/uavs3d/anda.hcl
+++ b/anda/multimedia/uavs3d/anda.hcl
@@ -4,6 +4,7 @@ project pkg {
         spec = "uavs3d.spec"
     }
     labels {
-        mock =1
+        mock = 1
+        subrepo = "multimedia"
     }
 }

--- a/anda/multimedia/vvdec/anda.hcl
+++ b/anda/multimedia/vvdec/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels {
         mock = 1
+        subrepo = "multimedia"
     }
 }

--- a/anda/multimedia/vvenc/anda.hcl
+++ b/anda/multimedia/vvenc/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
     }
     labels {
         mock = 1
+        subrepo = "multimedia"
     }
 }

--- a/anda/multimedia/x264-bootstrap/anda.hcl
+++ b/anda/multimedia/x264-bootstrap/anda.hcl
@@ -2,9 +2,10 @@ project pkg {
     arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "x264-bootstrap.spec"
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
     }
     labels {
         mock = 1
-        subrepo = "extras"
+        subrepo = "multimedia"
     }
 }

--- a/anda/multimedia/x264/anda.hcl
+++ b/anda/multimedia/x264/anda.hcl
@@ -2,9 +2,10 @@ project pkg {
     arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "x264.spec"
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
     }
     labels { 
         mock = 1
-        subrepo = "extras"
+        subrepo = "multimedia"
     }
 }

--- a/anda/multimedia/x265/anda.hcl
+++ b/anda/multimedia/x265/anda.hcl
@@ -2,9 +2,10 @@ project pkg {
     arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "x265.spec"
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
     }
     labels {
         mock = 1
-        subrepo = "extras"
+        subrepo = "multimedia"
    }
 }

--- a/anda/multimedia/xevd/anda.hcl
+++ b/anda/multimedia/xevd/anda.hcl
@@ -2,8 +2,10 @@ project pkg {
         arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "xevd.spec"
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
     }
     labels {
         mock = 1
+        subrepo = "multimedia"
     }
 }

--- a/anda/multimedia/xeve/anda.hcl
+++ b/anda/multimedia/xeve/anda.hcl
@@ -2,8 +2,10 @@ project pkg {
         arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "xeve.spec"
+        extra_repos = ["https://repos.fyralabs.com/terra\\$releasever-multimedia"]
     }
     labels {
         mock = 1
+        subrepo = "multimedia"
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [[f43] chore: Move packages to multimedia repo (#7417)](https://github.com/terrapkg/packages/pull/7244)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)