### PR TITLE
chore(andax/bump_extras.rhai): Bump EPEL to 10.1

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -41,7 +41,7 @@ fn as_bodhi_ver(branch) {
     if branch.starts_with("el") {
         branch.crop(2);
         if branch == "10" {
-            return "EPEL-10.0";
+            return "EPEL-10.1";
         }
         return `EPEL-${release}`;
     } else if branch == "frawhide" {


### PR DESCRIPTION
Our CI automatically started pulling Alma 10.1 packages so we should bump the EPEL version to match.