### PR TITLE
[f42] fix(rpcs3): Use large runners (#8524)

### DIFF
--- a/anda/games/rpcs3/anda.hcl
+++ b/anda/games/rpcs3/anda.hcl
@@ -2,7 +2,8 @@ project pkg {
 	rpm {
 		spec = "rpcs3.spec"
 	}
-        labels {
-                mock = 1
-        }
+    labels {
+		mock = 1
+		large = 1
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(rpcs3): Use large runners (#8524)](https://github.com/terrapkg/packages/pull/8524)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)