### PR TITLE
[f41] bump: mangowc rpcs3 rust-mise rust-topgrade (#7719)

### DIFF
--- a/anda/desktops/mangowc/mangowc.spec
+++ b/anda/desktops/mangowc/mangowc.spec
@@ -1,5 +1,5 @@
 Name:           mangowc
-Version:        0.10.5
+Version:        0.10.6
 Release:        1%?dist
 Summary:        wayland compositor base wlroots and scenefx (dwm but wayland)
 License:        GPL-3.0

--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -11,8 +11,8 @@
 # Need to get rid of everything Clang can't use and undefine -Wunused-command-line-argument where possible due to the project's build flags
 %global build_cflags %(echo %{build_cflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
 %global build_cxxflags %(echo %{build_cxxflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs\=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
-%global commit dc22584f7244b016697c5a21b0377f92ea66a254
-%global ver 0.0.38-18285
+%global commit 41aaa912e789db481a163b9d6eb8c49e43db97fc
+%global ver 0.0.38-18402
 
 Name:           rpcs3
 Version:        %(echo %{ver} | sed 's/-/^/g')

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -5,13 +5,8 @@
 %global crate mise
 
 Name:           rust-mise
-<<<<<<< HEAD
-Version:        2025.11.2
-Release:        2%?dist
-=======
 Version:        2025.11.8
 Release:        1%?dist
->>>>>>> db1c8a4b1 (bump: mangowc rpcs3 rust-mise rust-topgrade (#7719))
 Summary:        Front-end to your dev env
 
 License:        MIT

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -5,8 +5,13 @@
 %global crate mise
 
 Name:           rust-mise
+<<<<<<< HEAD
 Version:        2025.11.2
 Release:        2%?dist
+=======
+Version:        2025.11.8
+Release:        1%?dist
+>>>>>>> db1c8a4b1 (bump: mangowc rpcs3 rust-mise rust-topgrade (#7719))
 Summary:        Front-end to your dev env
 
 License:        MIT

--- a/anda/tools/topgrade/rust-topgrade.spec
+++ b/anda/tools/topgrade/rust-topgrade.spec
@@ -3,7 +3,7 @@
 
 Name:           rust-topgrade
 # renovate: datasource=github-releases depName=topgrade-rs/topgrade
-Version:        16.4.2
+Version:        16.5.0
 Release:        1%?dist
 Summary:        Upgrade all the things
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f41`:
 - [bump: mangowc rpcs3 rust-mise rust-topgrade (#7719)](https://github.com/terrapkg/packages/pull/7719)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)