### PR TITLE
[f41] add: PackageKit-bootc (#8042)

### DIFF
--- a/anda/system/packagekit-bootc/PackageKit-bootc.spec
+++ b/anda/system/packagekit-bootc/PackageKit-bootc.spec
@@ -1,0 +1,51 @@
+%global appid   com.fyralabs.PackageKit-bootc
+%global appstream_component addon
+Name:           PackageKit-bootc
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        bootc backend for PackageKit
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+License:        GPL-3.0-or-later
+URL:            https://github.com/FyraLabs/PackageKit-bootc
+Source0:        %{appid}.metainfo.xml
+
+BuildRequires:  PackageKit-glib-devel
+BuildRequires:  glib2-devel
+BuildRequires:  PackageKit-devel
+BuildRequires:  meson
+BuildRequires:  ninja-build
+BuildRequires:  gcc
+BuildRequires:  git
+BuildRequires:  anda-srpm-macros
+Requires:       PackageKit
+Requires:       bootc
+
+%description
+%{summary}.
+
+%prep
+%git_clone %{url}.git v%{version}
+
+
+%build
+%meson
+%meson_build
+
+
+
+%install
+%meson_install
+%terra_appstream -o %{SOURCE0}
+
+%files
+%license LICENSE
+%doc README.md
+%{_libdir}/packagekit-backend/libpk_backend_bootc.so
+%{_datadir}/PackageKit/helpers/bootc/bootcBackend.py
+%{_metainfodir}/%{appid}.metainfo.xml
+
+
+%changelog
+* Thu Dec 04 2025 Cappy Ishihara <cappy@cappuchino.xyz>
+- Initial Release

--- a/anda/system/packagekit-bootc/anda.hcl
+++ b/anda/system/packagekit-bootc/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "PackageKit-bootc.spec"
+	}
+}

--- a/anda/system/packagekit-bootc/com.fyralabs.PackageKit-bootc.metainfo.xml
+++ b/anda/system/packagekit-bootc/com.fyralabs.PackageKit-bootc.metainfo.xml
@@ -1,0 +1,10 @@
+<component type="addon">
+  <id>com.fyralabs.PackageKit-bootc</id>
+  <extends>org.freedesktop.packagekit</extends>
+  <name>bootc for PackageKit</name>
+  <summary>A PackageKit backend for bootc system updates.</summary>
+  <project_license>GPL-3.0+</project_license>
+  <categories>
+    <category>System</category>
+  </categories>
+</component>

--- a/anda/system/packagekit-bootc/update.rhai
+++ b/anda/system/packagekit-bootc/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("FyraLabs/PackageKit-bootc"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: PackageKit-bootc (#8042)](https://github.com/terrapkg/packages/pull/8042)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)