### PR TITLE
[f41] bump(nightly): flameshot-nightly hyprutils.nightly ghostty-nightly zed-nightly nim-nightly types-colorama opentabletdriver-nightly scx-scheds-nightly goofcord-nightly prismlauncher-nightly nim-nightly stardust-flatland stardust-server HeadsetControl-nightly (#8120)

### DIFF
--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,9 +1,9 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
 %global ver 13.3.0
-%global commit 0a9983b0574159bc9dd9f4bdf4bb8698460ea719
+%global commit 1837c8a41f33894c96ab0e8102f0f2c2aa858766
 %global shortcommit %{sub %{commit} 1 7}
-%global commit_date 20251205
+%global commit_date 20251206
 %global devel_name QtColorWidgets
 %global _distro_extra_cflags -fuse-ld=mold
 %global _distro_extra_cxxflags -fuse-ld=mold

--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -1,7 +1,7 @@
-%global commit dbe10e789ae55aa0f1ab8828b0341ac1104849e0
+%global commit df6d6b9c8ce880c8900c405f834136b83da710cf
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251204
-%global ver 1.11.2
+%global commit_date 20251207
+%global ver 1.11.3
 %global base_name goofcord
 %global git_name GoofCord
 %global debug_package %{nil}

--- a/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
+++ b/anda/desktops/hyprland/hyprutils/hyprutils.nightly.spec
@@ -1,10 +1,10 @@
 #? https://src.fedoraproject.org/rpms/hyprutils/blob/rawhide/f/hyprutils.spec
 
 %global realname hyprutils
-%global ver 0.10.2
+%global ver 0.11.0
 
-%global commit 2f2413801beee37303913fc3c964bbe92252a963
-%global commit_date 20251202
+%global commit fe686486ac867a1a24f99c753bb40ffed338e4b0
+%global commit_date 20251206
 %global shortcommit %{sub %commit 1 7}
 
 Name:           %realname.nightly

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit b4a48303ed9ea74d326ba450ddf5f1514dca76d0
+%global commit 08c9661683edc1e9e63d8e6abd469a68faaee575
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-12-01
+%global fulldate 2025-12-05
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 42583c1141b68f655335769f4770b3ceea84c263
+%global commit 9f344f093e1b5fee08937111569b106dbeee2410
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251205
+%global commit_date 20251207
 %global ver 0.217.0
 
 %bcond_with check

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,10 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-%global commit 92738feebae6e25bd2c06985516f66cc19eae01d
+%global commit aa0bd45d6cca34ab4ec79bfc6b9dec1beaa35cf8
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20251205
+%global commit_date 20251207
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit 5d4829415a575b02cd2c56fee841ec111496cb50
+%global commit c3a20fa890615fab288e347791ac93a311e18851
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20251205
+%global commit_date 20251207
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit a06e16eae236cff4db71be0aeb7a2172ddd1aef9
-%global commit_date 20251205
+%global commit 5d41fd6800407489925bc57d29dd5ffe6f71ce0b
+%global commit_date 20251206
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/stardust/flatland/stardust-flatland.spec
+++ b/anda/stardust/flatland/stardust-flatland.spec
@@ -1,12 +1,12 @@
-%global commit 77215fe4a69398b94d343f85d8925b1a49d470fc
-%global commit_date 20251202
+%global commit 10cf122d5c1ab9125562563eafe9e56dec10b674
+%global commit_date 20251207
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-flatland
 Version:        %commit_date.%shortcommit
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Flatland for Stardust XR
 URL:            https://github.com/StardustXR/flatland
 Source0:        %url/archive/%commit/flatland-%commit.tar.gz

--- a/anda/stardust/server/stardust-server.spec
+++ b/anda/stardust/server/stardust-server.spec
@@ -1,5 +1,5 @@
-%global commit 098abfa6c196bd8659082b64f0446e1c5f9146be
-%global commit_date 20251204
+%global commit a10b0705ac3fdebae240948983f74076014c57b9
+%global commit_date 20251207
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
+++ b/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
@@ -1,6 +1,6 @@
-%global commit ce1844dcb0dfc8550ac36db2ab2171d30ada19b7
+%global commit 1cad28e3f6bc1616d4f01fbea127b105cddc0bbe
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251121
+%global commit_date 20251206
 %global ver 0.6.6.2
 
 # We aren't using Mono but RPM expected Mono

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit cbec5563b9d09ccf6ded9f6c43afd146b59dcc77
+%global commit ade28a6f0cb89ddd820a87908507414f09f0a6c2
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251205
+%global commitdate 20251207
 %global ver 1.0.19
 %undefine __brp_mangle_shebangs
 

--- a/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
+++ b/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
@@ -1,6 +1,6 @@
 %global _udevrulesdir /usr/lib/udev/rules.d
 
-%global commit      152f5fb46775894fe986ccb8c712548f8eec4ad6
+%global commit      abe3ac8a6a561b1711769b9f747c1ad330b826dd
 %global commitdate  20251121
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [bump(nightly): flameshot-nightly hyprutils.nightly ghostty-nightly zed-nightly nim-nightly types-colorama opentabletdriver-nightly scx-scheds-nightly goofcord-nightly prismlauncher-nightly nim-nightly stardust-flatland stardust-server HeadsetControl-nightly (#8120)](https://github.com/terrapkg/packages/pull/6460)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)