### PR TITLE
[f42] chore: EOL 41 (#8476)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
   "repoOwner": "terrapkg",
   "repoName": "packages",
   "resetAuthor": true,
-  "targetBranchChoices": ["el10", "f41", "f42", "frawhide"],
+  "targetBranchChoices": ["frawhide", "f43", "f42", "el10"],
   "branchLabelMapping": {
     "^sync-(.+)$": "$1"
   }

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -15,7 +15,6 @@ jobs:
           - frawhide
           - f43
           - f42
-          - f41
           - el10
     container:
       image: ghcr.io/terrapkg/builder:f42

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - frawhide
       - f42
-      - f41
       - el10
     paths:
       - comps.xml

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -50,7 +50,6 @@ jobs:
             }
             copy_over f43 || true
             copy_over f42 || true
-            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -50,7 +50,6 @@ jobs:
             }
             copy_over f43 || true
             copy_over f42 || true
-            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -50,7 +50,6 @@ jobs:
             }
             copy_over f43 || true
             copy_over f42 || true
-            copy_over f41 || true
             copy_over el10 || true
             git push -u origin --all
           fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: EOL 41 (#8476)](https://github.com/terrapkg/packages/pull/8476)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)