### PR TITLE
[el10] chore: update stardust-server to reflect upstream changes (PART 1), switch to large runners and add LICENSE.dependencies (#7873)

### DIFF
--- a/anda/stardust/server/anda.hcl
+++ b/anda/stardust/server/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 	   nightly = 1
+		 large = 1
 	}
 }

--- a/anda/stardust/server/stardust-server.spec
+++ b/anda/stardust/server/stardust-server.spec
@@ -12,12 +12,31 @@ URL:            https://github.com/StardustXR/server
 Source0:        %url/archive/%commit/server-%commit.tar.gz
 License:        GPL-2.0-only
 
-BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros gcc-c++ mold
-BuildRequires:  glx-utils fontconfig-devel glibc libxcb-devel wayland-devel
-BuildRequires:  openxr-devel libglvnd-devel libglvnd-gles mesa-libgbm-devel
-BuildRequires:  libwayland-egl libX11-devel libXfixes-devel
-BuildRequires:  mesa-libEGL-devel libxkbcommon-devel
+BuildRequires:  cargo
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+BuildRequires:  mold
+BuildRequires:  anda-srpm-macros
+BuildRequires:  cargo-rpm-macros
+
+BuildRequires:  glx-utils
+BuildRequires:  fontconfig-devel
+BuildRequires:  glibc
+BuildRequires:  libxcb-devel
+BuildRequires:  wayland-devel
+BuildRequires:  openxr-devel
+BuildRequires:  libglvnd-devel
+BuildRequires:  libglvnd-gles
+BuildRequires:  mesa-libgbm-devel
+BuildRequires:  libwayland-egl
+BuildRequires:  libX11-devel
+BuildRequires:  libXfixes-devel
+BuildRequires:  libxkbcommon-devel
+BuildRequires:  alsa-lib-devel
+BuildRequires:  mesa-libEGL-devel
+
 Provides:       stardust-server
+
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
@@ -28,18 +47,22 @@ Usable Linux display server that reinvents human-computer interaction for all ki
 %cargo_prep_online
 
 %build
-export CXXFLAGS=""
 %cargo_build
 
 %install
-install -Dm755 target/rpm/stardust-xr-server %buildroot%_bindir/stardust-xr-server
-
+install -Dm755 target/rpm/stardust-xr-server %{buildroot}%{_bindir}/stardust-xr-server
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
 
 %files
-%_bindir/stardust-xr-server
+%{_bindir}/stardust-xr-server
 %license LICENSE
+%license LICENSE.dependencies
 %doc README.md
 
 %changelog
+* Tue Dec 02 2025 Owen Zimmerman <owen@fyralabs.com>
+- Update spec to reflect upstream changes, add LICENSE.dependencies
+
 * Sat Sep 14 2024 Owen-sz <owen@fyralabs.com>
 - Package StardustXR Server


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: update stardust-server to reflect upstream changes (PART 1), switch to large runners and add LICENSE.dependencies (#7873)](https://github.com/terrapkg/packages/pull/7873)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)