### PR TITLE
[f42] Add Zola Shell Completions (#7546)

### DIFF
--- a/anda/tools/zola/zola.spec
+++ b/anda/tools/zola/zola.spec
@@ -18,18 +18,31 @@ Packager:       arbormoss <arbormoss@woodsprite.dev>
 
 %build
 %cargo_build
+mkdir -p completions
+target/rpm/zola completion bash > completions/%{name}
+target/rpm/zola completion elvish > completions/%{name}.elv
+target/rpm/zola completion fish > completions/%{name}.fish
+target/rpm/zola completion zsh > completions/_%{name}
 
 %install
 install -Dm755 target/rpm/zola %{buildroot}%{_bindir}/zola
 %cargo_license_summary_online
 %{cargo_license_online -a} > LICENSE.dependencies
+install -Dpm 0644 completions/%{name} -t %{buildroot}%{bash_completions_dir}
+install -Dpm 0644 completions/%{name}.elv -t %{buildroot}%{elvish_completions_dir}
+install -Dpm 0644 completions/%{name}.fish -t %{buildroot}%{fish_completions_dir}
+install -Dpm 0644 completions/_%{name} -t %{buildroot}%{zsh_completions_dir}
 
 %files
 %doc README.md CHANGELOG.md CONTRIBUTING.md EXAMPLES.md
 %license LICENSE
 %license LICENSE.dependencies
 %{_bindir}/zola
+%pkg_completion -Befz %{name}
 
 %changelog
+* Thu Nov 20 2025 arbormoss <arbormoss@woodsprite.dev>
+- Add Shell Completions
+
 * Wed Nov 19 2025 arbormoss <arbormoss@woodsprite.dev>
 - Intial Commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Add Zola Shell Completions (#7546)](https://github.com/terrapkg/packages/pull/7546)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)