### PR TITLE
[f41] bump: zed-preview zed arduino-app-cli rust-bacon rust-mise (#8291)

### DIFF
--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -5,7 +5,7 @@
 %global debug_package %{nil}
 %endif
 
-%global ver 0.215.3-pre
+%global ver 0.216.1
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -15,8 +15,8 @@
 %global rustflags_debuginfo 0
 
 Name:           zed
-Version:        0.210.4
-Release:        2%?dist
+Version:        0.216.1
+Release:        1%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
 SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib

--- a/anda/langs/rust/bacon/rust-bacon.spec
+++ b/anda/langs/rust/bacon/rust-bacon.spec
@@ -5,7 +5,7 @@
 %global features "sound,clipboard"
 
 Name:           rust-bacon
-Version:        3.20.1
+Version:        3.20.3
 Release:        1%?dist
 Summary:        Background rust compiler
 Packager:       metcya <metcya@gmail.com>

--- a/anda/tools/arduino-app-cli/arduino-app-cli.spec
+++ b/anda/tools/arduino-app-cli/arduino-app-cli.spec
@@ -1,10 +1,10 @@
 %global goipath github.com/arduino/arduino-app-cli
-Version:        0.6.7
+Version:        0.8.0
 
 %gometa -f
 
 Name:           arduino-app-cli
-Release:        2%?dist
+Release:        1%?dist
 Summary:        The CLI and service that manages and runs Arduino Apps on UNO Q
 License:        GPL-3.0-only
 

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -5,7 +5,7 @@
 %global crate mise
 
 Name:           rust-mise
-Version:        2025.12.1
+Version:        2025.12.2
 Release:        1%?dist
 Summary:        Front-end to your dev env
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f41`:
 - [bump: zed-preview zed arduino-app-cli rust-bacon rust-mise (#8291)](https://github.com/terrapkg/packages/pull/8291)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)