### PR TITLE
[el10] bump: rust-mise (#7726)

### DIFF
--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -5,7 +5,7 @@
 %global crate mise
 
 Name:           rust-mise
-Version:        2025.11.8
+Version:        2025.11.10
 Release:        1%?dist
 Summary:        Front-end to your dev env
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [bump: rust-mise (#7726)](https://github.com/terrapkg/packages/pull/7726)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)