### PR TITLE
[f42] fix(nvidia-kmod-common): %post scripts and doc files (#7908)

### DIFF
--- a/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
+++ b/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
@@ -6,7 +6,7 @@
 
 Name:           nvidia-kmod-common
 Version:        580.105.08
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Common file for NVIDIA's proprietary driver kernel modules
 Epoch:          3
 License:        NVIDIA License
@@ -65,16 +65,15 @@ install -p -m 644 -D %{SOURCE20} %{buildroot}%{_udevrulesdir}/60-nvidia.rules
 mkdir -p %{buildroot}%{_prefix}/lib/firmware/nvidia/%{version}/
 install -p -m 644 firmware/* %{buildroot}%{_prefix}/lib/firmware/nvidia/%{version}
 
-%post
-%{_bindir}/nvidia-boot-update post
-
 # Old kernel.conf rewritten as a doc file.
-cp %{SOURCE18} .
+cp %{SOURCE16} .
 
 # Fallback service. Fall back to Nouveau if NVIDIA drivers fail.
 # This is actually from RPM Fusion.
 %dnl install -Dm644 %{SOURCE22} -t %{buildroot}%{_unitdir}
 %dnl install -Dm644 %{SOURCE23} -t %{buildroot}%{_udevrulesdir}
+%post
+%{_bindir}/nvidia-boot-update post
 
 %pre
 # Remove the kernel command line adjustments one last time when doing an upgrade
@@ -88,6 +87,7 @@ fi ||:
 dracut --regenerate-all --force
 
 %files
+%doc MODULE_VARIANT.txt
 %{_dracut_conf_d}/99-nvidia.conf
 %{_modprobedir}/nvidia.conf
 %dir %{_prefix}/lib/firmware


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(nvidia-kmod-common): %post scripts and doc files (#7908)](https://github.com/terrapkg/packages/pull/7908)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)