### PR TITLE
[f42] chore(openh264): Bump back down

### DIFF
--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -9,7 +9,7 @@ Summary:        Open Source H.264 Codec
 License:        BSD
 URL:            https://www.openh264.org/
 
-Source0:        https://github.com/cisco/%{name}/archive/v%{version}.tar.gz#/%{name}-v%{version}.tar.gz
+Source0:        https://github.com/cisco/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc-c++
 BuildRequires:  git-core

--- a/anda/lib/openh264/openh264.spec
+++ b/anda/lib/openh264/openh264.spec
@@ -2,7 +2,7 @@
 %global _make_verbose V=Yes
 
 Name:           openh264
-Version:        2.6.0
+Version:        2.5.1
 Release:        3%{?dist}
 Epoch:          1
 Summary:        Open Source H.264 Codec


### PR DESCRIPTION
It hasn't updated on Bodhi in this branch for so long tracking Bodhi doesn't work.

Honestly considering tracking the repo itself.