### PR TITLE
[f42] fix(halloy): bdep pkgconfig(xcb) (#7793)

### DIFF
--- a/anda/apps/halloy/halloy.spec
+++ b/anda/apps/halloy/halloy.spec
@@ -18,6 +18,7 @@ BuildRequires: alsa-lib-devel
 BuildRequires: cargo-rpm-macros >= 24
 BuildRequires: desktop-file-utils
 BuildRequires: openssl-devel
+BuildRequires: pkgconfig(xcb)
 
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(halloy): bdep pkgconfig(xcb) (#7793)](https://github.com/terrapkg/packages/pull/7793)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)