### PR TITLE
[el10] fix(chess-tui): bdep openssl (#8286)

### DIFF
--- a/anda/games/chess-tui/rust-chess-tui.spec
+++ b/anda/games/chess-tui/rust-chess-tui.spec
@@ -13,6 +13,7 @@ URL:            https://crates.io/crates/chess-tui
 Source:         %{crates_source}
 
 BuildRequires:  cargo-rpm-macros >= 24
+BuildRequires:  pkgconfig(openssl)
 
 %global _description %{expand:
 A rusty chess game in your terminal 🦀.}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(chess-tui): bdep openssl (#8286)](https://github.com/terrapkg/packages/pull/8286)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)