### PR TITLE
[el10] backport: fixup[fdk-aac]: add mock label so i686 builds correctly (#7604)

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -1,10 +1,11 @@
 project pkg {
-         arches = ["x86_64", "aarch64", "i686"]
+         arches = ["x86_64", "aarch64", "i386"]
   rpm {
     spec = "fdk-aac.spec"
   }
   labels {
-        subrepo = "extras"
+        mock=1
+        subrepo = "multimedia"
         weekly = 1
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `el10`:
 - [backport: fixup[fdk-aac]: add mock label so i686 builds correctly (#7604)](https://github.com/terrapkg/packages/pull/7604)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)