### PR TITLE
[f43] add: zlib (#7708)

### DIFF
--- a/anda/lib/zlib/anda.hcl
+++ b/anda/lib/zlib/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "zlib.spec"
+  }
+}

--- a/anda/lib/zlib/update.rhai
+++ b/anda/lib/zlib/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("madler/zlib"));

--- a/anda/lib/zlib/zlib.spec
+++ b/anda/lib/zlib/zlib.spec
@@ -1,0 +1,45 @@
+Name:           zlib
+Version:        1.3.1
+Release:        1%?dist
+License:        Zlib
+URL:            https://zlib.net
+Source:         https://github.com/madler/zlib/archive/v%{version}.tar.gz
+Summary:        A massively spiffy yet delicately unobtrusive compression library
+Conflicts:      zlib-ng
+
+BuildRequires:  gcc
+
+%description
+%summary.
+
+%package devel
+%pkg_devel_files
+
+%package static
+%pkg_static_files
+
+%prep
+%autosetup 
+export CFLAGS="%optflags"
+export LDFLAGS="%build_ldflags"
+./configure --libdir=%_libdir \
+            --includedir=%_includedir \
+            --sysconfdir=%_sysconfdir \
+            --localstatedir=%_localstatedir \
+            --prefix=%_prefix
+
+%build
+%make_build
+
+%install
+%make_install
+
+%files
+%license LICENSE
+%doc README 
+%_mandir/man3/zlib.3.*
+%_libdir/libz.so.*
+
+%changelog
+* Wed Nov 26 2025 metcya <metcya@gmail.com>
+- package zlib


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: zlib (#7708)](https://github.com/terrapkg/packages/pull/7708)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)