### PR TITLE
[f43] fix(goofcord-nightly): Update script (#8395)

### DIFF
--- a/anda/apps/goofcord/nightly/update.rhai
+++ b/anda/apps/goofcord/nightly/update.rhai
@@ -2,8 +2,8 @@ rpm.global("commit", gh_commit("Milkshiift/GoofCord"));
  if rpm.changed() {
    let v = gh_tag("Milkshiift/GoofCord");
    v.crop(1);
-   if `[\d.]+-beta\.\d+`.find_all(v).len == 0 {
-     let v = sub(`-beta\.\d+`, "~", v);
+   if `[\d.]+-beta\.\d+`.find_all(v).len == 1 {
+     let v = sub(`-beta\.\d+`, `~`, v);
      rpm.global("ver", v);
    } else {
    rpm.global("ver", v + `^`);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(goofcord-nightly): Update script (#8395)](https://github.com/terrapkg/packages/pull/8395)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)