### PR TITLE
[f41] fix(dracut-strip-trigger): Noarch (#7929)

### DIFF
--- a/anda/system/dracut-strip-trigger/anda.hcl
+++ b/anda/system/dracut-strip-trigger/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+        arches = ["x86_64"]
 	rpm {
 		spec = "dracut-strip-trigger.spec"
 	}

--- a/anda/system/dracut-strip-trigger/dracut-strip-trigger.spec
+++ b/anda/system/dracut-strip-trigger/dracut-strip-trigger.spec
@@ -1,12 +1,13 @@
 Name:		dracut-strip-trigger
 Version:	0
-Release:	6%?dist
+Release:	7%?dist
 Summary:	Strip initramfs aggressively
 License:	GPL-3.0-only
 Requires:	dracut installonlypkg(kernel)
 Conflicts:  dracut-config-generic
 Source0:	LICENSE
 Source1:    01-aggressive-strip.conf
+BuildArch: noarch
 
 %global _desc %{expand:
 Strip initramfs automatically for each kernel update using --hostonly --aggressive-strip.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(dracut-strip-trigger): Noarch (#7929)](https://github.com/terrapkg/packages/pull/7929)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)