### PR TITLE
[el10] fix(andax/bump_extras.rhai): Return the correct branch for Rawhide on Bodhi functions (#7455)

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -14,7 +14,7 @@ fn as_bodhi_ver(branch) {
         }
         return `EPEL-${release}`;
     } else if branch == "frawhide" {
-        return "F43";
+        return "F44";
     } else if branch.starts_with("f") {
         branch.crop(1);
         return branch;


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(andax/bump_extras.rhai): Return the correct branch for Rawhide on Bodhi functions (#7455)](https://github.com/terrapkg/packages/pull/7455)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)