### PR TITLE
[f42] feat(zed*): Better ZFS compat package name (#8483)

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -63,7 +63,7 @@ BuildRequires:  perl-lib
 BuildRequires:  rustup
 %endif
 BuildRequires:  vulkan-loader
-Requires: (%name-rename-zeditor if zfs else %name-cli)
+Requires: (%name-cli-compat-zfs if zfs else %name-cli)
 Suggests: %name-cli
 
 %description
@@ -73,33 +73,21 @@ Code at the speed of thought - Zed is a high-performance, multiplayer code edito
 Summary: Provides the /usr/bin/zed binary
 Conflicts: zfs
 Supplements: (%name unless zfs)
-%description cli
-This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
-%files cli
-%if %{without debug_no_build}
-%_bindir/zed
-%endif
-%{_datadir}/icons/hicolor/512x512/apps/%appid.png
-%{_datadir}/applications/%appid.desktop
-%{_metainfodir}/%appid.metainfo.xml
 
-%package rename-zeditor
+%description cli
+This package provides the /usr/bin/zed binary. If you use zfs, install %name-cli-compat-zfs instead.
+
+%package cli-compat-zfs
 Summary: Rename zed to zeditor to prevent collision with zfs
 Provides: %name-cli
 Conflicts: %name-cli
+Obsoletes: %{name}-rename-zeditor <= 0.217.3
 Supplements: (%name and zfs)
 RemovePathPostFixes: .zeditor
-%description rename-zeditor
+
+%description cli-compat-zfs
 This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
 The normal package is %name-cli.
-%files rename-zeditor
-%if %{without debug_no_build}
-%_bindir/zeditor
-%endif
-%{_datadir}/icons/hicolor/512x512/apps/%appid.png
-%_datadir/applications/%appid.desktop.zeditor
-%{_metainfodir}/%appid.metainfo.xml
-
 
 %prep
 %autosetup -n %{crate}-%{commit} -p1
@@ -202,6 +190,22 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%appid.desktop
 %if %{without debug_no_build}
 %{_libexecdir}/zed-editor
 %endif
+
+%files cli
+%if %{without debug_no_build}
+%_bindir/zed
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%{_datadir}/applications/%appid.desktop
+%{_metainfodir}/%appid.metainfo.xml
+
+%files cli-compat-zfs
+%if %{without debug_no_build}
+%_bindir/zeditor
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%_datadir/applications/%appid.desktop.zeditor
+%{_metainfodir}/%appid.metainfo.xml
 
 %changelog
 %autochangelog

--- a/anda/devs/zed/preview/update.rhai
+++ b/anda/devs/zed/preview/update.rhai
@@ -3,8 +3,6 @@ for release in releases {
   let tag = release.tag_name;
   tag.crop(1); // remove "v"
   rpm.global("ver", tag);
+  rpm.release();
   break;
-  if rpm.changed() {
-    rpm.release();
-  }
 }

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -17,7 +17,7 @@
 
 Name:           zed-preview
 Version:        %(echo %ver | sed 's/-/~/')
-Release:        5%?dist
+Release:        6%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
 SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
@@ -55,7 +55,7 @@ BuildRequires:  perl-File-Compare
 BuildRequires:  perl-File-Copy
 BuildRequires:  perl-lib
 BuildRequires:  vulkan-loader
-Requires: (%name-rename-zeditor if zfs else %name-cli)
+Requires: (%name-cli-compat-zfs if zfs else %name-cli)
 Suggests: %name-cli
 
 %description
@@ -65,33 +65,21 @@ Code at the speed of thought - Zed is a high-performance, multiplayer code edito
 Summary: Provides the /usr/bin/zed binary
 Conflicts: zfs
 Supplements: (%name unless zfs)
-%description cli
-This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
-%files cli
-%if %{without debug_no_build}
-%_bindir/zed
-%endif
-%{_datadir}/icons/hicolor/512x512/apps/%appid.png
-%{_datadir}/applications/%appid.desktop
-%{_metainfodir}/%appid.metainfo.xml
 
-%package rename-zeditor
+%description cli
+This package provides the /usr/bin/zed binary. If you use zfs, install %name-cli-compat-zfs instead.
+
+%package cli-compat-zfs
 Summary: Rename zed to zeditor to prevent collision with zfs
 Provides: %name-cli
 Conflicts: %name-cli
+Obsoletes: %{name}-rename-zeditor <= 0.217.3
 Supplements: (%name and zfs)
 RemovePathPostFixes: .zeditor
-%description rename-zeditor
+
+%description cli-compat-zfs
 This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
 The normal package is %name-cli.
-%files rename-zeditor
-%if %{without debug_no_build}
-%_bindir/zeditor
-%endif
-%{_datadir}/icons/hicolor/512x512/apps/%appid.png
-%_datadir/applications/%appid.desktop.zeditor
-%{_metainfodir}/%appid.metainfo.xml
-
 
 %prep
 %autosetup -n %{crate}-%{ver} -p1
@@ -192,6 +180,22 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%appid.desktop
 %if %{without debug_no_build}
 %{_libexecdir}/zed-editor
 %endif
+
+%files cli
+%if %{without debug_no_build}
+%_bindir/zed
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%{_datadir}/applications/%appid.desktop
+%{_metainfodir}/%appid.metainfo.xml
+
+%files cli-compat-zfs
+%if %{without debug_no_build}
+%_bindir/zeditor
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%_datadir/applications/%appid.desktop.zeditor
+%{_metainfodir}/%appid.metainfo.xml
 
 %changelog
 %autochangelog

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -16,7 +16,7 @@
 
 Name:           zed
 Version:        0.217.3
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Zed is a high-performance, multiplayer code editor
 SourceLicense:  AGPL-3.0-only AND Apache-2.0 AND GPL-3.0-or-later
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND AGPL.3.0-only AND AGPL-3.0-or-later AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND GPL-3.0-or-later AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
@@ -55,7 +55,7 @@ BuildRequires:  perl-File-Copy
 BuildRequires:  perl-lib
 BuildRequires:  vulkan-loader
 BuildRequires:  libcurl-devel
-Requires: (%name-rename-zeditor if zfs else %name-cli)
+Requires: (%name-cli-compat-zfs if zfs else %name-cli)
 Suggests: %name-cli
 
 %description
@@ -65,32 +65,21 @@ Code at the speed of thought - Zed is a high-performance, multiplayer code edito
 Summary: Provides the /usr/bin/zed binary
 Conflicts: zfs
 Supplements: (%name unless zfs)
-%description cli
-This package provides the /usr/bin/zed binary. If you use zfs, install %name-rename-zeditor instead.
-%files cli
-%if %{without debug_no_build}
-%_bindir/zed
-%endif
-%{_datadir}/icons/hicolor/512x512/apps/%appid.png
-%{_datadir}/applications/%appid.desktop
-%{_metainfodir}/%appid.metainfo.xml
 
-%package rename-zeditor
+%description cli
+This package provides the /usr/bin/zed binary. If you use zfs, install %name-cli-compat-zfs instead.
+
+%package cli-compat-zfs
 Summary: Rename zed to zeditor to prevent collision with zfs
 Provides: %name-cli
 Conflicts: %name-cli
+Obsoletes: %{name}-rename-zeditor <= 0.217.3
 Supplements: (%name and zfs)
 RemovePathPostFixes: .zeditor
-%description rename-zeditor
+
+%description cli-compat-zfs
 This package provides the %_bindir/zeditor binary instead of %_bindir/zed. This avoids conflicts with the zfs package.
 The normal package is %name-cli.
-%files rename-zeditor
-%if %{without debug_no_build}
-%_bindir/zeditor
-%endif
-%{_datadir}/icons/hicolor/512x512/apps/%appid.png
-%_datadir/applications/%appid.desktop.zeditor
-%{_metainfodir}/%appid.metainfo.xml
 
 %prep
 %autosetup -n %{crate}-%{version} -p1
@@ -189,6 +178,22 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%appid.desktop
 %if %{without debug_no_build}
 %{_libexecdir}/zed-editor
 %endif
+
+%files cli
+%if %{without debug_no_build}
+%_bindir/zed
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%{_datadir}/applications/%appid.desktop
+%{_metainfodir}/%appid.metainfo.xml
+
+%files cli-compat-zfs
+%if %{without debug_no_build}
+%_bindir/zeditor
+%endif
+%{_datadir}/icons/hicolor/512x512/apps/%appid.png
+%_datadir/applications/%appid.desktop.zeditor
+%{_metainfodir}/%appid.metainfo.xml
 
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(zed*): Better ZFS compat package name (#8483)](https://github.com/terrapkg/packages/pull/8483)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)