### PR TITLE
[el10] chore(libnvidia-container): Use %git_clone (#7886)

### DIFF
--- a/anda/lib/nvidia/libnvidia-container/libnvidia-container.spec
+++ b/anda/lib/nvidia/libnvidia-container/libnvidia-container.spec
@@ -25,20 +25,15 @@ BuildRequires:  rpcgen
 The nvidia-container library provides an interface to configure containers using NVIDIA hardware.
 
 %prep
-rm -rf ./*
 ### Must be built this way because the Makefile expects be to in a Git directory.
-git clone https://github.com/NVIDIA/%{name}.git
-cd %{name}
-git checkout v%{version}
+%git_clone %{url}.git v%{version}
 %autopatch -p1
 
 %build
-cd %{name}
 make distclean
 %make_build REVISION=%{version} WITH_LIBELF=yes
 
 %install
-cd %{name}
 make install DESTDIR=%{buildroot} REVISION=%{version} WITH_LIBELF=yes \
              LDCONFIG=/bin/true \
              prefix=%{_prefix} \


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(libnvidia-container): Use %git_clone (#7886)](https://github.com/terrapkg/packages/pull/7886)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)