### PR TITLE
[f42] chore(andax/bump_extras.rhai): Bump EPEL to 10.1 (#8182)

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -41,7 +41,7 @@ fn as_bodhi_ver(branch) {
     if branch.starts_with("el") {
         branch.crop(2);
         if branch == "10" {
-            return "EPEL-10.0";
+            return "EPEL-10.1";
         }
         return `EPEL-${release}`;
     } else if branch == "frawhide" {


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(andax/bump_extras.rhai): Bump EPEL to 10.1 (#8182)](https://github.com/terrapkg/packages/pull/8182)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)