### PR TITLE
[el10] fix(asusctl): remove unnecessary patch (#7464)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -2,12 +2,11 @@
 
 Name:           asusctl
 Version:        6.1.20
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops
 URL:            https://gitlab.com/asus-linux/asusctl
 Source0:        %url/-/archive/%version/asusctl-%version.tar.gz
 License:        MPL-2.0
-Patch0:         fix-makefile.patch
 BuildRequires:  anda-srpm-macros cargo-rpm-macros systemd-rpm-macros mold rust-udev-devel clang-devel
 BuildRequires:  desktop-file-utils
 BuildRequires:  cmake
@@ -84,5 +83,8 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.d
 %{_datadir}/rog-gui
 
 %changelog
+* Tue Nov 18 2025 Metcya <metcya@gmail.com>
+- Remove unnecessary patch
+
 * Sun Oct 26 2025 Metcya <metcya@gmail.com>
 - Package asusctl


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(asusctl): remove unnecessary patch (#7464)](https://github.com/terrapkg/packages/pull/7464)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)