### PR TITLE
[f42] add: fasm (#7629)

### DIFF
--- a/anda/tools/fasm/anda.hcl
+++ b/anda/tools/fasm/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64", "i686"]
+  rpm {
+    spec = "fasm.spec"
+  }
+}

--- a/anda/tools/fasm/fasm.spec
+++ b/anda/tools/fasm/fasm.spec
@@ -1,0 +1,36 @@
+%global debug_package %{nil}
+
+Name:           fasm
+Release:        1%{?dist}
+Version:        1.73.33
+Summary:        Fast assembler for the x86 and x86-64 architectures
+License:        BSD-2-Clause
+URL:            https://flatassembler.net
+Source:         %{url}/%{name}-%{version}.tgz
+Packager:       metcya <metcya@gmail.com>
+ExclusiveArch:  x86_64 i686
+
+%description
+%summary.
+
+%prep
+%autosetup -n %{name}
+
+%build
+%ifarch i686
+./fasm source/Linux/fasm.asm %{name}.out
+%elifarch x86_64
+./fasm.x64 source/Linux/x64/fasm.asm %{name}.out
+%endif
+
+%install
+install -Dm 755 %{name}.out %{buildroot}%{_bindir}/%{name}
+
+%files
+%doc fasm.txt whatsnew.txt
+%license license.txt
+%{_bindir}/%{name}
+
+%changelog
+* Sun Nov 23 2025 metcya <metcya@gmail.com>
+- Package fasm

--- a/anda/tools/fasm/update.rhai
+++ b/anda/tools/fasm/update.rhai
@@ -1,0 +1,3 @@
+let content = get("https://raw.githubusercontent.com/tgrysztar/fasm/master/SOURCE/VERSION.INC");
+let version = find("VERSION_STRING equ \"(\\d+\\.\\d+\\.\\d+)\"", content, 1);
+rpm.version(version);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: fasm (#7629)](https://github.com/terrapkg/packages/pull/7629)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)