### PR TITLE
[f42] fix(zig-master): Update script fix real?? (#7958)

### DIFF
--- a/anda/langs/zig/master/update.rhai
+++ b/anda/langs/zig/master/update.rhai
@@ -4,5 +4,6 @@ rpm.version(bump::madoguchi("zig-master", labels.branch));
 
 if rpm.changed() {
   let r = bump::madoguchi_json("zig-master", labels.branch).rel;
+  let r = sub(`(?m)(\.fc.*?|)$`, "", r).parse_int();
   rpm.release(r + 1);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(zig-master): Update script fix real?? (#7958)](https://github.com/terrapkg/packages/pull/7958)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)