### PR TITLE
[f43] add: carapace (#8076)

### DIFF
--- a/anda/tools/carapace/anda.hcl
+++ b/anda/tools/carapace/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "carapace.spec"
+	}
+}

--- a/anda/tools/carapace/carapace.spec
+++ b/anda/tools/carapace/carapace.spec
@@ -1,0 +1,49 @@
+%define debug_package %{nil}
+
+%global goipath github.com/carapace-sh/carapace-bin
+Version:        1.5.5
+
+%gometa -f
+
+Name:           carapace
+Release:        1%?dist
+Summary:        A multi-shell completion binary
+
+License:        MIT
+URL:            https://carapace.sh/
+Source0:        https://github.com/carapace-sh/carapace-bin/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang gcc go-rpm-macros
+Requires:       glibc
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%autosetup -n %{name}-bin-%{version}
+
+%build
+%define gomodulesmode GO111MODULE=on
+export CGO_CPPFLAGS="${CPPFLAGS}"
+export CGO_CFLAGS="${CFLAGS}"
+export CGO_CXXFLAGS="${CXXFLAGS}"
+export CGO_LDFLAGS="${LDFLAGS}"
+export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
+go generate ./cmd/...
+%gobuild -o %{gobuilddir}/cmd/carapace %{goipath}/cmd/carapace
+
+%install
+install -Dm 0755 %{gobuilddir}/cmd/carapace %{buildroot}%{_bindir}/carapace
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/carapace
+
+%changelog
+* Fri Dec 05 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/carapace/update.rhai
+++ b/anda/tools/carapace/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("carapace-sh/carapace-bin"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: carapace (#8076)](https://github.com/terrapkg/packages/pull/8076)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)