### PR TITLE
[f41] feat(terra-release): Use macros in a way that can be normalized on all branches (#7666)

### DIFF
--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -1,6 +1,8 @@
+%global dist %{nil}
+
 Name:           terra-release
-Version:        %{fedora}
-Release:        1%?dist
+Version:        %{?fedora:%{fedora}}%{?rhel:%{rhel}}
+Release:        6
 Summary:        Release package for Terra
 
 License:        MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(terra-release): Use macros in a way that can be normalized on all branches (#7666)](https://github.com/terrapkg/packages/pull/7666)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)