### PR TITLE
[el10] add: terra-glfw (#8199)

### DIFF
--- a/anda/lib/terra-glfw/0001-Key-Modifiers-Fix.patch
+++ b/anda/lib/terra-glfw/0001-Key-Modifiers-Fix.patch
@@ -1,0 +1,24 @@
+From c61fd441e57631196d7a486ffb52bf3b73863527 Mon Sep 17 00:00:00 2001
+From: BoyOrigin <ahmadyasinfikri@gmail.com>
+Date: Mon, 18 Sep 2023 01:39:37 +0700
+Subject: [PATCH] Key Modifiers Fix
+
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 5b491ffb..31fe9c14 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -1197,7 +1197,9 @@ static void inputText(_GLFWwindow* window, uint32_t scancode)
+         {
+             const int mods = _glfw.wl.xkb.modifiers;
+             const int plain = !(mods & (GLFW_MOD_CONTROL | GLFW_MOD_ALT));
+-            _glfwInputChar(window, codepoint, mods, plain);
++
++            if (plain)
++                _glfwInputChar(window, codepoint, mods, plain);
+         }
+     }
+ }
+-- 
+2.43.0
+

--- a/anda/lib/terra-glfw/0002-Fix-duplicate-pointer-scroll-events.patch
+++ b/anda/lib/terra-glfw/0002-Fix-duplicate-pointer-scroll-events.patch
@@ -1,0 +1,38 @@
+From fb39b826d4b087ee8653767bb4ac189adc46c249 Mon Sep 17 00:00:00 2001
+From: BoyOrigin <ahmadyasinfikri@gmail.com>
+Date: Tue, 19 Sep 2023 03:31:57 +0700
+Subject: [PATCH] Fix duplicate pointer scroll events
+
+
+diff --git a/src/wl_platform.h b/src/wl_platform.h
+index 149cd241..b17fa722 100644
+--- a/src/wl_platform.h
++++ b/src/wl_platform.h
+@@ -413,6 +413,8 @@ typedef struct _GLFWwindowWayland
+         _GLFWfallbackEdgeWayland    top, left, right, bottom;
+         struct wl_surface*          focus;
+     } fallback;
++
++    uint32_t                    pointerAxisTime;
+ } _GLFWwindowWayland;
+ 
+ // Wayland-specific global data
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 31fe9c14..aab79d01 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -1617,6 +1617,11 @@ static void pointerHandleAxis(void* userData,
+     if (!window)
+         return;
+ 
++    // On newer GNOME, there is a bug where scroll events are invoked twice. This code will fix that issue.
++    if (window->wl.pointerAxisTime == time)
++        return;
++    window->wl.pointerAxisTime = time;
++
+     // NOTE: 10 units of motion per mouse wheel step seems to be a common ratio
+     if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL)
+         _glfwInputScroll(window, -wl_fixed_to_double(value) / 10.0, 0.0);
+-- 
+2.43.0
+

