### PR TITLE
fix(akmod-nvidia): DON'T set build flags

### DIFF
--- a/anda/system/nvidia/nvidia-kmod/nvidia-kmod.spec
+++ b/anda/system/nvidia/nvidia-kmod/nvidia-kmod.spec
@@ -3,9 +3,12 @@
 # Build only the akmod package and no kernel module packages:
 %define buildforkernels akmod
 
+# Build flags should be inherited from the kernel!
+%undefine _auto_set_build_flags
+
 Name:           nvidia-kmod
 Version:        590.48.01
-Release:        2%?dist
+Release:        3%?dist
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License


### PR DESCRIPTION
This is needed for the transition from closed to open.