### PR TITLE
chore: EOL 41

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
   "repoOwner": "terrapkg",
   "repoName": "packages",
   "resetAuthor": true,
-  "targetBranchChoices": ["el10", "f41", "f42", "f43", "frawhide"],
+  "targetBranchChoices": ["frawhide", "f43", "f42", "el10"],
   "branchLabelMapping": {
     "^sync-(.+)$": "$1"
   }

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -15,7 +15,6 @@ jobs:
           - frawhide
           - f43
           - f42
-          - f41
           - el10
     container:
       image: ghcr.io/terrapkg/builder:frawhide

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -8,7 +8,6 @@ on:
       - frawhide
       - f43
       - f42
-      - f41
       - el10
     paths:
       - comps.xml

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -50,7 +50,6 @@ jobs:
             }
             copy_over f43 || true
             copy_over f42 || true
-            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -50,7 +50,6 @@ jobs:
             }
             copy_over f43 || true
             copy_over f42 || true
-            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -50,7 +50,6 @@ jobs:
             }
             copy_over f43 || true
             copy_over f42 || true
-            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi


### PR DESCRIPTION
It's not [here](https://docs.fedoraproject.org/en-US/releases/eol/) yet because of a funny but the official EOL date was 2025-12-15.

Relevant Fedora Discussion thread: https://discussion.fedoraproject.org/t/fedora-41-eol-whoops/175073