### PR TITLE
[f43] Discord-Canary: Fix symbolic link for DiscordCanary executable (#8220)

### DIFF
--- a/anda/apps/discord-canary/discord-canary.spec
+++ b/anda/apps/discord-canary/discord-canary.spec
@@ -7,7 +7,7 @@
 
 Name:           discord-canary
 Version:        0.0.822
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Free Voice and Text Chat for Gamers
 URL:            discord.com
 Source0:        https://dl-canary.discordapp.net/apps/linux/%{version}/discord-canary-%{version}.tar.gz
@@ -33,7 +33,7 @@ mkdir -p %{buildroot}%{_datadir}/applications/
 mkdir -p %{buildroot}%{_datadir}/pixmaps
 ln -s %_datadir/discord-canary/discord-canary.desktop %{buildroot}%{_datadir}/applications/
 ln -s %_datadir/discord-canary/discord.png %{buildroot}%{_datadir}/pixmaps/discord-canary.png
-ln -s %_datadir/discord/DiscordCanary %buildroot%_bindir/discord-canary
+ln -s %_datadir/discord-canary/DiscordCanary %buildroot%_bindir/discord-canary
 
 %files
 %_bindir/discord-canary


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [Discord-Canary: Fix symbolic link for DiscordCanary executable (#8220)](https://github.com/terrapkg/packages/pull/8220)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)