### PR TITLE
[el10] fix (gay): remove not needed lines (#7816)

### DIFF
--- a/anda/langs/python/gay/gay.spec
+++ b/anda/langs/python/gay/gay.spec
@@ -7,7 +7,7 @@
 
 Name:			python-%{pypi_name}
 Version:		%commit_date.%shortcommit
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Colour your text / terminal to be more gay
 License:		MIT
 URL:			https://github.com/ms-jpq/gay
@@ -44,8 +44,6 @@ Provides:       gay
 %doc README.md
 %license LICENSE
 %{_bindir}/gay
-%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
-%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
 %python3_sitelib/gay-1.3.4.dist-info/*
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (gay): remove not needed lines (#7816)](https://github.com/terrapkg/packages/pull/7816)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)