### PR TITLE
[f42] chore(gstreamer1-plugins-ugly): Bump epoch (#7244)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/gstreamer1-plugins-ugly.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/gstreamer1-plugins-ugly.spec
@@ -3,7 +3,7 @@
 Name:           gstreamer1-plugins-ugly
 Version:        1.26.8
 Release:        1%?dist
-Epoch:          1
+Epoch:          2
 Summary:        GStreamer streaming media framework "ugly" plugins
 License:        LGPL-2.0-or-later and LGPL-2.0-only
 URL:            http://gstreamer.freedesktop.org/


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [chore(gstreamer1-plugins-ugly): Bump epoch (#7244)](https://github.com/terrapkg/packages/pull/7244)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)