### PR TITLE
[f42] add: arduino-app-cli (#8062)

### DIFF
--- a/anda/tools/arduino-app-cli/anda.hcl
+++ b/anda/tools/arduino-app-cli/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "arduino-app-cli.spec"
+	}
+}

--- a/anda/tools/arduino-app-cli/arduino-app-cli.spec
+++ b/anda/tools/arduino-app-cli/arduino-app-cli.spec
@@ -1,0 +1,41 @@
+%global goipath github.com/arduino/arduino-app-cli
+Version:        0.6.7
+
+%gometa -f
+
+Name:           arduino-app-cli
+Release:        1%?dist
+Summary:        The CLI and service that manages and runs Arduino Apps on UNO Q
+License:        GPL-3.0-only
+
+URL:            https://github.com/arduino/arduino-app-cli
+Source:         %{gosource}
+BuildRequires:  anda-srpm-macros
+BuildRequires:  go-rpm-macros
+BuildRequires:  go-task
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%goprep -A
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/cmd/arduino-app-cli %{goipath}/cmd/arduino-app-cli
+
+%install
+install -Dm755 %{gobuilddir}/cmd/arduino-app-cli %{buildroot}%{_bindir}/arduino-app-cli
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/arduino-app-cli
+
+%changelog
+* Thu Dec 04 2024 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/arduino-app-cli/update.rhai
+++ b/anda/tools/arduino-app-cli/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/arduino-app-cli"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: arduino-app-cli (#8062)](https://github.com/terrapkg/packages/pull/8062)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)