### PR TITLE
[el10] fix (stardust flatland): add license.dependencies (#7943)

### DIFF
--- a/anda/stardust/flatland/stardust-flatland.spec
+++ b/anda/stardust/flatland/stardust-flatland.spec
@@ -32,12 +32,15 @@ export STARDUST_RES_PREFIXES=%_datadir
 
 mkdir -p %buildroot%_datadir
 cp -r res/* %buildroot%_datadir/
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
 
 
 %files
 %_bindir/flatland
 %_datadir/flatland/
 %license LICENSE
+%license LICENSE.dependencies
 %doc README.md
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (stardust flatland): add license.dependencies (#7943)](https://github.com/terrapkg/packages/pull/7943)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)