### PR TITLE
[f42] add: contribution section to README (#7572)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ And Terra EL itself can be installed with:
 sudo dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terrael$releasever' terra-release
 ```
 
+## Contributions
+
+First of all, thanks for being interested in contributing to Terra! If you have any questions about contributing, please [join our chats](https://wiki.ultramarine-linux.org/en/community/community/).
+
+- [Contribution Guide](https://developer.fyralabs.com/terra/contributing)
+- [FAQ](https://developer.fyralabs.com/terra/faq)
+- [Policy](https://developer.fyralabs.com/terra/policy)
+
+
 ## Documentation
 
 Our documentation can be found on our [Devdocs](https://developer.fyralabs.com/terra/).


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: contribution section to README (#7572)](https://github.com/terrapkg/packages/pull/7572)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)