### PR TITLE
[el10] fix (snowemu): rename binary as requested from upstream (#8566)

### DIFF
--- a/anda/apps/snow/com.github.snow.metainfo.xml
+++ b/anda/apps/snow/com.github.snow.metainfo.xml
@@ -23,7 +23,7 @@
 
   <url type="homepage">https://github.com/twvd/snow</url>
   <provides>
-    <binary>snow</binary>
+    <binary>snowemu</binary>
   </provides>
 
   <keywords>

--- a/anda/apps/snow/snow.desktop
+++ b/anda/apps/snow/snow.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Categories=System;Emulator;
 Comment=Classic Macintosh emulator
-Exec=snow
+Exec=snowemu
 Icon=snow_icon
 Name=snow
 Type=Application

--- a/anda/apps/snow/snow.spec
+++ b/anda/apps/snow/snow.spec
@@ -2,7 +2,7 @@
 
 Name:           snow
 Version:        1.2.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Classic Macintosh emulator
 URL:            https://github.com/twvd/snow
 Source0:        %url/archive/refs/tags/v%version.tar.gz
@@ -18,6 +18,7 @@ BuildRequires:  cargo-rpm-macros
 BuildRequires:  desktop-file-utils
 BuildRequires:  terra-appstream-helper
 BuildRequires:  SDL2-devel
+Provides:       snowemu
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
@@ -42,7 +43,7 @@ Documentation files for %{name}
 
 %install
 mkdir -p %{buildroot}%{_pkgdocdir}
-install -Dm755 target/rpm/snow_frontend_egui %{buildroot}%{_bindir}/snow
+install -Dm755 target/rpm/snow_frontend_egui %{buildroot}%{_bindir}/snowemu
 
 install -Dm644 docs/images/snow_icon.png     %{buildroot}%{_hicolordir}/1024x1024/apps/snow_icon.png
 
@@ -66,7 +67,7 @@ desktop-file-validate %{buildroot}%{_appsdir}/snow.desktop
 %doc README.md
 %license LICENSE
 %license LICENSE.dependencies
-%{_bindir}/snow
+%{_bindir}/snowemu
 %{_hicolordir}/1024x1024/apps/snow_icon.png
 %{_appsdir}/snow.desktop
 %{_metainfodir}/%appid.metainfo.xml


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (snowemu): rename binary as requested from upstream (#8566)](https://github.com/terrapkg/packages/pull/8566)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)