### PR TITLE
[f43] fix(openh264): Build i686 (#7851)

### DIFF
--- a/anda/lib/openh264/anda.hcl
+++ b/anda/lib/openh264/anda.hcl
@@ -1,8 +1,10 @@
 project pkg {
+        arches = ["x86_64", "aarch64", "i386"]
     rpm {
         spec = "openh264.spec"
     }
     labels {
         subrepo = "multimedia"
+        mock = 1
     }
 }

--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -1,107 +1,107 @@
-# ref: https://src.fedoraproject.org/rpms/openh264
+# To get the commit:
+# git clone https://github.com/cisco/openh264.git
+# cd openh264
+# rm -rf gmp-api; make gmp-bootstrap; cd gmp-api
+# git rev-parse HEAD
 %global commit1 1f5a2f07a565a9465c14d3a8b12f3202f83c775e
 %global shortcommit1 %(c=%{commit1}; echo ${c:0:7})
 
+# Makefile expects V=Yes instead of V=1:
+%global _make_verbose V=Yes
+
 Name:           openh264
 Version:        2.6.0
-# Also bump the Release tag for gstreamer1-plugin-openh264 down below
-Release:        2%?dist
-Summary:        H.264 codec library
-
+Release:        3%{?dist}
+Epoch:          1
+Summary:        Open Source H.264 Codec
 License:        BSD
 URL:            https://www.openh264.org/
-Source0:        https://github.com/cisco/openh264/archive/v%version/openh264-%version.tar.gz
+
+Source0:        https://github.com/cisco/%{name}/archive/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
 Source1:        https://github.com/mozilla/gmp-api/archive/%{commit1}/gmp-api-%{shortcommit1}.tar.gz
 
 BuildRequires:  gcc-c++
-BuildRequires:  gstreamer1-devel
-BuildRequires:  gstreamer1-plugins-base-devel
 BuildRequires:  make
-BuildRequires:  meson
 BuildRequires:  nasm
+
+Obsoletes:  noopenh264 < 1:0
+Obsoletes:  %{name}-libs < %{?epoch}:%{version}-%{release}
+Provides:   %{name}-libs = %{?epoch}:%{version}-%{release}
+Provides:   %{name}-libs%{?_isa} = %{?epoch}:%{version}-%{release}
 
 %description
 OpenH264 is a codec library which supports H.264 encoding and decoding. It is
 suitable for use in real time applications such as WebRTC.
 
+%package devel
+Summary:    Development files for %{name}
+Obsoletes:  noopenh264-devel < 1:0
+Requires:   %{name}%{?_isa} = %{?epoch}:%{version}-%{release}
 
-%package        devel
-Summary:        Development files for %{name}
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-
-%description    devel
+%description devel
 The %{name}-devel package contains libraries and header files for
 developing applications that use %{name}.
 
-
-%package     -n mozilla-openh264
-Summary:        H.264 codec support for Mozilla browsers
-Requires:       %{name}%{?_isa} = %{version}-%{release}
-Requires:       mozilla-filesystem%{?_isa}
+%package -n mozilla-%{name}
+Summary:    H.264 codec support for Mozilla browsers
+Requires:   %{name}%{?_isa} = %{?epoch}:%{version}-%{release}
+Requires:   mozilla-filesystem%{?_isa}
 
 %description -n mozilla-openh264
-The mozilla-openh264 package contains a H.264 codec plugin for Mozilla
-browsers.
-
+The mozilla-openh264 package contains a H.264 codec plugin for Mozilla browsers.
 
 %prep
-%setup -q
+%autosetup
 
 # Extract gmp-api archive
 tar -xf %{S:1}
 mv gmp-api-%{commit1} gmp-api
 
-
 %build
-# Update the makefile with our build options
-# Must be done in %%build in order to pick up correct LDFLAGS.
-sed -i -e 's|^CFLAGS_OPT=.*$|CFLAGS_OPT=%{optflags}|' Makefile
-sed -i -e 's|^PREFIX=.*$|PREFIX=%{_prefix}|' Makefile
-sed -i -e 's|^LIBDIR_NAME=.*$|LIBDIR_NAME=%{_lib}|' Makefile
-sed -i -e 's|^SHAREDLIB_DIR=.*$|SHAREDLIB_DIR=%{_libdir}|' Makefile
-sed -i -e '/^CFLAGS_OPT=/i LDFLAGS=%{__global_ldflags}' Makefile
-
-# First build the openh264 libraries
-make %{?_smp_mflags}
-
-# ... then build the mozilla plugin
-make plugin %{?_smp_mflags}
-
+sed -i \
+  -e 's@PREFIX=/usr/local@PREFIX=%{_prefix}@g' \
+  -e 's@SHAREDLIB_DIR=$(PREFIX)/lib@SHAREDLIB_DIR=%{_libdir}@g' \
+  -e 's@LIBDIR_NAME=lib@LIBDIR_NAME=%{_lib}@g' \
+  -e 's@CFLAGS_OPT=-O3@CFLAGS_OPT=%{optflags}@g' \
+  -e '/^CFLAGS_OPT=/i LDFLAGS=%{__global_ldflags}' \
+  Makefile
+%make_build
+%make_build plugin
 
 %install
 %make_install
+find %{buildroot} -name "*.a" -delete
 
 # Install mozilla plugin
-mkdir -p $RPM_BUILD_ROOT%{_libdir}/mozilla/plugins/gmp-gmpopenh264/system-installed
-cp -a libgmpopenh264.so* gmpopenh264.info $RPM_BUILD_ROOT%{_libdir}/mozilla/plugins/gmp-gmpopenh264/system-installed/
+mkdir -p %{buildroot}%{_libdir}/mozilla/plugins/gmp-gmpopenh264/system-installed
+cp -a libgmpopenh264.so* gmpopenh264.info %{buildroot}%{_libdir}/mozilla/plugins/gmp-gmpopenh264/system-installed/
 
-mkdir -p $RPM_BUILD_ROOT%{_libdir}/firefox/defaults/pref
-cat > $RPM_BUILD_ROOT%{_libdir}/firefox/defaults/pref/gmpopenh264.js << EOF
+mkdir -p %{buildroot}%{_libdir}/firefox/defaults/pref
+cat > %{buildroot}%{_libdir}/firefox/defaults/pref/gmpopenh264.js << EOF
 pref("media.gmp-gmpopenh264.autoupdate", false);
 pref("media.gmp-gmpopenh264.version", "system-installed");
+pref("media.gmp-gmpopenh264.enabled", true);
+pref("media.gmp-gmpopenh264.provider.enabled", true);
+pref("media.peerconnection.video.h264_enabled", true);
 EOF
 
-mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/profile.d
-cat > $RPM_BUILD_ROOT%{_sysconfdir}/profile.d/gmpopenh264.sh << EOF
-MOZ_GMP_PATH="${MOZ_GMP_PATH}${MOZ_GMP_PATH:+:}%{_libdir}/mozilla/plugins/gmp-gmpopenh264/system-installed"
+mkdir -p %{buildroot}%{_sysconfdir}/profile.d
+cat > %{buildroot}%{_sysconfdir}/profile.d/gmpopenh264.sh << EOF
+MOZ_GMP_PATH="%{_libdir}/mozilla/plugins/gmp-gmpopenh264/system-installed"
 export MOZ_GMP_PATH
 EOF
 
-# Remove static libraries
-rm $RPM_BUILD_ROOT%{_libdir}/*.a
-
-
 %files
 %license LICENSE
-%doc README.md
-%{_libdir}/libopenh264.so.*
+%doc README.md CONTRIBUTORS
+%{_libdir}/lib%{name}.so.*
 
 %files devel
-%{_includedir}/wels/
-%{_libdir}/libopenh264.so
-%{_libdir}/pkgconfig/openh264.pc
+%{_includedir}/*
+%{_libdir}/lib%{name}.so
+%{_libdir}/pkgconfig/%{name}.pc
 
-%files -n mozilla-openh264
+%files -n mozilla-%{name}
 %{_sysconfdir}/profile.d/gmpopenh264.sh
 %dir %{_libdir}/firefox
 %dir %{_libdir}/firefox/defaults


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(openh264): Build i686 (#7851)](https://github.com/terrapkg/packages/pull/7851)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)