### PR TITLE
add: wishlist

### DIFF
--- a/anda/langs/go/wishlist/anda.hcl
+++ b/anda/langs/go/wishlist/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+  	spec = "golang-github-charmbracelet-wishlist.spec"
+  }
+}

--- a/anda/langs/go/wishlist/anda.hcl
+++ b/anda/langs/go/wishlist/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
   rpm {
-  	spec = "golang-github-charmbracelet-wishlist.spec"
+  	spec = "wishlist.spec"
   }
 }

--- a/anda/langs/go/wishlist/golang-github-charmbracelet-wishlist.spec
+++ b/anda/langs/go/wishlist/golang-github-charmbracelet-wishlist.spec
@@ -1,0 +1,33 @@
+%global debug_package %{nil}
+
+Name:           wishlist
+Version:        0.15.2
+Release:        1%?dist
+Summary:        The SSH directory.
+URL:            https://github.com/charmbracelet/%{name}
+Source0:        https://github.com/charmbracelet/%{name}/archive/refs/tags/v%{version}.tar.gz
+License:        MIT
+BuildRequires:  anda-srpm-macros go
+
+Packager:       arbormoss <arbormoss@woodsprite.dev>
+
+%description
+%summary
+
+%prep
+%autosetup -n %name-%version
+
+%build
+go build -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -s -w" -buildmode pie -compiler gc -a -x ./cmd/%{name}
+
+%install
+install -Dm755 %{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/%{name}
+
+%changelog
+* Thu Dec 11 2025 arbormoss <arbormoss@woodsprite.dev>
+- Intial Commit

--- a/anda/langs/go/wishlist/update.rhai
+++ b/anda/langs/go/wishlist/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("charmbracelet/wishlist"));

--- a/anda/langs/go/wishlist/wishlist.spec
+++ b/anda/langs/go/wishlist/wishlist.spec
@@ -3,7 +3,7 @@
 Name:           wishlist
 Version:        0.15.2
 Release:        1%?dist
-Summary:        The SSH directory.
+Summary:        The SSH directory
 URL:            https://github.com/charmbracelet/%{name}
 Source0:        https://github.com/charmbracelet/%{name}/archive/refs/tags/v%{version}.tar.gz
 License:        MIT
@@ -12,7 +12,7 @@ BuildRequires:  anda-srpm-macros go
 Packager:       arbormoss <arbormoss@woodsprite.dev>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n %name-%version

--- a/anda/langs/go/wishlist/wishlist.spec
+++ b/anda/langs/go/wishlist/wishlist.spec
@@ -1,13 +1,16 @@
 %global debug_package %{nil}
 
-Name:           wishlist
+%global goipath github.com/charmbracelet/wishlist
 Version:        0.15.2
+
+%gometa -f
+
+Name:           wishlist
 Release:        1%?dist
 Summary:        The SSH directory
 URL:            https://github.com/charmbracelet/%{name}
 Source0:        https://github.com/charmbracelet/%{name}/archive/refs/tags/v%{version}.tar.gz
 License:        MIT
-BuildRequires:  anda-srpm-macros go
 
 Packager:       arbormoss <arbormoss@woodsprite.dev>
 
@@ -15,13 +18,15 @@ Packager:       arbormoss <arbormoss@woodsprite.dev>
 %summary.
 
 %prep
-%autosetup -n %name-%version
+%goprep -A
 
 %build
-go build -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -s -w" -buildmode pie -compiler gc -a -x ./cmd/%{name}
+%define currentgoldflags -X main.version=%version
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/%{name} ./cmd/%{name}
 
 %install
-install -Dm755 %{name} %{buildroot}%{_bindir}/%{name}
+install -Dm755 %{gobuilddir}/bin/%{name} %{buildroot}%{_bindir}/%{name}
 
 %files
 %license LICENSE


### PR DESCRIPTION
_go slop # 2/3_

This adds [wishlist](https://github.com/charmbracelet/wishlist) by [charmbracelet](https://charm.land), a tui and self-hosted tool for interfacing with ssh (an "ssh bastion" as they put it).

This breaks on rawhide but not on F43 because of an issue with rawhide (libxcrypt-devel isn't found on the fedora mirrors for some reason, this is true when building any package on rawhide for me right now).

This doesn't use the go macros because the packager didn't like them. This does still use the random -ldflags for security.

