### PR TITLE
[f43] add: Arduino App Lab (#8049)

### DIFF
--- a/anda/tools/arduino-app-lab-bin/anda.hcl
+++ b/anda/tools/arduino-app-lab-bin/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+          arches = ["x86_64"]
+	rpm {
+		spec = "arduino-app-lab-bin.spec"
+	}
+}

--- a/anda/tools/arduino-app-lab-bin/arduino-app-lab-bin.spec
+++ b/anda/tools/arduino-app-lab-bin/arduino-app-lab-bin.spec
@@ -1,0 +1,59 @@
+%global appid cc.arduino.AppLab
+
+Name:           arduino-app-lab-bin
+Version:        0.2.4
+Release:        1%{?dist}
+Summary:        A powerful visual environment for managing the Arduino UNO Q
+
+Provides:       arduino-app-lab
+URL:            https://www.arduino.cc/en/software
+License:        GPL-3.0
+
+Source0:        https://downloads.arduino.cc/AppLab/Stable/ArduinoAppLab_%{version}_Linux_x86-64.tar.gz
+Source1:        https://downloads.arduino.cc/AppLab/Stable/source-app-lab-%{version}.zip
+Source2:        cc.arduino.AppLab.desktop
+Source3:        cc.arduino.AppLab.metainfo.xml
+
+ExclusiveArch:  x86_64
+
+Requires:       android-tools
+
+BuildRequires:  terra-appstream-helper
+
+Suggests:       arduino-flasher-cli arduino-app-cli  
+
+Packager:       Jaiden Riordan <jade@fyralabs.com>
+
+%description
+%summary.
+
+%prep
+tar -xvf %{_sourcedir}/ArduinoAppLab_%{version}_Linux_x86-64.tar.gz
+unzip %{_sourcedir}/source-app-lab-%{version}.zip
+
+%install
+install -dm755 %{buildroot}%{_bindir}
+install -p -m755 ArduinoAppLab_%{version}_Linux_x86-64/arduino-app-lab %{buildroot}%{_bindir}/%{name}
+
+install -dm755 %{buildroot}%{_iconsdir}/hicolor/scalable/apps/
+install -p -m644 source-app-lab/ui-packages/images/assets/round-arduino-logo.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/cc.arduino.AppLab.svg
+
+install -dm755 %{buildroot}%{_datadir}/applications/
+install -p -m644 %{SOURCE2} %{buildroot}%{_datadir}/applications/%{appid}.desktop
+
+cp source-app-lab/LICENSE -t .
+cp source-app-lab/dependency_licenses -t .
+
+%terra_appstream -o %{SOURCE3}
+
+%files
+%license LICENSE
+%license dependency_licenses
+%{_bindir}/%{name}
+%{_iconsdir}/hicolor/scalable/apps/%{appid}.svg
+%{_datadir}/applications/%{appid}.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%changelog
+* Thu Dec 4 2025 Jaiden Riordan <jade@fyralabs.com>
+- Package arduino-app-lab-bin

--- a/anda/tools/arduino-app-lab-bin/cc.arduino.AppLab.desktop
+++ b/anda/tools/arduino-app-lab-bin/cc.arduino.AppLab.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Arduino App Lab
+Comment=A powerful visual environment for managing the Arduino UNO Q
+Exec=arduino-app-lab-bin
+Icon=cc.arduino.AppLab
+Terminal=false
+Type=Application
+Categories=Development
+StartupNotify=true
+Keywords=arduino;applab;lab
+StartupWMClass=arduino-app-lab-bin

--- a/anda/tools/arduino-app-lab-bin/cc.arduino.AppLab.metainfo.xml
+++ b/anda/tools/arduino-app-lab-bin/cc.arduino.AppLab.metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="runtime">
+  <id>cc.arduino.AppLab</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+
+  <name>Arduino App Lab</name>
+  <summary
+    >A powerful visual environment for managing the Arduino UNO Q</summary>
+
+  <icon type="local">
+  /usr/share/icons/hicolor/scalable/apps/cc.arduino.AppLab.svg
+  </icon>
+  <description>
+    <p>
+    A powerful visual environment for managing your UNO Q board — combine prebuilt modules, called Bricks, with AI models to define your board’s behavior with ease.
+    App Lab supports both classic C++ sketches via the Arduino IDE and Python, giving you full flexibility to develop the way you prefer.
+    </p>
+  </description>
+  <url type="homepage">https://arduino.cc</url>
+
+  <releases>
+    <release version="0.2.4" />
+  </releases>
+</component>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: Arduino App Lab (#8049)](https://github.com/terrapkg/packages/pull/8049)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)