### PR TITLE
[f41] fix(apparmor): files (#7857)

### DIFF
--- a/anda/lib/apparmor/apparmor.spec
+++ b/anda/lib/apparmor/apparmor.spec
@@ -276,10 +276,11 @@ make -C utils check
 %{_bindir}/aa-exec
 %{_bindir}/aa-features-abi
 %{_sbindir}/aa-load
-%{_sbindir}/aa-teardown
-%{_unitdir}/apparmor.service
+%{_sbindir}/aa-show-usage
+%dnl %{_sbindir}/aa-teardown
+%dnl %{_unitdir}/apparmor.service
 %{_presetdir}/70-apparmor.preset
-%{_prefix}/lib/apparmor
+%dnl %{_prefix}/lib/apparmor
 %dir %{_sysconfdir}/apparmor
 # FIXME: the confusion…? how did this happen
 %config(noreplace) %{_sysconfdir}/apparmor/default_unconfined.template
@@ -293,7 +294,8 @@ make -C utils check
 %{_mandir}/man7/apparmor.7.gz
 %{_mandir}/man7/apparmor_xattrs.7.gz
 %{_mandir}/man8/aa-load.8.gz
-%{_mandir}/man8/aa-teardown.8.gz
+%{_mandir}/man8/aa-show-usage.8.gz
+%dnl %{_mandir}/man8/aa-teardown.8.gz
 %{_mandir}/man8/apparmor_parser.8.gz
 
 %files utils -f apparmor-utils.lang


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(apparmor): files (#7857)](https://github.com/terrapkg/packages/pull/7857)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)