### PR TITLE
[f42] feat: Use Electron macros for...Electron (#8367)

### DIFF
--- a/anda/tools/electron/electron.spec
+++ b/anda/tools/electron/electron.spec
@@ -1,27 +1,15 @@
-%define debug_package %{nil}
-%global _build_id_links none
-
-%ifarch x86_64
-%global garch x64
-%elifarch aarch64
-%global garch arm64
-%endif
-
-# Exclude private libraries
-%global __requires_exclude libffmpeg.so
-%global __provides_exclude_from %{_libdir}/%{name}/.*\\.so
+%electronmeta
 
 Name:			electron
 Version:		39.2.7
 Release:		1%?dist
 Summary:		Build cross platform desktop apps with web technologies
-License:		MIT
+License:		%{electron_license}
 URL:			https://electronjs.org/
-Source0:		https://github.com/electron/electron/releases/download/v%{version}/chromedriver-v%{version}-linux-%{garch}.zip
-Source1:		https://github.com/electron/electron/releases/download/v%{version}/electron-v%{version}-linux-%{garch}.zip
+Source0:		https://github.com/electron/electron/releases/download/v%{version}/chromedriver-v%{version}-linux-%{_electron_cpu}.zip
+Source1:		https://github.com/electron/electron/releases/download/v%{version}/electron-v%{version}-linux-%{_electron_cpu}.zip
 Source2:		https://raw.githubusercontent.com/electron/electron/v%version/README.md
-Requires:		c-ares gtk3 minizip nss re2
-BuildRequires:	unzip
+BuildRequires:  anda-srpm-macros >= 0.2.26
 
 %description
 The Electron framework lets you write cross-platform desktop applications using


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat: Use Electron macros for...Electron (#8367)](https://github.com/terrapkg/packages/pull/8367)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)