### PR TITLE
[el10] add: wluma (#7742)

### DIFF
--- a/anda/system/wluma/anda.hcl
+++ b/anda/system/wluma/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "wluma.spec"
+    }
+}

--- a/anda/system/wluma/update.rhai
+++ b/anda/system/wluma/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("max-baz/wluma"))

--- a/anda/system/wluma/wluma.spec
+++ b/anda/system/wluma/wluma.spec
@@ -1,0 +1,34 @@
+Name:           wluma
+Version:        4.10.0
+Release:        1%?dist
+Summary:        Automatic brightness adjustment based on screen contents and ALS
+URL:            https://github.com/max-baz/wluma
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+License:        ISC
+BuildRequires:  cargo anda-srpm-macros cargo-rpm-macros mold v4l-utils libv4l-devel rust-libudev-devel vulkan-loader-devel dbus-devel clang
+Packager:       Its-J
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+%cargo_install
+%cargo_license_summary_online
+%{cargo_license_online -a} > LICENSE.dependencies
+
+%files
+%doc README.md
+%license LICENSE
+%license LICENSE.dependencies
+%{_bindir}/wluma
+
+%changelog
+* Fri Nov 28 2025 Its-J
+- Package wluma


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: wluma (#7742)](https://github.com/terrapkg/packages/pull/7742)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)