### PR TITLE
[f43] add: juce (#8529)

### DIFF
--- a/anda/apps/juce/anda.hcl
+++ b/anda/apps/juce/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "juce.spec"
+  }
+}

--- a/anda/apps/juce/fix-install-dirs.patch
+++ b/anda/apps/juce/fix-install-dirs.patch
@@ -1,0 +1,60 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f8864a6dc5..6518db0532 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -137,10 +137,10 @@ write_basic_package_version_file("${JUCE_BINARY_DIR}/JUCEConfigVersion.cmake"
+     VERSION ${JUCE_VERSION}
+     COMPATIBILITY ExactVersion)
+ 
+-set(JUCE_INSTALL_DESTINATION "lib/cmake/JUCE-${JUCE_VERSION}" CACHE STRING
++set(JUCE_INSTALL_DESTINATION "lib64/cmake/juce" CACHE STRING
+     "The location, relative to the install prefix, where the JUCE config file will be installed")
+ 
+-set(JUCE_MODULE_PATH "include/JUCE-${JUCE_VERSION}/modules")
++set(JUCE_MODULE_PATH "share/juce/modules")
+ set(UTILS_INSTALL_DIR "${JUCE_INSTALL_DESTINATION}")
+ set(JUCEAIDE_PATH "${JUCE_TOOL_INSTALL_DIR}/${JUCE_JUCEAIDE_NAME}")
+ configure_package_config_file("${JUCE_CMAKE_UTILS_DIR}/JUCEConfig.cmake.in"
+@@ -148,7 +148,6 @@ configure_package_config_file("${JUCE_CMAKE_UTILS_DIR}/JUCEConfig.cmake.in"
+     PATH_VARS UTILS_INSTALL_DIR JUCEAIDE_PATH JUCE_MODULE_PATH
+     INSTALL_DESTINATION "${JUCE_INSTALL_DESTINATION}")
+ 
+-set(JUCE_MODULE_PATH "${JUCE_MODULES_DIR}")
+ set(UTILS_INSTALL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extras/Build/CMake")
+ get_target_property(JUCEAIDE_PATH juceaide IMPORTED_LOCATION)
+ configure_package_config_file("${JUCE_CMAKE_UTILS_DIR}/JUCEConfig.cmake.in"
+@@ -181,7 +180,7 @@ if(("${CMAKE_SOURCE_DIR}" STREQUAL "${JUCE_SOURCE_DIR}") AND (NOT JUCE_BUILD_HEL
+     _juce_add_lv2_manifest_helper_target()
+ 
+     if(TARGET juce_lv2_helper)
+-        install(TARGETS juce_lv2_helper EXPORT LV2_HELPER DESTINATION "bin/JUCE-${JUCE_VERSION}")
++        install(TARGETS juce_lv2_helper EXPORT LV2_HELPER DESTINATION "bin")
+         install(EXPORT LV2_HELPER NAMESPACE juce:: DESTINATION "${JUCE_INSTALL_DESTINATION}")
+     endif()
+ endif()
+diff --git a/extras/Build/juceaide/CMakeLists.txt b/extras/Build/juceaide/CMakeLists.txt
+index 17e5520974..afcd55981d 100644
+--- a/extras/Build/juceaide/CMakeLists.txt
++++ b/extras/Build/juceaide/CMakeLists.txt
+@@ -168,7 +168,7 @@ else()
+ 
+     add_executable(juce::juceaide ALIAS juceaide)
+ 
+-    set(JUCE_TOOL_INSTALL_DIR "bin/JUCE-${JUCE_VERSION}" CACHE STRING
++    set(JUCE_TOOL_INSTALL_DIR "bin" CACHE STRING
+         "The location, relative to the install prefix, where juceaide will be installed")
+ 
+     install(PROGRAMS "${imported_location}" DESTINATION "${JUCE_TOOL_INSTALL_DIR}")
+diff --git a/modules/CMakeLists.txt b/modules/CMakeLists.txt
+index db8a56774d..652da64743 100644
+--- a/modules/CMakeLists.txt
++++ b/modules/CMakeLists.txt
+@@ -31,7 +31,7 @@
+ # ==============================================================================
+ 
+ juce_add_modules(
+-    INSTALL_PATH "include/JUCE-${JUCE_VERSION}/modules"
++    INSTALL_PATH "share/juce/modules"
+     ALIAS_NAMESPACE juce
+     juce_analytics
+     juce_animation

--- a/anda/apps/juce/juce.spec
+++ b/anda/apps/juce/juce.spec
@@ -1,0 +1,83 @@
+Name:           juce
+Version:        8.0.12
+Release:        1%{?dist}
+License:        AGPL-3.0
+Summary:        framework for audio application and plug-in development
+URL:            https://juce.com
+Source:         https://github.com/juce-framework/JUCE/archive/refs/tags/%{version}.tar.gz
+Patch0:         fix-install-dirs.patch
+Packager:       metcya <metcya@gmail.com>
+
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+BuildRequires:  pkgconfig(alsa)
+BuildRequires:  pkgconfig(freetype2)
+BuildRequires:  pkgconfig(flac)
+BuildRequires:  pkgconfig(gtk+-3.0)
+BuildRequires:  pkgconfig(jack)
+BuildRequires:  ladspa-devel
+BuildRequires:  pkgconfig(libjpeg)
+BuildRequires:  pkgconfig(libpng)
+BuildRequires:  pkgconfig(vorbis)
+BuildRequires:  pkgconfig(zlib)
+BuildRequires:  pkgconfig(libcurl)
+BuildRequires:  webkit2gtk4.1-devel
+
+# for building docs
+BuildRequires:  doxygen
+BuildRequires:  python3
+BuildRequires:  graphviz
+
+%description
+JUCE is an open-source cross-platform C++ application framework for creating
+desktop and mobile applications, including VST, VST3, AU, AUv3, AAX and LV2
+audio plug-ins and plug-in hosts. JUCE can be easily integrated with existing
+projects via CMake, or can be used as a project generation tool via the
+Projucer, which supports exporting projects for Xcode (macOS and iOS), Visual
+Studio, Android Studio, and Linux Makefiles as well as containing a source code
+editor.
+
+%package doc
+Summary:        Documentation files for %{name}
+
+%description doc
+Documentation files for %{name}
+
+%prep
+%autosetup -p1 -n JUCE-%{version}
+
+%build
+%cmake -DJUCER_ENABLE_GPL_MODE=1    \
+       -DJUCE_BUILD_EXTRAS=ON       \
+       -DJUCE_TOOL_INSTALL_DIR=bin
+%cmake_build
+
+pushd docs/doxygen
+python3 build.py
+popd
+
+%install
+%cmake_install
+
+pushd docs/doxygen/doc
+find -type f -exec install -Dm 644 '{}' -t %{buildroot}%{_pkgdocdir} \;
+popd
+
+%files
+%doc README.md CODE_OF_CONDUCT.md CHANGE_LIST.md BREAKING_CHANGES.md
+%license LICENSE.md
+%{_bindir}/juceaide
+%{_bindir}/juce_lv2_helper
+%dir %{_libdir}/cmake/%{name}
+%{_libdir}/cmake/%{name}/*
+%dir %{_datadir}/%{name}
+%dir %{_datadir}/%{name}/modules
+%{_datadir}/%{name}/modules/*
+
+%files doc
+%doc %{_pkgdocdir}/*
+
+%changelog
+* Fri Dec 19 2025 metcya <metcya@gmail.com> - 8.0.12
+- Package juce
+

--- a/anda/apps/juce/update.rhai
+++ b/anda/apps/juce/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("juce-framework/JUCE"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: juce (#8529)](https://github.com/terrapkg/packages/pull/8529)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)