### PR TITLE
[f42] fix(fdk-aac): Needs an i686 build (#7595)

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+         arches = ["x86_64", "aarch64", "i686"]
   rpm {
     spec = "fdk-aac.spec"
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(fdk-aac): Needs an i686 build (#7595)](https://github.com/terrapkg/packages/pull/7595)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)