### PR TITLE
[f41] fix(yarnpkg-berry): Work around NodeJS changes by installing to libdir (#7610)

### DIFF
--- a/anda/devs/yarn-berry/yarnpkg-berry.spec
+++ b/anda/devs/yarn-berry/yarnpkg-berry.spec
@@ -1,9 +1,8 @@
-%global debug_package %{nil}
 %bcond bootstrap 1
 
 Name:          yarnpkg-berry
 Version:       4.12.0
-Release:       1%?dist
+Release:       2%?dist
 Summary:       Active development version of Yarn
 License:       BSD-2-Clause
 URL:           https://yarnpkg.com
@@ -17,7 +16,6 @@ BuildRequires: yarnpkg
 %else
 BuildRequires: %{name}
 %endif
-Requires:      nodejs
 Provides:      yarn-berry
 Provides:      yarnpkg = %{evr}
 BuildArch:     noarch
@@ -39,11 +37,12 @@ This package contains extra doc files as well as contributor material for Yarn B
 %{__yarn} build:cli
 
 %install
-mkdir -p {%{buildroot}%{nodejs_sitelib}/yarn-berry,%{buildroot}%{_bindir}}
-cp -pr {scripts,packages,.pnp.cjs,.pnp.loader.mjs,.yarn} -t %{buildroot}%{nodejs_sitelib}/yarn-berry
+# Yarn cannot be installed in nodejs_sitelib due to using TypeScript runtimes and NodeJS changes disallowing TypeScript in node_modules
+mkdir -p {%{buildroot}%{_bindir},%{buildroot}%{_libdir}/yarn-berry}
+cp -pr {scripts,packages,.pnp.cjs,.pnp.loader.mjs,.yarn} -t %{buildroot}%{_libdir}/yarn-berry
 
 for bin in yarn yarnpkg; do
-   ln -sfr %{buildroot}%{nodejs_sitelib}/yarn-berry/scripts/bin/$bin %{buildroot}%{_bindir}/$bin
+   ln -sfr %{buildroot}%{_libdir}/yarn-berry/scripts/bin/$bin %{buildroot}%{_bindir}/$bin
 done
 
 %files
@@ -54,7 +53,7 @@ done
 %doc SECURITY.md
 %{_bindir}/yarn
 %{_bindir}/yarnpkg
-%{nodejs_sitelib}/yarn-berry/
+%{_libdir}/yarn-berry/
 
 %files doc
 %doc CODE_OF_CONDUCT.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(yarnpkg-berry): Work around NodeJS changes by installing to libdir (#7610)](https://github.com/terrapkg/packages/pull/7610)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)