### PR TITLE
[f43] feat(senpai): add metainfo (#7477)

### DIFF
--- a/anda/misc/senpai/org.sr.ht.delthas.senpai.metainfo.xml
+++ b/anda/misc/senpai/org.sr.ht.delthas.senpai.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="console-application">
+  <id>org.sr.ht.delthas.senpai</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>ISC</project_license>
+  <icon type="local">/usr/share/icons/hicolor/scalable/apps/senpai.svg</icon>
+
+  <name>senpai</name>
+  <summary>Your everyday TUI IRC student</summary>
+
+  <description>
+    <p>
+        senpai is an IRC client that works best with bouncers:
+    </p>
+    <ul>
+        <li>no logs are kept</li>
+        <li>history is fetched from the server via CHATHISTORY</li>
+        <li>networks are fetched from the server via bouncer-networks</li>
+        <li>messages can be searched in logs via SEARCH</li>
+        <li>files can be uploaded via FILEHOST (with drag &amp; drop!)</li>
+    </ul>
+  </description>
+
+<launchable type="desktop-id">senpai.desktop</launchable>
+
+  <url type="homepage">https://sr.ht/~taiite/senpai/</url>
+  <provides>
+      <mediatype>text/javascript</mediatype>
+      <mediatype>text/typescript</mediatype>
+  </provides>
+
+  <releases>
+    <release version="0.4.1" />
+  </releases>
+</component>

--- a/anda/misc/senpai/senpai.spec
+++ b/anda/misc/senpai/senpai.spec
@@ -1,11 +1,14 @@
+%global appid org.sr.ht.delthas.senpai
+
 Name:			senpai
 Version:		0.4.1
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Your everyday IRC student
 License:		ISC
-URL:			https://github.com/delthas/senpai
-Source0:		%url/archive/refs/tags/v%version.tar.gz
-BuildRequires:	golang scdoc gcc
+URL:			https://sr.ht/~delthas/senpai/
+Source0:		https://github.com/delthas/senpai/archive/refs/tags/v%version.tar.gz
+Source1:        org.sr.ht.delthas.senpai.metainfo.xml
+BuildRequires:	golang scdoc gcc anda-srpm-macros terra-appstream-helper
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
@@ -32,6 +35,8 @@ install -Dm644 contrib/senpai.desktop   %{buildroot}%{_datadir}/applications/sen
 install -Dm644 res/icon.48.png          %{buildroot}%{_iconsdir}/hicolor/48x48/apps/senpai.png
 install -Dm644 res/icon.svg             %{buildroot}%{_iconsdir}/hicolor/scalable/apps/senpai.svg
 
+%terra_appstream -o %{SOURCE1}
+
 %files
 %doc README.md
 %license LICENSE
@@ -41,7 +46,10 @@ install -Dm644 res/icon.svg             %{buildroot}%{_iconsdir}/hicolor/scalabl
 %{_datadir}/applications/senpai.desktop
 %{_iconsdir}/hicolor/48x48/apps/senpai.png
 %{_iconsdir}/hicolor/scalable/apps/senpai.svg
+%{_metainfodir}/org.sr.ht.delthas.senpai.metainfo.xml
 
 %changelog
+* Tue Nov 18 2025 Owen Zimmerman <owen@fyralabs.com>
+- Add metainfo
 * Fri Oct 31 2025 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat(senpai): add metainfo (#7477)](https://github.com/terrapkg/packages/pull/7477)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)