--- a/anda/lib/terra-glfw/0003-Implement-glfwSetCursorPosWayland.patch
+++ b/anda/lib/terra-glfw/0003-Implement-glfwSetCursorPosWayland.patch
@@ -1,0 +1,64 @@
+From a5f94d704dd418d6e39cc4f2fe6d6b569dce39f1 Mon Sep 17 00:00:00 2001
+From: FayBoy <ahmadyasinfikri@gmail.com>
+Date: Thu, 22 Feb 2024 19:30:53 +0700
+Subject: [PATCH] Implement glfwSetCursorPosWayland
+
+
+diff --git a/src/wl_platform.h b/src/wl_platform.h
+index 83cb12a5..d51c2134 100644
+--- a/src/wl_platform.h
++++ b/src/wl_platform.h
+@@ -415,6 +415,8 @@ typedef struct _GLFWwindowWayland
+     } fallback;
+ 
+     uint32_t                    pointerAxisTime;
++    double                      askedCursorPosX, askedCursorPosY;
++    GLFWbool                    didAskForSetCursorPos;
+ } _GLFWwindowWayland;
+ 
+ // Wayland-specific global data
+diff --git a/src/wl_window.c b/src/wl_window.c
+index aa4e419a..ae9a6728 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -2674,8 +2674,17 @@ void _glfwGetCursorPosWayland(_GLFWwindow* window, double* xpos, double* ypos)
+ 
+ void _glfwSetCursorPosWayland(_GLFWwindow* window, double x, double y)
+ {
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the cursor position");
++    if (window->wl.lockedPointer) {
++        zwp_locked_pointer_v1_set_cursor_position_hint(window->wl.lockedPointer,
++                                                       wl_fixed_from_double(x),
++                                                       wl_fixed_from_double(y));
++        window->wl.cursorPosX = x;
++        window->wl.cursorPosY = y;
++    } else {
++        window->wl.didAskForSetCursorPos = GLFW_TRUE;
++        window->wl.askedCursorPosX = x;
++        window->wl.askedCursorPosY = y;
++    }
+ }
+ 
+ void _glfwSetCursorModeWayland(_GLFWwindow* window, int mode)
+@@ -2909,6 +2918,17 @@ static const struct zwp_relative_pointer_v1_listener relativePointerListener =
+ static void lockedPointerHandleLocked(void* userData,
+                                       struct zwp_locked_pointer_v1* lockedPointer)
+ {
++    _GLFWwindow* window = userData;
++
++    if (window->wl.didAskForSetCursorPos)
++    {
++        window->wl.didAskForSetCursorPos = GLFW_FALSE;
++        zwp_locked_pointer_v1_set_cursor_position_hint(window->wl.lockedPointer,
++                                                       wl_fixed_from_double(window->wl.askedCursorPosX),
++                                                       wl_fixed_from_double(window->wl.askedCursorPosY));
++        window->wl.cursorPosX = window->wl.askedCursorPosX;
++        window->wl.cursorPosY = window->wl.askedCursorPosY;
++    }
+ }
+ 
+ static void lockedPointerHandleUnlocked(void* userData,
+-- 
+2.44.0
+

--- a/anda/lib/terra-glfw/0004-Fix-Window-size-on-unset-fullscreen.patch
+++ b/anda/lib/terra-glfw/0004-Fix-Window-size-on-unset-fullscreen.patch
@@ -1,0 +1,22 @@
+From d463fb4a7694ef537279bce4e1653bc22bf260a1 Mon Sep 17 00:00:00 2001
+From: BoyOrigin <ahmadyasinfikri@gmail.com>
+Date: Mon, 18 Sep 2023 01:37:44 +0700
+Subject: [PATCH] Fix Window size on unset fullscreen
+
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index b1b280a7..9cc76c3e 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -2282,6 +2282,8 @@ void _glfwSetWindowSizeWayland(_GLFWwindow* window, int width, int height)
+             libdecor_state_free(frameState);
+         }
+ 
++        _glfwInputWindowSize(window, width, height);
++
+         if (window->wl.visible)
+             _glfwInputWindowDamage(window);
+     }
+-- 
+2.43.0
+

