### PR TITLE
[f42] chore: remove unneeded stardust server build deps (#7917)

### DIFF
--- a/anda/stardust/server/stardust-server.spec
+++ b/anda/stardust/server/stardust-server.spec
@@ -19,21 +19,11 @@ BuildRequires:  mold
 BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros
 
-BuildRequires:  glx-utils
 BuildRequires:  fontconfig-devel
 BuildRequires:  glibc
-BuildRequires:  libxcb-devel
-BuildRequires:  wayland-devel
 BuildRequires:  openxr-devel
-BuildRequires:  libglvnd-devel
-BuildRequires:  libglvnd-gles
-BuildRequires:  mesa-libgbm-devel
-BuildRequires:  libwayland-egl
-BuildRequires:  libX11-devel
-BuildRequires:  libXfixes-devel
-BuildRequires:  libxkbcommon-devel
 BuildRequires:  alsa-lib-devel
-BuildRequires:  mesa-libEGL-devel
+BuildRequires:  wayland-devel
 
 Provides:       stardust-server
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: remove unneeded stardust server build deps (#7917)](https://github.com/terrapkg/packages/pull/7917)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)