### PR TITLE
[f42] feat(terra-gpg-keys): Auto update on Rawhide (#8462)

### DIFF
--- a/anda/terra/gpg-keys/update.rhai
+++ b/anda/terra/gpg-keys/update.rhai
@@ -1,0 +1,8 @@
+import "andax/bump_extras.rhai" as bump;
+
+open_file("anda/terra/gpg-keys/RELEASE.txt", "w").write(bump::as_bodhi_ver(labels.branch));
+
+let dir = sub(`/[^/]+$`, "", __script_path);
+if sh("[[ `git status " + dir + " --porcelain` ]] && exit 1 || exit 0", #{}).ctx.rc == 1 {
+    rpm.release();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(terra-gpg-keys): Auto update on Rawhide (#8462)](https://github.com/terrapkg/packages/pull/8462)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)