### PR TITLE
refactor(ci): Run branches from newest to oldest

### DIFF
--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         branch:
           - frawhide
-          - f41
-          - f42
           - f43
+          - f42
+          - f41
           - el10
     container:
       image: ghcr.io/terrapkg/builder:frawhide

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -48,9 +48,9 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
-            copy_over f41 || true
-            copy_over f42 || true
             copy_over f43 || true
+            copy_over f42 || true
+            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -48,9 +48,9 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
-            copy_over f41 || true
-            copy_over f42 || true
             copy_over f43 || true
+            copy_over f42 || true
+            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,9 +48,9 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
-            copy_over f41 || true
-            copy_over f42 || true
             copy_over f43 || true
+            copy_over f42 || true
+            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi


### PR DESCRIPTION
Reasons for this change:

- This order causes more update conflicts because it is MORE likely a package will not exist, or be out of date, on an older branch than a newer one. Several below Rawhide desyncs are caused due to this. Tested this via running a script similar to this locally.
- Makes sure packages hit newer branches sooner, a more expected user experience.