### PR TITLE
[el10] bump: walker (#7727)

### DIFF
--- a/anda/desktops/waylands/walker/walker.spec
+++ b/anda/desktops/waylands/walker/walker.spec
@@ -4,7 +4,7 @@
 # prevent library files from being installed
 %global cargo_install_lib 0
 
-%global upstream_version v2.9.2
+%global upstream_version v2.11.3
 %global ver %{sub %upstream_version 2}
 
 Name:           walker


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump: walker (#7727)](https://github.com/terrapkg/packages/pull/7727)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)