### PR TITLE
[f42] fix: stardust-xr-telescope (#8446)

### DIFF
--- a/anda/stardust/telescope/stardust-telescope.spec
+++ b/anda/stardust/telescope/stardust-telescope.spec
@@ -35,13 +35,15 @@ See the stars! Easy stardust setups to run on your computer.
 %build
 
 %install
-install -Dm755 scripts/telescope          %buildroot%_bindir/telescope
-install -Dm755 scripts/_telescope_startup %buildroot%_bindir/_telescope_startup
-install -Dm644 org.stardustxr.png         %buildroot%_iconsdir/hicolor/512x512/apps/org.stardustxr.png
+install -Dm755 scripts/telescope                 %buildroot%_bindir/telescope
+install -Dm755 scripts/_telescope_startup        %buildroot%_bindir/_telescope_startup
+install -Dm644 org.stardustxr.Telescope.desktop  %buildroot%_appsdir/org.stardustxr.Telescope.desktop
+install -Dm644 org.stardustxr.Telescope.png      %buildroot%_hicolordir/512x512/apps/org.stardustxr.Telescope.png
 
 %files
 %doc README.md
 %license LICENSE
 %_bindir/telescope
 %_bindir/_telescope_startup
-%_iconsdir/hicolor/512x512/apps/org.stardustxr.png
+%_appsdir/org.stardustxr.Telescope.desktop
+%_hicolordir/512x512/apps/org.stardustxr.Telescope.png


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: stardust-xr-telescope (#8446)](https://github.com/terrapkg/packages/pull/8446)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)