### PR TITLE
[f43] fix (stardust atmosphere): add license.dependencies (#7940)

### DIFF
--- a/anda/stardust/atmosphere/stardust-atmosphere.spec
+++ b/anda/stardust/atmosphere/stardust-atmosphere.spec
@@ -6,7 +6,7 @@
 
 Name:           stardust-xr-atmosphere
 Version:        %commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Environment, homespace, and setup client for Stardust XR
 URL:            https://github.com/StardustXR/atmosphere
 Source0:        %url/archive/%commit/atmosphere-%commit.tar.gz
@@ -28,10 +28,13 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %install
 %define __cargo_common_opts %{?_smp_mflags} -Z avoid-dev-deps --locked
 %cargo_install
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
 
 %files
 %_bindir/atmosphere
 %license LICENSE
+%license LICENSE.dependencies
 %doc README.md
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (stardust atmosphere): add license.dependencies (#7940)](https://github.com/terrapkg/packages/pull/7940)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)