### PR TITLE
[f41] fix(xone-nightly-kmods): Reset versions (#8280)

### DIFF
--- a/anda/system/xone/nightly/akmod/xone-nightly-kmod.spec
+++ b/anda/system/xone/nightly/akmod/xone-nightly-kmod.spec
@@ -1,14 +1,14 @@
 %global commit e927febbedbf8d6f040ff081b0c6703738e7e8d2
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commitdate 20251211
-%global ver v0.5.0
+%global ver 0.5.0
 %define buildforkernels akmod
 %global debug_package %{nil}
 %global modulename xone
 
 Name:           %{modulename}-nightly-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif

--- a/anda/system/xone/nightly/dkms/dkms-xone-nightly.spec
+++ b/anda/system/xone/nightly/dkms/dkms-xone-nightly.spec
@@ -1,13 +1,13 @@
 %global commit e927febbedbf8d6f040ff081b0c6703738e7e8d2
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commitdate 20251211
-%global ver v0.5.0
+%global ver 0.5.0
 %global debug_package %{nil}
 %global modulename xone
 
 Name:           dkms-%{modulename}-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix(xone-nightly-kmods): Reset versions (#8280)](https://github.com/terrapkg/packages/pull/8280)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)