### PR TITLE
[f43] fix (spotx-bash): only build on x86_64 runners (#8416)

### DIFF
--- a/anda/tools/spotx-bash/anda.hcl
+++ b/anda/tools/spotx-bash/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+        arches = ["x86_64"]
     rpm {
         spec = "spotx-bash.spec"
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (spotx-bash): only build on x86_64 runners (#8416)](https://github.com/terrapkg/packages/pull/8416)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)