### PR TITLE
[el10] feat(neohtop): add metadata  (#7496)

### DIFF
--- a/anda/apps/neohtop/com.github.neohtop.metainfo.xml
+++ b/anda/apps/neohtop/com.github.neohtop.metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>com.github.neohtop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <icon type="local">/usr/share/icons/hicolor/128x128/apps/NeoHtop.png</icon>
+
+  <name>NeoHtop</name>
+  <summary>System monitoring on steroids</summary>
+
+  <description>
+    <p>
+        A modern, cross-platform system monitor built on top of Svelte, Rust, and Tauri.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">NeoHtop.desktop</launchable>
+
+  <url type="homepage">https://abdenasser.github.io/neohtop/</url>
+  <provides>
+    <binary>neohtop</binary>
+  </provides>
+
+  <keywords>
+    <keyword>system monitor</keyword>
+  </keywords>
+
+  <releases>
+    <release version="1.2.0" />
+  </releases>
+</component>

--- a/anda/apps/neohtop/neohtop.spec
+++ b/anda/apps/neohtop/neohtop.spec
@@ -1,13 +1,15 @@
 %global __brp_mangle_shebangs %{nil}
+%global appid com.github.neohtop
 
 Name:           neohtop
 Version:        1.2.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        System monitoring on steroids
 License:        MIT
 URL:            https://github.com/Abdenasser/neohtop
 Source0:        %url/archive/refs/tags/v%version.tar.gz
 Source1:        NeoHtop.desktop
+Source2:        com.github.neohtop.metainfo.xml
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 BuildRequires:  rust
 BuildRequires:  nodejs-npm
@@ -18,6 +20,10 @@ BuildRequires:  gtk3-devel
 BuildRequires:  rust-gdk-pixbuf-sys-devel
 BuildRequires:  glib2-devel
 BuildRequires:  openssl-devel
+BuildRequires:  anda-srpm-macros
+BuildRequires:  terra-appstream-helper
+
+Provides:       NeoHtop
 
 %description
 %summary.
@@ -37,6 +43,8 @@ install -Dpm644 src-tauri/icons/128x128@2x.png %buildroot%{_iconsdir}/hicolor/25
 install -Dpm644 src-tauri/icons/32x32.png %buildroot%{_iconsdir}/hicolor/32x32/apps/NeoHtop.png
 install -Dpm644 src-tauri/icons/128x128.png %buildroot%{_iconsdir}/hicolor/128x128/apps/NeoHtop.png
 
+%terra_appstream -o %{SOURCE2}
+
 %files
 %doc README.md
 %license LICENSE
@@ -45,7 +53,10 @@ install -Dpm644 src-tauri/icons/128x128.png %buildroot%{_iconsdir}/hicolor/128x1
 %{_iconsdir}/hicolor/256x256@2/apps/NeoHtop.png
 %{_iconsdir}/hicolor/32x32/apps/NeoHtop.png
 %{_iconsdir}/hicolor/128x128/apps/NeoHtop.png
+%{_metainfodir}/com.github.neohtop.metainfo.xml
 
 %changelog
+* Wed Nov 19 2025 Owen Zimmerman <owen@fyralabs.com>
+- Add metainfo
 * Sat Feb 15 2025 Owen Zimmerman <owen@fyralabs.com>
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(neohtop): add metadata  (#7496)](https://github.com/terrapkg/packages/pull/7496)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)