### PR TITLE
add: uxn

### DIFF
--- a/anda/misc/uxn/stable/anda.hcl
+++ b/anda/misc/uxn/stable/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "uxn.spec"
+	}
+}

--- a/anda/misc/uxn/stable/uxn.spec
+++ b/anda/misc/uxn/stable/uxn.spec
@@ -1,0 +1,41 @@
+# uxn stable has no update script because this version
+# is permanently frozen.
+
+%define debug_package %nil
+
+Name:           uxn
+Version:        1.0
+Release:        1%?dist
+Summary:        An emulator for the Uxn computing stack
+URL:            https://100r.ca/site/%{name}.html
+Source0:        https://git.sr.ht/~rabbits/%{name}/archive/%{version}.tar.gz
+License:        MIT
+BuildRequires:  anda-srpm-macros SDL2-devel gcc
+Requires:       SDL2-devel
+
+Packager:       arbormoss <arbormoss@woodsprite.dev>
+
+%description
+%summary.
+
+%prep
+%autosetup -n %name-%version
+
+%build
+./build.sh
+
+%install
+install -Dm755 bin/%{name}asm %{buildroot}%{_bindir}/%{name}asm
+install -Dm755 bin/%{name}cli %{buildroot}%{_bindir}/%{name}cli
+install -Dm755 bin/%{name}emu %{buildroot}%{_bindir}/%{name}emu
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}asm
+%{_bindir}/%{name}cli
+%{_bindir}/%{name}emu
+
+%changelog
+* Sun Dec 21 2025 arbormoss <arbormoss@woodsprite.dev>
+- Intial Commit

--- a/anda/misc/uxn/stable/uxn.spec
+++ b/anda/misc/uxn/stable/uxn.spec
@@ -2,6 +2,8 @@
 # is permanently frozen. A nightly will be added once the
 # sourcehut versioning script is done.
 
+%global debug_package %{nil}
+
 Name:           uxn
 Version:        1.0
 Release:        1%?dist
@@ -20,7 +22,6 @@ Packager:       arbormoss <arbormoss@woodsprite.dev>
 %autosetup -n %name-%version
 
 %build
-sed -zi 's/debug=0/debug=1/' ./build.sh
 ./build.sh
 
 %install

--- a/anda/misc/uxn/stable/uxn.spec
+++ b/anda/misc/uxn/stable/uxn.spec
@@ -1,5 +1,6 @@
 # uxn stable has no update script because this version
-# is permanently frozen.
+# is permanently frozen. A nightly will be added once the
+# sourcehut versioning script is done.
 
 %define debug_package %nil
 

--- a/anda/misc/uxn/stable/uxn.spec
+++ b/anda/misc/uxn/stable/uxn.spec
@@ -2,8 +2,6 @@
 # is permanently frozen. A nightly will be added once the
 # sourcehut versioning script is done.
 
-%define debug_package %nil
-
 Name:           uxn
 Version:        1.0
 Release:        1%?dist
@@ -11,8 +9,7 @@ Summary:        An emulator for the Varvara virtual machine
 URL:            https://100r.ca/site/%{name}.html
 Source0:        https://git.sr.ht/~rabbits/%{name}/archive/%{version}.tar.gz
 License:        MIT
-BuildRequires:  anda-srpm-macros SDL2-devel gcc
-Requires:       SDL2-devel
+BuildRequires:  anda-srpm-macros SDL2-devel gcc libubsan libasan
 
 Packager:       arbormoss <arbormoss@woodsprite.dev>
 
@@ -23,6 +20,7 @@ Packager:       arbormoss <arbormoss@woodsprite.dev>
 %autosetup -n %name-%version
 
 %build
+sed -zi 's/debug=0/debug=1/' ./build.sh
 ./build.sh
 
 %install

--- a/anda/misc/uxn/stable/uxn.spec
+++ b/anda/misc/uxn/stable/uxn.spec
@@ -6,7 +6,7 @@
 Name:           uxn
 Version:        1.0
 Release:        1%?dist
-Summary:        An emulator for the Uxn computing stack
+Summary:        An emulator for the Varvara virtual machine
 URL:            https://100r.ca/site/%{name}.html
 Source0:        https://git.sr.ht/~rabbits/%{name}/archive/%{version}.tar.gz
 License:        MIT


### PR DESCRIPTION
This adds tooling for [uxn](https://100r.co/site/uxn.html), the uxn half of the uxn/varvara computing stack.

This is a draft dependent on a rolling release version in addition to the current permanently frozen stable version.

See this [Discord message](https://discord.com/channels/957104883490775061/1209327267852058704/1452519075187261543) for the full versioning issue for conversation on the versioning issue.

The stable version is currently functional.

Implementing the nightly version is TODO at time of initial draft PR.

_This should close #8538_

This duplicates #8809 , feel free to use either, they are alternate implementations of the same package.