### PR TITLE
[f42] add: arduino-lab-micropython-installer (#8163)

### DIFF
--- a/anda/tools/arduino-lab-micropython-installer/anda.hcl
+++ b/anda/tools/arduino-lab-micropython-installer/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "arduino-lab-micropython-installer.spec"
+	}
+}

--- a/anda/tools/arduino-lab-micropython-installer/arduino-lab-micropython-installer.spec
+++ b/anda/tools/arduino-lab-micropython-installer/arduino-lab-micropython-installer.spec
@@ -1,0 +1,41 @@
+
+Name:           lab-micropython-installer
+%electronmeta
+Version:        1.4.0
+Release:        1%?dist
+License:        AGPL-3.0 AND %electron_license
+Summary:        This repository hosts the entire code of the Arduino MicroPython Installer tool
+URL:            https://github.com/arduino/lab-micropython-installer
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+Source1:        micropython-installer.desktop
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+Requires:       libdrm libxcb
+BuildRequires:  anda-srpm-macros
+BuildRequires:  pnpm
+Provides:       arduino-lab-micropython-installer
+%description
+MicroPython Installer for Arduino is a cross-platform tool that streamlines the process of downloading
+and installing MicroPython firmware on compatible Arduino boards. It is compatible with macOS, Linux,
+and Windows and is built using the Electron framework.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%npm_build -r package
+
+%install
+%electron_install -i micropython-installer -s micropython-installer -d micropython-installer -b micropython-installer
+install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/applications/micropython-installer.desktop
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/micropython-installer
+%{_libdir}/micropython-installer/
+%{_hicolordir}/512x512/apps/micropython-installer.png
+%{_appsdir}/micropython-installer.desktop
+
+%changelog
+* Sat Dec 06 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/arduino-lab-micropython-installer/micropython-installer.desktop
+++ b/anda/tools/arduino-lab-micropython-installer/micropython-installer.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=micropython-installer
+Comment=A tool to flash MicroPython onto supported Arduino boards.
+GenericName=micropython-installer
+Exec=micropython-installer %U
+Icon=micropython-installer
+Type=Application
+StartupNotify=true
+Categories=GNOME;GTK;Utility;
+

--- a/anda/tools/arduino-lab-micropython-installer/update.rhai
+++ b/anda/tools/arduino-lab-micropython-installer/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/lab-micropython-installer"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: arduino-lab-micropython-installer (#8163)](https://github.com/terrapkg/packages/pull/8163)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)