### PR TITLE
[f41] bump(nightly): mpv-nightly zed-nightly prismlauncher-nightly types-colorama astal tdlib-nightly scx-scheds-nightly qdl (#7724)

### DIFF
--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,9 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-%global commit f6c116491a82314332f8ded74fc92b2b5cdf7e25
+%global commit b6c35b55a01fc78459069be80fffb480e11eea73
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251122
+%global commit_date 20251127
 %global ver 0.40.0
 
 Name:           mpv-nightly

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 7a5851e1558d7e0f4a064a51438db966b297a27f
+%global commit 82b768258f966c157ed960d19ae2d4bdce81779f
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251123
-%global ver 0.215.0
+%global commit_date 20251127
+%global ver 0.216.0
 
 %bcond_with check
 %bcond nightly 1

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,10 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-%global commit 8abf5ed7b1f31a89fad1b8d7fb1703639ca08426
+%global commit 64e923e977ad4d31c1ceaae559c52f1484d3fe35
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20251123
+%global commit_date 20251127
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit cc792321dd482a5336225229bf584ad51a3e85cd
-%global commit_date 20251122
+%global commit 94ffa6e3f512b491252a1d0674fef8a3f283534d
+%global commit_date 20251127
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/lib/astal/astal/astal.spec
+++ b/anda/lib/astal/astal/astal.spec
@@ -1,7 +1,7 @@
 
-%global commit 5baeb660214bcafc9ae0b733a1bc84f5fa6078f4
+%global commit 7d1fac8a4b2a14954843a978d2ddde86168c75ef
 %global shortcommit %{sub %commit 1 7}
-%global commit_date 20251108
+%global commit_date 20251127
 
 Name:			astal
 Version:		0^%commit_date.%shortcommit

--- a/anda/lib/tdlib/tdlib-nightly.spec
+++ b/anda/lib/tdlib/tdlib-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 36b05e9e0310c9a32ae6cb807fe22c96600f6061
-%global ver 1.8.56
-%global commit_date 20251017
+%global commit f0d04d357c4ab2d4a7288e52dbeec3c2d9dd0a2d
+%global ver 1.8.57
+%global commit_date 20251127
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:          tdlib-nightly

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 70ab12a7ca0d9cecd1904e8b00f42ec92bf4cb4c
+%global commit 57e99e619e7735d6e99c522d37db9048fc0fc5d0
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251123
+%global commitdate 20251127)
 %global ver 1.0.18
 %undefine __brp_mangle_shebangs
 

--- a/anda/tools/qdl/qdl.spec
+++ b/anda/tools/qdl/qdl.spec
@@ -1,10 +1,10 @@
-%global commit 661ca1cba2984d874effa5ee5864132b079fbba0
-%global commit_date 20251120
+%global commit 2db10bd0c65eefac3598e9426410e556716ad105
+%global commit_date 20251127
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           qdl
 Version:        0^%commit_date.%shortcommit
-Release:        2%?dist
+Release:        1%?dist
 Summary:        This tool communicates with USB devices of id 05c6:9008 to upload a flash loader and use this to flash images
 URL:            https://github.com/linux-msm/qdl
 Source0:        %{url}/archive/%{commit}/qdl-%{commit}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f41`:
 - [bump(nightly): mpv-nightly zed-nightly prismlauncher-nightly types-colorama astal tdlib-nightly scx-scheds-nightly qdl (#7724)](https://github.com/terrapkg/packages/pull/7724)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)