### PR TITLE
fix(electron): Put `%electronmeta` under name

### DIFF
--- a/anda/tools/electron/electron.spec
+++ b/anda/tools/electron/electron.spec
@@ -1,4 +1,5 @@
 Name:			electron
+%electronmeta
 Version:		39.2.7
 Release:		1%?dist
 Summary:		Build cross platform desktop apps with web technologies
@@ -8,8 +9,6 @@ Source0:		https://github.com/electron/electron/releases/download/v%{version}/chr
 Source1:		https://github.com/electron/electron/releases/download/v%{version}/electron-v%{version}-linux-%{_electron_cpu}.zip
 Source2:		https://raw.githubusercontent.com/electron/electron/v%version/README.md
 BuildRequires:  anda-srpm-macros >= 0.2.26
-
-%electronmeta
 
 %description
 The Electron framework lets you write cross-platform desktop applications using

--- a/anda/tools/electron/electron.spec
+++ b/anda/tools/electron/electron.spec
@@ -1,5 +1,3 @@
-%electronmeta
-
 Name:			electron
 Version:		39.2.7
 Release:		1%?dist
@@ -10,6 +8,8 @@ Source0:		https://github.com/electron/electron/releases/download/v%{version}/chr
 Source1:		https://github.com/electron/electron/releases/download/v%{version}/electron-v%{version}-linux-%{_electron_cpu}.zip
 Source2:		https://raw.githubusercontent.com/electron/electron/v%version/README.md
 BuildRequires:  anda-srpm-macros >= 0.2.26
+
+%electronmeta
 
 %description
 The Electron framework lets you write cross-platform desktop applications using


### PR DESCRIPTION
I just now realized I put this in the wrong spot because meta macros have to go under the preambles.