### PR TITLE
[f41] fix: signal-desktop (#7501)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -87,8 +87,10 @@ Signal Desktop links with Signal on Android or iOS and lets you message from you
 
 %build
 pnpm install --frozen-lockfile
-pnpm --prefix sticker-creator install
-pnpm --prefix sticker-creator build
+pushd sticker-creator
+pnpm install --frozen-lockfile
+pnpm build
+popd
 pnpm run build-linux --dir
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix: signal-desktop (#7501)](https://github.com/terrapkg/packages/pull/7501)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)