### PR TITLE
[el10] fix(xone): Add new firmware files and fix nightly update script (#8232)

### DIFF
--- a/anda/system/xone/nightly/kmod-common/update.rhai
+++ b/anda/system/xone/nightly/kmod-common/update.rhai
@@ -1,8 +1,6 @@
-import "andax/bump_extras.rhai" as bump;
-
 rpm.global("commit", gh_commit("dlundqvist/xone"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commitdate", date());
-    rpm.global("ver", bump::madoguchi("xone", labels.branch));
+    rpm.global("ver", gh("dlundqvist/xone"));
 }

--- a/anda/system/xone/nightly/kmod-common/xone-nightly.spec
+++ b/anda/system/xone/nightly/kmod-common/xone-nightly.spec
@@ -4,12 +4,14 @@
 %global ver 0.3.4
 %global modulename xone
 %global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
-%global firmware_hash0 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
-%global firmware_hash1 080ce4091e53a4ef3e5fe29939f51fd91f46d6a88be6d67eb6e99a5723b3a223
+%global firmware_hash0 080ce4091e53a4ef3e5fe29939f51fd91f46d6a88be6d67eb6e99a5723b3a223
+%global firmware_hash1 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
+%global firmware_hash2 0023a7bae02974834500c665a281e25b1ba52c9226c84989f9084fa5ce591d9b
+%global firmware_hash3 e2710daf81e7b36d35985348f68a81d18bc537a2b0c508ffdfde6ac3eae1bad7
 
 Name:           xone-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -18,11 +20,12 @@ License:        GPL-2.0-or-later
 URL:            https://github.com/dlundqvist/xone
 Source0:        %{url}/archive/%{commit}.tar.gz#/xone-%{shortcommit}.tar.gz
 Source1:        modules.conf
-### Windows drivers and firmware files:
-Source2:        http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
-Source3:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2015/12/20810869_8ce2975a7fbaa06bcfb0d8762a6275a1cf7c1dd3.cab
+Source2:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2017/03/2ea9591b-f751-442c-80ce-8f4692cdc67b_6b555a3a288153cf04aec6e03cba360afe2fce34.cab
+Source3:        https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
+Source4:        https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/06/1dbd7cb4-53bc-4857-a5b0-5955c8acaf71_9081931e7d664429a93ffda0db41b7545b7ac257.cab
+Source5:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2017/08/aeff215c-3bc4-4d36-a3ea-e14bfa8fa9d2_e58550c4f74a27e51e5cb6868b10ff633fa77164.cab
 ### Microsoft TOU copy:
-Source4:        https://www.microsoft.com/en-us/legal/terms-of-use
+Source6:        https://www.microsoft.com/en-us/legal/terms-of-use
 BuildRequires:  cabextract
 BuildRequires:  sed
 BuildRequires:  systemd-rpm-macros
@@ -59,12 +62,11 @@ Proprietary firmware for XBox controller dongles.
  
 %prep
 %autosetup -p1 -n %{modulename}-%{commit}
-/usr/bin/cp %{SOURCE4} .
 /usr/bin/sed -nE '/^BUILT_MODULE_NAME/{s@^.+"(.+)"@\1@; s|-|_|g; p}' dkms.conf > %{modulename}.conf
 
 ### Firmware:
-# The .bin files have the same name so put them in subdirs
-mkdir firm{0..1}
+# Some of the .bin files have the same name so put them in subdirs
+mkdir firm{0..4}
 
 pushd firm0
 cabextract -F FW_ACC_00U.bin %{SOURCE2}
@@ -76,6 +78,16 @@ cabextract -F FW_ACC_00U.bin %{SOURCE3}
 echo %{firmware_hash1} FW_ACC_00U.bin | sha256sum -c
 popd
 
+pushd firm2
+cabextract -F FW_ACC_CL.bin %{SOURCE4}
+echo %{firmware_hash2} FW_ACC_CL.bin | sha256sum -c
+popd
+
+pushd firm3
+cabextract -F FW_ACC_BR.bin %{SOURCE5}
+echo %{firmware_hash3} FW_ACC_BR.bin | sha256sum -c
+popd
+
 %install
 # xone-gip-headset module should have the snd-pcm and snd-seq modules be preloaded or it will give errors on boot due to injecting late.
 # It still loads afterwards, but this error is easily fixable by just loading the modules in the initramfs.
@@ -85,11 +97,16 @@ install -Dpm644 %{SOURCE1} %{buildroot}%{_dracutconfdir}/60-%{modulename}-snd.co
 install -Dpm644 install/modprobe.conf %{buildroot}%{_modprobedir}/60-%{modulename}.conf
 
 # Firmware:
-install -Dpm644 firm0/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xow_dongle.bin
-install -Dpm644 firm1/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xow_dongle_045e_02e6.bin
+install -Dpm644 firm0/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02e6.bin
+install -Dpm644 firm1/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02fe.bin
+install -Dpm644 firm2/FW_ACC_CL.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02f9.bin
+install -Dpm644 firm3/FW_ACC_BR.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_091e.bin
 
 # Akmods modules
 install -Dm644 %{modulename}.conf -t %{buildroot}%{_modulesloaddir}
+
+# TOU file
+/usr/bin/cp %{SOURCE6} .
 
 %files
 %license LICENSE
@@ -102,21 +119,22 @@ install -Dm644 %{modulename}.conf -t %{buildroot}%{_modulesloaddir}
 
 %files firmware
 %license terms-of-use
-%{_prefix}/lib/firmware/xow_dongle.bin
-%{_prefix}/lib/firmware/xow_dongle_045e_02e6.bin
-
-%post
-/usr/bin/dracut -f
+%{_prefix}/lib/firmware/xone_dongle_02e6.bin
+%{_prefix}/lib/firmware/xone_dongle_02fe.bin
+%{_prefix}/lib/firmware/xone_dongle_02f9.bin
+%{_prefix}/lib/firmware/xone_dongle_091e.bin
 
 %postun
-/usr/bin/dracut -f
+/usr/bin/dracut -f || :
 
 %post firmware
 echo "The firmware for the wireless dongle is subject to Microsoft's Terms of Use:"
 echo 'https://www.microsoft.com/en-us/legal/terms-of-use'
 
 %changelog
-* Thu Apr 17 2025 Gilver E. <rockgrub@disroot.org> - 0.3^20250418git.ecdd59e-2%{?dist}
+* Wed Dec 10 2025 Gilver E. <rockgrub@disroot.org> - 0.3.4^20250718git.778dbc9-2
+- Added new firmware files
+* Thu Apr 17 2025 Gilver E. <rockgrub@disroot.org> - 0.3^20250418git.ecdd59e-2
 - Added additional firmware needed for dongle pairing on some controllers
 * Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xone/stable/kmod-common/xone.spec
+++ b/anda/system/xone/stable/kmod-common/xone.spec
@@ -1,10 +1,12 @@
 %global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
-%global firmware_hash0 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
-%global firmware_hash1 080ce4091e53a4ef3e5fe29939f51fd91f46d6a88be6d67eb6e99a5723b3a223
+%global firmware_hash0 080ce4091e53a4ef3e5fe29939f51fd91f46d6a88be6d67eb6e99a5723b3a223
+%global firmware_hash1 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
+%global firmware_hash2 0023a7bae02974834500c665a281e25b1ba52c9226c84989f9084fa5ce591d9b
+%global firmware_hash3 e2710daf81e7b36d35985348f68a81d18bc537a2b0c508ffdfde6ac3eae1bad7
 
 Name:           xone
 Version:        0.5.0
-Release:        1%?dist
+Release:        2%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif
@@ -14,10 +16,12 @@ URL:            https://github.com/dlundqvist/xone
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 Source1:        modules.conf
 ### Windows drivers and firmware files:
-Source2:        http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
-Source3:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2015/12/20810869_8ce2975a7fbaa06bcfb0d8762a6275a1cf7c1dd3.cab
+Source2:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2017/03/2ea9591b-f751-442c-80ce-8f4692cdc67b_6b555a3a288153cf04aec6e03cba360afe2fce34.cab
+Source3:        https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
+Source4:        https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/06/1dbd7cb4-53bc-4857-a5b0-5955c8acaf71_9081931e7d664429a93ffda0db41b7545b7ac257.cab
+Source5:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2017/08/aeff215c-3bc4-4d36-a3ea-e14bfa8fa9d2_e58550c4f74a27e51e5cb6868b10ff633fa77164.cab
 ### Microsoft TOU copy:
-Source4:        https://www.microsoft.com/en-us/legal/terms-of-use
+Source6:        https://www.microsoft.com/en-us/legal/terms-of-use
 BuildRequires:  cabextract
 BuildRequires:  sed
 BuildRequires:  systemd-rpm-macros
@@ -60,12 +64,11 @@ Proprietary firmware for XBox controller dongles.
  
 %prep
 %autosetup -p1 -n %{name}-%{version}
-/usr/bin/cp %{SOURCE4} .
 /usr/bin/sed -nE '/^BUILT_MODULE_NAME/{s@^.+"(.+)"@\1@; s|-|_|g; p}' dkms.conf > %{name}.conf
 
 ### Firmware:
-# The .bin files have the same name so put them in subdirs
-mkdir firm{0..1}
+# Some of the .bin files have the same name so put them in subdirs
+mkdir firm{0..4}
 
 pushd firm0
 cabextract -F FW_ACC_00U.bin %{SOURCE2}
@@ -77,6 +80,16 @@ cabextract -F FW_ACC_00U.bin %{SOURCE3}
 echo %{firmware_hash1} FW_ACC_00U.bin | sha256sum -c
 popd
 
+pushd firm2
+cabextract -F FW_ACC_CL.bin %{SOURCE4}
+echo %{firmware_hash2} FW_ACC_CL.bin | sha256sum -c
+popd
+
+pushd firm3
+cabextract -F FW_ACC_BR.bin %{SOURCE5}
+echo %{firmware_hash3} FW_ACC_BR.bin | sha256sum -c
+popd
+
 %install
 # xone-gip-headset module should have the snd-pcm and snd-seq modules be preloaded or it will give errors on boot due to injecting late.
 # It still loads afterwards, but this error is easily fixable by just loading the modules in the initramfs.
@@ -86,11 +99,16 @@ install -Dpm644 %{SOURCE1} %{buildroot}%{_dracutconfdir}/60-%{name}-snd.conf
 install -Dpm644 install/modprobe.conf %{buildroot}%{_modprobedir}/60-%{name}.conf
 
 # Firmware:
-install -Dpm644 firm0/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xow_dongle.bin
-install -Dpm644 firm1/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xow_dongle_045e_02e6.bin
+install -Dpm644 firm0/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02e6.bin
+install -Dpm644 firm1/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02fe.bin
+install -Dpm644 firm2/FW_ACC_CL.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02f9.bin
+install -Dpm644 firm3/FW_ACC_BR.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_091e.bin
 
 # Akmods modules
 install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
+
+# TOU file
+/usr/bin/cp %{SOURCE6} .
 
 %files
 %license LICENSE
@@ -103,20 +121,17 @@ install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
 
 %files firmware
 %license terms-of-use
-%{_prefix}/lib/firmware/xow_dongle.bin
-%{_prefix}/lib/firmware/xow_dongle_045e_02e6.bin
-
-%post
-/usr/bin/dracut -f
+%{_prefix}/lib/firmware/xone_dongle_02e6.bin
+%{_prefix}/lib/firmware/xone_dongle_02fe.bin
+%{_prefix}/lib/firmware/xone_dongle_02f9.bin
+%{_prefix}/lib/firmware/xone_dongle_091e.bin
 
 %postun
-/usr/bin/dracut -f
-
-%post firmware
-echo "The firmware for the wireless dongle is subject to Microsoft's Terms of Use:"
-echo 'https://www.microsoft.com/en-us/legal/terms-of-use'
+/usr/bin/dracut -f || :
 
 %changelog
+* Wed Dec 10 2025 Gilver E. <rockgrub@disroot.org> - 0.5.0-2
+- Added new firmware files
 * Thu Apr 17 2025 Gilver E. <rockgrub@disroot.org> - 0.3^20250418git.ecdd59e-2%{?dist}
 - Added additional firmware needed for dongle pairing on some controllers
 * Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(xone): Add new firmware files and fix nightly update script (#8232)](https://github.com/terrapkg/packages/pull/8232)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)