### PR TITLE
[f41] fix (ScopeBuddy): add optional dependencies (#8430)

### DIFF
--- a/anda/games/ScopeBuddy/ScopeBuddy.spec
+++ b/anda/games/ScopeBuddy/ScopeBuddy.spec
@@ -1,6 +1,6 @@
 Name:           ScopeBuddy
 Version:        1.3.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A manager script to make gamescope easier to use on desktop
 License:        Apache-2.0
 URL:            https://github.com/HikariKnight/ScopeBuddy
@@ -10,6 +10,9 @@ BuildArch:      noarch
 Requires:       bash
 Requires:       perl
 Requires:       (gamescope or terra-gamescope)
+
+Suggests:       (kscreen-doctor or gnome-randr)
+Suggests:       jq
 
 Provides:       scopebuddy
 Provides:       scb


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f41`:
 - [fix (ScopeBuddy): add optional dependencies (#8430)](https://github.com/terrapkg/packages/pull/8430)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)