### PR TITLE
[el10] fix(zig-master,zig-master-bootstrap): Fix randomization (#7781)

### DIFF
--- a/anda/langs/zig/bootstrap/setup.sh
+++ b/anda/langs/zig/bootstrap/setup.sh
@@ -4,8 +4,8 @@ version=0.16.0-dev.1484+d0ba6642b
 
 mirrors=()
 
-for mirror in $(curl -s https://ziglang.org/download/community-mirrors.txt); do
-  mirrors+=($mirror)
+for m in $(curl -s https://ziglang.org/download/community-mirrors.txt); do
+  mirrors+=($m)
 done
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(zig-master,zig-master-bootstrap): Fix randomization (#7781)](https://github.com/terrapkg/packages/pull/7781)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)