### PR TITLE
[f43] fix(terra-gpg-keys): Make updbranch (#8471)

### DIFF
--- a/anda/terra/gpg-keys/anda.hcl
+++ b/anda/terra/gpg-keys/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
 	rpm {
 		spec = "terra-gpg-keys.spec"
 	}
+	labels {
+		updbranch = 1
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(terra-gpg-keys): Make updbranch (#8471)](https://github.com/terrapkg/packages/pull/8471)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)