### PR TITLE
[f43] arduino flasher (#7385)

### DIFF
--- a/anda/tools/arduino-flasher-cli/anda.hcl
+++ b/anda/tools/arduino-flasher-cli/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+	rpm {
+		spec = "arduino-flasher-cli.spec"
+	}
+}

--- a/anda/tools/arduino-flasher-cli/arduino-flasher-cli.spec
+++ b/anda/tools/arduino-flasher-cli/arduino-flasher-cli.spec
@@ -1,0 +1,46 @@
+%global goipath         github.com/arduino/arduino-flasher-cli
+Version:                0.3.0
+
+%gometa -f
+
+%global common_description %{expand:
+CLI tool to flash UNO Q boards with the latest Arduino Linux image.}
+
+%global golicenses      LICENSE license_header.tpl
+%global godocs          README.md
+
+Name:           arduino-flasher-cli
+Release:        1%?dist
+Summary:        CLI tool to flash UNO Q boards with the latest Arduino Linux image
+License:        GPL-3.0-only
+URL:            %{gourl}
+Source0:        %{gosource}
+Source1:        https://raw.githubusercontent.com/arduino/arduino-flasher-cli/refs/heads/main/README.md
+BuildRequires:  anda-srpm-macros qdl
+ExclusiveArch:  x86_64
+
+%description %{common_description}
+
+%gopkg
+
+%prep
+%goprep
+
+%build
+mkdir -p updater/artifacts/resources_linux_amd64
+cp %{_bindir}/qdl updater/artifacts/resources_linux_amd64/qdl
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/arduino-cli %{goipath}
+
+%install
+cp %{S:1} README.md
+install -Dm755 %{gobuilddir}/bin/arduino-cli -t %buildroot%{_bindir}
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/arduino-cli
+
+%changelog
+* Fri Nov 14 2025 Jaiden Riordan <jade@fyralabs.com>
+- Package Arduino Flasher :3

--- a/anda/tools/arduino-flasher-cli/update.rhai
+++ b/anda/tools/arduino-flasher-cli/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/arduino-flasher-cli"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [arduino flasher (#7385)](https://github.com/terrapkg/packages/pull/7385)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)