### PR TITLE
[f41] fix (stardust armillary): add license.dependencies (#7939)

### DIFF
--- a/anda/stardust/armillary/stardust-armillary.spec
+++ b/anda/stardust/armillary/stardust-armillary.spec
@@ -6,7 +6,7 @@
 
 Name:           stardust-xr-armillary
 Version:        %commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Model viewer for Stardust XR
 URL:            https://github.com/StardustXR/armillary
 Source0:        %url/archive/%commit/armillary-%commit.tar.gz
@@ -28,10 +28,13 @@ A model viewer for Stardust XR which works great for hand tracking, pointers, an
 %install
 %define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
 %cargo_install
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
 
 %files
 %_bindir/armillary
 %license LICENSE
+%license LICENSE.dependencies
 %doc README.md
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix (stardust armillary): add license.dependencies (#7939)](https://github.com/terrapkg/packages/pull/7939)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)