### PR TITLE
[el10] feat(terra-release): use local gpg keys (#8131)

### DIFF
--- a/anda/terra/release/terra-release.spec
+++ b/anda/terra/release/terra-release.spec
@@ -2,7 +2,7 @@
 
 Name:           terra-release
 Version:        %{?fedora:%{fedora}}%{?rhel:%{rhel}}
-Release:        6
+Release:        7
 Summary:        Release package for Terra
 
 License:        MIT
@@ -13,6 +13,8 @@ BuildArch:      noarch
 %dnl We probably shouldn't do this in Rawhide!
 %dnl Requires:       system-release(%{version})
 Requires:       (epel-release-latest-%{version} or epel-release)
+
+Requires:       terra-gpg-keys
 
 %description
 Release package for Terra, containing the Terra repository configuration.

--- a/anda/terra/release/terra.repo
+++ b/anda/terra/release/terra.repo
@@ -5,7 +5,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terrael$releasever&arch=$ba
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terrael$releasever/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terrael$releasever
 repo_gpgcheck=1
 enabled=1
 enabled_metadata=1
@@ -19,7 +19,7 @@ metalink=https://tetsudou.fyralabs.com/metalink?repo=terrael$releasever-source&a
 metadata_expire=6h
 type=rpm
 gpgcheck=1
-gpgkey=https://repos.fyralabs.com/terrael$releasever-source/key.asc
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-terrael$releasever-source
 repo_gpgcheck=1
 enabled=0
 enabled_metadata=0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(terra-release): use local gpg keys (#8131)](https://github.com/terrapkg/packages/pull/8131)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)