### PR TITLE
fixup[fdk-aac]: add mock label so i686 builds correctly

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -1,9 +1,10 @@
 project pkg {
-         arches = ["x86_64", "aarch64", "i686"]
+         arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "fdk-aac.spec"
   }
   labels {
+        mock=1
         subrepo = "multimedia"
         weekly = 1
     }


### PR DESCRIPTION
seems like the issue was the rpmbuild backend being used to build fdk-aac. Mock succeeds in building the i686 package.

i386 also seems to be the correct label as the terra-rawhide-i686 mock config doesn't exist, but the terra-rawhide-i386 one does.
