### PR TITLE
[el10] bump(nightly): envision flameshot-nightly mpv-nightly zed-nightly prismlauncher-nightly nim-nightly types-colorama tdlib-nightly stardust-telescope scx-scheds-nightly rpi-utils (#8055)

### DIFF
--- a/anda/apps/envision/envision.spec
+++ b/anda/apps/envision/envision.spec
@@ -1,5 +1,5 @@
-%global commit 9615228a515fd77abb0cab5de21528f1f33d26f6
-%global commit_date 20251104
+%global commit 6f3bee3b4a1c9ec65fcba586fc7fc1a804d567ba
+%global commit_date 20251205
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           envision-nightly

--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,9 +1,9 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
 %global ver 13.3.0
-%global commit e9a8aed8ac33d455da40cac004250f710a167b1a
+%global commit 0a9983b0574159bc9dd9f4bdf4bb8698460ea719
 %global shortcommit %{sub %{commit} 1 7}
-%global commit_date 20251129
+%global commit_date 20251205
 %global devel_name QtColorWidgets
 %global _distro_extra_cflags -fuse-ld=mold
 %global _distro_extra_cxxflags -fuse-ld=mold

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,9 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-%global commit 23f9381b8053ad7fcba11b61607497ce43eaebc7
+%global commit dbd7a905b6ed47dd8f0acd09a1f4cc9a08e854a6
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251129
+%global commit_date 20251205
 %global ver 0.40.0
 
 Name:           mpv-nightly

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,7 @@
-%global commit b27ad98520a74c1d967bfa92d9eae29d62d8238c
+%global commit 42583c1141b68f655335769f4770b3ceea84c263
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251202
-%global ver 0.216.0
+%global commit_date 20251205
+%global ver 0.217.0
 
 %bcond_with check
 %bcond_with debug_no_build

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -1,10 +1,10 @@
 %global real_name prismlauncher
 %global nice_name PrismLauncher
 
-%global commit 5e54f9e2233c68c2d367bb3fe35267f149ccea10
+%global commit 92738feebae6e25bd2c06985516f66cc19eae01d
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20251202
+%global commit_date 20251205
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit 91febf1f4cb5a3ba689c0bfac670d83dff0be657
+%global commit 5d4829415a575b02cd2c56fee841ec111496cb50
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20251202
+%global commit_date 20251205
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit cb592d4f3ea9216988006067454b8993f80ae248
-%global commit_date 20251202
+%global commit a06e16eae236cff4db71be0aeb7a2172ddd1aef9
+%global commit_date 20251205
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/lib/tdlib/tdlib-nightly.spec
+++ b/anda/lib/tdlib/tdlib-nightly.spec
@@ -1,6 +1,6 @@
-%global commit f0d04d357c4ab2d4a7288e52dbeec3c2d9dd0a2d
-%global ver 1.8.57
-%global commit_date 20251127
+%global commit 889bdf06029f98f3d04cac874dafab6f4f847c47
+%global ver 1.8.58
+%global commit_date 20251205
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:          tdlib-nightly

--- a/anda/stardust/telescope/stardust-telescope.spec
+++ b/anda/stardust/telescope/stardust-telescope.spec
@@ -1,5 +1,5 @@
-%global commit 2c514175efc53be985d7d092601f158b38dc29b4
-%global commit_date 20251201
+%global commit 942d5e951620d0cbee822df3e041bbf3c7f194a0
+%global commit_date 20251205
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           stardust-xr-telescope

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,7 +1,7 @@
-%global commit ff182ec9019d7ca987bfb4c3eb8f785e172f8278
+%global commit cbec5563b9d09ccf6ded9f6c43afd146b59dcc77
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251202
-%global ver 1.0.18
+%global commitdate 20251205
+%global ver 1.0.19
 %undefine __brp_mangle_shebangs
 
 Name:           scx-scheds-nightly

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -1,5 +1,5 @@
-%global commit e95a44ca65c997d05e7b55bb3528030f14f0acf5
-%global commit_date 20251128
+%global commit a66e0178eddd510b9d1a86007ff484751f8e551f
+%global commit_date 20251205
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %define _unpackaged_files_terminate_build 0


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump(nightly): envision flameshot-nightly mpv-nightly zed-nightly prismlauncher-nightly nim-nightly types-colorama tdlib-nightly stardust-telescope scx-scheds-nightly rpi-utils (#8055)](https://github.com/terrapkg/packages/pull/8055)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)