### PR TITLE
[el10] fix (stardust protostar): add license.dependencies (#7949)

### DIFF
--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -6,7 +6,7 @@
 
 Name:           stardust-xr-protostar
 Version:        %commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Prototype application launcher for Stardust XR
 URL:            https://github.com/StardustXR/protostar
 Source0:        %url/archive/%commit/protostar-%commit.tar.gz
@@ -38,10 +38,13 @@ wait
 mkdir -p %buildroot%_datadir
 cp -r res/* %buildroot%_datadir/
 
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
+
 %files
 %doc README.md
 %license LICENSE
-%_bindir/app_grid
+%license LICENSE.dependencies
 %_bindir/hexagon_launcher
 %_bindir/single
 %_bindir/sirius


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (stardust protostar): add license.dependencies (#7949)](https://github.com/terrapkg/packages/pull/7949)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)