### PR TITLE
[f43] add: xcur2png (#8337)

### DIFF
--- a/anda/tools/xcur2png/anda.hcl
+++ b/anda/tools/xcur2png/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "xcur2png.spec"
+  }
+}

--- a/anda/tools/xcur2png/update.rhai
+++ b/anda/tools/xcur2png/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("eworm-de/xcur2png"));

--- a/anda/tools/xcur2png/xcur2png.spec
+++ b/anda/tools/xcur2png/xcur2png.spec
@@ -1,0 +1,38 @@
+%global _distro_extra_cflags -Wno-parenthesis -Wno-implicit-int
+
+Name:           xcur2png
+Version:        0.7.1
+Release:        1%{?dist}
+License:        GPL-3.0-or-later
+Summary:        Convert X cursors to PNG images
+URL:            https://github.com/eworm-de/xcur2png
+Source:         %{url}/releases/download/%{version}/%{name}-%{version}.tar.gz
+Packager:       Metcya <metcya@gmail.com>
+
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  pkgconfig(libpng)
+BuildRequires:  pkgconfig(xcursor)
+
+%description
+xcur2png is a program which let you take PNG image from X cursor, and generate config-file which is reusable by xcursorgen. To put it simply, it is converter from X cursor to PNG image.
+
+%prep
+%autosetup
+
+%build
+%configure
+%make_build
+
+%install
+%make_install
+
+%files
+%license COPYING
+%doc AUTHORS INSTALL NEWS README
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1.*
+
+%changelog
+* Sat Dec 13 2025 Metcya <metcya@gmail.com> - 0.7.1
+- package xcur2png


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: xcur2png (#8337)](https://github.com/terrapkg/packages/pull/8337)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)