### PR TITLE
[el10] chore(terra-gpg-keys): Bump release back up (#8475)

### DIFF
--- a/anda/terra/gpg-keys/terra-gpg-keys.spec
+++ b/anda/terra/gpg-keys/terra-gpg-keys.spec
@@ -2,7 +2,7 @@
 
 Name:           terra-gpg-keys
 Version:        %{?fedora:%{fedora}}%{?rhel:%{rhel}}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        GPG keys for Terra
 Requires:       filesystem >= 3.18-6
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(terra-gpg-keys): Bump release back up (#8475)](https://github.com/terrapkg/packages/pull/8475)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)