### PR TITLE
[f41] fix(yarnpkg-berry): Include all build and runtime files, patch package for system installation) (#7565)

### DIFF
--- a/anda/devs/yarn-berry/setup-ts-cache.patch
+++ b/anda/devs/yarn-berry/setup-ts-cache.patch
@@ -1,0 +1,21 @@
+# Quick and dirty patch to make Yarn Berry's build cache system work when installed as a system package.
+# This patch is created for and maintained solely for Terra.
+--- a/scripts/setup-ts-cache.js	2025-11-22 00:36:54.889317752 -0600
++++ b/scripts/setup-ts-cache.js	2025-11-22 00:44:29.823498920 -0600
+@@ -1,6 +1,7 @@
+ const crypto = require(`crypto`);
+ const esbuild = require(`esbuild`);
+ const fs = require(`fs`);
++const os = require('os');
+ const path = require(`path`);
+ const v8 = require(`v8`);
+ const zlib = require(`zlib`);
+@@ -25,7 +26,7 @@
+   isDirty: false,
+ };
+ 
+-const cachePath = path.join(__dirname, `../node_modules/.cache/yarn/esbuild-transpile-cache.bin`);
++const cachePath = path.join(os.homedir(), `.cache/yarn/esbuild-transpile-cache.bin`);
+ try {
+   const cacheData = v8.deserialize(zlib.brotliDecompressSync(fs.readFileSync(cachePath)));
+   if (cacheData.version === cache.version) {

--- a/anda/devs/yarn-berry/yarnpkg-berry.spec
+++ b/anda/devs/yarn-berry/yarnpkg-berry.spec
@@ -3,11 +3,12 @@
 
 Name:          yarnpkg-berry
 Version:       4.11.0
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Active development version of Yarn
 License:       BSD-2-Clause
 URL:           https://yarnpkg.com
 Source0:       https://github.com/yarnpkg/berry/archive/refs/tags/@yarnpkg/cli/%{version}.tar.gz
+Patch0:        setup-ts-cache.patch
 BuildRequires: anda-srpm-macros
 BuildRequires: nodejs
 BuildRequires: nodejs-packaging
@@ -32,14 +33,14 @@ Summary:       Extra documentation and contributor guides for Yarn Berry.
 This package contains extra doc files as well as contributor material for Yarn Berry.
 
 %prep
-%autosetup -n berry--yarnpkg-cli-%{version}
+%autosetup -p1 -n berry--yarnpkg-cli-%{version}
 
 %build
 %{__yarn} build:cli
 
 %install
 mkdir -p {%{buildroot}%{nodejs_sitelib}/yarn-berry,%{buildroot}%{_bindir}}
-cp -pr {scripts,node_modules,packages} -t %{buildroot}%{nodejs_sitelib}/yarn-berry
+cp -pr {scripts,packages,.pnp.cjs,.pnp.loader.mjs,.yarn} -t %{buildroot}%{nodejs_sitelib}/yarn-berry
 
 for bin in yarn yarnpkg; do
    ln -sfr %{buildroot}%{nodejs_sitelib}/yarn-berry/scripts/bin/$bin %{buildroot}%{_bindir}/$bin


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(yarnpkg-berry): Include all build and runtime files, patch package for system installation) (#7565)](https://github.com/terrapkg/packages/pull/7565)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)