### PR TITLE
[f43] update seto-fonts homepage to archive.org since the original host is dead (#8110)

### DIFF
--- a/anda/fonts/seto/seto-fonts.spec
+++ b/anda/fonts/seto/seto-fonts.spec
@@ -1,7 +1,7 @@
 Name:      seto-fonts
 Version:   6.20
-Release:   3%?dist
-URL:       https://ja.osdn.net/projects/setofont/
+Release:   4%?dist
+URL:       https://web.archive.org/web/20240226230836/https://ja.osdn.net/projects/setofont/
 Source0:   https://github.com/terrapkg/pkg-seto-fonts/archive/refs/tags/%version.tar.gz
 License:   OFL-1.1
 Summary:   A handwritten font that contains kanji up to JIS 4th level and difficult kanji


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [update seto-fonts homepage to archive.org since the original host is dead (#8110)](https://github.com/terrapkg/packages/pull/8110)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)