### PR TITLE
[f43] fix(zlib): Move to Extras (#8507)

### DIFF
--- a/anda/lib/zlib/anda.hcl
+++ b/anda/lib/zlib/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "zlib.spec"
   }
+  labels {
+    subrepo = "extras"
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(zlib): Move to Extras (#8507)](https://github.com/terrapkg/packages/pull/8507)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)