### PR TITLE
[f42] fix(electron): Put `%electronmeta` under name (#8383)

### DIFF
--- a/anda/tools/electron/electron.spec
+++ b/anda/tools/electron/electron.spec
@@ -1,6 +1,5 @@
-%electronmeta
-
 Name:			electron
+%electronmeta
 Version:		39.2.7
 Release:		1%?dist
 Summary:		Build cross platform desktop apps with web technologies


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(electron): Put &#x60;%electronmeta&#x60; under name (#8383)](https://github.com/terrapkg/packages/pull/8383)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)