### PR TITLE
[f43] fix(nvm): Hardcode default dir unless explicitly set otherwise (#7833)

### DIFF
--- a/anda/tools/nvm/binscript
+++ b/anda/tools/nvm/binscript
@@ -1,5 +1,5 @@
 #!/usr/bin/sh
 
-source /etc/profile.d/nvm.sh
+. /etc/profile.d/nvm.sh
 
 nvm $@

--- a/anda/tools/nvm/nvm-always-use-default-dir.patch
+++ b/anda/tools/nvm/nvm-always-use-default-dir.patch
@@ -1,0 +1,11 @@
+--- a/nvm.sh	2025-04-23 18:34:31.000000000 -0500
++++ b/nvm.sh	2025-12-01 07:26:54.550237797 -0600
+@@ -449,7 +449,7 @@
+     NVM_SCRIPT_SOURCE="${BASH_SOURCE}"
+   fi
+   # shellcheck disable=SC2086
+-  NVM_DIR="$(nvm_cd ${NVM_CD_FLAGS} "$(dirname "${NVM_SCRIPT_SOURCE:-$0}")" >/dev/null && \pwd)"
++  NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+   export NVM_DIR
+ else
+   # https://unix.stackexchange.com/a/198289

--- a/anda/tools/nvm/nvm.spec
+++ b/anda/tools/nvm/nvm.spec
@@ -1,11 +1,13 @@
 Name:     nvm
 Version:  0.40.3
-Release:  1%{?dist}
+Release:  2%{?dist}
 Summary:  Node Version Manager
 License:  MIT
 URL:      https://github.com/nvm-sh/nvm
 Source0:  %{url}/archive/refs/tags/v%{version}.tar.gz
 Source1:  binscript
+# Make sure NVM always chooses "$HOME/.nvm" as the directory for local files unless explicitly set otherwise
+Patch0:   nvm-always-use-default-dir.patch
 # Only works with POSIX compliant shells
 Requires:  (bash or dash or ksh or zsh)
 BuildArch: noarch
@@ -17,7 +19,7 @@ POSIX-compliant script to manage multiple active Node.js versions.
 %pkg_completion -bz
 
 %prep
-%autosetup -n %{name}-%{version}
+%autosetup -n %{name}-%{version} -p1
 
 %build
 # Anyone home?


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(nvm): Hardcode default dir unless explicitly set otherwise (#7833)](https://github.com/terrapkg/packages/pull/7833)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)