### PR TITLE
[el10] fix(mommy): use make (#8111)

### DIFF
--- a/anda/misc/mommy/fix-makefile.patch
+++ b/anda/misc/mommy/fix-makefile.patch
@@ -1,0 +1,30 @@
+diff --git a/GNUmakefile b/GNUmakefile
+index c288fd1..08d0c5d 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -14,8 +14,8 @@ zsh_prefix = $(prefix)/share/zsh/site-functions/
+ shellspec_bin := shellspec
+ 
+ # Man page compression method
+-man_compress_cmd := gzip -9nf
+-man_compress_ext := .gz
++man_compress_cmd := true
++man_compress_ext :=
+ 
+ 
+ ## Target-specific overrides
+@@ -109,10 +109,10 @@ install: build
+ 	@install -m 755 -d "$(bin_prefix)" "$(man_prefix)/man1/" "$(fish_prefix)" "$(zsh_prefix)"
+ 
+ 	@# Copy files
+-	@install -m 755 "$(build_dir)/bin/mommy" "$(bin_prefix)"
+-	@install -m 644 "$(build_dir)/man/man1/mommy.1$(man_compress_ext)" "$(man_prefix)/man1/"
+-	@install -m 644 "$(build_dir)/completions/fish/mommy.fish" "$(fish_prefix)"
+-	@install -m 644 "$(build_dir)/completions/zsh/_mommy" "$(zsh_prefix)"
++	@install -Dm 755 "$(build_dir)/bin/mommy" "$(bin_prefix)"
++	@install -Dm 644 "$(build_dir)/man/man1/mommy.1$(man_compress_ext)" "$(man_prefix)/man1/"
++	@install -Dm 644 "$(build_dir)/completions/fish/mommy.fish" "$(fish_prefix)"
++	@install -Dm 644 "$(build_dir)/completions/zsh/_mommy" "$(zsh_prefix)"
+ 
+ # Install, with target-specific overrides from the preamble
+ .PHONY: install/%

--- a/anda/misc/mommy/mommy.spec
+++ b/anda/misc/mommy/mommy.spec
@@ -1,23 +1,28 @@
 Name:           mommy
 Version:        1.8.0
-Release:        2%?dist
+Release:        3%?dist
 Summary:        mommy's here to support you, in any shell, on any system~ ❤️ 
 URL:            https://github.com/fwdekker/mommy
 Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
+Patch0:         fix-makefile.patch
 License:        Unlicense
 BuildArch:      noarch
+BuildRequires:  make
 
 %description
 mommy's here to support you! mommy will compliment you if things go well, and will encourage you if things are not going so well~
 
 %prep
-%autosetup
+%autosetup -p1
+
+sed GNUmakefile -i \
+        -e 's|bin_prefix = .*|bin_prefix = %buildroot%_bindir|g' \
+        -e 's|man_prefix = .*|man_prefix = %buildroot%_mandir|g' \
+        -e 's|fish_prefix = .*|fish_prefix = %buildroot%fish_completions_dir|g' \
+        -e 's|zsh_prefix = .*|zsh_prefix = %buildroot%zsh_completions_dir|g'
 
 %install
-install -Dm 755 src/main/sh/%{name} %{buildroot}%{_bindir}/%{name}
-install -Dm 644 src/main/man/man1/%{name}.1 %{buildroot}%{_mandir}/man1/%{name}.1
-install -Dm 644 src/main/completions/fish/%{name}.fish %{buildroot}%{fish_completions_dir}/%{name}.fish
-install -Dm 644 src/main/completions/zsh/_%{name} %{buildroot}%{zsh_completions_dir}/_%{name}
+%make_install
 
 %files
 %license LICENSE
@@ -28,5 +33,8 @@ install -Dm 644 src/main/completions/zsh/_%{name} %{buildroot}%{zsh_completions_
 %pkg_completion -zf
 
 %changelog
+* Sun Dec 6 2025 metcya <metcya@gmail.com> - 1.8.0
+- use make
+
 * Wed Dec 3 2025 metcya <metcya@gmail.com>
 - package mommy~ ❤️


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(mommy): use make (#8111)](https://github.com/terrapkg/packages/pull/8111)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)