### PR TITLE
[el10] add: pop (#8319)

### DIFF
--- a/anda/langs/go/pop/anda.hcl
+++ b/anda/langs/go/pop/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+  	spec = "pop.spec"
+  }
+}

--- a/anda/langs/go/pop/pop.spec
+++ b/anda/langs/go/pop/pop.spec
@@ -1,0 +1,40 @@
+%global debug_package %{nil}
+
+%global goipath github.com/charmbracelet/pop
+Version:        0.2.0
+
+%gometa -f
+
+Name:           pop
+Release:        1%?dist
+Summary:        Send emails from your terminal
+URL:            https://github.com/charmbracelet/%{name}
+Source0:        https://github.com/charmbracelet/%{name}/archive/refs/tags/v%{version}.tar.gz
+License:        MIT
+
+Packager:       arbormoss <arbormoss@woodsprite.dev>
+
+%description
+%summary.
+
+%gopkg
+
+%prep
+%goprep -A
+
+%build
+%define currentgoldflags -X main.version=%version
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/%{name} .
+
+%install
+install -Dm755 %{gobuilddir}/bin/%{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md
+%{_bindir}/%{name}
+
+%changelog
+* Fri Dec 12 2025 arbormoss <arbormoss@woodsprite.dev>
+- Intial Commit

--- a/anda/langs/go/pop/update.rhai
+++ b/anda/langs/go/pop/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("charmbracelet/pop"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: pop (#8319)](https://github.com/terrapkg/packages/pull/8319)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)