### PR TITLE
[el10] add: cmark-gfm (#8574)

### DIFF
--- a/anda/lib/cmark-gfm/anda.hcl
+++ b/anda/lib/cmark-gfm/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "cmark-gfm.spec"
+  }
+}

--- a/anda/lib/cmark-gfm/cmark-gfm.spec
+++ b/anda/lib/cmark-gfm/cmark-gfm.spec
@@ -1,0 +1,65 @@
+Name:           cmark-gfm
+Version:        0.29.0.gfm.13
+Release:        1%{?dist}
+License:        BSD-2-Clause AND MIT
+URL:            https://github.com/github/cmark-gfm
+Source:         %{url}/archive/refs/tags/%{version}.tar.gz
+Summary:        GitHub's fork of cmark, a CommonMark parsing and rendering library and program in C
+Packager:       metcya <metcya@gmail.com>
+
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+
+%description
+cmark-gfm is an extended version of the C reference implementation of
+CommonMark, a rationalized version of Markdown syntax with a spec. This
+repository adds GitHub Flavored Markdown extensions to the upstream
+implementation, as defined in the spec.
+
+%package libs
+Summary:        Library files for %{name}
+%pkg_libs_files
+
+%description libs
+Library files for %{name}.
+
+%package static
+Summary:        Static library files for %{name}
+%pkg_static_files
+
+%description static
+Static library files for %{name}.
+
+%package devel
+Summary:        Development files for %{name}
+Requires:       %{name}-libs = %{evr}
+%pkg_devel_files
+
+%description devel
+Development files for %{name}.
+
+%prep
+%autosetup
+
+%build
+%cmake
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%license COPYING
+%doc README.md
+%{_bindir}/%{name}
+%{_mandir}/man1/%{name}.1.*
+%{_mandir}/man3/%{name}.3.*
+
+%files devel
+%{_libdir}/cmake/*.cmake
+%dir %{_libdir}/cmake-gfm-extensions
+%{_libdir}/cmake-gfm-extensions/*.cmake
+
+%changelog
+* Wed Dec 24 2025 metcya <metcya@gmail.com> - 0.29.0.gfm.13
+- Package cmark-gfm

--- a/anda/lib/cmark-gfm/update.rhai
+++ b/anda/lib/cmark-gfm/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("github/cmark-gfm"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: cmark-gfm (#8574)](https://github.com/terrapkg/packages/pull/8574)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)