--- a/anda/lib/terra-glfw/0005-Implement-glfwSetWindowIcon.patch
+++ b/anda/lib/terra-glfw/0005-Implement-glfwSetWindowIcon.patch
@@ -1,0 +1,383 @@
+From f8e6fca745f27adc8f40f022d415b4ac7cbc375e Mon Sep 17 00:00:00 2001
+From: JakobDev <jakobdev@gmx.de>
+Date: Wed, 12 Feb 2025 19:24:19 +0100
+Subject: [PATCH] Wayland: Implement glfwSetWindowIcon
+
+---
+ deps/wayland/xdg-toplevel-icon-v1.xml | 205 ++++++++++++++++++++++++++
+ include/GLFW/glfw3.h                  |   6 +-
+ src/CMakeLists.txt                    |   1 +
+ src/wl_init.c                         |  14 ++
+ src/wl_platform.h                     |   1 +
+ src/wl_window.c                       |  52 ++++++-
+ 6 files changed, 274 insertions(+), 5 deletions(-)
+ create mode 100644 deps/wayland/xdg-toplevel-icon-v1.xml
+
+diff --git a/deps/wayland/xdg-toplevel-icon-v1.xml b/deps/wayland/xdg-toplevel-icon-v1.xml
+new file mode 100644
+index 0000000000..fc409fef7c
+--- /dev/null
++++ b/deps/wayland/xdg-toplevel-icon-v1.xml
+@@ -0,0 +1,205 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<protocol name="xdg_toplevel_icon_v1">
++
++  <copyright>
++    Copyright © 2023-2024 Matthias Klumpp
++    Copyright ©      2024 David Edmundson
++
++    Permission is hereby granted, free of charge, to any person obtaining a
++    copy of this software and associated documentation files (the "Software"),
++    to deal in the Software without restriction, including without limitation
++    the rights to use, copy, modify, merge, publish, distribute, sublicense,
++    and/or sell copies of the Software, and to permit persons to whom the
++    Software is furnished to do so, subject to the following conditions:
++
++    The above copyright notice and this permission notice (including the next
++    paragraph) shall be included in all copies or substantial portions of the
++    Software.
++
++    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++    DEALINGS IN THE SOFTWARE.
++  </copyright>
++
++  <description summary="protocol to assign icons to toplevels">
++    This protocol allows clients to set icons for their toplevel surfaces
++    either via the XDG icon stock (using an icon name), or from pixel data.
++
++    A toplevel icon represents the individual toplevel (unlike the application
++    or launcher icon, which represents the application as a whole), and may be
++    shown in window switchers, window overviews and taskbars that list
++    individual windows.
++
++    This document adheres to RFC 2119 when using words like "must",
++    "should", "may", etc.
++
++    Warning! The protocol described in this file is currently in the testing
++    phase. Backward compatible changes may be added together with the
++    corresponding interface version bump. Backward incompatible changes can
++    only be done by creating a new major version of the extension.
++  </description>
++
++  <interface name="xdg_toplevel_icon_manager_v1" version="1">
++    <description summary="interface to manage toplevel icons">
++      This interface allows clients to create toplevel window icons and set
++      them on toplevel windows to be displayed to the user.
++    </description>
++
++    <request name="destroy" type="destructor">
++      <description summary="destroy the toplevel icon manager">
++        Destroy the toplevel icon manager.
++        This does not destroy objects created with the manager.
++      </description>
++    </request>
++
++    <request name="create_icon">
++      <description summary="create a new icon instance">
++        Creates a new icon object. This icon can then be attached to a
++        xdg_toplevel via the 'set_icon' request.
++      </description>
++      <arg name="id" type="new_id" interface="xdg_toplevel_icon_v1"/>
++    </request>
++
++    <request name="set_icon">
++      <description summary="set an icon on a toplevel window">
++        This request assigns the icon 'icon' to 'toplevel', or clears the
++        toplevel icon if 'icon' was null.
++        This state is double-buffered and is applied on the next
++        wl_surface.commit of the toplevel.
++
++        After making this call, the xdg_toplevel_icon_v1 provided as 'icon'
++        can be destroyed by the client without 'toplevel' losing its icon.
++        The xdg_toplevel_icon_v1 is immutable from this point, and any
++        future attempts to change it must raise the
++        'xdg_toplevel_icon_v1.immutable' protocol error.
++
++        The compositor must set the toplevel icon from either the pixel data
++        the icon provides, or by loading a stock icon using the icon name.
++        See the description of 'xdg_toplevel_icon_v1' for details.
++
++        If 'icon' is set to null, the icon of the respective toplevel is reset
++        to its default icon (usually the icon of the application, derived from
++        its desktop-entry file, or a placeholder icon).
++        If this request is passed an icon with no pixel buffers or icon name
++        assigned, the icon must be reset just like if 'icon' was null.
++      </description>
++      <arg name="toplevel" type="object" interface="xdg_toplevel" summary="the toplevel to act on"/>
++      <arg name="icon" type="object" interface="xdg_toplevel_icon_v1" allow-null="true"/>
++    </request>
++
++    <event name="icon_size">
++      <description summary="describes a supported &amp; preferred icon size">
++        This event indicates an icon size the compositor prefers to be
++        available if the client has scalable icons and can render to any size.
++
++        When the 'xdg_toplevel_icon_manager_v1' object is created, the
++        compositor may send one or more 'icon_size' events to describe the list
++        of preferred icon sizes. If the compositor has no size preference, it
++        may not send any 'icon_size' event, and it is up to the client to
++        decide a suitable icon size.
++
++        A sequence of 'icon_size' events must be finished with a 'done' event.
++        If the compositor has no size preferences, it must still send the
++        'done' event, without any preceding 'icon_size' events.
++      </description>
++      <arg name="size" type="int"
++	   summary="the edge size of the square icon in surface-local coordinates, e.g. 64"/>
++    </event>
++
++    <event name="done">
++      <description summary="all information has been sent">
++        This event is sent after all 'icon_size' events have been sent.
++      </description>
++    </event>
++  </interface>
++
++  <interface name="xdg_toplevel_icon_v1" version="1">
++    <description summary="a toplevel window icon">
++      This interface defines a toplevel icon.
++      An icon can have a name, and multiple buffers.
++      In order to be applied, the icon must have either a name, or at least
++      one buffer assigned. Applying an empty icon (with no buffer or name) to
++      a toplevel should reset its icon to the default icon.
++
++      It is up to compositor policy whether to prefer using a buffer or loading
++      an icon via its name. See 'set_name' and 'add_buffer' for details.
++    </description>
++
++    <enum name="error">
++      <entry name="invalid_buffer"
++             summary="the provided buffer does not satisfy requirements"
++	     value="1"/>
++      <entry name="immutable"
++             summary="the icon has already been assigned to a toplevel and must not be changed"
++	     value="2"/>
++      <entry name="no_buffer"
++             summary="the provided buffer has been destroyed before the toplevel icon"
++             value="3"/>
++    </enum>
++
++    <request name="destroy" type="destructor">
++      <description summary="destroy the icon object">
++        Destroys the 'xdg_toplevel_icon_v1' object.
++        The icon must still remain set on every toplevel it was assigned to,
++        until the toplevel icon is reset explicitly.
++      </description>
++    </request>
++
++    <request name="set_name">
++      <description summary="set an icon name">
++        This request assigns an icon name to this icon.
++        Any previously set name is overridden.
++
++        The compositor must resolve 'icon_name' according to the lookup rules
++        described in the XDG icon theme specification[1] using the
++        environment's current icon theme.
++
++        If the compositor does not support icon names or cannot resolve
++        'icon_name' according to the XDG icon theme specification it must
++        fall back to using pixel buffer data instead.
++
++        If this request is made after the icon has been assigned to a toplevel
++        via 'set_icon', a 'immutable' error must be raised.
++
++        [1]: https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
++      </description>
++      <arg name="icon_name" type="string"/>
++    </request>
++
++    <request name="add_buffer">
++      <description summary="add icon data from a pixel buffer">
++        This request adds pixel data supplied as wl_buffer to the icon.
++
++        The client should add pixel data for all icon sizes and scales that
++        it can provide, or which are explicitly requested by the compositor
++        via 'icon_size' events on xdg_toplevel_icon_manager_v1.
++
++        The wl_buffer supplying pixel data as 'buffer' must be backed by wl_shm
++        and must be a square (width and height being equal).
++        If any of these buffer requirements are not fulfilled, a 'invalid_buffer'
++        error must be raised.
++
++        If this icon instance already has a buffer of the same size and scale
++        from a previous 'add_buffer' request, data from the last request
++        overrides the preexisting pixel data.
++
++        The wl_buffer must be kept alive for as long as the xdg_toplevel_icon
++        it is associated with is not destroyed, otherwise a 'no_buffer' error
++        is raised. The buffer contents must not be modified after it was
++        assigned to the icon. As a result, the region of the wl_shm_pool's
++        backing storage used for the wl_buffer must not be modified after this
++        request is sent. The wl_buffer.release event is unused.
++
++        If this request is made after the icon has been assigned to a toplevel
++        via 'set_icon', a 'immutable' error must be raised.
++      </description>
++      <arg name="buffer" type="object" interface="wl_buffer"/>
++      <arg name="scale" type="int"
++	   summary="the scaling factor of the icon, e.g. 1"/>
++    </request>
++  </interface>
++</protocol>
+diff --git a/include/GLFW/glfw3.h b/include/GLFW/glfw3.h
+index 79b0628849..1dd1cda85a 100644
+--- a/include/GLFW/glfw3.h
++++ b/include/GLFW/glfw3.h
+@@ -3399,9 +3399,9 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
+  *
+  *  [bundle-guide]: https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/
+  *
+- *  @remark @wayland There is no existing protocol to change an icon, the
+- *  window will thus inherit the one defined in the application's desktop file.
+- *  This function will emit @ref GLFW_FEATURE_UNAVAILABLE.
++ *  @remark @wayland This only works on compositors implementing the XDG toplevel icon protocol.
++ *  This function will emit @ref GLFW_FEATURE_UNAVAILABLE if this protocol is not available.
++ *  The icon must be square. Otherwise @ref GLFW_INVALID_VALUE will be emited.
+  *
+  *  @thread_safety This function must only be called from the main thread.
+  *
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 1a085b2b6a..8118e45ed6 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -105,6 +105,7 @@ if (GLFW_BUILD_WAYLAND)
+     generate_wayland_protocol("fractional-scale-v1.xml")
+     generate_wayland_protocol("xdg-activation-v1.xml")
+     generate_wayland_protocol("xdg-decoration-unstable-v1.xml")
++    generate_wayland_protocol("xdg-toplevel-icon-v1.xml")
+ endif()
+ 
+ if (WIN32 AND GLFW_BUILD_SHARED_LIBRARY)
+diff --git a/src/wl_init.c b/src/wl_init.c
+index ef9e450360..0ff46c1891 100644
+--- a/src/wl_init.c
++++ b/src/wl_init.c
+@@ -49,6 +49,7 @@
+ #include "fractional-scale-v1-client-protocol.h"
+ #include "xdg-activation-v1-client-protocol.h"
+ #include "idle-inhibit-unstable-v1-client-protocol.h"
++#include "xdg-toplevel-icon-v1-client-protocol.h"
+ 
+ // NOTE: Versions of wayland-scanner prior to 1.17.91 named every global array of
+ //       wl_interface pointers 'types', making it impossible to combine several unmodified
+@@ -91,6 +92,10 @@
+ #include "idle-inhibit-unstable-v1-client-protocol-code.h"
+ #undef types
+ 
++#define types _glfw_toplevel_icon_types
++#include "xdg-toplevel-icon-v1-client-protocol-code.h"
++#undef types
++
+ static void wmBaseHandlePing(void* userData,
+                              struct xdg_wm_base* wmBase,
+                              uint32_t serial)
+@@ -208,6 +213,13 @@ static void registryHandleGlobal(void* userData,
+                              &wp_fractional_scale_manager_v1_interface,
+                              1);
+     }
++    else if (strcmp(interface, xdg_toplevel_icon_manager_v1_interface.name) == 0)
++    {
++        _glfw.wl.toplevelIconManager =
++            wl_registry_bind(registry, name,
++                             &xdg_toplevel_icon_manager_v1_interface,
++                             1);
++    }
+ }
+ 
+ static void registryHandleGlobalRemove(void* userData,
+@@ -988,6 +1000,8 @@ void _glfwTerminateWayland(void)
+         xdg_activation_v1_destroy(_glfw.wl.activationManager);
+     if (_glfw.wl.fractionalScaleManager)
+         wp_fractional_scale_manager_v1_destroy(_glfw.wl.fractionalScaleManager);
++    if (_glfw.wl.toplevelIconManager)
++        xdg_toplevel_icon_manager_v1_destroy(_glfw.wl.toplevelIconManager);
+     if (_glfw.wl.registry)
+         wl_registry_destroy(_glfw.wl.registry);
+     if (_glfw.wl.display)
+diff --git a/src/wl_platform.h b/src/wl_platform.h
+index afa6f50af5..86116e086d 100644
+--- a/src/wl_platform.h
++++ b/src/wl_platform.h
+@@ -438,6 +438,7 @@ typedef struct _GLFWlibraryWayland
+     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
+     struct xdg_activation_v1*               activationManager;
+     struct wp_fractional_scale_manager_v1*  fractionalScaleManager;
++    struct xdg_toplevel_icon_manager_v1*    toplevelIconManager;
+ 
+     _GLFWofferWayland*          offers;
+     unsigned int                offerCount;
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 72c1a40260..0fa20bb2bb 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -51,6 +51,7 @@
+ #include "xdg-activation-v1-client-protocol.h"
+ #include "idle-inhibit-unstable-v1-client-protocol.h"
+ #include "fractional-scale-v1-client-protocol.h"
++#include "xdg-toplevel-icon-v1-client-protocol.h"
+ 
+ #define GLFW_BORDER_SIZE    4
+ #define GLFW_CAPTION_HEIGHT 24
+@@ -2227,8 +2228,55 @@ void _glfwSetWindowTitleWayland(_GLFWwindow* window, const char* title)
+ void _glfwSetWindowIconWayland(_GLFWwindow* window,
+                                int count, const GLFWimage* images)
+ {
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the window icon");
++    if (!_glfw.wl.toplevelIconManager)
++    {
++        _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
++                        "Wayland: The platform does not support setting the window icon");
++        return;
++    }
++
++    if (!count)
++    {
++        if (window->wl.libdecor.frame)
++            xdg_toplevel_icon_manager_v1_set_icon(_glfw.wl.toplevelIconManager,
++                                                libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame),
++                                                NULL);
++        else if (window->wl.xdg.toplevel)
++            xdg_toplevel_icon_manager_v1_set_icon(_glfw.wl.toplevelIconManager, window->wl.xdg.toplevel, NULL);
++        return;
++    }
++
++    for (int i = 0;  i < count;  i++)
++    {
++        if (images[i].width != images[i].height)
++        {
++            _glfwInputError(GLFW_INVALID_VALUE,
++                            "Wayland: The icon must be a square");
++            return;
++        }
++    }
++
++    struct xdg_toplevel_icon_v1 *icon = xdg_toplevel_icon_manager_v1_create_icon(_glfw.wl.toplevelIconManager);
++    struct wl_buffer *bufferArr[count];
++
++    for (int i = 0;  i < count;  i++)
++    {
++        bufferArr[i] = createShmBuffer(&images[i]);
++        xdg_toplevel_icon_v1_add_buffer(icon, bufferArr[i], 1);
++    }
++
++    if (window->wl.libdecor.frame)
++        xdg_toplevel_icon_manager_v1_set_icon(_glfw.wl.toplevelIconManager,
++                                                libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame),
++                                                icon);
++    else if (window->wl.xdg.toplevel)
++        xdg_toplevel_icon_manager_v1_set_icon(_glfw.wl.toplevelIconManager, window->wl.xdg.toplevel, icon);
++    xdg_toplevel_icon_v1_destroy(icon);
++
++    for (int i = 0;  i < count;  i++)
++    {
++        wl_buffer_destroy(bufferArr[i]);
++    }
+ }
+ 
+ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)

