### PR TITLE
[f41] feat(zig-master{,-bootstrap}): Better mirror handling, refactor bootstrapping (#7503)

### DIFF
--- a/anda/langs/zig/bootstrap/.gitignore
+++ b/anda/langs/zig/bootstrap/.gitignore
@@ -1,0 +1,2 @@
+*.tar.xz
+*.tar.xz.minisig

--- a/anda/langs/zig/bootstrap/pre.rhai
+++ b/anda/langs/zig/bootstrap/pre.rhai
@@ -1,0 +1,2 @@
+let dir = sub(`/[^/]+$`, "", __script_path);
+sh(`./setup.sh fetch`, #{ "cwd": dir });

--- a/anda/langs/zig/bootstrap/setup.sh
+++ b/anda/langs/zig/bootstrap/setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+version=0.16.0-dev.1484+d0ba6642b
+
+mirrors=()
+
+for mirror in $(curl -s https://ziglang.org/download/community-mirrors.txt); do
+  mirrors+=($mirror)
+done
+
+
+# Self explanatory
+function randomize_mirrors() {
+  number=${#mirrors[@]}
+  index=$(( RANDOM % number ))
+  mirror=${mirrors[$index]}
+}
+
+if [ "$1" == "fetch" ]; then
+   until curl -If ${mirror}/zig-${version}.tar.xz &>/dev/null && curl -If ${mirror}/zig-${version}.tar.xz.minisig &>/dev/null; do
+     randomize_mirrors
+   done
+   echo -e "\033[0;32mNote:\033[0m Selected mirror $mirror"
+   curl -A "rpmdev-spectool" -H "Accept-Encoding: identity" -O ${mirror}/zig-${version}.tar.xz
+   curl -A "rpmdev-spectool" -H "Accept-Encoding: identity" -O ${mirror}/zig-${version}.tar.xz.minisig
+elif [ "$1" == "version" ]; then
+   echo $version
+# Grab a random mirror. For debugging purposes.
+elif [ "$1" == "mirror" ]; then
+   randomize_mirrors
+   echo "Your random mirror is $mirror"
+elif [ "$1" == "mirrors" ]; then
+   echo "$mirrors"
+fi
+
+exit 0

--- a/anda/langs/zig/bootstrap/update.rhai
+++ b/anda/langs/zig/bootstrap/update.rhai
@@ -2,6 +2,10 @@ let url = `https://ziglang.org/download/index.json`;
 let json = get(url).json();
 let v = json.master.version;
 rpm.global("ver", v);
+
 if rpm.changed() {
    rpm.release();
+   // Update the Zig version in the script
+   let dir = sub(`/[^/]+$`, "", __script_path);
+   sh(`sed -i 's|version=.*|version=${v}|' setup.sh`, #{ "cwd": dir });
 }

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -36,17 +36,15 @@
 %global zig_install_options %zig_build_options %{shrink: \
     --prefix "%{_prefix}" \
 }
-%global zig_mirrors ("https://pkg.machengine.org/zig" "https://zigmirror.hryx.net/zig" "https://zig.linus.dev/zig" "https://zig.squirl.dev" "https://zig.florent.dev")
-%global mirror_url %(mirrors=%{zig_mirrors}; index=$(( RANDOM % ${#mirrors[@]} )); echo ${mirrors[$index]})
 
-Name:           zig-master-bootstrap
+Name:           zig-master
 Version:        %(echo %{ver} | sed 's/-/~/g')
 Release:        1%?dist
-Summary:        Boostrap builds for Zig.
+Summary:        Bootstrapped build of Zig from master.
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
-Source0:        %{mirror_url}/zig-%{ver}.tar.xz
-Source1:        %{mirror_url}/zig-%{ver}.tar.xz.minisig
+Source0:        zig-%{version_no_tilde}.tar.xz
+Source1:        zig-%{version_no_tilde}.tar.xz.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
 Patch3:         0005-link.Elf-add-root-directory-of-libraries-to-linker-p.patch
 BuildRequires:  cmake
@@ -63,11 +61,14 @@ BuildRequires:  help2man
 BuildRequires:  minisign
 %if %{without bootstrap}
 BuildRequires:  %{name} = %{version}
+Obsoletes:      %{name}-bootstrap < %{version}
 %endif
 %if %{with test}
 BuildRequires:  elfutils-libelf-devel
 BuildRequires:  libstdc++-static
 %endif
+# For the version_no_tilde macro
+BuildRequires:  rust-srpm-macros
 Requires:       %{name}-libs = %{version}
 # Apache-2.0 WITH LLVM-exception OR NCSA OR MIT
 Provides:       bundled(compiler-rt) = %{llvm_version}
@@ -91,7 +92,7 @@ Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
 Zig is an open source alternative to C. 
-This package provides the bootstrap to build full "prerelease"/master builds of Zig.
+This package provides the bootstrapped build to build full "prerelease"/master builds of Zig.
 It is not recommended to use this build on its own.
 
 # The Zig stdlib only contains uncompiled code
@@ -198,6 +199,8 @@ install -Dpm644 zig.1 -t %{buildroot}%{_mandir}/man1/
 %endif
 
 %changelog
+* Mon Nov 24 2025 Gilver E. <rockgrub@disroot.org> - 0.16.0~dev.1456+16fc083f2-2
+- Moved to new method of bootstrapping, deprecated zig-master-bootstrap
 * Sat May 10 2025 Gilver E. <rockgrub@disroot.org> - 0.15.0~dev.482+2c241b263-2
 - Added GCC runtime dependency to pass system information to Zig
 * Fri Apr 25 2025 Gilver E. <rockgrub@disroot.org> - 0.15.0~dev.384+c06fecd46-2

--- a/anda/langs/zig/master/.gitignore
+++ b/anda/langs/zig/master/.gitignore
@@ -1,0 +1,2 @@
+*.tar.xz
+*.tar.xz.minisig

--- a/anda/langs/zig/master/pre.rhai
+++ b/anda/langs/zig/master/pre.rhai
@@ -1,0 +1,2 @@
+let dir = sub(`/[^/]+$`, "", __script_path);
+sh(`../bootstrap/setup.sh fetch`, #{ "cwd": dir });

--- a/anda/langs/zig/master/update.rhai
+++ b/anda/langs/zig/master/update.rhai
@@ -1,3 +1,8 @@
 import "andax/bump_extras.rhai" as bump;
 
-rpm.version(bump::madoguchi("zig-master-bootstrap", labels.branch));
+rpm.version(bump::madoguchi("zig-master", labels.branch));
+
+if rpm.changed {
+  let r = bump::madoguchi_json("zig-master", labels.branch).rel;
+  rpm.release(r + 1);
+}

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -11,17 +11,15 @@
 %bcond docs      %{without bootstrap}
 %bcond test      1
 %global zig_cache_dir %{builddir}/zig-cache
-%global zig_mirrors ("https://pkg.machengine.org/zig" "https://zigmirror.hryx.net/zig" "https://zig.linus.dev/zig" "https://zig.squirl.dev" "https://zig.florent.dev")
-%global mirror_url %(mirrors=%{zig_mirrors}; index=$(( RANDOM % ${#mirrors[@]} )); echo ${mirrors[$index]})
 
 Name:           zig-master
-Version:        0.16.0~dev.1216+846854972
-Release:        1%?dist
+Version:        0.16.0~dev.1484+d0ba6642b
+Release:        2%?dist
 Summary:        Master builds of the Zig language
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
-Source0:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz
-Source1:        %{mirror_url}/zig-%{version_no_tilde}.tar.xz.minisig
+Source0:        zig-%{version_no_tilde}.tar.xz
+Source1:        zig-%{version_no_tilde}.tar.xz.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
 Patch3:         0005-link.Elf-add-root-directory-of-libraries-to-linker-p.patch
 BuildRequires:  cmake
@@ -37,7 +35,8 @@ BuildRequires:  help2man
 # for signature verification
 BuildRequires:  minisign
 %if %{without bootstrap}
-BuildRequires:  %{name}-bootstrap = %{version}
+BuildRequires:  %{name} = %{version}
+Obsoletes:      %{name}-bootstrap < %{version}
 %endif
 %if %{with test}
 BuildRequires:  elfutils-libelf-devel

--- a/anda/terra/obsolete/terra-obsolete.spec
+++ b/anda/terra/obsolete/terra-obsolete.spec
@@ -4,7 +4,7 @@ Version:    %{?fedora:%{fedora}}%{?rhel:%{rhel}}
 # The dist number is the version here, it is intentionally not repeated in the release
 %global dist %nil
 
-Release:    3
+Release:    4
 Summary:    A package to obsolete retired packages, based on Fedora's equivalent package
 
 License:    LicenseRef-Fedora-Public-Domain
@@ -156,6 +156,9 @@ BuildArch:  noarch
 %obsolete x264-bootstrap 0.0.165-17.20250609gitb35605ac_bootstrap
 %obsolete x264-bootstrap-libs 0.0.165-17.20250609gitb35605ac_bootstrap
 %obsolete x264-bootstrap-devel 0.0.165-17.20250609gitb35605ac_bootstrap
+
+%obsolete_ticket https://github.com/terrapkg/packages/pull/7503
+%obsolete zig-master-bootstrap 0.16.0~dev.1484+d0ba6642b-2
 
 %description
 Currently obsoleted packages:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [feat(zig-master{,-bootstrap}): Better mirror handling, refactor bootstrapping (#7503)](https://github.com/terrapkg/packages/pull/7503)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)