### PR TITLE
[f42] zed: use new metainfo scripts (#7523)

### DIFF
--- a/anda/devs/zed/nightly/override.xml
+++ b/anda/devs/zed/nightly/override.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop-application">
+  <!-- the terra appstream builder will auto-fill this, this is a quirk of terra-appstream-builder -->
+  <name>Zed</name>
+  <id>dev.zed.Zed</id>
+  <icon>dev.zed.Zed-nightly</icon>
+</component>

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -4,13 +4,19 @@
 %global ver 0.216.0
 
 %bcond_with check
+%bcond_with debug_no_build
 %bcond nightly 1
+
+%if 0%{?with_debug_no_build}
+%global debug_package %{nil}
+%endif
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 %global crate zed
-%global app_id dev.zed.Zed-Nightly
+%global appid dev.zed.Zed-nightly
+%global appstream_component desktop-application
 
 %global rustflags_debuginfo 0
 
@@ -22,6 +28,7 @@ SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
 URL:            https://zed.dev/
 Source0:        https://github.com/zed-industries/zed/archive/%{commit}.tar.gz
+Source1:        override.xml
 
 Conflicts:      zed
 Conflicts:      zed-preview
@@ -69,9 +76,12 @@ Supplements: (%name unless zfs)
 %description cli
 This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
 %files cli
+%if %{without debug_no_build}
 %_bindir/zed
-%{_datadir}/applications/%app_id.desktop
-%{_metainfodir}/%app_id.metainfo.xml
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%{_datadir}/applications/%appid.desktop
+%{_metainfodir}/%appid.metainfo.xml
 
 %package rename-zeditor
 Summary: Rename zed to zeditor to prevent collision with zfs
@@ -83,21 +93,26 @@ RemovePathPostFixes: .zeditor
 This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
 The normal package is %name-cli.
 %files rename-zeditor
+%if %{without debug_no_build}
 %_bindir/zeditor
-%_datadir/applications/%app_id.desktop.zeditor
-%{_metainfodir}/%app_id.metainfo.xml
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%_datadir/applications/%appid.desktop.zeditor
+%{_metainfodir}/%appid.metainfo.xml
 
 
 %prep
 %autosetup -n %{crate}-%{commit} -p1
+%if %{without debug_no_build}
 %if %{with nightly}
 %rustup_nightly
 %endif
 %cargo_prep_online
+%endif
 
 export DO_STARTUP_NOTIFY="true"
-export APP_ID="%app_id"
-export APP_ICON="%app_id"
+export APP_ID="%appid"
+export APP_ICON="%appid"
 export APP_NAME="Zed Nightly"
 export APP_CLI="zed"
 export APP="%{_libexecdir}/zed-editor"
@@ -107,35 +122,40 @@ export ZED_RELEASE_CHANNEL=nightly
 export BRANDING_LIGHT="#e9aa6a"
 export BRANDING_DARK="#1a5fb4"
 
-echo "StartupWMClass=$APP_ID" >> crates/zed/resources/zed.desktop.in
-envsubst < "crates/zed/resources/zed.desktop.in" > $APP_ID.desktop # from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zed-git#n52
+echo "StartupWMClass=$appid" >> crates/zed/resources/zed.desktop.in
+envsubst < "crates/zed/resources/zed.desktop.in" > %{appid}.desktop # from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zed-git#n52
 sed -i "s|@release_info@||g" "crates/zed/resources/flatpak/zed.metainfo.xml.in"
 
-envsubst < "crates/zed/resources/flatpak/zed.metainfo.xml.in" > $APP_ID.metainfo.xml
+envsubst < "crates/zed/resources/flatpak/zed.metainfo.xml.in" > %{appid}.metainfo.xml
 
 %build
+%if %{without debug_no_build}
 export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed Nightly from Terra."
 echo "nightly" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
 ALLOW_MISSING_LICENSES=1 script/generate-licenses
+%endif
 
 %install
+%if %{without debug_no_build}
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zeditor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
 %__cargo clean
+%endif
 
-install -Dm644 %app_id.desktop %{buildroot}%{_datadir}/applications/%app_id.desktop
-sed 's/Exec=zed/Exec=zeditor/' %app_id.desktop > %app_id.desktop.zeditor
-install -Dm644 %app_id.desktop.zeditor -t %buildroot%_datadir/applications/
-install -Dm644 crates/zed/resources/app-icon-nightly.png %{buildroot}%{_datadir}/pixmaps/%app_id.png
+install -Dm644 %appid.desktop %{buildroot}%{_datadir}/applications/%appid.desktop
+sed 's/Exec=zed/Exec=zeditor/' %appid.desktop > %appid.desktop.zeditor
+install -Dm644 %appid.desktop.zeditor -t %buildroot%_datadir/applications/
+install -Dm644 crates/zed/resources/app-icon-nightly.png %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%appid.png
 
-install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
+install -Dm644 %appid.metainfo.xml %{buildroot}%{_metainfodir}/%appid.metainfo.xml
 
 # The license generation script doesn't generate licenses for ALL compiled dependencies, just direct deps of Zed, and it does not "group" licenses
 # Zed also needs a special approach to fetch the dep licenses
+%if %{without debug_no_build}
 %{__cargo} tree                                                             \
     -Z avoid-dev-deps                                                       \
     --workspace                                                             \
@@ -148,16 +168,20 @@ install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo
     | sed -e '/.*(\*).*/d' -e '/^: pet/ s/./MIT&/'                          \
     | sort -u                                                               \
 > LICENSE.dependencies
+%endif
 mv assets/icons/LICENSES LICENSE.icons
 mv assets/themes/LICENSES LICENSE.themes
 mv assets/fonts/ibm-plex-sans/license.txt LICENSE.fonts
+%terra_appstream -o %{SOURCE1}
 
 %if %{with check}
 %check
-appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
-desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
+appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%appid.metainfo.xml
+desktop-file-validate %{buildroot}%{_datadir}/applications/%appid.desktop
 
+%if %{without debug_no_build}
 %cargo_test
+%endif
 %endif
 
 %files
@@ -166,13 +190,18 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
 %license LICENSE-AGPL
 %license LICENSE-APACHE
 %license LICENSE-GPL
+%if %{without debug_no_build}
 %license LICENSE.dependencies
+%endif
 %license LICENSE.fonts
 %license LICENSE.icons
 %license LICENSE.themes
+%if %{without debug_no_build}
 %license assets/licenses.md
+%endif
+%if %{without debug_no_build}
 %{_libexecdir}/zed-editor
-%{_datadir}/pixmaps/%app_id.png
+%endif
 
 %changelog
 %autochangelog

--- a/anda/devs/zed/preview/override.xml
+++ b/anda/devs/zed/preview/override.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop-application">
+  <name>Zed (Preview)</name>
+  <id>dev.zed.Zed-preview</id>
+  <icon>dev.zed.Zed-preview</icon>
+</component>

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -1,11 +1,17 @@
 %bcond_with check
+%bcond_with debug_no_build
+
+%if 0%{?with_debug_no_build}
+%global debug_package %{nil}
+%endif
 
 %global ver 0.215.3-pre
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 %global crate zed
-%global app_id dev.zed.Zed-Preview
+%global appid dev.zed.Zed-preview
+%global appstream_component desktop-application
 
 %global rustflags_debuginfo 0
 
@@ -17,6 +23,7 @@ SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
 URL:            https://zed.dev/
 Source0:        https://github.com/zed-industries/zed/archive/refs/tags/v%{ver}.tar.gz
+Source1:        override.xml
 
 Conflicts:      zed
 Conflicts:      zed-nightly
@@ -61,9 +68,12 @@ Supplements: (%name unless zfs)
 %description cli
 This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
 %files cli
+%if %{without debug_no_build}
 %_bindir/zed
-%{_datadir}/applications/%app_id.desktop
-%{_metainfodir}/%app_id.metainfo.xml
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%{_datadir}/applications/%appid.desktop
+%{_metainfodir}/%appid.metainfo.xml
 
 %package rename-zeditor
 Summary: Rename zed to zeditor to prevent collision with zfs
@@ -75,18 +85,23 @@ RemovePathPostFixes: .zeditor
 This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
 The normal package is %name-cli.
 %files rename-zeditor
+%if %{without debug_no_build}
 %_bindir/zeditor
-%_datadir/applications/%app_id.desktop.zeditor
-%{_metainfodir}/%app_id.metainfo.xml
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%_datadir/applications/%appid.desktop.zeditor
+%{_metainfodir}/%appid.metainfo.xml
 
 
 %prep
 %autosetup -n %{crate}-%{ver} -p1
+%if %{without debug_no_build}
 %cargo_prep_online
+%endif
 
 export DO_STARTUP_NOTIFY="true"
-export APP_ID="%app_id"
-export APP_ICON="%app_id"
+export APP_ID="%appid"
+export APP_ICON="%appid"
 export APP_NAME="Zed Preview"
 export APP_CLI="zed"
 export APP="%{_libexecdir}/zed-editor"
@@ -96,35 +111,40 @@ export ZED_RELEASE_CHANNEL=preview
 export BRANDING_LIGHT="#99c1f1"
 export BRANDING_DARK="#1a5fb4"
 
-echo "StartupWMClass=$APP_ID" >> crates/zed/resources/zed.desktop.in
-envsubst < "crates/zed/resources/zed.desktop.in" > $APP_ID.desktop # from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zed-git#n52
+echo "StartupWMClass=$appid" >> crates/zed/resources/zed.desktop.in
+envsubst < "crates/zed/resources/zed.desktop.in" > %{appid}.desktop # from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zed-git#n52
 sed -i "s|@release_info@||g" "crates/zed/resources/flatpak/zed.metainfo.xml.in"
 
-envsubst < "crates/zed/resources/flatpak/zed.metainfo.xml.in" > $APP_ID.metainfo.xml
+envsubst < "crates/zed/resources/flatpak/zed.metainfo.xml.in" > %{appid}.metainfo.xml
 
 %build
+%if %{without debug_no_build}
 export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed Preview from Terra."
 echo "preview" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
 ALLOW_MISSING_LICENSES=1 script/generate-licenses
+%endif
 
 %install
+%if %{without debug_no_build}
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zeditor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
 %__cargo clean
+%endif
 
-install -Dm644 %app_id.desktop %{buildroot}%{_datadir}/applications/%app_id.desktop
-sed 's/Exec=zed/Exec=zeditor/' %app_id.desktop > %app_id.desktop.zeditor
-install -Dm644 %app_id.desktop.zeditor -t %buildroot%_datadir/applications/
-install -Dm644 crates/zed/resources/app-icon-preview.png %{buildroot}%{_datadir}/pixmaps/%app_id.png
+install -Dm644 %appid.desktop %{buildroot}%{_datadir}/applications/%appid.desktop
+sed 's/Exec=zed/Exec=zeditor/' %appid.desktop > %appid.desktop.zeditor
+install -Dm644 %appid.desktop.zeditor -t %buildroot%_datadir/applications/
+install -Dm644 crates/zed/resources/app-icon-preview.png %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%appid.png
 
-install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
+install -Dm644 %appid.metainfo.xml %{buildroot}%{_metainfodir}/%appid.metainfo.xml
 
 # The license generation script doesn't generate licenses for ALL compiled dependencies, just direct deps of Zed, and it does not "group" licenses
 # Zed also needs a special approach to fetch the dep licenses
+%if %{without debug_no_build}
 %{__cargo} tree                                                             \
     -Z avoid-dev-deps                                                       \
     --workspace                                                             \
@@ -137,16 +157,21 @@ install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo
     | sed -e '/.*(\*).*/d' -e '/^: pet/ s/./MIT&/'                          \
     | sort -u                                                               \
 > LICENSE.dependencies
+%endif
 mv assets/icons/LICENSES LICENSE.icons
 mv assets/themes/LICENSES LICENSE.themes
 mv assets/fonts/ibm-plex-sans/license.txt LICENSE.fonts
 
+%terra_appstream -o %{SOURCE1}
+
 %if %{with check}
 %check
-appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
-desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
+appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%appid.metainfo.xml
+desktop-file-validate %{buildroot}%{_datadir}/applications/%appid.desktop
 
+%if %{without debug_no_build}
 %cargo_test
+%endif
 %endif
 
 %files
@@ -155,13 +180,18 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
 %license LICENSE-AGPL
 %license LICENSE-APACHE
 %license LICENSE-GPL
+%if %{without debug_no_build}
 %license LICENSE.dependencies
+%endif
 %license LICENSE.fonts
 %license LICENSE.icons
 %license LICENSE.themes
+%if %{without debug_no_build}
 %license assets/licenses.md
+%endif
+%if %{without debug_no_build}
 %{_libexecdir}/zed-editor
-%{_datadir}/pixmaps/%app_id.png
+%endif
 
 %changelog
 %autochangelog

--- a/anda/devs/zed/stable/override.xml
+++ b/anda/devs/zed/stable/override.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop-application">
+  <name>Zed</name>
+  <id>dev.zed.Zed</id>
+  <icon>dev.zed.Zed</icon>
+</component>

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -1,10 +1,16 @@
 %bcond_with check
+%bcond_with debug_no_build
+
+%if %{with debug_no_build}
+%global debug_package %{nil}
+%endif
 
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 %global crate zed
-%global app_id dev.zed.Zed
+%global appid dev.zed.Zed
+%global appstream_component desktop-application
 
 %global rustflags_debuginfo 0
 
@@ -16,6 +22,7 @@ SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
 URL:            https://zed.dev/
 Source0:        https://github.com/zed-industries/zed/archive/refs/tags/v%{version}.tar.gz
+Source1:        override.xml
 
 Conflicts:      zed-nightly
 Conflicts:      zed-preview
@@ -61,9 +68,12 @@ Supplements: (%name unless zfs)
 %description cli
 This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
 %files cli
+%if %{without debug_no_build}
 %_bindir/zed
-%{_datadir}/applications/%app_id.desktop
-%{_metainfodir}/%app_id.metainfo.xml
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%{_datadir}/applications/%appid.desktop
+%{_metainfodir}/%appid.metainfo.xml
 
 %package rename-zeditor
 Summary: Rename zed to zeditor to prevent collision with zfs
@@ -75,19 +85,23 @@ RemovePathPostFixes: .zeditor
 This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
 The normal package is %name-cli.
 %files rename-zeditor
+%if %{without debug_no_build}
 %_bindir/zeditor
-%_datadir/applications/%app_id.desktop.zeditor
-%{_metainfodir}/%app_id.metainfo.xml
-
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%_datadir/applications/%appid.desktop.zeditor
+%{_metainfodir}/%appid.metainfo.xml
 
 %prep
 %autosetup -n %{crate}-%{version} -p1
+%if %{without debug_no_build}
 %cargo_prep_online
+%endif
 
 export DO_STARTUP_NOTIFY="true"
-export APP_ID="%app_id"
-export APP_ICON="%app_id"
-export APP_NAME="Zed Editor"
+export APP_ID="%appid"
+export APP_ICON="%appid"
+export APP_NAME="Zed"
 export APP_CLI="zed"
 export APP="%{_libexecdir}/zed-editor"
 export APP_ARGS="%U"
@@ -96,35 +110,40 @@ export ZED_RELEASE_CHANNEL=stable
 export BRANDING_LIGHT="#e9aa6a"
 export BRANDING_DARK="#1a5fb4"
 
-echo "StartupWMClass=$APP_ID" >> crates/zed/resources/zed.desktop.in
-envsubst < "crates/zed/resources/zed.desktop.in" > $APP_ID.desktop # from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zed-git#n52
+echo "StartupWMClass=$appid" >> crates/zed/resources/zed.desktop.in
+envsubst < "crates/zed/resources/zed.desktop.in" > %{appid}.desktop # from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=zed-git#n52
 sed -i "s|@release_info@||g" "crates/zed/resources/flatpak/zed.metainfo.xml.in"
 
-envsubst < "crates/zed/resources/flatpak/zed.metainfo.xml.in" > $APP_ID.metainfo.xml
+envsubst < "crates/zed/resources/flatpak/zed.metainfo.xml.in" > %{appid}.metainfo.xml
 
 %build
+%if %{without debug_no_build}
 export ZED_UPDATE_EXPLANATION="Run dnf up to update Zed from Terra."
 echo "stable" > crates/zed/RELEASE_CHANNEL
 
 %cargo_build -- --package zed --package cli
 ALLOW_MISSING_LICENSES=1 script/generate-licenses
+%endif
 
 %install
+%if %{without debug_no_build}
 install -Dm755 target/rpm/zed %{buildroot}%{_libexecdir}/zed-editor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zeditor
 install -Dm755 target/rpm/cli %{buildroot}%{_bindir}/zed
 
 %__cargo clean
+%endif
 
-install -Dm644 %app_id.desktop %{buildroot}%{_datadir}/applications/%app_id.desktop
-sed 's/Exec=zed/Exec=zeditor/' %app_id.desktop > %app_id.desktop.zeditor
-install -Dm644 %app_id.desktop.zeditor -t %buildroot%_datadir/applications/
-install -Dm644 crates/zed/resources/app-icon.png %{buildroot}%{_datadir}/pixmaps/%app_id.png
+install -Dm644 %appid.desktop %{buildroot}%{_datadir}/applications/%appid.desktop
+sed 's/Exec=zed/Exec=zeditor/' %appid.desktop > %appid.desktop.zeditor
+install -Dm644 %appid.desktop.zeditor -t %buildroot%_datadir/applications/
+install -Dm644 crates/zed/resources/app-icon.png %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%appid.png
 
-install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
+install -Dm644 %appid.metainfo.xml %{buildroot}%{_metainfodir}/%appid.metainfo.xml
 
 # The license generation script doesn't generate licenses for ALL compiled dependencies, just direct deps of Zed, and it does not "group" licenses
 # Zed also needs a special approach to fetch the dep licenses
+%if %{without debug_no_build}
 %{__cargo} tree                                                             \
     -Z avoid-dev-deps                                                       \
     --workspace                                                             \
@@ -137,16 +156,21 @@ install -Dm644 %app_id.metainfo.xml %{buildroot}%{_metainfodir}/%app_id.metainfo
     | sed -e '/.*(\*).*/d' -e '/^: pet/ s/./MIT&/'                          \
     | sort -u                                                               \
 > LICENSE.dependencies
+%endif
 mv assets/icons/LICENSES LICENSE.icons
 mv assets/themes/LICENSES LICENSE.themes
 mv assets/fonts/ibm-plex-sans/license.txt LICENSE.fonts
 
+%terra_appstream -o %{SOURCE1}
+
 %if %{with check}
 %check
-appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%app_id.metainfo.xml
-desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
+appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%appid.metainfo.xml
+desktop-file-validate %{buildroot}%{_datadir}/applications/%appid.desktop
 
+%if %{without debug_no_build}
 %cargo_test
+%endif
 %endif
 
 %files
@@ -155,13 +179,17 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%app_id.desktop
 %license LICENSE-AGPL
 %license LICENSE-APACHE
 %license LICENSE-GPL
+%if %{without debug_no_build}
 %license LICENSE.dependencies
+%license assets/licenses.md
+%endif
 %license LICENSE.fonts
 %license LICENSE.icons
 %license LICENSE.themes
-%license assets/licenses.md
+%if %{without debug_no_build}
 %{_libexecdir}/zed-editor
-%{_datadir}/pixmaps/%app_id.png
+%endif
+
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [zed: use new metainfo scripts (#7523)](https://github.com/terrapkg/packages/pull/7523)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)