### PR TITLE
[f41] chore(rustdesk-selinux): https link (#8304)

### DIFF
--- a/anda/misc/rustdesk-selinux/rustdesk-selinux.spec
+++ b/anda/misc/rustdesk-selinux/rustdesk-selinux.spec
@@ -9,12 +9,12 @@ restorecon -R /usr/lib/rustdesk/rustdesk; \
 
 Name:   rustdesk-selinux
 Version:	1.0
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	SELinux policy module for rustdesk
 
 Group:	System Environment/Base		
 License:	GPLv2+	
-URL:		http://rustdesk.com
+URL:		https://rustdesk.com
 Source0:	rustdesk.te
 
 Requires: policycoreutils, libselinux-utils


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [chore(rustdesk-selinux): https link (#8304)](https://github.com/terrapkg/packages/pull/8304)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)