### PR TITLE
[f43] bun: fix logo (#7445)

### DIFF
--- a/anda/devs/bun/bun-bin.spec
+++ b/anda/devs/bun/bun-bin.spec
@@ -5,15 +5,17 @@
 %global a aarch64
 %endif
 
+%global appid sh.oven.bun
+
 Name:			bun-bin
 Version:		1.3.2
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one
 License:		MIT
 URL:			https://bun.sh
 Source0:		https://github.com/oven-sh/bun/releases/download/bun-v%version/bun-linux-%a.zip
 Source1:        sh.oven.bun.metainfo.xml
-BuildRequires:	unzip
+BuildRequires:	unzip anda-srpm-macros terra-appstream-helper
 
 %description
 %summary.
@@ -58,7 +60,7 @@ install -Dm644 bun.bash -t %buildroot%bash_completions_dir
 install -Dm644 bun.fish -t %buildroot%fish_completions_dir
 ln -s bun %buildroot%_bindir/bunx
 
-install -Dm644 %{SOURCE1} %buildroot%{_datadir}/metainfo/sh.oven.bun.metainfo.xml
+%terra_appstream -o %{SOURCE1}
 
 %files
 %license LICENSE

--- a/anda/devs/bun/sh.oven.bun.metainfo.xml
+++ b/anda/devs/bun/sh.oven.bun.metainfo.xml
@@ -3,10 +3,10 @@
   <id>sh.oven.bun</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
+  <icon type="stock">applications-development</icon>
 
   <name>Bun</name>
-  <summary
-    >Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one</summary>
+  <summary>Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one</summary>
 
   <description>
     <p>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [bun: fix logo (#7445)](https://github.com/terrapkg/packages/pull/7445)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)