### PR TITLE
[f42] add: HeadsetControl nightly (#7714)

### DIFF
--- a/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
+++ b/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
@@ -1,0 +1,42 @@
+%global _udevrulesdir /usr/lib/udev/rules.d
+
+%global commit      152f5fb46775894fe986ccb8c712548f8eec4ad6
+%global commitdate  20251121
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           HeadsetControl-nightly
+Version:        0^%{commitdate}.%{shortcommit}
+Release:        1%?dist
+Summary:        A tool to control certain aspects of USB-connected headsets on Linux
+URL:            https://github.com/Sapd/HeadsetControl
+Source:         %{url}/archive/%{commit}.tar.gz
+License:        GPL-3.0
+Provides:       headsetcontrol-nightly
+Conflicts:      headsetcontrol
+
+BuildRequires:  cmake gcc hidapi-devel
+
+%description
+A tool to control certain aspects of USB-connected headsets on Linux.
+Currently, support is provided for adjusting sidetone, getting battery
+state, controlling LEDs, and setting the inactive time.
+
+%prep
+%autosetup -n HeadsetControl-%{commit}
+
+%build
+%cmake
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%doc README.md
+%license license
+%{_bindir}/headsetcontrol
+%{_udevrulesdir}/70-headsets.rules
+
+%changelog
+* Wed Nov 26 2025 metcya <metcya@gmail.com>
+- package HeadsetControl

--- a/anda/tools/HeadsetControl-nightly/anda.hcl
+++ b/anda/tools/HeadsetControl-nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "HeadsetControl-nightly.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/tools/HeadsetControl-nightly/update.rhai
+++ b/anda/tools/HeadsetControl-nightly/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("Sapd/HeadsetControl"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: HeadsetControl nightly (#7714)](https://github.com/terrapkg/packages/pull/7714)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)