### PR TITLE
[f41] bump(nightly): envision legcord-nightly ghostty-nightly zed-nightly types-colorama stardust-telescope nvidia-patch opentabletdriver-nightly xone-nightly (#8261)

### DIFF
--- a/anda/apps/envision/envision.spec
+++ b/anda/apps/envision/envision.spec
@@ -1,5 +1,5 @@
-%global commit 0d370ff597101ec92bed781589127063cbed498f
-%global commit_date 20251210
+%global commit b50c32d7c3e74af4faeb92fb0e8f49108d85ff90
+%global commit_date 20251211
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           envision-nightly

--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,5 +1,5 @@
-%global commit 94128d8fbcac0a14af4c529b29e0d91b0b997796
-%global commit_date 20251114
+%global commit 57102c1d368d863741c598ac67dce750c78f1c0c
+%global commit_date 20251211
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global debug_package %nil
 %global __strip /bin/true

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit cf06417b7dfbd0daeb58a9143f9b6ee194cbce26
+%global commit 4a173052fb181580b1ea013555508b8f37c0407e
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-12-09
+%global fulldate 2025-12-10
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0
@@ -9,7 +9,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 4353b8ecd5da2ddcc3497e99d84fe75cf95e843d
+%global commit 25d74480aac797ec38a60aed46d055d69767e8cc
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251210
-%global ver 0.217.0
+%global commit_date 20251211
+%global ver 0.218.0
 
 %bcond_with check
 %bcond_with debug_no_build

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit 0153c409f1966e910ddba9543f35c86bbc21001d
-%global commit_date 20251210
+%global commit fcc9ebccb563aaa95cb84c81029d55b20038b82d
+%global commit_date 20251211
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/stardust/telescope/stardust-telescope.spec
+++ b/anda/stardust/telescope/stardust-telescope.spec
@@ -1,5 +1,5 @@
-%global commit 942d5e951620d0cbee822df3e041bbf3c7f194a0
-%global commit_date 20251205
+%global commit a66e28e4eba976181419676abd3733edf1c6bbec
+%global commit_date 20251211
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           stardust-xr-telescope

--- a/anda/system/nvidia-patch/nvidia-patch.spec
+++ b/anda/system/nvidia-patch/nvidia-patch.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
-%global commit a7690e64b5080452596ffd55062c625abe05fa3a
+%global commit 8a1829fba432d7947df3d7159a3524248cde4df1
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251108
+%global commit_date 20251211
 
 
 %global patches %{_datadir}/src/nvidia-patch

--- a/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
+++ b/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 1cad28e3f6bc1616d4f01fbea127b105cddc0bbe
+%global commit 5d5f6fb69c1090feab2dfe3f953fa955de123031
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251206
+%global commit_date 20251211
 %global ver 0.6.6.2
 
 # We aren't using Mono but RPM expected Mono

--- a/anda/system/xone/nightly/kmod-common/xone-nightly.spec
+++ b/anda/system/xone/nightly/kmod-common/xone-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 778dbc953b1987d259ea6d802fd6967b6a0d2097
+%global commit e927febbedbf8d6f040ff081b0c6703738e7e8d2
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20250718
-%global ver 0.3.4
+%global commitdate 20251211
+%global ver v0.5.0
 %global modulename xone
 %global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
 %global firmware_hash0 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `f41`:
 - [bump(nightly): envision legcord-nightly ghostty-nightly zed-nightly types-colorama stardust-telescope nvidia-patch opentabletdriver-nightly xone-nightly (#8261)](https://github.com/terrapkg/packages/pull/8261)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)