### PR TITLE
[el10] feat(terra-obsolete): Use macros to correctly track versions (#7665)

### DIFF
--- a/anda/terra/obsolete/terra-obsolete.spec
+++ b/anda/terra/obsolete/terra-obsolete.spec
@@ -1,10 +1,10 @@
 Name:       terra-obsolete
 # Please keep the version equal to the targeted Terra release
-Version:    42
+Version:    %{?fedora:%{fedora}}%{?rhel:%{rhel}}
 # The dist number is the version here, it is intentionally not repeated in the release
 %global dist %nil
 
-Release:    1%?dist
+Release:    2
 Summary:    A package to obsolete retired packages, based on Fedora's equivalent package
 
 License:    LicenseRef-Fedora-Public-Domain


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(terra-obsolete): Use macros to correctly track versions (#7665)](https://github.com/terrapkg/packages/pull/7665)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)