### PR TITLE
fix(rpcs3): Use large runners

### DIFF
--- a/anda/games/rpcs3/anda.hcl
+++ b/anda/games/rpcs3/anda.hcl
@@ -2,7 +2,8 @@ project pkg {
 	rpm {
 		spec = "rpcs3.spec"
 	}
-        labels {
-                mock = 1
-        }
+    labels {
+		mock = 1
+		large = 1
+    }
 }


### PR DESCRIPTION
x86_64 runs out of space on Rawhide and 43. Deeply cursed.