### PR TITLE
feat(yarnpkg-berry): Don't fully override Yarnpkg if installed

### DIFF
--- a/anda/devs/yarn-berry/yarnpkg-berry.spec
+++ b/anda/devs/yarn-berry/yarnpkg-berry.spec
@@ -2,7 +2,7 @@
 
 Name:          yarnpkg-berry
 Version:       4.12.0
-Release:       3%?dist
+Release:       4%?dist
 Summary:       Active development version of Yarn
 License:       BSD-2-Clause
 URL:           https://yarnpkg.com
@@ -17,7 +17,7 @@ BuildRequires: yarnpkg
 BuildRequires: %{name}
 %endif
 Provides:      yarn-berry
-Provides:      yarnpkg = %{evr}
+Conflicts:     yarnpkg
 BuildArch:     noarch
 Packager:      Gilver E. <rockgrub@disroot.org>
 


### PR DESCRIPTION
Minor tweak, package fully works as it currently exists.