### PR TITLE
[f41] bump(nightly): flameshot-nightly mpv-nightly hyprutils.nightly ghostty-nightly zed-nightly prismlauncher-nightly types-colorama scx-tools-nightly glasgow micro-nightly nim-nightly types-colorama uwufetch scx-scheds-nightly qdl rpi-utils (#7757)

### DIFF
--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,9 +1,9 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
 %global ver 13.3.0
-%global commit 0f37bf09972c7e66ed78ad0460d2ebce97b82809
+%global commit e9a8aed8ac33d455da40cac004250f710a167b1a
 %global shortcommit %{sub %{commit} 1 7}
-%global commit_date 20251119
+%global commit_date 20251129
 %global devel_name QtColorWidgets
 %global _distro_extra_cflags -fuse-ld=mold
 %global _distro_extra_cxxflags -fuse-ld=mold

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,9 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-%global commit b6c35b55a01fc78459069be80fffb480e11eea73
+%global commit 23f9381b8053ad7fcba11b61607497ce43eaebc7
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251127
+%global commit_date 20251129
 %global ver 0.40.0
 
 Name:           mpv-nightly

--- a/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
+++ b/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
@@ -3,8 +3,8 @@
 %global realname hyprutils
 %global ver 0.10.2
 
-%global commit 16a7fe760d7da8956cd9d72abc0532d8c72be2ce
-%global commit_date 20251123
+%global commit a64517c23613b302a3ecc5f4608f3919e8e29830
+%global commit_date 20251129
 %global shortcommit %{sub %commit 1 7}
 
 Name:           %realname.nightly

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 6b28671eade5d31ef737349cdf53a2e6470a8648
+%global commit 9baf37a9b2a1119c697b0eabf32391bfb41ef287
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-11-22
+%global fulldate 2025-11-28
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0

--- a/anda/devs/micro/micro-nightly.spec
+++ b/anda/devs/micro/micro-nightly.spec
@@ -12,8 +12,8 @@
 
 # Naming variable as something other than "commit" is necessary
 # to stop %%gometa from putting commit hash in release
-%global commit_hash bc5e59c670c6ea971c52a9f60262122bd39eec32
-%global commit_date 20251119
+%global commit_hash 70dfc7fcb4d0f53e155fa0d8ac5ea200d8736d16
+%global commit_date 20251128
 %global shortcommit %{sub %{commit_hash} 1 7}
 %global ver 2.0.14
 

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 82b768258f966c157ed960d19ae2d4bdce81779f
+%global commit 200a4a5c786cf23dedf0f9f38d86af764b69f8ea
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251127
+%global commit_date 20251129
 %global ver 0.216.0
 
 %bcond_with check

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,10 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-%global commit 64e923e977ad4d31c1ceaae559c52f1484d3fe35
+%global commit 5c8b18098faf43a73a7f2a2db913da82d45f7678
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20251127
+%global commit_date 20251129
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit 6543040d40b063ce2c872f582c153c6cff9ef0aa
+%global commit 66560840043d2ea8a96b4ce46ab55f0faed37349
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20251122
+%global commit_date 20251128
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit 94ffa6e3f512b491252a1d0674fef8a3f283534d
-%global commit_date 20251127
+%global commit 148b8e631d9a76f7bdcc5478d36692ff79e16227
+%global commit_date 20251129
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -1,7 +1,7 @@
-%global commit 28b471b813d1c9aab77eeeb61f65304e586fb275
+%global commit f3d4503e72fa5b7dff466e527453cfbf2c95cc01
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20240423
-%global ver 2.1
+%global commit_date 20251128
+%global ver .1
 %global debug_package %{nil}
 
 Name:          uwufetch

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 57e99e619e7735d6e99c522d37db9048fc0fc5d0
+%global commit 365d85d48f4315e94562cd307223234e71b161b8
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251127)
+%global commitdate 20251128
 %global ver 1.0.18
 %undefine __brp_mangle_shebangs
 

--- a/anda/system/scx-tools/nightly/scx-tools-nightly.spec
+++ b/anda/system/scx-tools/nightly/scx-tools-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 0bacdf766269592d82c7e5f847e541af56f4ed26
+%global commit b60b6a95bdee4419634e60978db0597f2a9ca710
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251120
+%global commitdate 20251129
 %global ver 1.0.18
 %global appid com.sched_ext.scx
 %global developer "sched-ext Contributors"

--- a/anda/tools/glasgow/glasgow.spec
+++ b/anda/tools/glasgow/glasgow.spec
@@ -1,5 +1,5 @@
-%global commit 67a8574a9b59af18e36e81411a981e23fe205ff3
-%global commit_date 20251116
+%global commit 91f5b1bcdd4131a515d3face1a4d1e39ce6a7d8d
+%global commit_date 20251129
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name glasgow

--- a/anda/tools/qdl/qdl.spec
+++ b/anda/tools/qdl/qdl.spec
@@ -1,5 +1,5 @@
-%global commit 2db10bd0c65eefac3598e9426410e556716ad105
-%global commit_date 20251127
+%global commit a88edc58ed26128d6ff75cf41e9ab72f7c399c7e
+%global commit_date 20251128
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           qdl

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -1,5 +1,5 @@
-%global commit 6e0779b1c552976e0da2374c0325a8c9c77b6010
-%global commit_date 20251120
+%global commit e95a44ca65c997d05e7b55bb3528030f14f0acf5
+%global commit_date 20251128
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %define _unpackaged_files_terminate_build 0


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [bump(nightly): flameshot-nightly mpv-nightly hyprutils.nightly ghostty-nightly zed-nightly prismlauncher-nightly types-colorama scx-tools-nightly glasgow micro-nightly nim-nightly types-colorama uwufetch scx-scheds-nightly qdl rpi-utils (#7757)](https://github.com/terrapkg/packages/pull/7757)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)