--- a/anda/lib/terra-glfw/0006-Fix-fullscreen-location.patch
+++ b/anda/lib/terra-glfw/0006-Fix-fullscreen-location.patch
@@ -1,0 +1,46 @@
+From 305fcbbf940a612731d55898aa20815204be55c2 Mon Sep 17 00:00:00 2001
+From: OlegAckbar <oleg@np880.ru>
+Date: Mon, 24 Jun 2024 22:39:43 +0300
+Subject: [PATCH] Wayland: unset output for fullscreen set operation
+
+---
+ src/wl_window.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 2e842aaaac..54efe0e58b 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -503,12 +503,12 @@ static void acquireMonitor(_GLFWwindow* window)
+     if (window->wl.libdecor.frame)
+     {
+         libdecor_frame_set_fullscreen(window->wl.libdecor.frame,
+-                                      window->monitor->wl.output);
++                                      NULL);
+     }
+     else if (window->wl.xdg.toplevel)
+     {
+         xdg_toplevel_set_fullscreen(window->wl.xdg.toplevel,
+-                                    window->monitor->wl.output);
++                                    NULL);
+     }
+ 
+     setIdleInhibitor(window, GLFW_TRUE);
+@@ -849,7 +849,7 @@ static GLFWbool createLibdecorFrame(_GLFWwindow* window)
+     if (window->monitor)
+     {
+         libdecor_frame_set_fullscreen(window->wl.libdecor.frame,
+-                                      window->monitor->wl.output);
++                                      NULL);
+         setIdleInhibitor(window, GLFW_TRUE);
+     }
+     else
+@@ -942,7 +942,7 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
+ 
+     if (window->monitor)
+     {
+-        xdg_toplevel_set_fullscreen(window->wl.xdg.toplevel, window->monitor->wl.output);
++        xdg_toplevel_set_fullscreen(window->wl.xdg.toplevel, NULL);
+         setIdleInhibitor(window, GLFW_TRUE);
+     }
+     else

