### PR TITLE
[f43] feat: Update Mesa to 25.3.1 (#8435)

### DIFF
--- a/anda/lib/mesa/gamescope.patch
+++ b/anda/lib/mesa/gamescope.patch
@@ -1,0 +1,88 @@
+diff --git a/src/gallium/frontends/dri/loader_dri3_helper.c b/src/gallium/frontends/dri/loader_dri3_helper.c
+index 2c8caba08fd..2c9159672dc 100644
+--- a/src/gallium/frontends/dri/loader_dri3_helper.c
++++ b/src/gallium/frontends/dri/loader_dri3_helper.c
+@@ -297,6 +297,30 @@ dri3_update_max_num_back(struct loader_dri3_drawable *draw)
+    }
+ }
+ 
++static unsigned
++gamescope_swapchain_override()
++{
++   const char *path = getenv("GAMESCOPE_LIMITER_FILE");
++   if (!path)
++      return 0;
++
++   static simple_mtx_t mtx = SIMPLE_MTX_INITIALIZER;
++   static int fd = -1;
++
++   simple_mtx_lock(&mtx);
++   if (fd < 0) {
++      fd = open(path, O_RDONLY);
++   }
++   simple_mtx_unlock(&mtx);
++
++   if (fd < 0)
++      return 0;
++
++   uint32_t override_value = 0;
++   pread(fd, &override_value, sizeof(override_value), 0);
++   return override_value;
++}
++
+ void
+ loader_dri3_set_swap_interval(struct loader_dri3_drawable *draw, int interval)
+ {
+@@ -311,10 +335,12 @@ loader_dri3_set_swap_interval(struct loader_dri3_drawable *draw, int interval)
+     * PS. changing from value A to B and A < B won't cause swap out of order but
+     * may still gets wrong target_msc value at the beginning.
+     */
+-   if (draw->swap_interval != interval)
++   if (draw->orig_swap_interval != interval)
+       loader_dri3_swapbuffer_barrier(draw);
+ 
+-   draw->swap_interval = interval;
++   draw->orig_swap_interval = interval;
++   if (gamescope_swapchain_override() != 1)
++      draw->swap_interval = interval;
+ }
+ 
+ static void
+@@ -443,6 +469,12 @@ loader_dri3_drawable_init(xcb_connection_t *conn,
+ 
+    draw->swap_interval = dri_get_initial_swap_interval(draw->dri_screen_render_gpu);
+ 
++   draw->orig_swap_interval = draw->swap_interval;
++
++   unsigned gamescope_override = gamescope_swapchain_override();
++   if (gamescope_override == 1)
++      draw->swap_interval = 1;
++
+    dri3_update_max_num_back(draw);
+ 
+    /* Create a new drawable */
+@@ -1085,6 +1117,12 @@ loader_dri3_swap_buffers_msc(struct loader_dri3_drawable *draw,
+    if (draw->type == LOADER_DRI3_DRAWABLE_WINDOW) {
+       dri3_fence_reset(draw->conn, back);
+ 
++      unsigned gamescope_override = gamescope_swapchain_override();
++      if (gamescope_override == 1)
++         draw->swap_interval = 1;
++      else
++         draw->swap_interval = draw->orig_swap_interval;
++
+       /* Compute when we want the frame shown by taking the last known
+        * successful MSC and adding in a swap interval for each outstanding swap
+        * request. target_msc=divisor=remainder=0 means "Use glXSwapBuffers()
+diff --git a/src/gallium/frontends/dri/loader_dri3_helper.h b/src/gallium/frontends/dri/loader_dri3_helper.h
+index 26f138d1b83..3f0f3f66fac 100644
+--- a/src/gallium/frontends/dri/loader_dri3_helper.h
++++ b/src/gallium/frontends/dri/loader_dri3_helper.h
+@@ -169,6 +169,7 @@ struct loader_dri3_drawable {
+    bool block_on_depleted_buffers;
+    bool queries_buffer_age;
+    int swap_interval;
++   int orig_swap_interval;
+ 
+    const struct loader_dri3_vtable *vtable;
+ 

--- a/anda/lib/mesa/horizon5.patch
+++ b/anda/lib/mesa/horizon5.patch
@@ -1,0 +1,14 @@
+diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
+index e36357b9e4a..68a1957ee7b 100644
+--- a/src/util/00-radv-defaults.conf
++++ b/src/util/00-radv-defaults.conf
+@@ -311,5 +311,9 @@ Application bugs worked around in this file:
+         <application name="No Man's Sky" application_name_match="No Man's Sky">
+             <option name="radv_app_layer" value="no_mans_sky" />
+         </application>
++
++        <application name="Forza Horizon 5" application_name_match="ForzaHorizon5.exe">
++            <option name="vk_x11_override_min_image_count" value="4" />
++        </application>
+     </device>
+ </driconf>

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -82,7 +82,7 @@
 
 Name:           %{srcname}
 Summary:        Mesa graphics libraries
-%global ver 25.3.0
+%global ver 25.3.1
 Epoch:          1
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
 Release:        %autorelease
@@ -116,8 +116,10 @@ Source15:       https://crates.io/api/v1/crates/rustc-hash/%{rustc_hash_ver}/dow
 # Teflon: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/38532
 Patch12:        mesa-38532.patch
 
-# https://github.com/bazzite-org/mesa
-Patch20:        bazzite.patch
+# Gaming Patches
+Patch20:        gamescope.patch
+Patch21:        wine-wayland.patch
+Patch22:        horizon5.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc

--- a/anda/lib/mesa/wine-wayland.patch
+++ b/anda/lib/mesa/wine-wayland.patch
@@ -1,232 +1,3 @@
-From 822117cacfa1eb2f327734c9b95739b7882c17ae Mon Sep 17 00:00:00 2001
-From: Kyle Gospodnetich <me@kylegospodneti.ch>
-Date: Mon, 24 Nov 2025 21:07:27 -0800
-Subject: [PATCH 1/8] [BEGIN] SteamOS Changes
-
--- 
-2.52.0
-
-
-From 94b012e3b5858db415b4fff612df61667ea85f7b Mon Sep 17 00:00:00 2001
-From: Bas Nieuwenhuizen <bas@basnieuwenhuizen.nl>
-Date: Fri, 14 Jan 2022 15:58:45 +0100
-Subject: [PATCH 2/8] STEAMOS: radv: min image count override for FH5
-
-Otherwise in combination with the vblank time reservation in
-gamescope the game could get stuck in low power states.
----
- src/util/00-radv-defaults.conf | 4 ++++
- 1 file changed, 4 insertions(+)
-
-diff --git a/src/util/00-radv-defaults.conf b/src/util/00-radv-defaults.conf
-index e36357b9e4a..68a1957ee7b 100644
---- a/src/util/00-radv-defaults.conf
-+++ b/src/util/00-radv-defaults.conf
-@@ -311,5 +311,9 @@ Application bugs worked around in this file:
-         <application name="No Man's Sky" application_name_match="No Man's Sky">
-             <option name="radv_app_layer" value="no_mans_sky" />
-         </application>
-+
-+        <application name="Forza Horizon 5" application_name_match="ForzaHorizon5.exe">
-+            <option name="vk_x11_override_min_image_count" value="4" />
-+        </application>
-     </device>
- </driconf>
--- 
-2.52.0
-
-
-From 482112717feaee42098c18eb9143d5afd6f5e173 Mon Sep 17 00:00:00 2001
-From: Samuel Pitoiset <samuel.pitoiset@gmail.com>
-Date: Thu, 22 Feb 2024 22:32:45 +0100
-Subject: [PATCH 3/8] STEAMOS: Dynamic swapchain override for gamescope limiter
- for DRI3 only
-
-The original patch (from Bas) contained WSI VK support too but it's
-been removed because the Gamescope WSI layer already handles that.
-
-Signed-off-by: Samuel Pitoiset <samuel.pitoiset@gmail.com>
----
- .../frontends/dri/loader_dri3_helper.c        | 42 ++++++++++++++++++-
- .../frontends/dri/loader_dri3_helper.h        |  1 +
- 2 files changed, 41 insertions(+), 2 deletions(-)
-
-diff --git a/src/gallium/frontends/dri/loader_dri3_helper.c b/src/gallium/frontends/dri/loader_dri3_helper.c
-index 2c8caba08fd..2c9159672dc 100644
---- a/src/gallium/frontends/dri/loader_dri3_helper.c
-+++ b/src/gallium/frontends/dri/loader_dri3_helper.c
-@@ -297,6 +297,30 @@ dri3_update_max_num_back(struct loader_dri3_drawable *draw)
-    }
- }
- 
-+static unsigned
-+gamescope_swapchain_override()
-+{
-+   const char *path = getenv("GAMESCOPE_LIMITER_FILE");
-+   if (!path)
-+      return 0;
-+
-+   static simple_mtx_t mtx = SIMPLE_MTX_INITIALIZER;
-+   static int fd = -1;
-+
-+   simple_mtx_lock(&mtx);
-+   if (fd < 0) {
-+      fd = open(path, O_RDONLY);
-+   }
-+   simple_mtx_unlock(&mtx);
-+
-+   if (fd < 0)
-+      return 0;
-+
-+   uint32_t override_value = 0;
-+   pread(fd, &override_value, sizeof(override_value), 0);
-+   return override_value;
-+}
-+
- void
- loader_dri3_set_swap_interval(struct loader_dri3_drawable *draw, int interval)
- {
-@@ -311,10 +335,12 @@ loader_dri3_set_swap_interval(struct loader_dri3_drawable *draw, int interval)
-     * PS. changing from value A to B and A < B won't cause swap out of order but
-     * may still gets wrong target_msc value at the beginning.
-     */
--   if (draw->swap_interval != interval)
-+   if (draw->orig_swap_interval != interval)
-       loader_dri3_swapbuffer_barrier(draw);
- 
--   draw->swap_interval = interval;
-+   draw->orig_swap_interval = interval;
-+   if (gamescope_swapchain_override() != 1)
-+      draw->swap_interval = interval;
- }
- 
- static void
-@@ -443,6 +469,12 @@ loader_dri3_drawable_init(xcb_connection_t *conn,
- 
-    draw->swap_interval = dri_get_initial_swap_interval(draw->dri_screen_render_gpu);
- 
-+   draw->orig_swap_interval = draw->swap_interval;
-+
-+   unsigned gamescope_override = gamescope_swapchain_override();
-+   if (gamescope_override == 1)
-+      draw->swap_interval = 1;
-+
-    dri3_update_max_num_back(draw);
- 
-    /* Create a new drawable */
-@@ -1085,6 +1117,12 @@ loader_dri3_swap_buffers_msc(struct loader_dri3_drawable *draw,
-    if (draw->type == LOADER_DRI3_DRAWABLE_WINDOW) {
-       dri3_fence_reset(draw->conn, back);
- 
-+      unsigned gamescope_override = gamescope_swapchain_override();
-+      if (gamescope_override == 1)
-+         draw->swap_interval = 1;
-+      else
-+         draw->swap_interval = draw->orig_swap_interval;
-+
-       /* Compute when we want the frame shown by taking the last known
-        * successful MSC and adding in a swap interval for each outstanding swap
-        * request. target_msc=divisor=remainder=0 means "Use glXSwapBuffers()
-diff --git a/src/gallium/frontends/dri/loader_dri3_helper.h b/src/gallium/frontends/dri/loader_dri3_helper.h
-index 26f138d1b83..3f0f3f66fac 100644
---- a/src/gallium/frontends/dri/loader_dri3_helper.h
-+++ b/src/gallium/frontends/dri/loader_dri3_helper.h
-@@ -169,6 +169,7 @@ struct loader_dri3_drawable {
-    bool block_on_depleted_buffers;
-    bool queries_buffer_age;
-    int swap_interval;
-+   int orig_swap_interval;
- 
-    const struct loader_dri3_vtable *vtable;
- 
--- 
-2.52.0
-
-
-From 46d91c20dfb4f314a6e261ef4f1ae7ae65d90569 Mon Sep 17 00:00:00 2001
-From: Kyle Gospodnetich <me@kylegospodneti.ch>
-Date: Mon, 24 Nov 2025 21:08:23 -0800
-Subject: [PATCH 4/8] [BEGIN] SteamOS Backports
-
--- 
-2.52.0
-
-
-From 6823720adcf0fc209bcc341999b3e3fe76b6c189 Mon Sep 17 00:00:00 2001
-From: Kyle Gospodnetich <me@kylegospodneti.ch>
-Date: Mon, 24 Nov 2025 21:08:31 -0800
-Subject: [PATCH 5/8] [BEGIN] Our Mesa Backports
-
--- 
-2.52.0
-
-
-From 227cd7d88802583e47ea3c7ff006103266330ec9 Mon Sep 17 00:00:00 2001
-From: Antheas Kapenekakis <git@antheas.dev>
-Date: Mon, 24 Mar 2025 19:50:51 +0100
-Subject: [PATCH 6/8] Revert "winsys/amdgpu: use VM_ALWAYS_VALID for all VRAM
- and GTT allocations"
-
-This reverts commit 8c91624614c1f939974fe0d2d1a3baf83335cecb.
-
-Messes with AutoVRAM, who would have thought?
----
- src/gallium/winsys/amdgpu/drm/amdgpu_bo.c | 5 -----
- 1 file changed, 5 deletions(-)
-
-diff --git a/src/gallium/winsys/amdgpu/drm/amdgpu_bo.c b/src/gallium/winsys/amdgpu/drm/amdgpu_bo.c
-index ce4e9f67659..47703444abf 100644
---- a/src/gallium/winsys/amdgpu/drm/amdgpu_bo.c
-+++ b/src/gallium/winsys/amdgpu/drm/amdgpu_bo.c
-@@ -624,11 +624,6 @@ static struct amdgpu_winsys_bo *amdgpu_create_bo(struct amdgpu_winsys *aws,
-    if (flags & RADEON_FLAG_GTT_WC)
-       request.flags |= AMDGPU_GEM_CREATE_CPU_GTT_USWC;
- 
--   if (aws->info.has_vm_always_valid &&
--       initial_domain & (RADEON_DOMAIN_VRAM_GTT | RADEON_DOMAIN_DOORBELL) &&
--       flags & RADEON_FLAG_NO_INTERPROCESS_SHARING)
--      request.flags |= AMDGPU_GEM_CREATE_VM_ALWAYS_VALID;
--
-    if (flags & RADEON_FLAG_DISCARDABLE &&
-        aws->info.drm_minor >= 47)
-       request.flags |= AMDGPU_GEM_CREATE_DISCARDABLE;
--- 
-2.52.0
-
-
-From 4f1a882f75edd79690610135738f5d5317263ffd Mon Sep 17 00:00:00 2001
-From: Kyle Gospodnetich <me@kylegospodneti.ch>
-Date: Mon, 24 Nov 2025 21:09:02 -0800
-Subject: [PATCH 7/8] [BEGIN] Proton-GE Patches
-
--- 
-2.52.0
-
-
-From 59eb16ed2551892c18d75e146a29a213964aee6b Mon Sep 17 00:00:00 2001
-From: Kyle Gospodnetich <me@kylegospodneti.ch>
-Date: Sun, 18 May 2025 09:42:23 -0700
-Subject: [PATCH 8/8] radv: min image count patch for Wine Wayland/Path of
- Exile 2 Credit to Glorious Eggroll.
-
----
- src/amd/vulkan/radv_instance.c       |  2 +-
- src/asahi/vulkan/hk_instance.c       |  2 +-
- src/freedreno/vulkan/tu_device.cc    |  2 +-
- src/intel/vulkan/anv_instance.c      |  2 +-
- src/intel/vulkan_hasvk/anv_device.c  |  2 +-
- src/nouveau/vulkan/nvk_instance.c    |  2 +-
- src/panfrost/vulkan/panvk_instance.c |  2 +-
- src/util/00-mesa-defaults.conf       | 10 ++++++----
- src/util/driconf.h                   |  4 ++--
- src/virtio/vulkan/vn_instance.c      |  2 +-
- src/vulkan/wsi/wsi_common.c          |  2 +-
- src/vulkan/wsi/wsi_common.h          |  4 ++++
- src/vulkan/wsi/wsi_common_private.h  |  3 ++-
- src/vulkan/wsi/wsi_common_wayland.c  | 21 +++++++++++++++++----
- src/vulkan/wsi/wsi_common_x11.c      |  4 ++--
- 15 files changed, 42 insertions(+), 22 deletions(-)
-
 diff --git a/src/amd/vulkan/radv_instance.c b/src/amd/vulkan/radv_instance.c
 index c43b8f9a00c..fb0db9769e6 100644
 --- a/src/amd/vulkan/radv_instance.c
@@ -267,7 +38,7 @@ index 05ffad6424d..e32862161de 100644
        DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
        DRI_CONF_VK_XWAYLAND_WAIT_READY(false)
 diff --git a/src/intel/vulkan/anv_instance.c b/src/intel/vulkan/anv_instance.c
-index 73a46dc72ee..b51b055ca7b 100644
+index a6f2c5985c0..b509fa21404 100644
 --- a/src/intel/vulkan/anv_instance.c
 +++ b/src/intel/vulkan/anv_instance.c
 @@ -10,7 +10,7 @@
@@ -277,8 +48,8 @@ index 73a46dc72ee..b51b055ca7b 100644
 -      DRI_CONF_VK_X11_OVERRIDE_MIN_IMAGE_COUNT(0)
 +      DRI_CONF_VK_OVERRIDE_MIN_IMAGE_COUNT(0)
        DRI_CONF_VK_X11_STRICT_IMAGE_COUNT(false)
+       DRI_CONF_VK_WSI_DISABLE_UNORDERED_SUBMITS(false)
        DRI_CONF_VK_XWAYLAND_WAIT_READY(false)
-       DRI_CONF_ANV_ASSUME_FULL_SUBGROUPS(0)
 diff --git a/src/intel/vulkan_hasvk/anv_device.c b/src/intel/vulkan_hasvk/anv_device.c
 index d111c96ae7a..42e3f82eff9 100644
 --- a/src/intel/vulkan_hasvk/anv_device.c
@@ -319,10 +90,10 @@ index bb425414bb1..39f137d5ab3 100644
        DRI_CONF_VK_X11_ENSURE_MIN_IMAGE_COUNT(false)
        DRI_CONF_VK_XWAYLAND_WAIT_READY(false)
 diff --git a/src/util/00-mesa-defaults.conf b/src/util/00-mesa-defaults.conf
-index b09512adfbb..bd816765bf0 100644
+index 926db52670e..78c6934b829 100644
 --- a/src/util/00-mesa-defaults.conf
 +++ b/src/util/00-mesa-defaults.conf
-@@ -639,24 +639,24 @@ TODO: document the other workarounds.
+@@ -645,24 +645,24 @@ TODO: document the other workarounds.
  
          <application name="gfxbench" executable="testfw_app">
              <option name="mesa_glthread_app_profile" value="0" />
@@ -351,7 +122,7 @@ index b09512adfbb..bd816765bf0 100644
              <option name="vk_x11_strict_image_count" value="true" />
          </application>
  
-@@ -717,10 +717,12 @@ TODO: document the other workarounds.
+@@ -723,10 +723,12 @@ TODO: document the other workarounds.
  
          <application name="Path of Exile" executable="PathOfExile_x64Steam.exe">
              <option name="vk_zero_vram" value="true" />
@@ -365,10 +136,10 @@ index b09512adfbb..bd816765bf0 100644
  
          <application name="X4 Foundations" executable="X4">
 diff --git a/src/util/driconf.h b/src/util/driconf.h
-index 45ed8a40579..84934b24dd9 100644
+index ab9aca4cb07..d6dd50f7539 100644
 --- a/src/util/driconf.h
 +++ b/src/util/driconf.h
-@@ -453,8 +453,8 @@
+@@ -456,8 +456,8 @@
     DRI_CONF_OPT_B(vk_wsi_disable_unordered_submits, def, \
                    "Disable unordered WSI submits to workaround application synchronization bugs")
  
@@ -394,7 +165,7 @@ index 523f0590e9a..b1f642f1c2e 100644
        DRI_CONF_VK_XWAYLAND_WAIT_READY(true)
        DRI_CONF_VENUS_IMPLICIT_FENCING(false)
 diff --git a/src/vulkan/wsi/wsi_common.c b/src/vulkan/wsi/wsi_common.c
-index 362e50f2aec..2d22e6bfc3d 100644
+index 0c4a4ce652e..2a95cfd557b 100644
 --- a/src/vulkan/wsi/wsi_common.c
 +++ b/src/vulkan/wsi/wsi_common.c
 @@ -220,7 +220,7 @@ wsi_device_init(struct wsi_device *wsi,
@@ -520,6 +291,3 @@ index 2cd023dadcf..7872a2a899f 100644
        }
        if (driCheckOption(dri_options, "vk_x11_strict_image_count", DRI_BOOL)) {
           wsi_device->x11.strict_imageCount =
--- 
-2.52.0
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update Mesa to 25.3.1 (#8435)](https://github.com/terrapkg/packages/pull/8435)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)