### PR TITLE
[f43] feat(.devcontainer, .vscode, add .zed): add more devcontainer lang extensions and clean up, add more extensions to .vscode, create .zed folder and install extensions there too (#7520)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,17 @@
 {
   "name": "Terra Devcontainer",
   "image": "ghcr.io/terrapkg/builder:frawhide",
-  "runArgs": [
-    "--privileged"
-  ],
+  "runArgs": ["--privileged"],
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {}
   },
   "customizations": {
     "vscode": {
       "extensions": [
-        "rhaiscript.vscode-rhai"
+        "rhaiscript.vscode-rhai",
+        "1dot75cm.rpmspec",
+        "hashicorp.hcl",
+        "redhat.vscode-xml"
       ]
     }
   },

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,8 @@
 {
   "recommendations": [
-    "rhaiscript.vscode-rhai"
+    "rhaiscript.vscode-rhai",
+    "1dot75cm.rpmspec",
+    "hashicorp.hcl",
+    "redhat.vscode-xml"
   ]
 }

--- a/.zed/settings.jsonc
+++ b/.zed/settings.jsonc
@@ -1,0 +1,9 @@
+// There is no HCL extension, but the Terraform extension grants HCL support
+{
+  "auto_install_extensions": {
+    "RPM Spec": true,
+    "XML": true,
+    "rhai": true,
+    "Terraform": true
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat(.devcontainer, .vscode, add .zed): add more devcontainer lang extensions and clean up, add more extensions to .vscode, create .zed folder and install extensions there too (#7520)](https://github.com/terrapkg/packages/pull/7520)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)