### PR TITLE
[f43] fixup: add mock label so i686 builds correctly (#7601)

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -1,9 +1,10 @@
 project pkg {
-         arches = ["x86_64", "aarch64", "i686"]
+         arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "fdk-aac.spec"
   }
   labels {
+        mock=1
         subrepo = "multimedia"
         weekly = 1
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fixup: add mock label so i686 builds correctly (#7601)](https://github.com/terrapkg/packages/pull/7601)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)