### PR TITLE
[el10] fix(ags): now we need to cd into cli (#8306)

### DIFF
--- a/anda/lib/astal/ags/ags.spec
+++ b/anda/lib/astal/ags/ags.spec
@@ -41,11 +41,13 @@ Packager:       madonuko <mado@fyralabs.com>
 %autopatch -p1
 
 %build
+cd cli
 %define currentgoldflags -X main.version=%version
 %define gomodulesmode GO111MODULE=on
 %gobuild -o %{gobuilddir}/bin/ags .
 
 %install
+cd cli
 %gopkginstall
 install -m 0755 -vd                     %{buildroot}%{_bindir}
 install -m 0755 -vp %{gobuilddir}/bin/* %{buildroot}%{_bindir}/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(ags): now we need to cd into cli (#8306)](https://github.com/terrapkg/packages/pull/8306)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)