### PR TITLE
[el10] feat(asusctl): add metainfo (#8229)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -1,11 +1,13 @@
 %global debug_package %{nil}
+%global appid org.asus_linux.rog_control_center
 
 Name:           asusctl
 Version:        6.2.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops
 URL:            https://gitlab.com/asus-linux/asusctl
 Source0:        %url/-/archive/%version/asusctl-%version.tar.gz
+Source1:        %{appid}.metainfo.xml
 License:        MPL-2.0
 BuildRequires:  anda-srpm-macros cargo-rpm-macros systemd-rpm-macros mold rust-udev-devel clang-devel
 BuildRequires:  desktop-file-utils
@@ -47,6 +49,7 @@ a notification service, and ability to run in the background.
 install -D -m 0644 README.md %{buildroot}/%{_docdir}/%{name}/README.md
 install -D -m 0644 rog-anime/README.md %{buildroot}/%{_docdir}/%{name}/README-anime.md
 install -D -m 0644 rog-anime/data/diagonal-template.png %{buildroot}/%{_docdir}/%{name}/diagonal-template.png
+%terra_appstream -o %{S:1}
 
 desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.desktop
 
@@ -94,8 +97,12 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.d
 %{_datadir}/applications/rog-control-center.desktop
 %{_datadir}/icons/hicolor/512x512/apps/rog-control-center.png
 %{_datadir}/rog-gui
+%{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Tue Dec 9 2025 Metcya <metcya@gmail.com> - 6.2.0
+- Add metainfo
+
 * Mon Dec 1 2025 Metcya <metcya@gmail.com>
 - Add systemd scriptlets
 

--- a/anda/system/asusctl/org.asus_linux.rog_control_center.metainfo.xml
+++ b/anda/system/asusctl/org.asus_linux.rog_control_center.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.asus_linux.rog_control_center</id>
+  
+  <name>Rog Control Center</name>
+  <summary>A one-stop-shop GUI tool for asusd/asusctl.</summary>
+  <icon type="local">/usr/share/icons/hicolor/512x512/apps/rog-control-center.png</icon>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MPL-2.0</project_license>
+  
+  <url type="homepage">https://asus-linux.org</url>
+
+  <description>
+    <p>
+      A one-stop-shop GUI tool for asusd/asusctl. It aims to provide most controls, a notification service, and ability to run in the background.
+    </p>
+  </description>
+
+  <releases>
+    <release version="6.2.0" date="2025-12-13" />
+  </releases>
+
+  <keywords>
+    <keyword>ASUS</keyword>
+    <keyword>ROG</keyword>
+    <keyword>asusctl</keyword>
+  </keywords>
+
+  <provides>
+    <binary>rog-control-center</binary>
+  </provides>
+
+  <launchable type="desktop-id">rog-control-center.desktop</launchable>
+</component>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat(asusctl): add metainfo (#8229)](https://github.com/terrapkg/packages/pull/8229)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)