### PR TITLE
[el10] fix(akmod-nvidia): DON'T set build flags (#8530)

### DIFF
--- a/anda/system/nvidia/nvidia-kmod/nvidia-kmod.spec
+++ b/anda/system/nvidia/nvidia-kmod/nvidia-kmod.spec
@@ -3,9 +3,12 @@
 # Build only the akmod package and no kernel module packages:
 %define buildforkernels akmod
 
+# Build flags should be inherited from the kernel!
+%undefine _auto_set_build_flags
+
 Name:           nvidia-kmod
 Version:        590.48.01
-Release:        2%?dist
+Release:        3%?dist
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(akmod-nvidia): DON&#x27;T set build flags (#8530)](https://github.com/terrapkg/packages/pull/8530)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)