### PR TITLE
[f43] chore(uwufetch): Update for semi-active branch (#7761)

### DIFF
--- a/anda/misc/uwufetch/update.rhai
+++ b/anda/misc/uwufetch/update.rhai
@@ -1,8 +1,11 @@
-rpm.global("commit", gh_commit("ad-oliviero/uwufetch"));
+let json = get(`https://api.github.com/repos/ad-oliviero/uwufetch/commits/development`).json();
+let c = json.sha;
+let d = json.commit.author.date;
+rpm.global("commit", c);
 if rpm.changed() {
     rpm.release();
-    rpm.global("commit_date", date());
+    rpm.global("fulldate", d);
+    d.truncate(10);
     let ver = gh_tag("ad-oliviero/uwufetch");
-    ver.crop(1);
     rpm.global("ver", ver);
 }

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -1,7 +1,8 @@
 %global commit f3d4503e72fa5b7dff466e527453cfbf2c95cc01
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251128
-%global ver .1
+%global fulldate 2024-02-14
+%global commit_date %(echo %{fulldate} | sed 's/-//g')
+%global ver 2.1
 %global debug_package %{nil}
 
 Name:          uwufetch


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore(uwufetch): Update for semi-active branch (#7761)](https://github.com/terrapkg/packages/pull/7761)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)