### PR TITLE
chore(uwufetch): Update for semi-active branch

### DIFF
--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -1,4 +1,5 @@
 let url = `https://api.github.com/repos/ad-oliviero/uwufetch/commits/development`;
+let json = get(url).json();
 let c = json.sha;
 let d = json.commit.author.date;
 rpm.global("commit", c);

--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -1,5 +1,4 @@
-let url = `https://api.github.com/repos/ad-oliviero/uwufetch/commits/development`;
-let json = get(url).json();
+let json = get(`https://api.github.com/repos/ad-oliviero/uwufetch/commits/development`).json();
 let c = json.sha;
 let d = json.commit.author.date;
 rpm.global("commit", c);

--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -6,7 +6,6 @@ if rpm.changed() {
     rpm.release();
     rpm.global("fulldate", d);
     d.truncate(10);
-    let ver = gh("ad-oliviero/uwufetch");
-    ver.crop(1);
+    let ver = gh_tag("ad-oliviero/uwufetch");
     rpm.global("ver", ver);
 }

--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -1,7 +1,11 @@
-rpm.global("commit", gh_commit("ad-oliviero/uwufetch"));
+let url = `https://api.github.com/repos/ad-oliviero/uwufetch/commits/development`;
+let c = json.sha;
+let d = json.commit.author.date;
+rpm.global("commit", c);
 if rpm.changed() {
     rpm.release();
-    rpm.global("commit_date", date());
+    rpm.global("fulldate", d);
+    d.truncate(10);
     let ver = gh_tag("ad-oliviero/uwufetch");
     ver.crop(1);
     rpm.global("ver", ver);

--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -6,7 +6,7 @@ if rpm.changed() {
     rpm.release();
     rpm.global("fulldate", d);
     d.truncate(10);
-    let ver = gh_tag("ad-oliviero/uwufetch");
+    let ver = gh("ad-oliviero/uwufetch");
     ver.crop(1);
     rpm.global("ver", ver);
 }

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -1,7 +1,8 @@
 %global commit f3d4503e72fa5b7dff466e527453cfbf2c95cc01
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251128
-%global ver .1
+%global fulldate 2024-02-14
+%global commit_date %(echo %{fulldate} | sed 's/-//g')
+%global ver 2.1
 %global debug_package %{nil}
 
 Name:          uwufetch


### PR DESCRIPTION
The date being bumped down is expected, the latest commit to Uwufetch was saying to use this branch instead. https://github.com/ad-oliviero/uwufetch/commit/f3d4503e72fa5b7dff466e527453cfbf2c95cc01