### PR TITLE
[f41] fix(xone-nightly): Import wasn't working for some reason? (#7945)

### DIFF
--- a/anda/system/xone/nightly/kmod-common/update.rhai
+++ b/anda/system/xone/nightly/kmod-common/update.rhai
@@ -1,9 +1,8 @@
+import "andax/bump_extras.rhai" as bump;
+
 rpm.global("commit", gh_commit("dlundqvist/xone"));
 if rpm.changed() {
-    import "andax/bump_extras.rhai" as bump;
     rpm.release();
     rpm.global("commitdate", date());
-    let ver = bump::madoguchi("xone", labels.branch);
-    ver.crop(1);
-    rpm.global("ver", ver);
+    rpm.global("ver", bump::madoguchi("xone", labels.branch));
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(xone-nightly): Import wasn&#x27;t working for some reason? (#7945)](https://github.com/terrapkg/packages/pull/7945)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)