### PR TITLE
fix(zlib): Move to Extras

### DIFF
--- a/anda/lib/zlib/anda.hcl
+++ b/anda/lib/zlib/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "zlib.spec"
   }
+  labels {
+    subrepo = "extras"
+  }
 }


### PR DESCRIPTION
DNF is autosolving this for the libraries, which causes issues with most installs as most packages are expecting `zlib-ng-compat`.