### PR TITLE
[f42] fix (PGPy13): remove not needed build dep (#7811)

### DIFF
--- a/anda/langs/python/pgpy13/pgpy13.spec
+++ b/anda/langs/python/pgpy13/pgpy13.spec
@@ -10,7 +10,6 @@ URL:			https://github.com/memory/PGPy
 Source0:		https://files.pythonhosted.org/packages/source/P/PGPy13/pgpy13-%{version}.tar.gz
 BuildArch:      noarch
 
-BuildRequires:  python3
 BuildRequires:  python3.10
 BuildRequires:  python3-build
 BuildRequires:  python3-installer


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (PGPy13): remove not needed build dep (#7811)](https://github.com/terrapkg/packages/pull/7811)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)