### PR TITLE
[el10] 8bitdo: Tighter rules matches, provide AppStream metainfo (#7483)

### DIFF
--- a/anda/games/8bitdo-udev-rules/71-8bitdo.rules
+++ b/anda/games/8bitdo-udev-rules/71-8bitdo.rules
@@ -1,4 +1,4 @@
 # 2.4GHz/Dongle
 KERNEL=="hidraw*", ATTRS{idVendor}=="2dc8", MODE="0660", TAG+="uaccess"
 # Bluetooth
-KERNEL=="hidraw*", KERNELS=="*2DC8:*", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", KERNELS=="0005:2DC8:*", MODE="0660", TAG+="uaccess"

--- a/anda/games/8bitdo-udev-rules/8bitdo-udev-rules.spec
+++ b/anda/games/8bitdo-udev-rules/8bitdo-udev-rules.spec
@@ -1,13 +1,17 @@
+%global appid com.8bitdo.Udev
+
 
 Name:           8bitdo-udev-rules
-Version:        1.0
+Version:        1.1
 Release:        1%{?dist}
 Summary:        Udev rules for 8Bitdo controllers
 Provides: 8bitdo-udev = %{version}-%{release}
 License:        Unlicense
 Source0:        71-8bitdo.rules
+Source1:        com.8bitdo.Udev.metainfo.xml
 BuildArch:      noarch
 BuildRequires:  systemd
+BuildRequires:  anda-srpm-macros
 Requires:       systemd-udev
 
 %global udev_order 71
@@ -22,6 +26,7 @@ and generic gamepad support in Linux.
 
 %install
 install -D -p -m 644 %SOURCE0 %{buildroot}%{_udevrulesdir}/%{udev_order}-8bitdo.rules
+%terra_appstream -o %{SOURCE1}
 
 %post
 %udev_rules_update
@@ -31,6 +36,7 @@ install -D -p -m 644 %SOURCE0 %{buildroot}%{_udevrulesdir}/%{udev_order}-8bitdo.
 
 %files
 %_udevrulesdir/%{udev_order}-8bitdo.rules
+%{_metainfodir}/%{appid}.metainfo.xml
 
 
 

--- a/anda/games/8bitdo-udev-rules/com.8bitdo.Udev.metainfo.xml
+++ b/anda/games/8bitdo-udev-rules/com.8bitdo.Udev.metainfo.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="driver">
+  <id>com.8bitdo.Udev</id>
+  <name>udev Rules for 8BitDo devices</name>
+  <description>
+    <p>Udev rules for 8BitDo controllers to enable proper functionality and device access on Linux systems.</p>
+  </description>
+  <developer id="com.8bitdo">
+    <name>Shenzhen 8BitDo Tech Co., Ltd.</name>
+  </developer>
+  <provides>
+    <modalias>hid:v00002DC8p*</modalias>
+    <modalias>hid:b0003v00002DC8p*</modalias>
+    <modalias>hid:b0005v00002DC8p*</modalias>
+  </provides>
+</component>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [8bitdo: Tighter rules matches, provide AppStream metainfo (#7483)](https://github.com/terrapkg/packages/pull/7483)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)