### PR TITLE
[el10] bump(nightly): hyprutils.nightly ghostty-nightly zed-nightly prismlauncher-nightly nim-nightly types-colorama stardust-atmosphere stardust-comet stardust-flatland stardust-protostar stardust-server scx-scheds-nightly scx-tools-nightl

### DIFF
--- a/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
+++ b/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
@@ -3,8 +3,8 @@
 %global realname hyprutils
 %global ver 0.10.2
 
-%global commit a64517c23613b302a3ecc5f4608f3919e8e29830
-%global commit_date 20251129
+%global commit 2f2413801beee37303913fc3c964bbe92252a963
+%global commit_date 20251202
 %global shortcommit %{sub %commit 1 7}
 
 Name:           %realname.nightly

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 9baf37a9b2a1119c697b0eabf32391bfb41ef287
+%global commit 5714ed07a1012573261b7b7e3ed2add9c1504496
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-11-28
+%global fulldate 2025-12-01
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 200a4a5c786cf23dedf0f9f38d86af764b69f8ea
+%global commit b27ad98520a74c1d967bfa92d9eae29d62d8238c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251129
+%global commit_date 20251202
 %global ver 0.216.0
 
 %bcond_with check

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -1,10 +1,10 @@
 %global real_name prismlauncher
 %global nice_name PrismLauncher
 
-%global commit 5c8b18098faf43a73a7f2a2db913da82d45f7678
+%global commit 5e54f9e2233c68c2d367bb3fe35267f149ccea10
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20251129
+%global commit_date 20251202
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit 66560840043d2ea8a96b4ce46ab55f0faed37349
+%global commit 91febf1f4cb5a3ba689c0bfac670d83dff0be657
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20251128
+%global commit_date 20251202
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit 148b8e631d9a76f7bdcc5478d36692ff79e16227
-%global commit_date 20251129
+%global commit cb592d4f3ea9216988006067454b8993f80ae248
+%global commit_date 20251202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/stardust/atmosphere/stardust-atmosphere.spec
+++ b/anda/stardust/atmosphere/stardust-atmosphere.spec
@@ -1,5 +1,5 @@
-%global commit 0c8bfb91e8ca32a4895f858067334ed265517309
-%global commit_date 20240822
+%global commit af38adafe7491498c48905b77518f8a6e9541f67
+%global commit_date 20251202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/stardust/comet/stardust-comet.spec
+++ b/anda/stardust/comet/stardust-comet.spec
@@ -1,5 +1,5 @@
-%global commit afbf6109398794791ffb30317712d742143fd08a
-%global commit_date 20240831
+%global commit 529e13b59b6a888b2bc1c3afb1576204b8e51d9b
+%global commit_date 20251202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/stardust/flatland/stardust-flatland.spec
+++ b/anda/stardust/flatland/stardust-flatland.spec
@@ -1,5 +1,5 @@
-%global commit 0914dd3df54a5e6258dfc0a02d65af1c0fc0fc90
-%global commit_date 20240920
+%global commit 77215fe4a69398b94d343f85d8925b1a49d470fc
+%global commit_date 20251202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -1,5 +1,5 @@
-%global commit 9b73eb1e128b49a6d40a27a4cde7715d8cbd2674
-%global commit_date 20241230
+%global commit 11bf3972f261f93dd78c688ea282ce2fb89ee505
+%global commit_date 20251202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/stardust/server/stardust-server.spec
+++ b/anda/stardust/server/stardust-server.spec
@@ -1,5 +1,5 @@
-%global commit 3e31905b5bc9bd78e285099ed94a4b31fdc6810b
-%global commit_date 20250402
+%global commit 77d5a638150fb36313f29b108f9d3e2c69c22db4
+%global commit_date 20251202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 365d85d48f4315e94562cd307223234e71b161b8
+%global commit ff182ec9019d7ca987bfb4c3eb8f785e172f8278
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251128
+%global commitdate 20251202
 %global ver 1.0.18
 %undefine __brp_mangle_shebangs
 

--- a/anda/system/scx-tools/nightly/scx-tools-nightly.spec
+++ b/anda/system/scx-tools/nightly/scx-tools-nightly.spec
@@ -1,6 +1,6 @@
-%global commit b60b6a95bdee4419634e60978db0597f2a9ca710
+%global commit 97f335eea7c39f958b6dca2a19836e17a46e3b09
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251129
+%global commitdate 20251202
 %global ver 1.0.18
 %global appid com.sched_ext.scx
 %global developer "sched-ext Contributors"

--- a/anda/tools/glasgow/glasgow.spec
+++ b/anda/tools/glasgow/glasgow.spec
@@ -1,5 +1,5 @@
-%global commit 91f5b1bcdd4131a515d3face1a4d1e39ce6a7d8d
-%global commit_date 20251129
+%global commit b1e9a04b86d9ca5a94cdec990836383d73bbc2b6
+%global commit_date 20251202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name glasgow

--- a/anda/tools/raindrop/raindrop.spec
+++ b/anda/tools/raindrop/raindrop.spec
@@ -1,5 +1,5 @@
-%global commit 74c88be096c8fe7d1795158eda900c3c5a634238
-%global commit_date 20251030
+%global commit 2e3859fe3afd65c89eeacb63bdaf7c432f2df30d
+%global commit_date 20251202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           raindrop


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump(nightly): hyprutils.nightly ghostty-nightly zed-nightly prismlauncher-nightly nim-nightly types-colorama stardust-atmosphere stardust-comet stardust-flatland stardust-protostar stardust-server scx-scheds-nightly scx-tools-nightly glasgow raindrop (#7864)](https://github.com/terrapkg/packages/pull/7864)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)