### PR TITLE
[f43] fix: Add SteamVR patch for Mesa (#8508)

### DIFF
--- a/anda/lib/mesa/mesa-38987.patch
+++ b/anda/lib/mesa/mesa-38987.patch
@@ -1,0 +1,37 @@
+From 3dbbff571f31899e47ec4a002f3ecbe96cc48981 Mon Sep 17 00:00:00 2001
+From: Yuxuan Shui <yshui@codeweavers.com>
+Date: Wed, 17 Dec 2025 08:14:24 +0000
+Subject: [PATCH] wsi/display: Set atomic client cap in AcquireDrmDisplayEXT as
+ well.
+
+Previously we only added the atomic client cap to the drmFd passed to
+GetDrmDisplayEXT (through wsi_display_get_connector). But the drmFd
+passed to AcquireDrmDisplayEXT might be different. And that drmFd is
+what mesa will use for later operations.
+
+For example, SteamVR uses a non-master drm fd for GetDrmDisplayEXT, then
+later uses a different, leased drm fd for AcquireDrmDisplayEXT. This
+breaks things like drmModeObjectGetProperties because all atomic
+properties will be missing.
+
+Fixes: 513ffea1d366 ("wsi/display: use atomic mode setting")
+Signed-off-by: Yuxuan Shui <yshui@codeweavers.com>
+---
+ src/vulkan/wsi/wsi_common_display.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/vulkan/wsi/wsi_common_display.c b/src/vulkan/wsi/wsi_common_display.c
+index 4c9451a6d000f..8b004563ff44e 100644
+--- a/src/vulkan/wsi/wsi_common_display.c
++++ b/src/vulkan/wsi/wsi_common_display.c
+@@ -4074,6 +4074,7 @@ wsi_AcquireDrmDisplayEXT(VkPhysicalDevice physicalDevice,
+ 
+    drmModeFreeConnector(drm_connector);
+ 
++   drmSetClientCap(drmFd, DRM_CLIENT_CAP_ATOMIC, 1);
+    wsi->fd = drmFd;
+    return VK_SUCCESS;
+ }
+-- 
+GitLab
+

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -85,7 +85,7 @@ Summary:        Mesa graphics libraries
 %global ver 25.3.1
 Epoch:          1
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        %autorelease
+Release:        2
 Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
@@ -116,10 +116,15 @@ Source15:       https://crates.io/api/v1/crates/rustc-hash/%{rustc_hash_ver}/dow
 # Teflon: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/38532
 Patch12:        mesa-38532.patch
 
-# Gaming Patches
-Patch20:        gamescope.patch
+# SteamVR: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/38987
+Patch20:        mesa-38987.patch
+
+# Add required patches for Wine Wayland (From Proton-GE Release Notes)
 Patch21:        wine-wayland.patch
-Patch22:        horizon5.patch
+
+# SteamOS Patches
+Patch30:        gamescope.patch
+Patch31:        horizon5.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: Add SteamVR patch for Mesa (#8508)](https://github.com/terrapkg/packages/pull/8508)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)