### PR TITLE
[f43] fix(zig-master): update.rhai typo (#7934)

### DIFF
--- a/anda/langs/zig/master/update.rhai
+++ b/anda/langs/zig/master/update.rhai
@@ -2,7 +2,7 @@ import "andax/bump_extras.rhai" as bump;
 
 rpm.version(bump::madoguchi("zig-master", labels.branch));
 
-if rpm.changed {
+if rpm.changed() {
   let r = bump::madoguchi_json("zig-master", labels.branch).rel;
   rpm.release(r + 1);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(zig-master): update.rhai typo (#7934)](https://github.com/terrapkg/packages/pull/7934)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)