### PR TITLE
[el10] bump: walker golang-github-abenz1267-elephant (#8187)

### DIFF
--- a/anda/desktops/waylands/walker/walker.spec
+++ b/anda/desktops/waylands/walker/walker.spec
@@ -4,7 +4,7 @@
 # prevent library files from being installed
 %global cargo_install_lib 0
 
-%global upstream_version v2.11.3
+%global upstream_version v2.12.1
 %global ver %{sub %upstream_version 2}
 
 Name:           walker

--- a/anda/langs/go/elephant/golang-github-abenz1267-elephant.spec
+++ b/anda/langs/go/elephant/golang-github-abenz1267-elephant.spec
@@ -14,7 +14,7 @@
 
 # https://github.com/abenz1267/elephant
 %global goipath         github.com/abenz1267/elephant
-Version:                2.14.1
+Version:                2.17.1
 
 %gometa -f
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump: walker golang-github-abenz1267-elephant (#8187)](https://github.com/terrapkg/packages/pull/8187)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)