### PR TITLE
[el10] fix: submarine (#6767)

### DIFF
--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -14,7 +14,12 @@ Release:		1%?dist
 Summary:		Experimental bootloader for ChomeOS's depthcharge
 License:		GPL-3.0
 URL:			https://github.com/FyraLabs/submarine
-BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git depthcharge-tools uboot-tools
+BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git depthcharge-tools uboot-tools openssl-devel-engine
+%ifarch aarch64
+BuildRequires:  python3-importlib-metadata
+BuildRequires:  python3-packaging
+BuildRequires:  python3-importlib-resources
+%endif
 
 %description
 An experimental bootloader for ChomeOS's depthcharge.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: submarine (#6767)](https://github.com/terrapkg/packages/pull/6767)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)