### PR TITLE
[f43] add: librepods (#7502)

### DIFF
--- a/anda/apps/librepods/anda.hcl
+++ b/anda/apps/librepods/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+	  spec = "librepods.spec"
+  }
+}

--- a/anda/apps/librepods/com.github.librepods.metainfo.xml
+++ b/anda/apps/librepods/com.github.librepods.metainfo.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>com.github.librepods</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <icon
+        type="remote"
+    >https://github.com/kavishdevar/librepods/blob/main/linux/assets/librepods.png</icon>
+
+  <name>librepods</name>
+  <summary>AirPods liberated from Apple's ecosystem</summary>
+
+  <description>
+    <p>
+    LibrePods unlocks Apple's exclusive AirPods features on non-Apple devices.
+    Get access to noise control modes, adaptive transparency, ear detection,
+    hearing aid, customized transparency mode, battery status, and more - all the
+    premium features you paid for but Apple locked to their ecosystem.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">me.kavishdevar.librepods.desktop</launchable>
+
+  <url type="homepage">https://github.com/kavishdevar/librepods</url>
+  <provides>
+    <binary>librepods</binary>
+  </provides>
+
+  <keywords>
+    <keyword>airpods</keyword>
+    <keyword>librepods</keyword>
+  </keywords>
+
+  <releases>
+    <release version="0.1.0" />
+  </releases>
+</component>

--- a/anda/apps/librepods/librepods.spec
+++ b/anda/apps/librepods/librepods.spec
@@ -1,0 +1,63 @@
+%global appid com.github.librepods
+
+Name:           librepods
+Summary:        AirPods liberated from Apple's ecosystem
+Version:        0.1.0
+Release:        1%?dist
+License:        GPL-3.0-only
+URL:            https://github.com/kavishdevar/librepods
+Source0:        %url/archive/refs/tags/linux-v%version.tar.gz
+Source1:        com.github.librepods.metainfo.xml
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  cmake
+BuildRequires:  gcc
+BuildRequires:  g++
+BuildRequires:  qt6-qtbase-devel
+BuildRequires:  qt6-qtconnectivity-devel
+BuildRequires:  qt6-qtmultimedia-devel
+BuildRequires:  qt6-qtdeclarative-devel
+BuildRequires:  openssl-devel
+BuildRequires:  anda-srpm-macros
+BuildRequires:  terra-appstream-helper
+
+Requires: glibc
+Requires: openssl
+Requires: qt6-qtbase
+Requires: qt6-qtconnectivity
+Requires: qt6-qtdeclarative
+
+%description
+LibrePods unlocks Apple's exclusive AirPods features on non-Apple devices.
+Get access to noise control modes, adaptive transparency, ear detection,
+hearing aid, customized transparency mode, battery status, and more - all the
+premium features you paid for but Apple locked to their ecosystem.
+
+%prep
+%autosetup -n %{name}-linux-v%{version}
+
+%build
+pushd linux
+%cmake
+%cmake_build
+popd
+
+%install
+install -Dm644 linux-rust/assets/icon.png %{buildroot}%{_iconsdir}/hicolor/512x512/apps/librepods.png
+pushd linux
+%cmake_install
+popd
+%terra_appstream -o %{SOURCE1}
+
+%files
+%doc README.md linux/README.md CHANGELOG.md
+%license LICENSE
+%{_bindir}/librepods
+%{_datadir}/applications/me.kavishdevar.librepods.desktop
+%{_metainfodir}/com.github.librepods.metainfo.xml
+%{_iconsdir}/hicolor/512x512/apps/librepods.png
+
+%changelog
+* Wed Nov 19 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/apps/librepods/update.rhai
+++ b/anda/apps/librepods/update.rhai
@@ -1,0 +1,4 @@
+let tags = json_arr(get("https://api.github.com/repos/kavishdevar/librepods/tags"));
+let tag = tags.find(|t| t.name.starts_with("linux-v"));
+tag.name.crop(7);
+rpm.version(tag.name);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: librepods (#7502)](https://github.com/terrapkg/packages/pull/7502)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)