### PR TITLE
add: glaze

### DIFF
--- a/anda/lib/glaze/anda.hcl
+++ b/anda/lib/glaze/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "glaze.spec"
+  }
+}

--- a/anda/lib/glaze/glaze.spec
+++ b/anda/lib/glaze/glaze.spec
@@ -38,7 +38,7 @@ mkdocs build
 %install
 %cmake_install
 pushd site
-find -type f -exec install -Dm 644 '{}' -t %{buildroot}%{_pkgdocdir} \;
+find -type f -exec install -Dm 644 '{}' -t '%{buildroot}%{_pkgdocdir}/{}' \;
 popd
 
 %files

--- a/anda/lib/glaze/glaze.spec
+++ b/anda/lib/glaze/glaze.spec
@@ -52,6 +52,6 @@ popd
 %{_pkgdocdir}/
 
 %changelog
-* Wed Dec 24 2025 metcya <metcya@gmail.com> - {version}
+* Wed Dec 24 2025 metcya <metcya@gmail.com> - 6.4.0-1
 - Package glaze
 

--- a/anda/lib/glaze/glaze.spec
+++ b/anda/lib/glaze/glaze.spec
@@ -1,0 +1,57 @@
+# not needed because this is a header only library
+%global debug_package %{nil}
+
+Name:           glaze-devel
+Version:        6.4.0
+Release:        1%{?dist}
+License:        MIT
+URL:            https://stephenberry.github.io/glaze
+Source:         https://github.com/stephenberry/glaze/archive/refs/tags/v%{version}.tar.gz
+Summary:        in memory JSON parsing and reflection library for modern C++
+Packager:       metcya <metcya@gmail.com>
+
+BuildRequires:  cmake
+# even though we're not building anything, cmake still wants a c++ compiler
+BuildRequires:  gcc-c++
+BuildRequires:  mkdocs
+BuildRequires:  mkdocs-material
+BuildRequires:  python3-mkdocs-autorefs
+
+%description
+One of the fastest JSON libraries in the world. Glaze reads and writes from
+object memory, simplifying interfaces and offering incredible performance.
+
+%package -n glaze-docs
+Summary:    Documentation files for glaze
+
+%description -n glaze-docs
+Documentation files for glaze.
+
+%prep
+%autosetup -n glaze-%{version}
+
+%build
+%cmake -Dglaze_DEVELOPER_MODE=OFF \
+       -Dglaze_INSTALL_CMAKEDIR=%{_libdir}/cmake
+mkdocs build
+
+%install
+%cmake_install
+pushd site
+find -type f -exec install -Dm 644 '{}' -t %{buildroot}%{_pkgdocdir} \;
+popd
+
+%files
+%license LICENSE
+%doc README.md
+%{_includedir}/glaze/
+%{_libdir}/cmake/*.cmake
+
+%files -n glaze-docs
+%license LICENSE
+%{_pkgdocdir}/
+
+%changelog
+* Wed Dec 24 2025 metcya <metcya@gmail.com> - {version}
+- Package glaze
+

--- a/anda/lib/glaze/glaze.spec
+++ b/anda/lib/glaze/glaze.spec
@@ -38,7 +38,7 @@ mkdocs build
 %install
 %cmake_install
 pushd site
-find -type f -exec install -Dm 644 '{}' -t '%{buildroot}%{_pkgdocdir}/{}' \;
+find -type f -exec install -Dm 644 '{}' '%{buildroot}%{_pkgdocdir}/{}' \;
 popd
 
 %files

--- a/anda/lib/glaze/update.rhai
+++ b/anda/lib/glaze/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("stephenberry/glaze"));


### PR DESCRIPTION
yet another dependency for #8454. because this is a header only library the package is called `glaze-devel`, see other packages like [atomic-queue-devel](https://packages.fedoraproject.org/pkgs/atomic-queue/atomic-queue-devel/index.html)