### PR TITLE
[f43] fix (neohtop): metainfo (#8027)

### DIFF
--- a/anda/misc/senpai/org.sr.ht.delthas.senpai.metainfo.xml
+++ b/anda/misc/senpai/org.sr.ht.delthas.senpai.metainfo.xml
@@ -24,10 +24,6 @@
 <launchable type="desktop-id">senpai.desktop</launchable>
 
   <url type="homepage">https://sr.ht/~taiite/senpai/</url>
-  <provides>
-      <mediatype>text/javascript</mediatype>
-      <mediatype>text/typescript</mediatype>
-  </provides>
 
   <releases>
     <release version="0.4.1" />

--- a/anda/misc/senpai/senpai.spec
+++ b/anda/misc/senpai/senpai.spec
@@ -2,7 +2,7 @@
 
 Name:			senpai
 Version:		0.4.1
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Your everyday IRC student
 License:		ISC
 URL:			https://sr.ht/~delthas/senpai/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (neohtop): metainfo (#8027)](https://github.com/terrapkg/packages/pull/8027)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)