### PR TITLE
[f41] chore(metainfo): edit (#7446)

### DIFF
--- a/anda/devs/edit/com.microsoft.edit.metainfo.xml
+++ b/anda/devs/edit/com.microsoft.edit.metainfo.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="console-application">
+  <id>com.microsoft.edit</id>
+  <name>Microsoft Edit</name>
+  <summary>We all edit.</summary>
+  <screenshots>
+    <image type="source">https://github.com/microsoft/edit/blob/main/assets/edit_hero_image.png</image>
+  </screenshots>
+  <description>
+    <p>A simple editor for simple needs.</p>
+    <p>
+    This editor pays homage to the classic MS-DOS Editor, but with a modern interface and input controls similar to VS Code.
+    The goal is to provide an accessible editor that even users largely unfamiliar with terminals can easily use.
+    </p>
+  </description>
+  <url type="vcs-browser">https://github.com/microsoft/edit</url>
+  <developer id="com.microsoft">
+    <name>Microsoft Corporation</name>
+  </developer>
+  <icon type="stock">com.microsoft.edit</icon>
+</component>

--- a/anda/devs/edit/edit.spec
+++ b/anda/devs/edit/edit.spec
@@ -2,15 +2,19 @@
 An editor that pays homage to the classic MS-DOS Editor, but with a modern interface and input controls similar to VS Code.}
 %global crate edit
 %bcond rust_nightly 0
+%global appid com.microsoft.edit
+%global org com.microsoft
+%global appstream_component console-application
 
 Name:          %{crate}
 Version:       1.2.1
-Release:       1%?dist
+Release:       2%?dist
 Summary:       A simple editor for simple needs.
 SourceLicense: MIT
 License:       MIT AND (MIT OR Apache-2.0)
 URL:           https://github.com/microsoft/edit
 Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
+Source1:       %{appid}.metainfo.xml
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo-rpm-macros
 %if %{with rust_nightly}
@@ -34,6 +38,11 @@ Packager:      Gilver E. <rockgrub@disroot.org>
 %install
 %crate_install_bin
 %{cargo_license_online} > LICENSE.dependencies
+install -Dm644 assets/edit.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/%{appid}.svg
+
+sed -i "s|^Icon=edit$|Icon=%{appid}|g" assets/%{appid}.desktop
+install -Dm644 assets/%{appid}.desktop %{buildroot}%{_datadir}/applications/%{appid}.desktop
+%terra_appstream -o %{SOURCE1}
 
 %files
 %doc CODE_OF_CONDUCT.md
@@ -42,6 +51,9 @@ Packager:      Gilver E. <rockgrub@disroot.org>
 %license LICENSE
 %license LICENSE.dependencies
 %{_bindir}/%{name}
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_iconsdir}/hicolor/scalable/apps/%{appid}.svg
+%{_datadir}/applications/%{appid}.desktop
 
 %changelog
 * Thu May 22 2025 Gilver E. <rockgrub@disroot.org> - 1.0.0-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(metainfo): edit (#7446)](https://github.com/terrapkg/packages/pull/7446)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)