### PR TITLE
[f42] chore(.github/workflows/sync.yml): Update Backport Action (#7628)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,7 +25,7 @@ jobs:
           git config --global commit.gpgsign true
 
       - name: Backport Action
-        uses: sorenlouv/backport-github-action@v9.5.1
+        uses: sorenlouv/backport-github-action@v10.2.0
         with:
           github_token: ${{ secrets.RABONEKO_BACKPORT_GITHUB_TOKEN }}
           auto_backport_label_prefix: sync-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(.github/workflows/sync.yml): Update Backport Action (#7628)](https://github.com/terrapkg/packages/pull/7628)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)