### PR TITLE
fixup: Adjust fdk-aac spec on top of #7597

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+         arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "fdk-aac.spec"
   }

--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
-         arches = ["x86_64", "aarch64", "i386"]
+         arches = ["x86_64", "aarch64", "i686"]
   rpm {
     spec = "fdk-aac.spec"
   }

--- a/anda/lib/fdk-aac/fdk-aac.spec
+++ b/anda/lib/fdk-aac/fdk-aac.spec
@@ -15,6 +15,7 @@ BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  gcc-c++
 BuildRequires:  libtool
+BuildArch:      x86_64 aarch64 i686
 
 %description
 Fraunhofer FDK Advanced Audio Coding Codec Library for Android.


### PR DESCRIPTION
I just checked the artifacts of the last pr and the i686 build was building an x86_64 package instead. I need to be certain this builds right before this gets merged.

Deeply apologize. This won't happen again