### PR TITLE
[f41] chore(cuda-profiler): noarch (#8186)

### DIFF
--- a/anda/lib/nvidia/cuda-profiler/anda.hcl
+++ b/anda/lib/nvidia/cuda-profiler/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
-   arches = ["x86_64", "aarch64", "i386"]
+   arches = ["x86_64"]
     rpm {
         spec = "cuda-profiler.spec"
     }

--- a/anda/lib/nvidia/cuda-profiler/cuda-profiler.spec
+++ b/anda/lib/nvidia/cuda-profiler/cuda-profiler.spec
@@ -6,11 +6,11 @@
 Name:           cuda-profiler
 Epoch:          1
 Version:        13.1.80
-Release:        1%?dist
+Release:        2%?dist
 Summary:        CUDA Profiler API
 License:        CUDA Toolkit
 URL:            https://developer.nvidia.com/cuda-toolkit
-ExclusiveArch:  x86_64 ppc64le aarch64 %{ix86}
+BuildArch:      noarch
 
 # Different tarballs per architecture but they all contain the same headers:
 Source0:        https://developer.download.nvidia.com/compute/cuda/redist/%{real_name}/linux-x86_64/%{real_name}-linux-x86_64-%{version}-archive.tar.xz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(cuda-profiler): noarch (#8186)](https://github.com/terrapkg/packages/pull/8186)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)