### PR TITLE
[el10] bump(nightly): goofcord-nightly mpv-nightly ghostty-nightly micro-nightly zed-nightly prismlauncher-nightly nim-nightly types-colorama cros-keyboard-map opentabletdriver-nightly scx-scheds-nightly glasgow natscli rpi-update spotx-bash (#8484)

### DIFF
--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 5574b90cd9a3ccd12e44e73ee5af74dd00f60c37
+%global commit 09aac6c05d5844741abf3970ec32a708545d7cc7
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251218
+%global commit_date 20251219
 %global ver 1.11.3^
 %global base_name goofcord
 %global git_name GoofCord

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,9 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-%global commit dbd7a905b6ed47dd8f0acd09a1f4cc9a08e854a6
+%global commit 6739fd490b63ae8092da511c2fb81a94f5ae1efc
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251205
+%global commit_date 20251219
 %global ver 0.40.0
 
 Name:           mpv-nightly

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit a4cb73db848c733a5fb686038a90abe6d175aabe
+%global commit fa0a982ff26ac851b6cb5d31717ad3deb037be9c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2025-12-17
+%global fulldate 2025-12-19
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0

--- a/anda/devs/micro/micro-nightly.spec
+++ b/anda/devs/micro/micro-nightly.spec
@@ -12,8 +12,8 @@
 
 # Naming variable as something other than "commit" is necessary
 # to stop %%gometa from putting commit hash in release
-%global commit_hash 70dfc7fcb4d0f53e155fa0d8ac5ea200d8736d16
-%global commit_date 20251128
+%global commit_hash 467eb88df02cf281d372e141e71a79985961f0c8
+%global commit_date 20251219
 %global shortcommit %{sub %{commit_hash} 1 7}
 %global ver 2.0.14
 

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 77cdef35966549ee61e101af10d33ece3be40d84
+%global commit e0ff995e2d5673af67af275187271776b57436d7
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251218
+%global commit_date 20251219
 %global ver 0.219.0
 
 %bcond_with check

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,10 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-%global commit c33d104dc32d560a86ca4f65de41bd71a231466e
+%global commit 53e090f0350ecc068e763b53f76265304fbda12f
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20251214
+%global commit_date 20251219
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 %bcond_without qt6

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit 334ac3f58860584f1e24b9164054007348b7f0eb
+%global commit 548b1c6ef8d3698bcf27d0535d3c418e4323f4cb
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20251218
+%global commit_date 20251219
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit fcc9ebccb563aaa95cb84c81029d55b20038b82d
-%global commit_date 20251211
+%global commit cc53f5497f9983bc01f2381d9625e20f792e6455
+%global commit_date 20251219
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/system/cros-keyboard-map/cros-keyboard-map.spec
+++ b/anda/system/cros-keyboard-map/cros-keyboard-map.spec
@@ -1,6 +1,6 @@
-%global commit_date 20250921
+%global commit_date 20251219
 
-%global tree_commit 7f7bfe5647635084b5699b2b7f4f5dfb489bbdae
+%global tree_commit 146753f3646a13f069bf3ea1e2fb8ebbe0d1b46a
 %global tree_shortcommit %(c=%{tree_commit}; echo ${c:0:7})
 
 %global um_commit 46892acafb2fff3f3ace425d4694382c92645feb

--- a/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
+++ b/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 5d5f6fb69c1090feab2dfe3f953fa955de123031
+%global commit 4a1063577664d299d40507365c5c43b962a66707
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251211
+%global commit_date 20251219
 %global ver 0.6.6.2
 
 # We aren't using Mono but RPM expected Mono

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 822a32f9b44eab883eb683481a9af79de5df2c15
+%global commit 9a34f73ece9dd27f41a7179a0ee55ee1bdb7ecc4
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251218
+%global commitdate 20251219
 %global ver 1.0.19
 %undefine __brp_mangle_shebangs
 

--- a/anda/tools/glasgow/glasgow.spec
+++ b/anda/tools/glasgow/glasgow.spec
@@ -1,5 +1,5 @@
-%global commit b1e9a04b86d9ca5a94cdec990836383d73bbc2b6
-%global commit_date 20251202
+%global commit 49973e450c2a359dd9967ca82e139da12b471808
+%global commit_date 20251219
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name glasgow

--- a/anda/tools/natscli/natscli.spec
+++ b/anda/tools/natscli/natscli.spec
@@ -1,7 +1,7 @@
 # https://github.com/nats-io/natscli
 %global goipath         github.com/nats-io/natscli
-%global commit          9cebb956791ff8f9f10d35f11af8d471af0cdbd8
-%global commit_date     20251113
+%global commit          2542380465e9e3453a92ededd9bb991f15875cb7
+%global commit_date     20251219
 %global shortcommit     %{sub %{commit} 1 7}
 
 %gometa -f

--- a/anda/tools/rpi-update/rpi-update.spec
+++ b/anda/tools/rpi-update/rpi-update.spec
@@ -1,7 +1,7 @@
 %define debug_package %nil
 
-%global commit 0407f61fc32ca84598b2ed23cec32f07fce6ab08
-%global commit_date 20250805
+%global commit e30e6978b61abed7f6f665eff55dc74835c9de85
+%global commit_date 20251219
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           rpi-update

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,5 +1,5 @@
-%global commit a2bd8479a2a80a068e749530aa5a78b2918358b8
-%global commit_date 20251108
+%global commit 6fae30701115685fc20cff9047bc8437aae75a7e
+%global commit_date 20251219
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           spotx-bash


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump(nightly): goofcord-nightly mpv-nightly ghostty-nightly micro-nightly zed-nightly prismlauncher-nightly nim-nightly types-colorama cros-keyboard-map opentabletdriver-nightly scx-scheds-nightly glasgow natscli rpi-update spotx-bash (#8484)](https://github.com/terrapkg/packages/pull/8484)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)