### PR TITLE
[f42] fix (stardust black hole): add license.dependencies (#7941)

### DIFF
--- a/anda/stardust/black-hole/stardust-black-hole.spec
+++ b/anda/stardust/black-hole/stardust-black-hole.spec
@@ -6,7 +6,7 @@
 
 Name:           stardust-xr-black-hole
 Version:        %commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Spatial storage for Stardust XR
 URL:            https://github.com/StardustXR/black-hole
 Source0:        %url/archive/%commit/black-hole-%commit.tar.gz
@@ -29,6 +29,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
 export STARDUST_RES_PREFIXES=%_datadir
 %cargo_install
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
 
 mkdir -p %buildroot%_datadir
 cp -r res/* %buildroot%_datadir/
@@ -36,6 +38,7 @@ cp -r res/* %buildroot%_datadir/
 %files
 %doc README.md
 %license LICENSE
+%license LICENSE.dependencies
 %_bindir/black-hole
 %_datadir/black_hole/
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (stardust black hole): add license.dependencies (#7941)](https://github.com/terrapkg/packages/pull/7941)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)