### PR TITLE
[f42] refactor(ci): Run branches from newest to oldest (#7720)

### DIFF
--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -13,8 +13,9 @@ jobs:
       matrix:
         branch:
           - frawhide
-          - f41
+          - f43
           - f42
+          - f41
           - el10
     container:
       image: ghcr.io/terrapkg/builder:f42

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -48,6 +48,8 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
+            copy_over f43 || true
+            copy_over f42 || true
             copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -48,6 +48,8 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
+            copy_over f43 || true
+            copy_over f42 || true
             copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -48,6 +48,8 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
+            copy_over f43 || true
+            copy_over f42 || true
             copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [refactor(ci): Run branches from newest to oldest (#7720)](https://github.com/terrapkg/packages/pull/7720)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)