### PR TITLE
[f43] fix (JUCE): install license to doc subpackage (#8550)

### DIFF
--- a/anda/apps/juce/juce.spec
+++ b/anda/apps/juce/juce.spec
@@ -1,6 +1,6 @@
 Name:           juce
 Version:        8.0.12
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        AGPL-3.0
 Summary:        framework for audio application and plug-in development
 URL:            https://juce.com
@@ -75,9 +75,13 @@ popd
 %{_datadir}/%{name}/modules/*
 
 %files doc
+%license LICENSE.md
 %doc %{_pkgdocdir}/*
 
 %changelog
+* Tue Dec 23 2025 Owen Zimmerman <owen@fyralabs.com>
+- Install doc subpackage license
+
 * Fri Dec 19 2025 metcya <metcya@gmail.com> - 8.0.12
 - Package juce
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (JUCE): install license to doc subpackage (#8550)](https://github.com/terrapkg/packages/pull/8550)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)