### PR TITLE
add: pop

### DIFF
--- a/anda/langs/go/pop/anda.hcl
+++ b/anda/langs/go/pop/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+  	spec = "golang-github-charmbracelet-pop.spec"
+  }
+}

--- a/anda/langs/go/pop/anda.hcl
+++ b/anda/langs/go/pop/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
   rpm {
-  	spec = "golang-github-charmbracelet-pop.spec"
+  	spec = "pop.spec"
   }
 }

--- a/anda/langs/go/pop/golang-github-charmbracelet-pop.spec
+++ b/anda/langs/go/pop/golang-github-charmbracelet-pop.spec
@@ -1,0 +1,33 @@
+%global debug_package %{nil}
+
+Name:           pop
+Version:        0.2.0
+Release:        1%?dist
+Summary:        Send emails from your terminal.
+URL:            https://github.com/charmbracelet/%{name}
+Source0:        https://github.com/charmbracelet/%{name}/archive/refs/tags/v%{version}.tar.gz
+License:        MIT
+BuildRequires:  anda-srpm-macros go
+
+Packager:       arbormoss <arbormoss@woodsprite.dev>
+
+%description
+%summary
+
+%prep
+%autosetup -n %name-%version
+
+%build
+go build -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -s -w" -buildmode pie -compiler gc -a -x .
+
+%install
+install -Dm755 %{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md
+%{_bindir}/%{name}
+
+%changelog
+* Fri Dec 12 2025 arbormoss <arbormoss@woodsprite.dev>
+- Intial Commit

--- a/anda/langs/go/pop/pop.spec
+++ b/anda/langs/go/pop/pop.spec
@@ -1,27 +1,34 @@
 %global debug_package %{nil}
 
-Name:           pop
+%global goipath github.com/charmbracelet/pop
 Version:        0.2.0
+
+%gometa -f
+
+Name:           pop
 Release:        1%?dist
 Summary:        Send emails from your terminal
 URL:            https://github.com/charmbracelet/%{name}
 Source0:        https://github.com/charmbracelet/%{name}/archive/refs/tags/v%{version}.tar.gz
 License:        MIT
-BuildRequires:  anda-srpm-macros go
 
 Packager:       arbormoss <arbormoss@woodsprite.dev>
 
 %description
 %summary.
 
+%gopkg
+
 %prep
-%autosetup -n %name-%version
+%goprep -A
 
 %build
-go build -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -s -w" -buildmode pie -compiler gc -a -x .
+%define currentgoldflags -X main.version=%version
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/%{name} .
 
 %install
-install -Dm755 %{name} %{buildroot}%{_bindir}/%{name}
+install -Dm755 %{gobuilddir}/bin/%{name} %{buildroot}%{_bindir}/%{name}
 
 %files
 %license LICENSE

--- a/anda/langs/go/pop/pop.spec
+++ b/anda/langs/go/pop/pop.spec
@@ -3,7 +3,7 @@
 Name:           pop
 Version:        0.2.0
 Release:        1%?dist
-Summary:        Send emails from your terminal.
+Summary:        Send emails from your terminal
 URL:            https://github.com/charmbracelet/%{name}
 Source0:        https://github.com/charmbracelet/%{name}/archive/refs/tags/v%{version}.tar.gz
 License:        MIT
@@ -12,7 +12,7 @@ BuildRequires:  anda-srpm-macros go
 Packager:       arbormoss <arbormoss@woodsprite.dev>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n %name-%version

--- a/anda/langs/go/pop/update.rhai
+++ b/anda/langs/go/pop/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("charmbracelet/pop"));


### PR DESCRIPTION
_go slop # 3/3_

This adds [pop](https://github.com/charmbracelet/pop) by [charmbracelet](https://charm.land/), a tui email client that uses the [resend](https://resend.com/) api.

This breaks on rawhide but not on F43 because of an issue with rawhide (libxcrypt-devel isn't found on the fedora mirrors for some reason, this is true when building any package on rawhide for me right now).

This doesn't use the go macros because the packager didn't like them. This does still use the random -ldflags for security.