### PR TITLE
[f41] chore: Obsolete x264-bootstrap (#7659)

### DIFF
--- a/anda/terra/obsolete/terra-obsolete.spec
+++ b/anda/terra/obsolete/terra-obsolete.spec
@@ -1,10 +1,10 @@
 Name:       terra-obsolete
 # Please keep the version equal to the targeted Terra release
-Version:    40
+Version:    42
 # The dist number is the version here, it is intentionally not repeated in the release
 %global dist %nil
 
-Release:    3
+Release:    1
 Summary:    A package to obsolete retired packages, based on Fedora's equivalent package
 
 License:    LicenseRef-Fedora-Public-Domain
@@ -121,8 +121,39 @@ BuildArch:  noarch
 %obsolete_ticket https://github.com/terrapkg/packages/issues/991
 %obsolete iosevka-fusion-fonts 25.1.1-2
 
+%obsolete_ticket https://github.com/terrapkg/packages/pull/3138
+%obsolete terra-sddm 0.21.0-6
+%obsolete terra-rgbds 0.9.0-3
+%obsolete terra-libplacebo 7.349.0-3
+%obsolete terra-libplacebo-devel 7.349.0-3
+%obsolete terra-wl-clipboard 2.2.1-2
+%obsolete terra-maturin 1.8.1-3
+%obsolete terra-libindicator 16.10.0-3
+%obsolete terra-libindicator-devel 16.10.0-3
+%obsolete terra-libindicator-gtk3 16.10.0-3
+%obsolete terra-libindicator-gtk3-devel 16.10.0-3
+%obsolete terra-blueprint-compiler 0.16.0-3
+%obsolete nushell 0.101.0-3
+%obsolete uutils-coreutils-util-linux 0.0.29-2
+%obsolete uutils-coreutils-util-linux-replace 0.0.29-2
+# pantheon packages only packaged in terra
+%obsolete elementary-appcenter 7.4.0-3
+%obsolete switchboard-plug-datetime 8.0.0-2
+%obsolete switchboard-plug-locale 8.0.0-2
+%obsolete switchboard-plug-parental-controls 8.0.0-2
+%obsolete switchboard-plug-power 8.0.0-2
+%obsolete switchboard-plug-security-privacy 8.0.0-2
+%obsolete switchboard-plug-useraccounts 8.0.0-2
+%obsolete switchboard-plug-wacom 8.0.0-2
 
+%obsolete_ticket https://github.com/terrapkg/packages/pull/7098
 %obsolete terra-surface-dtx-daemon 0.3.10-1
+
+%obsolete_ticket https://github.com/terrapkg/packages/pull/7521
+%obsolete x264-bash-completion 0.165-17.20250609gitb35605ac
+
+%obsolete_ticket https://github.com/terrapkg/packages/pull/7659
+%obsolete x264-bootstrap 0.0.164-15.20231001git31e19f92
 
 %description
 Currently obsoleted packages:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore: Obsolete x264-bootstrap (#7659)](https://github.com/terrapkg/packages/pull/7659)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)