### PR TITLE
[el10] fix: fdk-aac no multimedia repo on 41 and el10 (#7606)

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -5,7 +5,6 @@ project pkg {
   }
   labels {
         mock=1
-        subrepo = "multimedia"
         weekly = 1
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f41` to `el10`:
 - [fix: fdk-aac no multimedia repo on 41 and el10 (#7606)](https://github.com/terrapkg/packages/pull/7606)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)