### PR TITLE
[f41] bump: zed zed-preview (#8441)

### DIFF
--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -5,7 +5,7 @@
 %global debug_package %{nil}
 %endif
 
-%global ver 0.216.1
+%global ver 0.218.2-pre
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -15,7 +15,7 @@
 %global rustflags_debuginfo 0
 
 Name:           zed
-Version:        0.216.1
+Version:        0.217.2
 Release:        1%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
 SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f41`:
 - [bump: zed zed-preview (#8441)](https://github.com/terrapkg/packages/pull/8441)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)