### PR TITLE
[f42] fix(asusctl): bdep pkgconfig(fontconfig) (#8305)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -18,6 +18,7 @@ BuildRequires:  pkgconfig(libseat)
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(fontconfig)
 ExclusiveArch:  x86_64
 
 Packager:       Metcya <metcya@gmail.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [fix(asusctl): bdep pkgconfig(fontconfig) (#8305)](https://github.com/terrapkg/packages/pull/8305)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)