### PR TITLE
[el10] fix(gstreamer1-plugins-bad): Reset Requires too (#7919)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/gstreamer1-plugins-bad.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugins-bad/gstreamer1-plugins-bad.spec
@@ -3,8 +3,8 @@
 %global         majorminor 1.0
 
 Name:           gstreamer1-plugins-bad
-Version:        1.26.8
-Release:        3%?dist
+Version:        1.26.9
+Release:        4%?dist
 Epoch:          2
 Summary:        GStreamer streaming media framework "bad" plugins
 License:        LGPL-2.0-or-later and LGPL-2.0-only
@@ -48,7 +48,6 @@ Provides:       %{name}-free-libs%{?_isa} = %{?epoch}:%{version}-%{release}
 Obsoletes:      gstreamer1-plugin-vaapi < %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-plugin-vaapi = %{?epoch}:%{version}-%{release}
 Provides:       gstreamer1-plugin-vaapi%{?_isa} = %{?epoch}:%{version}-%{release}
-Requires:       %{name}-libs = %{?epoch}:%{version}-%{release}
 
 BuildRequires:  gcc-c++
 BuildRequires:  meson >= 0.62


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(gstreamer1-plugins-bad): Reset Requires too (#7919)](https://github.com/terrapkg/packages/pull/7919)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)