### PR TITLE
[f43] fix (ghostty-nautilus): depend on nautilus-python (#8237)

### DIFF
--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -4,7 +4,7 @@
 
 Name:           ghostty
 Version:        1.2.3
-Release:        2%?dist
+Release:        3%?dist
 Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
 URL:            https://ghostty.org/
@@ -88,6 +88,7 @@ This package allows Ghostty to interact with KIO.
 Summary:        Nautilus menu support for Ghostty
 Supplements:    (%{name} and nautilus)
 Requires:       %{name} = %{evr}
+Requires:       nautilus-python
 BuildArch:      noarch
 
 %description    nautilus


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (ghostty-nautilus): depend on nautilus-python (#8237)](https://github.com/terrapkg/packages/pull/8237)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)