### PR TITLE
[f43] add: JuliaMono-fonts (#7540)

### DIFF
--- a/anda/fonts/juliamono/anda.hcl
+++ b/anda/fonts/juliamono/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	      arches = ["x86_64"]
+	rpm {
+		spec = "juliamono.spec"
+	}
+}

--- a/anda/fonts/juliamono/juliamono.spec
+++ b/anda/fonts/juliamono/juliamono.spec
@@ -1,0 +1,33 @@
+Name:      juliamono-fonts
+Version:   0.061
+Release:   1%?dist
+URL:       https://juliamono.netlify.app/
+Source0:   https://github.com/cormullion/juliamono/archive/refs/tags/v%{version}.tar.gz
+License:   OFL-1.1
+Summary:   A monospaced font with reasonable unicode support
+Requires:  xorg-x11-font-utils
+BuildArch: noarch
+Provides:  JuliaMono-fonts
+Packager:  Its-J
+
+
+%description
+JuliaMono is a monospaced typeface designed for programming in text editing environments that require a wide range of specialist and technical unicode characters.
+
+%prep
+%autosetup -n juliamono-%{version}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_fontbasedir}/juliamono/
+install -Dm644 *.ttf %{buildroot}%{_fontbasedir}/juliamono/
+
+%files
+%doc README.md
+%license LICENSE
+%{_fontbasedir}/juliamono/*.ttf
+
+%changelog
+* Fri Nov 21 2025 Its-J
+- Package JuliaMono

--- a/anda/fonts/juliamono/update.rhai
+++ b/anda/fonts/juliamono/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("cormullion/juliamono"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: JuliaMono-fonts (#7540)](https://github.com/terrapkg/packages/pull/7540)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)