### PR TITLE
[f43] fix(openh264): Track Bodhi, let Makefile handle the Mozilla libs (#7918)

### DIFF
--- a/anda/lib/openh264/anda.hcl
+++ b/anda/lib/openh264/anda.hcl
@@ -6,5 +6,6 @@ project pkg {
     labels {
         subrepo = "multimedia"
         mock = 1
+        updbranch = 1
     }
 }

--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -1,11 +1,3 @@
-# To get the commit:
-# git clone https://github.com/cisco/openh264.git
-# cd openh264
-# rm -rf gmp-api; make gmp-bootstrap; cd gmp-api
-# git rev-parse HEAD
-%global commit1 1f5a2f07a565a9465c14d3a8b12f3202f83c775e
-%global shortcommit1 %(c=%{commit1}; echo ${c:0:7})
-
 # Makefile expects V=Yes instead of V=1:
 %global _make_verbose V=Yes
 
@@ -18,9 +10,9 @@ License:        BSD
 URL:            https://www.openh264.org/
 
 Source0:        https://github.com/cisco/%{name}/archive/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
-Source1:        https://github.com/mozilla/gmp-api/archive/%{commit1}/gmp-api-%{shortcommit1}.tar.gz
 
 BuildRequires:  gcc-c++
+BuildRequires:  git-core
 BuildRequires:  make
 BuildRequires:  nasm
 
@@ -53,10 +45,6 @@ The mozilla-openh264 package contains a H.264 codec plugin for Mozilla browsers.
 %prep
 %autosetup
 
-# Extract gmp-api archive
-tar -xf %{S:1}
-mv gmp-api-%{commit1} gmp-api
-
 %build
 sed -i \
   -e 's@PREFIX=/usr/local@PREFIX=%{_prefix}@g' \
@@ -65,6 +53,7 @@ sed -i \
   -e 's@CFLAGS_OPT=-O3@CFLAGS_OPT=%{optflags}@g' \
   -e '/^CFLAGS_OPT=/i LDFLAGS=%{__global_ldflags}' \
   Makefile
+%{__make} gmp-bootstrap
 %make_build
 %make_build plugin
 

--- a/anda/lib/openh264/update.rhai
+++ b/anda/lib/openh264/update.rhai
@@ -1,4 +1,3 @@
-rpm.global("commit1", gh_commit("mozilla/gmp-api"));
-let h264 = gh("cisco/openh264");
-h264.crop(1);
-rpm.version(h264);
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::bodhi("openh264", bump::as_bodhi_ver(labels.branch)));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(openh264): Track Bodhi, let Makefile handle the Mozilla libs (#7918)](https://github.com/terrapkg/packages/pull/7918)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)