### PR TITLE
[el10] fix(peazip): set to not portable (#8180)

### DIFF
--- a/anda/apps/peazip/peazip.spec
+++ b/anda/apps/peazip/peazip.spec
@@ -3,7 +3,7 @@
 
 Name:           peazip
 Version:        10.8.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Free Zip / Unzip software and Rar file extractor. Cross-platform file and archive manager
 License:        LGPL-3.0-only
 URL:            https://peazip.github.io
@@ -88,6 +88,7 @@ Qt6 version of pea.
 
 %build
 cd peazip-sources
+rm res/portable
 lazbuild --add-package dev/metadarkstyle/metadarkstyle.lpk
 lazbuild --ws=gtk2 dev/project_peach.lpi && cp dev/peazip ../peazip.gtk2
 lazbuild --ws=gtk3 dev/project_peach.lpi && cp dev/peazip ../peazip.gtk3


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(peazip): set to not portable (#8180)](https://github.com/terrapkg/packages/pull/8180)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)