### PR TITLE
[el10] add: rpinters (#7681)

### DIFF
--- a/anda/apps/rpinters/anda.hcl
+++ b/anda/apps/rpinters/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "rpinters.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/apps/rpinters/rpinters.spec
+++ b/anda/apps/rpinters/rpinters.spec
@@ -1,0 +1,45 @@
+%global commit 1815ad67432803843058a3cf7eefbf376e9c02c9
+%global commit_date 20251029
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           rpinters
+Version:        0~%commit_date.git~%shortcommit
+Release:        1%?dist
+Summary:        Raspberry Pi printing utility module
+License:        GPL-2+ AND BSD-3-Clause
+URL:            https://github.com/raspberrypi-ui/rpinters
+Source0:        %url/archive/%commit.tar.gz
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires: meson
+BuildRequires: ninja-build
+BuildRequires: gcc
+BuildRequires: pkgconfig(gtk+-3.0)
+BuildRequires: pkgconfig(smbclient)
+BuildRequires: pkgconfig(cups)
+BuildRequires: pkgconfig(polkit-gobject-1)
+BuildRequires: pkgconfig(gsettings-desktop-schemas)
+
+%description
+%summary.
+
+%prep
+%autosetup -n rpinters-%commit
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+%find_lang rpcc_%{name}
+
+%files -f rpcc_%{name}.lang
+%doc README
+%license debian/copyright
+%{_datadir}/rpcc/ui/%{name}.ui
+%{_libdir}/rpcc/librpcc_rpinters.so
+
+%changelog
+* Fri Aug 08 2025 Owen Zimmerman <owen@fyralabs.com>
+- Package bookshelf

--- a/anda/apps/rpinters/update.rhai
+++ b/anda/apps/rpinters/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("raspberrypi-ui/rpinters"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: rpinters (#7681)](https://github.com/terrapkg/packages/pull/7681)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)