### PR TITLE
[f41] fix(goofcord-nightly): Update script (#7946)

### DIFF
--- a/anda/apps/goofcord/nightly/update.rhai
+++ b/anda/apps/goofcord/nightly/update.rhai
@@ -1,5 +1,5 @@
 rpm.global("commit", gh_commit("Milkshiift/GoofCord"));
- if rpm.changed {
+ if rpm.changed() {
    let v = gh_tag("Milkshiift/GoofCord");
    v.crop(1);
    rpm.global("ver", v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(goofcord-nightly): Update script (#7946)](https://github.com/terrapkg/packages/pull/7946)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)