### PR TITLE
[f43] feat(yarnpkg-berry): Track NPM (#7840)

### DIFF
--- a/anda/devs/yarn-berry/update.rhai
+++ b/anda/devs/yarn-berry/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(find("([\\d.]+)", gh("yarnpkg/berry"), 1));
+rpm.version(npm("@yarnpkg/cli"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat(yarnpkg-berry): Track NPM (#7840)](https://github.com/terrapkg/packages/pull/7840)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)