### PR TITLE
[el10] fix(nvm): Fix some Bashisms (#8378)

### DIFF
--- a/anda/tools/nvm/binscript
+++ b/anda/tools/nvm/binscript
@@ -1,5 +1,5 @@
-#!/usr/bin/sh
+#!/usr/bin/bash
 
-. /etc/profile.d/nvm.sh
+\. /etc/profile.d/nvm.sh --no-use
 
 nvm $@

--- a/anda/tools/nvm/nvm.spec
+++ b/anda/tools/nvm/nvm.spec
@@ -1,6 +1,6 @@
 Name:     nvm
 Version:  0.40.3
-Release:  4%{?dist}
+Release:  5%{?dist}
 Summary:  Node Version Manager
 License:  MIT
 URL:      https://github.com/nvm-sh/nvm
@@ -9,7 +9,7 @@ Source1:  binscript
 # Make sure NVM always chooses "$HOME/.nvm" as the directory for local files unless explicitly set otherwise
 Patch0:   nvm-always-use-default-dir.patch
 # Only works with POSIX compliant shells
-Requires:  (bash or dash or ksh or zsh)
+Requires: bash
 BuildArch: noarch
 Packager:  Gilver E. <rockgrub@disroot.org>
 
@@ -26,6 +26,9 @@ POSIX-compliant script to manage multiple active Node.js versions.
 
 %install
 install -Dm755 %{SOURCE1} %{buildroot}%{_bindir}/%{name}
+
+# Give nvm-exec the correct search directory
+sed -i 's|DIR=.*|DIR="%{_sysconfdir}/profile.d"|g' nvm-exec
 install -Dm755 nvm-exec -t %{buildroot}%{_bindir}
 
 install -Dm644 bash_completion %{buildroot}%{bash_completions_dir}/%{name}.bash


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(nvm): Fix some Bashisms (#8378)](https://github.com/terrapkg/packages/pull/8378)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)