### PR TITLE
[f42] add: glaze (#8575)

### DIFF
--- a/anda/lib/glaze/anda.hcl
+++ b/anda/lib/glaze/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "glaze.spec"
+  }
+}

--- a/anda/lib/glaze/glaze.spec
+++ b/anda/lib/glaze/glaze.spec
@@ -1,0 +1,57 @@
+# not needed because this is a header only library
+%global debug_package %{nil}
+
+Name:           glaze-devel
+Version:        6.4.0
+Release:        1%{?dist}
+License:        MIT
+URL:            https://stephenberry.github.io/glaze
+Source:         https://github.com/stephenberry/glaze/archive/refs/tags/v%{version}.tar.gz
+Summary:        in memory JSON parsing and reflection library for modern C++
+Packager:       metcya <metcya@gmail.com>
+
+BuildRequires:  cmake
+# even though we're not building anything, cmake still wants a c++ compiler
+BuildRequires:  gcc-c++
+BuildRequires:  mkdocs
+BuildRequires:  mkdocs-material
+BuildRequires:  python3-mkdocs-autorefs
+
+%description
+One of the fastest JSON libraries in the world. Glaze reads and writes from
+object memory, simplifying interfaces and offering incredible performance.
+
+%package -n glaze-docs
+Summary:    Documentation files for glaze
+
+%description -n glaze-docs
+Documentation files for glaze.
+
+%prep
+%autosetup -n glaze-%{version}
+
+%build
+%cmake -Dglaze_DEVELOPER_MODE=OFF \
+       -Dglaze_INSTALL_CMAKEDIR=%{_libdir}/cmake
+mkdocs build
+
+%install
+%cmake_install
+pushd site
+find -type f -exec install -Dm 644 '{}' '%{buildroot}%{_pkgdocdir}/{}' \;
+popd
+
+%files
+%license LICENSE
+%doc README.md
+%{_includedir}/glaze/
+%{_libdir}/cmake/*.cmake
+
+%files -n glaze-docs
+%license LICENSE
+%{_pkgdocdir}/
+
+%changelog
+* Wed Dec 24 2025 metcya <metcya@gmail.com> - 6.4.0-1
+- Package glaze
+

--- a/anda/lib/glaze/update.rhai
+++ b/anda/lib/glaze/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("stephenberry/glaze"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: glaze (#8575)](https://github.com/terrapkg/packages/pull/8575)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)