### PR TITLE
[f43] fix: gradle (#8012)

### DIFF
--- a/anda/tools/buildsys/gradle/anda.hcl
+++ b/anda/tools/buildsys/gradle/anda.hcl
@@ -1,6 +1,7 @@
 project pkg {
-	arches = ["x86_64"]
+    arches = ["x86_64"]
 	rpm {
 		spec = "gradle.spec"
+    extra_repos = ["https://packages.adoptium.net/artifactory/rpm/fedora/\\$releasever/\\$basearch"]
 	}
 }

--- a/anda/tools/buildsys/gradle/ci_setup.rhai
+++ b/anda/tools/buildsys/gradle/ci_setup.rhai
@@ -1,0 +1,2 @@
+import "andax/ci/extra_repos.rhai" as extra_repos;
+extra_repos::install(labels);

--- a/anda/tools/buildsys/gradle/gradle.spec
+++ b/anda/tools/buildsys/gradle/gradle.spec
@@ -3,17 +3,16 @@ Version:		9.2.1
 Release:		1%?dist
 Summary:		Powerful build system for the JVM
 URL:			https://gradle.org/
-Source0:		https://services.gradle.org/distributions/%{name}-%{version}-src.zip
-Source1:		https://services.gradle.org/distributions/%{name}-%{version}-all.zip
+Source0:		https://github.com/gradle/gradle/archive/refs/tags/v%{version}.tar.gz
 License:		Apache-2.0
-Requires:		java-latest-openjdk coreutils findutils sed which bash
-BuildRequires:	java-11-openjdk-devel asciidoc xmlto groovy unzip git
+Requires:		java coreutils findutils sed which bash
+BuildRequires:	java-21-openjdk-devel asciidoc xmlto groovy unzip git
+BuildRequires:  temurin-17-jdk temurin-17-jre anda-srpm-macros
 BuildArch:		noarch
 Recommends:		gradle-doc gradle-src
 
 %description
 Gradle is a build tool with a focus on build automation and support for multi-language development. If you are building, testing, publishing, and deploying software on any platform, Gradle offers a flexible model that can support the entire development lifecycle from compiling and packaging code to publishing web sites. Gradle has been designed to support build automation across multiple languages and platforms including Java, Scala, Android, Kotlin, C/C++, and Groovy, and is closely integrated with development tools and continuous integration servers including Eclipse, IntelliJ, and Jenkins.
-
 
 %package doc
 Summary:	Gradle documentation
@@ -25,102 +24,77 @@ Summary:	Gradle sources
 %description src
 Sources for gradle, a powerful build system for the JVM.
 
-
-# See PKGBUILD on Arch Linux
-
 %prep
-unzip %{SOURCE1} %{name}-%{version}/{README,LICENSE}
-mv %{name}-%{version}/README .
-mv %{name}-%{version}/LICENSE .
-rmdir %{name}-%{version}
-unzip %{SOURCE0}
-cd %{name}-%{version}
+%autosetup -n %{name}-%{version}
 
-cat <<EOF > dist/gradle.sh
+cat <<EOF > gradle.sh
 #!/bin/sh
 export GRADLE_HOME=/usr/share/java/gradle
 EOF
 
-# remove ADOPTIUM contraint from all build related files
-sed -i '/JvmVendorSpec.ADOPTIUM/d' \
-	build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts \
-	subprojects/docs/src/snippets/java/toolchain-filters/groovy/build.gradle \
-	subprojects/docs/src/snippets/java/toolchain-filters/kotlin/build.gradle.kts \
-	build-logic-commons/gradle-plugin/src/main/kotlin/common.kt
-# inhibit automatic download of binary gradle
-sed -i "s#distributionUrl=.*#distributionUrl=file\:%{SOURCE1}#" \
-	gradle/wrapper/gradle-wrapper.properties
-
-
 %build
-cd %{name}-%{version}
-export PATH="/usr/lib/jvm/java-11-openjdk/bin:${PATH}"
-./gradlew installAll \
+export PATH="/usr/lib/jvm/java-21-openjdk/bin:${PATH}"
+./gradlew installAll --parallel \
 	-Porg.gradle.java.installations.auto-download=false \
 	-PfinalRelease=true \
 	-Pgradle_installPath="$(pwd)/dist" \
+	-Porg.gradle.ignoreBuildJavaVersionCheck=true \
+	--warning-mode all \
 	--no-configuration-cache
 
-
 %install
-cd %{name}-%{version}/dist
 
 # install profile.d script
-install -Dm755 gradle.sh %{buildroot}/etc/profile.d/
+mkdir -p %{buildroot}%{_sysconfdir}/profile.d/
+install -Dm755 gradle.sh %{buildroot}/%{_sysconfdir}/profile.d/
 
 # create the necessary directory structure
-install -d "%{buildroot}/usr/share/java/%{name}/bin"
-install -d "%{buildroot}/usr/share/java/%{name}/lib/plugins"
-install -d "%{buildroot}/usr/share/java/%{name}/init.d"
+install -d "%{buildroot}%{_javadir}/%{name}/bin"
+install -d "%{buildroot}%{_javadir}/%{name}/lib/plugins"
+install -d "%{buildroot}%{_javadir}/%{name}/lib/agents"
+install -d "%{buildroot}%{_javadir}/%{name}/init.d"
 
 # copy across jar files
-install -Dm644 lib/*.jar "%{buildroot}/usr/share/java/%{name}/lib"
-install -Dm644 lib/plugins/*.jar "%{buildroot}/usr/share/java/%{name}/lib/plugins"
+install -Dm644 dist/lib/*.jar "%{buildroot}%{_javadir}/%{name}/lib"
+install -Dm644 dist/lib/plugins/*.jar "%{buildroot}%{_javadir}/%{name}/lib/plugins"
+install -Dm644 dist/lib/agents/*.jar "%{buildroot}%{_javadir}/%{name}/lib/agents"
 
 # copy across supporting text documentation and scripts
-install -m644 NOTICE "%{buildroot}/usr/share/java/%{name}"
-install -m755 bin/gradle "%{buildroot}/usr/share/java/%{name}/bin"
-install -m644 init.d/*.* "%{buildroot}/usr/share/java/%{name}/init.d"
+install -m644 dist/NOTICE "%{buildroot}%{_javadir}/%{name}"
+mkdir -p %{buildroot}%{_javadir}/%{name}/bin
+install -m755 dist/bin/%{name} "%{buildroot}%{_javadir}/%{name}/bin"
+install -m644 dist/init.d/*.* "%{buildroot}%{_javadir}/%{name}/init.d"
 
 # link gradle script to /usr/bin
-ln -s /usr/share/java/%{name}/bin/%{name} "%{buildroot}/usr/bin"
+mkdir -p "%{buildroot}/%{_bindir}"
+ln -s %{_javadir}/%{name}/bin/%{name} "%{buildroot}%{_bindir}/%{name}"
 
+install -d %{buildroot}%{_javadir}/%{name}/docs
+cp -r dist/docs/* %{buildroot}%{_javadir}/%{name}/docs
 
-install -d %{buildroot}/usr/share/java/gradle/docs
-cp -r docs/* %{buildroot}/usr/share/java/gradle/docs
-
-
-install -d %{buildroot}/usr/share/java/gradle/src
-cp -r src/* %{buildroot}/usr/share/java/gradle/src
-
-
-install -Dm644 %{SOURCE2} %{buildroot}/%{_datadir}/licenses/%{name}/
-install -Dm644 %{SOURCE2} %{buildroot}/%{_datadir}/licenses/%{name}-doc/
-install -Dm644 %{SOURCE2} %{buildroot}/%{_datadir}/licenses/%{name}-src/
-install -Dm644 %{SOURCE3} %{buildroot}/%{_datadir}/doc/%{name}/
-install -Dm644 %{SOURCE3} %{buildroot}/%{_datadir}/doc/%{name}-doc/
-install -Dm644 %{SOURCE3} %{buildroot}/%{_datadir}/doc/%{name}-src/
-
+install -d %{buildroot}%{_javadir}/%{name}/src
+cp -r dist/src/* %{buildroot}%{_javadir}/%{name}/src
 
 %files
-%doc README
+%doc README.md
 %license LICENSE
-/etc/profile.d/gradle.sh
-/usr/share/java/%{name}/
-/usr/bin/%{name}
+%{_sysconfdir}/profile.d/gradle.sh
+%{_javadir}/%{name}/
+%{_bindir}/%{name}
 
 %files doc
-%doc README
+%doc README.md
 %license LICENSE
-/usr/share/java/gradle/docs
+%{_javadir}/%{name}/docs
 
 %files src
-%doc README
+%doc README.md
 %license LICENSE
-/usr/share/java/gradle/src
-
+%{_javadir}/%{name}/src
 
 %changelog
+* Fri Dec 05 2025 Owen Zimmerman <owen@fyralabs.com>
+- Pull in adoptium repo, fix many build issues, change source to GitHub release artifacts
+
 * Tue Feb 7 2023 windowsboy111 <windowsboy111@fyralabs.com>
 - Initial package
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: gradle (#8012)](https://github.com/terrapkg/packages/pull/8012)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)