### PR TITLE
[f41] fix(goofcord): Remove bun.lock and fix update scripts to handle beta releases (#6460)

### DIFF
--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -1,38 +1,22 @@
 %global commit df6d6b9c8ce880c8900c405f834136b83da710cf
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20251207
-%global ver 1.11.3
+%global ver 1.11.3^
 %global base_name goofcord
 %global git_name GoofCord
-%global debug_package %{nil}
-# Exclude private libraries
-%global __provides_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
-%ifnarch aarch64 armv7hl armv7l
-%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\aarch64*\\.so.*))$
-%elifarch aarch64 armv7hl armv7l
-%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\x86_64*\\.so.*)|(.*\\x86-64*\\.so.*))$
-%endif
+
+%electronmeta
 
 Name:          %{base_name}-nightly
-Version:       %{ver}^%{commit_date}.git.%{shortcommit}
+Version:       %{ver}%{commit_date}.git.%{shortcommit}
 Release:       1%?dist
 License:       OSL-3.0
 Summary:       A privacy-minded Legcord fork.
 Group:         Applications/Internet
 URL:           https://github.com/Milkshiift/%{git_name}
 Source0:       %{url}/archive/%{commit}/%{git_name}-%{commit}.tar.gz
+BuildRequires: anda-srpm-macros >= 0.2.26
 BuildRequires: bun-bin
-BuildRequires: desktop-file-utils
-BuildRequires: gcc
-BuildRequires: gcc-c++
-BuildRequires: git
-BuildRequires: make
-BuildRequires: nodejs
-BuildRequires: nodejs-npm
-BuildRequires: python3
-%ifarch aarch64
-BuildRequires: zlib-ng-compat-devel
-%endif
 Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description
@@ -42,59 +26,31 @@ A highly configurable and privacy minded Discord client.
 %autosetup -n %{git_name}-%{commit}
 
 %build
-%ifarch aarch64 armv7hl armv7l
+%ifarch %{arm64} armv7hl armv7l
 sed -i '/\"x64\",/d' electron-builder.ts
 %endif
-bun install
-bun run packageLinux --publish=never
+%bun_build -r build -R
 
 %install
