### PR TITLE
[f43] fix(nvm): Give binscript the correct perms (#7888)

### DIFF
--- a/anda/tools/nvm/nvm.spec
+++ b/anda/tools/nvm/nvm.spec
@@ -1,6 +1,6 @@
 Name:     nvm
 Version:  0.40.3
-Release:  2%{?dist}
+Release:  3%{?dist}
 Summary:  Node Version Manager
 License:  MIT
 URL:      https://github.com/nvm-sh/nvm
@@ -25,7 +25,7 @@ POSIX-compliant script to manage multiple active Node.js versions.
 # Anyone home?
 
 %install
-install -Dm744 %{SOURCE1} %{buildroot}%{_bindir}/%{name}
+install -Dm755 %{SOURCE1} %{buildroot}%{_bindir}/%{name}
 
 install -Dm644 bash_completion %{buildroot}%{bash_completions_dir}/%{name}.bash
 # Another cursed script that uses bashcompinit to use one file for Bash and Zsh completions


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(nvm): Give binscript the correct perms (#7888)](https://github.com/terrapkg/packages/pull/7888)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)