### PR TITLE
[f41] fix(andax/bump_extras.rhai): Add repo field to `alma` (#8185)

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -24,7 +24,7 @@ fn alma_vr(pkg, repo, branch) {
     }
 }
 
-fn alma(pkg, branch) {
+fn alma(pkg, repo, branch) {
   let vr = alma_vr(pkg, repo, branch);
   return(vr[1]);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(andax/bump_extras.rhai): Add repo field to &#x60;alma&#x60; (#8185)](https://github.com/terrapkg/packages/pull/8185)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)