-mkdir -p %{buildroot}%{_datadir}/%{git_name}
-%ifarch x86_64
-mv dist/linux-unpacked/* -t %{buildroot}%{_datadir}/%{git_name}
-%elifarch aarch64
-mv dist/linux-arm64-unpacked/* -t %{buildroot}%{_datadir}/%{git_name}
-%elifarch armv7hl armv7l
-mv dist/linux-armv7l-unpacked/* -t %{buildroot}%{_datadir}/%{git_name}
-%endif
-
-mkdir -p %{buildroot}%{_bindir}
-ln -sf %{_datadir}/%{git_name}/%{git_name} %{buildroot}%{_bindir}/%{git_name}
-install -Dm644 dist/.icon-set/icon_16x16.png %{buildroot}/%{_iconsdir}/hicolor/16x16/apps/%{git_name}.png
-install -Dm644 dist/.icon-set/icon_32.png %{buildroot}/%{_iconsdir}/hicolor/32x32/apps/%{git_name}.png
-install -Dm644 dist/.icon-set/icon_48x48.png %{buildroot}/%{_iconsdir}/hicolor/48x48/apps/%{git_name}.png
-install -Dm644 dist/.icon-set/icon_64.png %{buildroot}/%{_iconsdir}/hicolor/64x64/apps/%{git_name}.png
-install -Dm644 dist/.icon-set/icon_128.png %{buildroot}/%{_iconsdir}/hicolor/128x128/apps/%{git_name}.png
-install -Dm644 dist/.icon-set/icon_256.png %{buildroot}/%{_iconsdir}/hicolor/256x256/apps/%{git_name}.png
-install -Dm644 dist/.icon-set/icon_512.png %{buildroot}/%{_iconsdir}/hicolor/512x512/apps/%{git_name}.png
-install -Dm644 dist/.icon-set/icon_1024.png %{buildroot}/%{_iconsdir}/hicolor/1024x1024/apps/%{git_name}.png
-
-%ifarch x86_64
-dist/%{git_name}-*x86_64.AppImage --appimage-extract '*.desktop'
-%elifarch aarch64
-dist/%{git_name}-*arm64.AppImage --appimage-extract '*.desktop'
-%elifarch armv7hl armv7l
-dist/%{git_name}-*armv7l.AppImage --appimage-extract '*.desktop'
-%endif
-desktop-file-install --set-key=Exec --set-value="%{_datadir}/%{git_name}/%{git_name} --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto %U" squashfs-root/%{git_name}.desktop
+%electron_install -d %{base_name} -s %{base_name} -i %{base_name} -D -O -U %U -E UseOzonePlatform,WaylandWindowDecorations
 
 %check
-desktop-file-validate %{buildroot}%{_datadir}/applications/%{git_name}.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{base_name}.desktop
 
 %files
 %doc README.md
 %license LICENSE
-%{_bindir}/%{git_name}
-%{_datadir}/applications/%{git_name}.desktop
-%{_datadir}/%{git_name}/
-%{_iconsdir}/hicolor/16x16/apps/%{git_name}.png
-%{_iconsdir}/hicolor/32x32/apps/%{git_name}.png
-%{_iconsdir}/hicolor/48x48/apps/%{git_name}.png
-%{_iconsdir}/hicolor/64x64/apps/%{git_name}.png
-%{_iconsdir}/hicolor/128x128/apps/%{git_name}.png
-%{_iconsdir}/hicolor/256x256/apps/%{git_name}.png
-%{_iconsdir}/hicolor/512x512/apps/%{git_name}.png
-%{_iconsdir}/hicolor/1024x1024/apps/%{git_name}.png
+%{_bindir}/%{base_name}
+%{_datadir}/applications/%{base_name}.desktop
+%{_libdir}/%{base_name}/
+%{_iconsdir}/hicolor/16x16/apps/%{base_name}.png
+%{_iconsdir}/hicolor/32x32/apps/%{base_name}.png
+%{_iconsdir}/hicolor/48x48/apps/%{base_name}.png
+%{_iconsdir}/hicolor/64x64/apps/%{base_name}.png
+%{_iconsdir}/hicolor/128x128/apps/%{base_name}.png
+%{_iconsdir}/hicolor/256x256/apps/%{base_name}.png
+%{_iconsdir}/hicolor/512x512/apps/%{base_name}.png
+%{_iconsdir}/hicolor/1024x1024/apps/%{base_name}.png
 
 %changelog
 * Sat Jun 28 2025 Gilver E. <rockgrub@disroot.org> - 1.10.1^20250615.git.3f5eda1

--- a/anda/apps/goofcord/nightly/update.rhai
+++ b/anda/apps/goofcord/nightly/update.rhai
@@ -2,7 +2,12 @@ rpm.global("commit", gh_commit("Milkshiift/GoofCord"));
  if rpm.changed() {
    let v = gh_tag("Milkshiift/GoofCord");
    v.crop(1);
-   rpm.global("ver", v);
+   if `[\d.]+-beta\.\d+`.find_all(v).len == 0 {
+     let v = sub(`-beta\.\d+`, "~", v);
+     rpm.global("ver", v);
+   } else {
+   rpm.global("ver", v + `^`);
+   }
    rpm.global("commit_date", date());
    rpm.release();
 }

--- a/anda/apps/goofcord/stable/anda.hcl
+++ b/anda/apps/goofcord/stable/anda.hcl
@@ -2,7 +2,7 @@ project pkg {
 	rpm {
 		spec = "goofcord.spec"
 	}
-        labels {
-                mock = 1
-        } 
+	labels {
+		mock = 1
+	}
 } 

--- a/anda/apps/goofcord/stable/goofcord.spec
+++ b/anda/apps/goofcord/stable/goofcord.spec
@@ -1,12 +1,6 @@
 %global git_name GoofCord
-%global debug_package %{nil}
-# Exclude private libraries
-%global __provides_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*))$
-%ifnarch aarch64 armv7hl armv7l
-%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\aarch64*\\.so.*))$
-%elifarch aarch64 armv7hl armv7l
-%global __requires_exclude ^((libffmpeg[.]so.*)|(lib.*\\.so.*)|(.*\\x86_64*\\.so.*)|(.*\\x86-64*\\.so.*))$
-%endif
+
+%electronmeta
 
 Name:          goofcord
 Version:       1.11.3
@@ -16,17 +10,8 @@ Summary:       A privacy-minded Legcord fork.
 Group:         Applications/Internet
 URL:           https://github.com/Milkshiift/%{git_name}
 Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires: anda-srpm-macros >= 0.2.26
 BuildRequires: bun-bin
-BuildRequires: desktop-file-utils
-BuildRequires: gcc
-BuildRequires: gcc-c++
-BuildRequires: make
-BuildRequires: nodejs
-BuildRequires: nodejs-npm
-BuildRequires: python3
-%ifarch aarch64
-BuildRequires: zlib-ng-compat-devel
-%endif
 Packager:      Gilver E. <rockgrub@disroot.org>
 
 %description
@@ -36,41 +21,13 @@ A highly configurable and privacy minded Discord client.
 %autosetup -n %{git_name}-%{version}
 
 %build
-%ifarch aarch64 armv7hl armv7l
+%ifarch %{arm64} armv7hl armv7l
 sed -i '/\"x64\",/d' electron-builder.ts
 %endif
-bun install
-bun run packageLinux
+%bun_build -r build -R
 
 %install
-mkdir -p %{buildroot}%{_datadir}/%{name}
-%ifarch x86_64
-mv dist/linux-unpacked/* -t %{buildroot}%{_datadir}/%{name}
-%elifarch aarch64
-mv dist/linux-arm64-unpacked/* -t %{buildroot}%{_datadir}/%{name}
-%elifarch armv7hl armv7l
-mv dist/linux-armv7l-unpacked/* -t %{buildroot}%{_datadir}/%{name}
-%endif
-
-mkdir -p %{buildroot}%{_bindir}
-ln -sf %{_datadir}/%{name}/%{name} %{buildroot}%{_bindir}/%{name}
-install -Dm644 dist/.icon-set/icon_16x16.png %{buildroot}/%{_iconsdir}/hicolor/16x16/apps/%{name}.png
-install -Dm644 dist/.icon-set/icon_32.png %{buildroot}/%{_iconsdir}/hicolor/32x32/apps/%{name}.png
-install -Dm644 dist/.icon-set/icon_48x48.png %{buildroot}/%{_iconsdir}/hicolor/48x48/apps/%{name}.png
-install -Dm644 dist/.icon-set/icon_64.png %{buildroot}/%{_iconsdir}/hicolor/64x64/apps/%{name}.png
-install -Dm644 dist/.icon-set/icon_128.png %{buildroot}/%{_iconsdir}/hicolor/128x128/apps/%{name}.png
-install -Dm644 dist/.icon-set/icon_256.png %{buildroot}/%{_iconsdir}/hicolor/256x256/apps/%{name}.png
-install -Dm644 dist/.icon-set/icon_512.png %{buildroot}/%{_iconsdir}/hicolor/512x512/apps/%{name}.png
-install -Dm644 dist/.icon-set/icon_1024.png %{buildroot}/%{_iconsdir}/hicolor/1024x1024/apps/%{name}.png
-
-%ifarch x86_64
-dist/%{git_name}-*x86_64.AppImage --appimage-extract '*.desktop'
-%elifarch aarch64
-dist/%{git_name}-*arm64.AppImage --appimage-extract '*.desktop'
-%elifarch armv7hl armv7l
-dist/%{git_name}-*armv7l.AppImage --appimage-extract '*.desktop'
-%endif
-desktop-file-install --set-key=Exec --set-value="%{_datadir}/%{name}/%{name} --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto %U" squashfs-root/%{name}.desktop
+%electron_install -D -O -U %U -E UseOzonePlatform,WaylandWindowDecorations
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
@@ -80,7 +37,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %license LICENSE
 %{_bindir}/%{name}
 %{_datadir}/applications/%{name}.desktop
-%{_datadir}/%{name}/
+%{_libdir}/%{name}/
 %{_iconsdir}/hicolor/16x16/apps/%{name}.png
 %{_iconsdir}/hicolor/32x32/apps/%{name}.png
 %{_iconsdir}/hicolor/48x48/apps/%{name}.png

--- a/anda/apps/goofcord/stable/update.rhai
+++ b/anda/apps/goofcord/stable/update.rhai
@@ -1,1 +1,5 @@
-rpm.version(gh_tag("Milkshiift/GoofCord"));
+let v = gh_tag("Milkshiift/GoofCord");
+
+if `[\d.]+-beta\.\d+`.find_all(v).len == 0 {
+  rpm.version(v);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [fix(goofcord): Remove bun.lock and fix update scripts to handle beta releases (#6460)](https://github.com/terrapkg/packages/pull/6460)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)