### PR TITLE
[f42] feat: add terra-surface-dtx-daemon to terra-obsoletes (#7098)

### DIFF
--- a/anda/terra/obsolete/terra-obsolete.spec
+++ b/anda/terra/obsolete/terra-obsolete.spec
@@ -146,6 +146,8 @@ BuildArch:  noarch
 %obsolete switchboard-plug-useraccounts 8.0.0-2
 %obsolete switchboard-plug-wacom 8.0.0-2
 
+%obsolete terra-surface-dtx-daemon 0.3.10-1
+
 %description
 Currently obsoleted packages:
 
@@ -157,4 +159,3 @@ Currently obsoleted packages:
 
 %changelog
 %autochangelog
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat: add terra-surface-dtx-daemon to terra-obsoletes (#7098)](https://github.com/terrapkg/packages/pull/7098)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)