### PR TITLE
[f43] fix: Update scripts that are missing a spec import (#7834)

### DIFF
--- a/anda/multimedia/LCEVCdec/update.rhai
+++ b/anda/multimedia/LCEVCdec/update.rhai
@@ -1,4 +1,7 @@
-rpm.version(gh("v-novaltd/LCEVCdec"));
+import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
+
+rpm.version(find(`\s+VERSION ([\d.]+)`, gh_rawfile("v-novaltd/LCEVCdec", "main", "CMakeLists.txt"), 1));
 
 open_file("anda/multimedia/LCEVCdec/VERSION_ffmpeg.txt", "w").write(bump::madoguchi("ffmpeg", labels.branch));
 

--- a/anda/multimedia/ffmpeg/update.rhai
+++ b/anda/multimedia/ffmpeg/update.rhai
@@ -1,4 +1,5 @@
 import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
 
 // rpm.version(find(`<small>ffmpeg-([\d.]+?)\.tar\.xz</small>`, get("https://ffmpeg.org/download.html"), 1));
 rpm.version(bump::bodhi("ffmpeg", bump::as_bodhi_ver(labels.branch)));

--- a/anda/multimedia/gstreamer1/gstreamer1-plugin-libav/update.rhai
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugin-libav/update.rhai
@@ -1,4 +1,5 @@
 import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
 
 let vr = bump::bodhi_vr("gstreamer1-plugin-libav", bump::as_bodhi_ver(labels.branch));
 rpm.version(vr[1]);

--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/update.rhai
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/update.rhai
@@ -1,4 +1,5 @@
 import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
 
 let bodhi_branch = bump::as_bodhi_ver(labels.branch);
 
@@ -11,6 +12,7 @@ rpm.version(vr[1]);
 
 open_file("anda/multimedia/gstreamer1/gstreamer1-plugins-bad/OPENCV_VERSION.txt", "w").write(bump::bodhi("opencv", bodhi_branch));
 open_file("anda/multimedia/gstreamer1/gstreamer1-plugins-bad/LCEVCdec_VERSION.txt", "w").write(bump::madoguchi("LCEVCdec", labels.branch));
+open_file("anda/multimedia/gstreamer1/gstreamer1-plugins-bad/OPENH264_VERSION.txt", "w").write(bump::madoguchi("openh264", labels.branch));
 
 let dir = sub(`/[^/]+$`, "", __script_path);
 if sh("[[ `git status " + dir + " --porcelain` ]] && exit 1 || exit 0", #{}).ctx.rc == 1 {

--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/update.rhai
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-ugly/update.rhai
@@ -1,4 +1,5 @@
 import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
 
 let vr = bump::bodhi_vr("gstreamer1-plugins-ugly-free", bump::as_bodhi_ver(labels.branch));
 rpm.version(vr[1]);

--- a/anda/multimedia/gstreamer1/gstreamer1-vaapi/update.rhai
+++ b/anda/multimedia/gstreamer1/gstreamer1-vaapi/update.rhai
@@ -1,4 +1,5 @@
 import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
 
 let vr = bump::bodhi_vr("gstreamer1-vaapi", bump::as_bodhi_ver(labels.branch));
 rpm.version(vr[1]);

--- a/anda/themes/kde-material-you-colors/update.rhai
+++ b/anda/themes/kde-material-you-colors/update.rhai
@@ -1,4 +1,5 @@
 import "andax/bump_extras.rhai" as bump;
+import "andax/spec.rhai" as spec;
 
 rpm.version(pypi("kde-material-you-colors"));
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: Update scripts that are missing a spec import (#7834)](https://github.com/terrapkg/packages/pull/7834)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)