### PR TITLE
[f41] chore(scx-tools-nightly): New D-Bus file (#7456)

### DIFF
--- a/anda/system/scx-tools/nightly/scx-tools-nightly.spec
+++ b/anda/system/scx-tools/nightly/scx-tools-nightly.spec
@@ -76,6 +76,7 @@ install -Dm755 target/rpm/*.so -t %{buildroot}%{_libdir} || :
 %doc README.md
 %{_bindir}/scx*
 %{_unitdir}/scx_loader.service
+%{_datadir}/dbus-1/interfaces/org.scx.Loader.xml
 %{_datadir}/dbus-1/system-services/org.scx.Loader.service
 %{_datadir}/dbus-1/system.d/org.scx.Loader.conf
 %{_datadir}/polkit-1/actions/org.scx.Loader.policy


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(scx-tools-nightly): New D-Bus file (#7456)](https://github.com/terrapkg/packages/pull/7456)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)