### PR TITLE
[f42] feat(terra-release): use local gpg keys (#8131)

### DIFF
--- a/anda/terra/release/terra-extras.repo
+++ b/anda/terra/release/terra-extras.repo
@@ -5,7 +5,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-extras&arc
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-extras/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-extras
 repo_gpgcheck=1
 enabled=1
 enabled_metadata=1
@@ -19,7 +19,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-extras-sou
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-extras-source/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-extras-source
 repo_gpgcheck=1
 enabled=0
 enabled_metadata=0

--- a/anda/terra/release/terra-mesa.repo
+++ b/anda/terra/release/terra-mesa.repo
@@ -5,7 +5,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-mesa&arch=
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-mesa/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-mesa
 repo_gpgcheck=1
 enabled=1
 enabled_metadata=1
@@ -19,7 +19,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-mesa-sourc
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-mesa-source/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-mesa-source
 repo_gpgcheck=1
 enabled=0
 enabled_metadata=0

--- a/anda/terra/release/terra-multimedia.repo
+++ b/anda/terra/release/terra-multimedia.repo
@@ -5,7 +5,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-multimedia
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-multimedia/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-multimedia
 repo_gpgcheck=1
 enabled=1
 enabled_metadata=1
@@ -19,7 +19,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-multimedia
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-multimedia-source/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-multimedia-source
 repo_gpgcheck=1
 enabled=0
 enabled_metadata=0

--- a/anda/terra/release/terra-nvidia.repo
+++ b/anda/terra/release/terra-nvidia.repo
@@ -5,7 +5,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-nvidia&arc
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-nvidia/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-nvidia
 repo_gpgcheck=1
 enabled=1
 enabled_metadata=1
@@ -19,7 +19,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-nvidia-sou
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-nvidia-source/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-nvidia-source
 repo_gpgcheck=1
 enabled=0
 enabled_metadata=0

--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -2,7 +2,7 @@
 
 Name:           terra-release
 Version:        %{?fedora:%{fedora}}%{?rhel:%{rhel}}
-Release:        6
+Release:        7
 Summary:        Release package for Terra
 
 License:        MIT
@@ -16,6 +16,8 @@ BuildArch:      noarch
 
 Requires:       system-release(%{version})
 
+Requires:       terra-gpg-keys
+
 %description
 Release package for Terra, containing the Terra repository configuration.
 
@@ -24,6 +26,8 @@ Summary: Release package for Terra Extras
 Obsoletes: terra-release-extra < 42-3
 Provides: terra-release-extra = %version-%release
 
+Requires:       terra-gpg-keys
+
 %description extras
 Release package for Terra Extras, which is a repository with packages that might cause
 conflict with Fedora.
@@ -31,17 +35,23 @@ conflict with Fedora.
 %package nvidia
 Summary: Release package for the nvidia subrepo of Terra Extras
 
+Requires:       terra-gpg-keys
+
 %description nvidia
 Release package for the Terra Extras nvidia subrepo, which provides nvidia drivers that might cause a conflict with Fedora.
 
 %package mesa
 Summary: Release package for the mesa subrepo of Terra Extras
 
+Requires:       terra-gpg-keys
+
 %description mesa
 Release package for the Terra Extras mesa subrepo, which provides a patched and updated version of mesa that might cause a conflict with Fedora.
 
 %package multimedia
 Summary: Release package for the multimedia subrepo of Terra Extras
+
+Requires:       terra-gpg-keys
 
 %description multimedia
 Release package for the Terra Extras multimedia subrepo, which provides codecs that might cause a conflict with Fedora.

--- a/anda/terra/release/terra.repo
+++ b/anda/terra/release/terra.repo
@@ -5,7 +5,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever&arch=$base
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever
 repo_gpgcheck=1
 enabled=1
 enabled_metadata=1
@@ -18,7 +18,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terra$releasever-source&arc
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terra$releasever-source/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terra$releasever-source
 repo_gpgcheck=1
 enabled=0
 enabled_metadata=0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(terra-release): use local gpg keys (#8131)](https://github.com/terrapkg/packages/pull/8131)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)