### PR TITLE
[el10] fix(stardust-xr-atmosphere): Binary name?? (#7967)

### DIFF
--- a/anda/stardust/atmosphere/stardust-atmosphere.spec
+++ b/anda/stardust/atmosphere/stardust-atmosphere.spec
@@ -32,7 +32,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{cargo_license_online} > LICENSE.dependencies
 
 %files
-%_bindir/atmosphere
+%_bindir/%{name}
 %license LICENSE
 %license LICENSE.dependencies
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(stardust-xr-atmosphere): Binary name?? (#7967)](https://github.com/terrapkg/packages/pull/7967)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)