### PR TITLE
fix: use go macros for soft-serve

### DIFF
--- a/anda/langs/go/soft-serve/soft-serve.spec
+++ b/anda/langs/go/soft-serve/soft-serve.spec
@@ -4,28 +4,35 @@
 # The standard use for the tool is `soft serve`.
 %global cmd_name soft
 
-Name:           soft-serve
+%global goipath github.com/charmbracelet/soft-serve
 Version:        0.11.1
+
+%gometa -f
+
+Name:           soft-serve
 Release:        1%?dist
 Summary:        The mighty, self-hostable Git server for the command line
 URL:            https://github.com/charmbracelet/%{name}
 Source0:        https://github.com/charmbracelet/%{name}/archive/refs/tags/v%{version}.tar.gz
 License:        MIT
-BuildRequires:  anda-srpm-macros go
 
 Packager:       arbormoss <arbormoss@woodsprite.dev>
 
 %description
-%summary.
+%{summary}.
+
+%gopkg
 
 %prep
-%autosetup -n %name-%version
+%goprep -A
 
 %build
-go build -ldflags "-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n') -s -w" -buildmode pie -compiler gc -a -x ./cmd/%{cmd_name}
+%define currentgoldflags -X main.version=%version
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/%{cmd_name} ./cmd/%{cmd_name}
 
 %install
-install -Dm755 %{cmd_name} %{buildroot}%{_bindir}/%{cmd_name}
+install -Dm755 %{gobuilddir}/bin/%{cmd_name} %{buildroot}%{_bindir}/%{cmd_name}
 
 %files
 %license LICENSE
@@ -33,5 +40,8 @@ install -Dm755 %{cmd_name} %{buildroot}%{_bindir}/%{cmd_name}
 %{_bindir}/%{cmd_name}
 
 %changelog
+* Sat Dec 13 2025 arbormoss <arbormoss@woodsprite.dev>
+- Refactor to use go rpm macros
+
 * Fri Dec 12 2025 arbormoss <arbormoss@woodsprite.dev>
 - Intial Commit


### PR DESCRIPTION
This refactors soft-serve to use go rpm macros.