### PR TITLE
[f43] feat(yarnpkg-berry): Don't fully override Yarnpkg if installed (#7887)

### DIFF
--- a/anda/devs/yarn-berry/yarnpkg-berry.spec
+++ b/anda/devs/yarn-berry/yarnpkg-berry.spec
@@ -2,7 +2,7 @@
 
 Name:          yarnpkg-berry
 Version:       4.12.0
-Release:       3%?dist
+Release:       4%?dist
 Summary:       Active development version of Yarn
 License:       BSD-2-Clause
 URL:           https://yarnpkg.com
@@ -17,7 +17,7 @@ BuildRequires: yarnpkg
 BuildRequires: %{name}
 %endif
 Provides:      yarn-berry
-Provides:      yarnpkg = %{evr}
+Conflicts:     yarnpkg
 BuildArch:     noarch
 Packager:      Gilver E. <rockgrub@disroot.org>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat(yarnpkg-berry): Don&#x27;t fully override Yarnpkg if installed (#7887)](https://github.com/terrapkg/packages/pull/7887)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)