### PR TITLE
[el10] fix(lightdm-kde-greeter): Don't dep on a non-existent package, update files (#8247)

### DIFF
--- a/anda/desktops/kde/lightdm-kde-greeter/lightdm-kde-greeter.spec
+++ b/anda/desktops/kde/lightdm-kde-greeter/lightdm-kde-greeter.spec
@@ -2,7 +2,7 @@
 
 Name:           lightdm-kde-greeter
 Version:        6.1.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Login screen using the LightDM framework
 License:        GPL-3.0-or-later
 URL:            https://invent.kde.org/plasma/%name
@@ -22,10 +22,11 @@ BuildRequires:  cmake(KF6Auth)
 BuildRequires:  cmake(KF6NetworkManagerQt)
 BuildRequires:  cmake(Plasma)
 BuildRequires:  pkgconfig(gtk+-2.0)
+BuildRequires:  pkgconfig(libei-1.0)
 BuildRequires:  pkgconfig(liblightdm-gobject-1)
 BuildRequires:  systemd-rpm-macros
 Requires: lightdm
-Requires: plasma-workspace-qml
+Requires: plasma-workspace
 Requires: polkit
 Provides: lightdm-greeter
 
@@ -81,7 +82,8 @@ mkdir -p %buildroot%_sharedstatedir/%name
 %_datadir/dbus-1/system-services/org.kde.kcontrol.kcmlightdm.service
 %_datadir/dbus-1/system.d/org.kde.kcontrol.kcmlightdm.conf
 %_datadir/polkit-1/actions/org.kde.kcontrol.kcmlightdm.policy
-%_datadir/xgreeters/lightdm-kde-greeter.desktop
+%_datadir/lightdm/greeters/lightdm-kde-greeter.desktop
+%_datadir/xgreeters/lightdm-kde-greeter-x11.desktop
 %_datadir/%name/
 %_kf6_libexecdir/kauth/kcmlightdmhelper
 %_qt6_plugindir/plasma/kcms/systemsettings/kcm_lightdm.so


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(lightdm-kde-greeter): Don&#x27;t dep on a non-existent package, update files (#8247)](https://github.com/terrapkg/packages/pull/8247)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)