### PR TITLE
[el10] fix(mesa-compat): Epoch on obsoletion (#7522)

### DIFF
--- a/anda/lib/mesa-compat/mesa-compat.spec
+++ b/anda/lib/mesa-compat/mesa-compat.spec
@@ -4,7 +4,7 @@ Name:           %{origname}-compat
 Summary:        Mesa graphics libraries - legacy compatibility libraries
 %global ver 25.0.7
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Epoch:          1
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
@@ -44,7 +44,7 @@ BuildRequires:  python3-pyyaml
 Summary:        Mesa XA state tracker
 Provides:       libxatracker%{?_isa}
 Provides:       mesa-libxatracker%{?_isa}
-Obsoletes:      mesa-libxatracker < 25.3
+Obsoletes:      mesa-libxatracker < %{?epoch:%{epoch}:}25.3
 
 %description libxatracker
 %{summary}.
@@ -52,7 +52,7 @@ Obsoletes:      mesa-libxatracker < 25.3
 %package libxatracker-devel
 Summary:        Mesa XA state tracker development package
 Requires: %{name}-libxatracker%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Obsoletes:      mesa-libxatracker-devel < 25.3
+Obsoletes:      mesa-libxatracker-devel < %{?epoch:%{epoch}:}25.3
 
 %description libxatracker-devel
 %{summary}.


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [fix(mesa-compat): Epoch on obsoletion (#7522)](https://github.com/terrapkg/packages/pull/7522)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)