### PR TITLE
[f42] feat(terra-release): Use %{fedora} macro for version field (#7439)

### DIFF
--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -1,5 +1,5 @@
 Name:           terra-release
-Version:        42
+Version:        %{fedora}
 Release:        1
 Summary:        Release package for Terra
 
@@ -12,8 +12,7 @@ Source3:        terra-mesa.repo
 Source4:        terra-multimedia.repo
 BuildArch:      noarch
 
-%dnl We probably shouldn't do this in Rawhide!
-%dnl Requires:       system-release(%{version})
+Requires:       system-release(%{version})
 
 %description
 Release package for Terra, containing the Terra repository configuration.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(terra-release): Use %{fedora} macro for version field (#7439)](https://github.com/terrapkg/packages/pull/7439)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)