--- a/anda/lib/terra-glfw/0007-Fix-forge-crash.patch
+++ b/anda/lib/terra-glfw/0007-Fix-forge-crash.patch
@@ -1,0 +1,25 @@
+diff --git a/src/wl_window.c b/src/wl_window.c
+index 5b491ffb..05239e02 100644
+--- a/src/wl_window.c
++++ b/src/wl_window.c
+@@ -2236,16 +2236,16 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
+     // A Wayland client is not aware of its position, so just warn and leave it
+     // as (0, 0)
+
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not provide the window position");
++    fprintf(stderr,
++                    "Wayland: The platform does not provide the window position\n");
+ }
+
+ void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
+ {
+     // A Wayland client can not set its position, so just warn
+
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the window position");
++    fprintf(stderr,
++                    "Wayland: The platform does not support setting the window position\n");
+ }
+
+ void _glfwGetWindowSizeWayland(_GLFWwindow* window, int* width, int* height)

--- a/anda/lib/terra-glfw/anda.hcl
+++ b/anda/lib/terra-glfw/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+  arches = ["x86_64", "aarch64", "i386"]
+  rpm {
+    spec = "terra-glfw.spec"
+  }
+  labels {
+    mock = 1
+  }
+}

--- a/anda/lib/terra-glfw/terra-glfw.spec
+++ b/anda/lib/terra-glfw/terra-glfw.spec
@@ -1,0 +1,99 @@
+Name:           terra-glfw
+%global cleanarch %(echo %{_arch} | sed 's/_/-/g')
+%global _default_patch_fuzz 3
+Version:        3.4
+Release:        2%{?dist}
+Epoch:          1
+Summary:        A multi-platform library for OpenGL, OpenGL ES, Vulkan, window and input (wayland, patched for Minecraft)
+License:        Zlib
+URL:            https://github.com/BoyOrigin/glfw-wayland
+Obsoletes:      glfw <= %{version}
+Provides:       glfw = %{epoch}:%{version}-%{release}
+Provides:       glfw(%{cleanarch}) = %{epoch}:%{version}-%{release}
+Conflicts:      glfw
+Packager:      Cappy Ishihara <cappy@fyralabs.com>
+Source0:       https://github.com/glfw/glfw/archive/%{version}/glfw-%{version}.tar.gz
+Patch1:        0001-Key-Modifiers-Fix.patch
+Patch2:        0002-Fix-duplicate-pointer-scroll-events.patch
+Patch3:        0003-Implement-glfwSetCursorPosWayland.patch
+Patch4:        0004-Fix-Window-size-on-unset-fullscreen.patch
+Patch5:        0005-Implement-glfwSetWindowIcon.patch
+Patch6:        0006-Fix-fullscreen-location.patch
+Patch7:        0007-Fix-forge-crash.patch
+
+Supplements:   prismlauncher
+Supplements:   minecraft-launcher
+
+BuildRequires:  gcc
+BuildRequires:  cmake
+BuildRequires:  doxygen
+BuildRequires:  pkgconfig(dri)
+BuildRequires:  pkgconfig(glu)
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xcursor)
+BuildRequires:  pkgconfig(xi)
+BuildRequires:  pkgconfig(xinerama)
+BuildRequires:  pkgconfig(xrandr)
+
+BuildRequires:  extra-cmake-modules
+BuildRequires:  libxkbcommon-devel
+BuildRequires:  vulkan-devel
+BuildRequires:  wayland-devel
+BuildRequires:  wayland-protocols-devel
+
+%description
+GLFW is a multi-platform library for OpenGL, OpenGL ES, Vulkan, window and input.
+
+This is a fedora port of the AUR package under the same name.
+It fixes various issues when using this library with minecraft on wayland.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       pkgconfig(dri)
+Requires:       pkgconfig(glu)
+Requires:       pkgconfig(x11)
+Requires:       pkgconfig(xcursor)
+Requires:       pkgconfig(xi)
+Requires:       pkgconfig(xinerama)
+Requires:       pkgconfig(xrandr)
+
+%description devel
+The glfw-devel package contains header files for developing glfw
+applications.
+
+%package        doc
+Summary:        Documentation for %{name}
+BuildArch:      noarch
+
+%description doc
+The %{name}-doc package contains documentation for developing applications
+with %{name}.
+
+
+%prep
+%autosetup -n glfw-%{version} -p1
+
+%build
+%cmake
+%cmake_build --target all
+
+%install
+%cmake_install
+
+%files
+%license LICENSE.md
+%doc README.md
+%{_libdir}/libglfw.so.3*
+
+%files devel
+%{_includedir}/GLFW/
+%{_libdir}/libglfw.so
+%{_libdir}/pkgconfig/glfw3.pc
+%{_libdir}/cmake/glfw3/
+
+%files doc
+%doc %{_docdir}/GLFW/
+
+%changelog
+%autochangelog

--- a/anda/lib/terra-glfw/update.rhai
+++ b/anda/lib/terra-glfw/update.rhai
@@ -1,0 +1,3 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::bodhi("glfw", bump::as_bodhi_ver(labels.branch)));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: terra-glfw (#8199)](https://github.com/terrapkg/packages/pull/8199)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)