### PR TITLE
[f42] fix(kde-material-you-colors): Updbranch label (#7806)

### DIFF
--- a/anda/themes/kde-material-you-colors/anda.hcl
+++ b/anda/themes/kde-material-you-colors/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "kde-material-you-colors.spec"
 	}
+    labels {
+        updbranch = 1
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(kde-material-you-colors): Updbranch label (#7806)](https://github.com/terrapkg/packages/pull/7806)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)