### PR TITLE
[f42] add: bitwarden-rofi (#8323)

### DIFF
--- a/anda/misc/bitwarden-rofi/anda.hcl
+++ b/anda/misc/bitwarden-rofi/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+	spec = "bitwarden-rofi.spec"
+  }
+}

--- a/anda/misc/bitwarden-rofi/bitwarden-rofi.spec
+++ b/anda/misc/bitwarden-rofi/bitwarden-rofi.spec
@@ -1,0 +1,41 @@
+Name:           bitwarden-rofi
+Version:        0.5
+Release:        1%?dist
+Summary:        Wrapper for Bitwarden cli and Rofi
+License:        GPL-3.0
+URL:            https://github.com/mattydebie/bitwarden-rofi
+Source0:        %url/archive/refs/tags/%version.tar.gz
+Requires:       bash
+BuildArch:      noarch
+
+Requires:       rofi
+Requires:       bitwarden-cli
+Requires:       jq
+
+Recommends:     wl-clipboard
+Recommends:     ydotool
+Recommends:     xclip
+Recommends:     xsel
+Recommends:     xdotool
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary.
+
+%prep
+%autosetup
+
+%install
+install -Dm755 lib-bwmenu %{buildroot}%{_bindir}/lib-bwmenu
+install -Dm755 bwmenu %{buildroot}%{_bindir}/bwmenu
+
+%files
+%doc README.md img/screenshot1.png
+%license LICENSE
+%{_bindir}/bwmenu
+%{_bindir}/lib-bwmenu
+
+%changelog
+* Sat Dec 13 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/misc/bitwarden-rofi/update.rhai
+++ b/anda/misc/bitwarden-rofi/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("mattydebie/bitwarden-rofi"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: bitwarden-rofi (#8323)](https://github.com/terrapkg/packages/pull/8323)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)