### PR TITLE
[el10] fix (stardust comet): add license.dependencies (#7942)

### DIFF
--- a/anda/stardust/comet/stardust-comet.spec
+++ b/anda/stardust/comet/stardust-comet.spec
@@ -6,7 +6,7 @@
 
 Name:           stardust-xr-comet
 Version:        %commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Annotate things in Stardust XR
 URL:            https://github.com/StardustXR/comet
 Source0:        %url/archive/%commit/comet-%commit.tar.gz
@@ -28,10 +28,13 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %install
 %define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
 %cargo_install
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
 
 %files
 %_bindir/comet
 %license LICENSE
+%license LICENSE.dependencies
 %doc README.md
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (stardust comet): add license.dependencies (#7942)](https://github.com/terrapkg/packages/pull/7942)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)