### PR TITLE
[f41] add: ScopeBuddy (#8417)

### DIFF
--- a/anda/games/ScopeBuddy/ScopeBuddy.spec
+++ b/anda/games/ScopeBuddy/ScopeBuddy.spec
@@ -1,0 +1,38 @@
+Name:           ScopeBuddy
+Version:        1.3.0
+Release:        1%?dist
+Summary:        A manager script to make gamescope easier to use on desktop
+License:        Apache-2.0
+URL:            https://github.com/HikariKnight/ScopeBuddy
+Source0:        %url/archive/refs/tags/%version.tar.gz
+BuildArch:      noarch
+
+Requires:       bash
+Requires:       perl
+Requires:       (gamescope or terra-gamescope)
+
+Provides:       scopebuddy
+Provides:       scb
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+A manager script to make gamescope easier to use on the desktop (or if you use it in desktop mode and gamemode).
+
+%prep
+%autosetup
+
+%install
+install -Dm 755 bin/scopebuddy %{buildroot}%{_bindir}/scopebuddy
+
+%post
+%{__ln_s} -f %{_bindir}/scopebuddy %{_bindir}/scb
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/scopebuddy
+
+%changelog
+* Tue Dec 16 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/games/ScopeBuddy/anda.hcl
+++ b/anda/games/ScopeBuddy/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+    rpm {
+        spec = "ScopeBuddy.spec"
+    }
+}

--- a/anda/games/ScopeBuddy/update.rhai
+++ b/anda/games/ScopeBuddy/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("HikariKnight/ScopeBuddy"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [add: ScopeBuddy (#8417)](https://github.com/terrapkg/packages/pull/8417)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)