### PR TITLE
[f41] bump: rpcs3 libnvidia-container nvidia-container-toolkit (#7885)

### DIFF
--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -10,8 +10,8 @@
 # Need to get rid of everything Clang can't use and undefine -Wunused-command-line-argument where possible due to the project's build flags
 %global build_cflags %(echo %{build_cflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
 %global build_cxxflags %(echo %{build_cxxflags} | sed 's:-Werror ::g' | sed 's:-Wunused-command-line-argument ::g' | sed 's:-specs\=/usr/lib/rpm/redhat/redhat-annobin-cc1 ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors ::g' | sed 's:-specs=/usr/lib/rpm/redhat/redhat-package-notes ::g') -Wno-unused-command-line-argument
-%global commit 25badf9534440e7a723aa14a0f16ddd5aa24b793
-%global ver 0.0.38-18429
+%global commit 6489fca16b81e4517a71ae7773819b1bbadd312f
+%global ver 0.0.38-18435
 
 Name:           rpcs3
 Version:        %(echo %{ver} | sed 's/-/^/g')

--- a/anda/lib/nvidia/libnvidia-container/libnvidia-container.spec
+++ b/anda/lib/nvidia/libnvidia-container/libnvidia-container.spec
@@ -1,7 +1,7 @@
 %global _major 1
 
 Name:           libnvidia-container
-Version:        1.17.9
+Version:        1.18.1
 Release:        1%?dist
 Summary:        NVIDIA container runtime library
 License:        BSD-3-Clause AND Apache-2.0 AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND GPL-2.0-only

--- a/anda/system/nvidia/nvidia-container-toolkit/nvidia-container-toolkit.spec
+++ b/anda/system/nvidia/nvidia-container-toolkit/nvidia-container-toolkit.spec
@@ -1,5 +1,5 @@
 Name:             nvidia-container-toolkit
-Version:          1.18.0
+Version:          1.18.1
 Release:          1%?dist
 Summary:          NVIDIA Container Toolkit
 License:          Apache-2.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f41`:
 - [bump: rpcs3 libnvidia-container nvidia-container-toolkit (#7885)](https://github.com/terrapkg/packages/pull/7885)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)