### PR TITLE
[f42] add: ls-iommu (#8536)

### DIFF
--- a/anda/tools/ls-iommu/anda.hcl
+++ b/anda/tools/ls-iommu/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "ls-iommu.spec"
+	}
+}

--- a/anda/tools/ls-iommu/ls-iommu.spec
+++ b/anda/tools/ls-iommu/ls-iommu.spec
@@ -1,0 +1,40 @@
+%global goipath github.com/HikariKnight/ls-iommu
+Version:        2.3.0
+
+%gometa -f
+
+Name:           ls-iommu
+Release:        1%?dist
+Summary:        A tool to list devices in iommu groups, useful for setting up VFIO
+
+License:        MIT
+URL:            https://github.com/HikariKnight/ls-iommu
+Source0:        %url/archive/refs/tags/%version.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang gcc go-rpm-macros
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%goprep
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -ldflags="-X github.com/HikariKnight/ls-iommu/internal/version.Version=%version" -o ls-iommu ./cmd
+
+%install
+install -Dm 0755 ls-iommu %{buildroot}%{_bindir}/ls-iommu
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/ls-iommu
+
+%changelog
+* Sun Dec 21 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/ls-iommu/update.rhai
+++ b/anda/tools/ls-iommu/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("HikariKnight/ls-iommu"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: ls-iommu (#8536)](https://github.com/terrapkg/packages/pull/8536)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)