### PR TITLE
[el10] Update URLs and build steps (fix missing debug_package) (#8105)

### DIFF
--- a/anda/langs/crystal/blahaj/blahaj.spec
+++ b/anda/langs/crystal/blahaj/blahaj.spec
@@ -1,14 +1,12 @@
-%define debug_package %nil
-
-Name:			blahaj
-Version:		2.2.0
-Release:		1%{?dist}
-Summary:		Gay sharks at your local terminal - lolcat-like CLI tool
-License:		BSD-2-Clause
-URL:			https://blahaj.queer.software
-Source0:		https://github.com/GeopJr/BLAHAJ/archive/refs/tags/v%version.tar.gz
-BuildRequires:	crystal gcc libyaml-devel pcre-devel libgc-devel libevent-devel
-ExclusiveArch:	x86_64
+Name:           blahaj
+Version:        2.2.0
+Release:        2%{?dist}
+Summary:        Gay sharks at your local terminal - lolcat-like CLI tool
+License:        BSD-2-Clause
+URL:            https://blahaj.geopjr.dev/
+Source0:        https://codeberg.org/GeopJr/BLAHAJ/archive/v%{version}.tar.gz
+BuildRequires:  crystal shards make gcc libyaml-devel pcre-devel libgc-devel libevent-devel bash
+ExclusiveArch:  x86_64
 
 %description
 Apart from a cute cuddly shark plushie from IKEA, BLÅHAJ is a lolcat-like CLI
@@ -17,17 +15,13 @@ It has a wide variety of flags/colors to choose from and many options from flag
 size to whether to colorize by line, word or character.
 
 %prep
-%autosetup -n BLAHAJ-%{version}
+%autosetup -n %{name}
 
 %build
-shards build --production --release -D "-fPIE" --link-flags "-pie"
+shards build --production --release
 
 %install
-mkdir -p %buildroot%_bindir
-install -Dm755 bin/blahaj %buildroot%_bindir/
-
-%check
-crystal spec --order random -Dpreview_mt
+%make_install
 
 %files
 %doc README.md
@@ -35,5 +29,7 @@ crystal spec --order random -Dpreview_mt
 %_bindir/blahaj
 
 %changelog
+* Sat Dec 06 2025 june-fish <june@fyralabs.com> - 2.2.0-2
+- Update URLs and build steps (fix missing debug_package)
 * Sat Apr 15 2023 windowsboy111 <windowsboy111@fyralabs.com> - 2.0.1-1
 - Initial package.

--- a/anda/langs/crystal/blahaj/update.rhai
+++ b/anda/langs/crystal/blahaj/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh("GeopJr/BLAHAJ"));
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::codeberg("GeopJr/BLAHAJ"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Update URLs and build steps (fix missing debug_package) (#8105)](https://github.com/terrapkg/packages/pull/8105)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)