### PR TITLE
[f41] fix(zlib): only conflict with zlib-ng-compat (#7878)

### DIFF
--- a/anda/lib/zlib/zlib.spec
+++ b/anda/lib/zlib/zlib.spec
@@ -5,7 +5,7 @@ License:        Zlib
 URL:            https://zlib.net
 Source:         https://github.com/madler/zlib/archive/v%{version}.tar.gz
 Summary:        A massively spiffy yet delicately unobtrusive compression library
-Conflicts:      zlib-ng
+Conflicts:      zlib-ng-compat
 
 BuildRequires:  gcc
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(zlib): only conflict with zlib-ng-compat (#7878)](https://github.com/terrapkg/packages/pull/7878)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)