### PR TITLE
[f43] chore(gstreamer1-plugins-bad): Reset spec (#7884)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/gstreamer1-plugins-bad.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/gstreamer1-plugins-bad.spec
@@ -1,10 +1,10 @@
 %define _legacy_common_support 1
-%global __brp_check_rpaths %{nil}
+%undefine __brp_check_rpaths
 %global         majorminor 1.0
 
 Name:           gstreamer1-plugins-bad
 Version:        1.26.8
-Release:        2%?dist
+Release:        3%?dist
 Epoch:          2
 Summary:        GStreamer streaming media framework "bad" plugins
 License:        LGPL-2.0-or-later and LGPL-2.0-only
@@ -42,6 +42,9 @@ Provides:       gstreamer1-plugin-openh264%{?_isa} = %{?epoch}:%{version}-%{rele
 Obsoletes:      gstreamer1-svt-hevc < %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-svt-hevc = %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-svt-hevc%{?_isa} = %{?epoch}:%{version}-%{release}
+Obsoletes:      %{name}-free-libs < %{?epoch}:%{version}-%{release}
+Provides:       %{name}-free-libs = %{?epoch}:%{version}-%{release}
+Provides:       %{name}-free-libs%{?_isa} = %{?epoch}:%{version}-%{release}
 Obsoletes:      gstreamer1-plugin-vaapi < %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-plugin-vaapi = %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-plugin-vaapi%{?_isa} = %{?epoch}:%{version}-%{release}
@@ -233,17 +236,6 @@ Provides:       %{name}-free-fluidsynth%{?_isa} = %{?epoch}:%{version}-%{release
 
 %description    fluidsynth
 This package contains the GStreamer Fluidsynth plugin.
-
-
-%package        libs
-Summary:        Runtime libraries for the GStreamer "bad" plugins
-Obsoletes:      %{name}-free-libs < %{?epoch}:%{version}-%{release}
-Provides:       %{name}-free-libs = %{?epoch}:%{version}-%{release}
-Provides:       %{name}-free-libs%{?_isa} = %{?epoch}:%{version}-%{release}
-Requires:       %{name} = %{?epoch}:%{version}-%{release}
-
-%description    libs
-%summary.
 
 %package        devel
 Summary:        Development files for the GStreamer "bad" plugins
@@ -502,6 +494,32 @@ install -p -m 644 -D %{SOURCE1} %{buildroot}%{_metainfodir}/gstreamer-bad.metain
 %doc AUTHORS NEWS README.md RELEASE REQUIREMENTS
 %{_bindir}/gst-transcoder-1.0
 %{_metainfodir}/gstreamer-bad.metainfo.xml
+%{_libdir}/girepository-%{majorminor}/CudaGst-%{majorminor}.typelib
+%{_libdir}/girepository-%{majorminor}/Gst*-%{majorminor}.typelib
+%{_libdir}/libgstadaptivedemux-%{majorminor}.so.*
+%{_libdir}/libgstanalytics-%{majorminor}.so.*
+%{_libdir}/libgstbadaudio-%{majorminor}.so.*
+%{_libdir}/libgstbasecamerabinsrc-%{majorminor}.so.*
+%{_libdir}/libgstcodecparsers-%{majorminor}.so.*
+%{_libdir}/libgstcodecs-%{majorminor}.so.*
+%{_libdir}/libgstcuda-%{majorminor}.so.*
+%{_libdir}/libgstdxva-%{majorminor}.so.*
+%{_libdir}/libgstinsertbin-%{majorminor}.so.*
+%{_libdir}/libgstisoff-%{majorminor}.so.*
+%{_libdir}/libgstmpegts-%{majorminor}.so.*
+%{_libdir}/libgstmse-%{majorminor}.so.*
+%{_libdir}/libgstopencv-%{majorminor}.so.*
+%{_libdir}/libgstphotography-%{majorminor}.so.*
+%{_libdir}/libgstplayer-%{majorminor}.so.*
+%{_libdir}/libgstplay-%{majorminor}.so.*
+%{_libdir}/libgstsctp-%{majorminor}.so.*
+%{_libdir}/libgsttranscoder-%{majorminor}.so.*
+%{_libdir}/libgsturidownloader-%{majorminor}.so.*
+%{_libdir}/libgstva-%{majorminor}.so.*
+%{_libdir}/libgstvulkan-%{majorminor}.so.*
+%{_libdir}/libgstwayland-%{majorminor}.so.*
+%{_libdir}/libgstwebrtc-%{majorminor}.so.*
+%{_libdir}/libgstwebrtcnice-%{majorminor}.so.*
 # Encoder profiles
 %dir %{_datadir}/gstreamer-%{majorminor}/encoding-profiles/
 %dir %{_datadir}/gstreamer-%{majorminor}/encoding-profiles/device/
@@ -682,36 +700,6 @@ install -p -m 644 -D %{SOURCE1} %{buildroot}%{_metainfodir}/gstreamer-bad.metain
 
 %files fluidsynth
 %{_libdir}/gstreamer-%{majorminor}/libgstfluidsynthmidi.so
-%{_libdir}/gstreamer-%{majorminor}/libgstmidi.so
-%{_libdir}/gstreamer-%{majorminor}/libgstwildmidi.so
-
-%files libs
-%{_libdir}/girepository-%{majorminor}/CudaGst-%{majorminor}.typelib
-%{_libdir}/girepository-%{majorminor}/Gst*-%{majorminor}.typelib
-%{_libdir}/libgstadaptivedemux-%{majorminor}.so.*
-%{_libdir}/libgstanalytics-%{majorminor}.so.*
-%{_libdir}/libgstbadaudio-%{majorminor}.so.*
-%{_libdir}/libgstbasecamerabinsrc-%{majorminor}.so.*
-%{_libdir}/libgstcodecparsers-%{majorminor}.so.*
-%{_libdir}/libgstcodecs-%{majorminor}.so.*
-%{_libdir}/libgstcuda-%{majorminor}.so.*
-%{_libdir}/libgstdxva-%{majorminor}.so.*
-%{_libdir}/libgstinsertbin-%{majorminor}.so.*
-%{_libdir}/libgstisoff-%{majorminor}.so.*
-%{_libdir}/libgstmpegts-%{majorminor}.so.*
-%{_libdir}/libgstmse-%{majorminor}.so.*
-%{_libdir}/libgstopencv-%{majorminor}.so.*
-%{_libdir}/libgstphotography-%{majorminor}.so.*
-%{_libdir}/libgstplayer-%{majorminor}.so.*
-%{_libdir}/libgstplay-%{majorminor}.so.*
-%{_libdir}/libgstsctp-%{majorminor}.so.*
-%{_libdir}/libgsttranscoder-%{majorminor}.so.*
-%{_libdir}/libgsturidownloader-%{majorminor}.so.*
-%{_libdir}/libgstva-%{majorminor}.so.*
-%{_libdir}/libgstvulkan-%{majorminor}.so.*
-%{_libdir}/libgstwayland-%{majorminor}.so.*
-%{_libdir}/libgstwebrtc-%{majorminor}.so.*
-%{_libdir}/libgstwebrtcnice-%{majorminor}.so.*
 
 %files devel
 %{_datadir}/gir-%{majorminor}/CudaGst-%{majorminor}.gir


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore(gstreamer1-plugins-bad): Reset spec (#7884)](https://github.com/terrapkg/packages/pull/7884)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)