### PR TITLE
[f41] fix(terra-obsolete): Bump some package versions and releases (#7841)

### DIFF
--- a/anda/terra/obsolete/terra-obsolete.spec
+++ b/anda/terra/obsolete/terra-obsolete.spec
@@ -4,7 +4,7 @@ Version:    %{?fedora:%{fedora}}%{?rhel:%{rhel}}
 # The dist number is the version here, it is intentionally not repeated in the release
 %global dist %nil
 
-Release:    4
+Release:    5
 Summary:    A package to obsolete retired packages, based on Fedora's equivalent package
 
 License:    LicenseRef-Fedora-Public-Domain
@@ -147,18 +147,18 @@ BuildArch:  noarch
 %obsolete switchboard-plug-wacom 8.0.0-2
 
 %obsolete_ticket https://github.com/terrapkg/packages/pull/7098
-%obsolete terra-surface-dtx-daemon 0.3.10-1
+%obsolete terra-surface-dtx-daemon v0.3.10~1-5
 
 %obsolete_ticket https://github.com/terrapkg/packages/pull/7521
-%obsolete x264-bash-completion 0.165-17.20250609gitb35605ac
+%obsolete x264-bash-completion 0.165-18.20250609gitb35605ac
 
 %obsolete_ticket https://github.com/terrapkg/packages/pull/7659
-%obsolete x264-bootstrap 0.0.165-17.20250609gitb35605ac_bootstrap
-%obsolete x264-bootstrap-libs 0.0.165-17.20250609gitb35605ac_bootstrap
-%obsolete x264-bootstrap-devel 0.0.165-17.20250609gitb35605ac_bootstrap
+%obsolete x264-bootstrap 0.0.165-18.20250609gitb35605ac_bootstrap
+%obsolete x264-bootstrap-libs 0.0.165-18.20250609gitb35605ac_bootstrap
+%obsolete x264-bootstrap-devel 0.0.165-18.20250609gitb35605ac_bootstrap
 
 %obsolete_ticket https://github.com/terrapkg/packages/pull/7503
-%obsolete zig-master-bootstrap 0.16.0~dev.1484+d0ba6642b-2
+%obsolete zig-master-bootstrap 0.16.0~dev.1484+d0ba6642b-3
 
 %description
 Currently obsoleted packages:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(terra-obsolete): Bump some package versions and releases (#7841)](https://github.com/terrapkg/packages/pull/7841)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)