### PR TITLE
[f41] feat(terra-release): Use %{fedora} macro for version field (#7439)

### DIFF
--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -1,5 +1,5 @@
 Name:           terra-release
-Version:        41
+Version:        %{fedora}
 Release:        4
 Summary:        Release package for Terra
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(terra-release): Use %{fedora} macro for version field (#7439)](https://github.com/terrapkg/packages/pull/7439)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)