### PR TITLE
[f43] feat(andax/bump_extras.rhai): Alma functions (#7858)

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -1,3 +1,34 @@
+fn alma_vr(pkg, repo, branch) {
+    if branch.starts_with("el") {
+        branch.crop(2);
+    } else if branch.starts_with("f") {
+        print(`E: alma functions can only be used on el branches`);
+        terminate();
+    } else {
+        print(`E: unsupported branch: ${labels.branch}`);
+        terminate();
+    }
+    let majorminor = [];
+    for matches in find_all(`(${branch}\.[\d]+)/`, get("https://repo.almalinux.org/almalinux/")) {
+        majorminor += matches[1].parse_float();
+    }
+    majorminor.dedup();
+    majorminor.sort();
+    let url = get(`https://repo.almalinux.org/almalinux/${majorminor[majorminor.len()-1]}/${repo}/x86_64/os/Packages/`);
+    let matches = find_all(`${pkg}-([\d.]+)-([\d.]+)\.el${branch}.*?\.rpm`, url);
+    //                             ──────── ───── .el??
+    //                             version  release
+    matches.dedup();
+    if matches.len() != 0 {
+        return matches[0];
+    }
+}
+
+fn alma(pkg, branch) {
+  let vr = alma_vr(pkg, repo, branch);
+  return(vr[1]);
+}
+
 fn codeberg_commit(repo) {
     return get(`https://codeberg.org/api/v1/repos/${repo}/commits?stat=false&verification=false&files=false&limit=1`).json_arr()[0].sha;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat(andax/bump_extras.rhai): Alma functions (#7858)](https://github.com/terrapkg/packages/pull/7858)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)