### PR TITLE
[f43] fix(deno): Update the cursed rust2rpm patch, add dx executable (#8573)

### DIFF
--- a/anda/devs/deno/deno-fix-metadata-auto.diff
+++ b/anda/devs/deno/deno-fix-metadata-auto.diff
@@ -1,11 +1,11 @@
---- deno-2.5.6/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ deno-2.5.6/Cargo.toml	2025-11-02T08:06:51.091942+00:00
-@@ -654,24 +654,3 @@
+--- deno-2.6.3/Cargo.toml	1970-01-01T00:00:01+00:00
++++ deno-2.6.3/Cargo.toml	2025-12-24T13:35:12.790326+00:00
+@@ -657,24 +657,3 @@
  [target."cfg(unix)".dependencies.shell-escape]
  version = "=0.1.5"
  
 -[target."cfg(windows)".dependencies.deno_subprocess_windows]
--version = "0.16.0"
+-version = "0.20.0"
 -
 -[target."cfg(windows)".dependencies.winapi]
 -version = "=0.3.9"

--- a/anda/devs/deno/rust-deno.spec
+++ b/anda/devs/deno/rust-deno.spec
@@ -28,6 +28,8 @@ BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  clang
 BuildRequires:  clang-devel
+# Why did Deno name their NPX equivalent this? At least OpenDX is pretty much dead.
+Conflicts:      dx
 
 %global _description %{expand:
 Provides the deno executable.}
@@ -47,6 +49,7 @@ License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) 
 %doc README.md
 %{_metainfodir}/%{appid}.metainfo.xml
 %{_bindir}/deno
+%{_bindir}/dx
 
 %pkg_completion -Bfzn %crate
 
@@ -73,4 +76,7 @@ target/rpm/deno completions bash > %buildroot%bash_completions_dir/deno
 %dnl target/rpm/deno completions elvish > %buildroot%elvish_completions_dir/deno.elv
 target/rpm/deno completions fish > %buildroot%fish_completions_dir/deno.fish
 target/rpm/deno completions zsh > %buildroot%zsh_completions_dir/_deno
+pushd %{buildroot}%{_bindir}
+./deno x --install-alias
+popd
 %terra_appstream -o %{SOURCE3}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(deno): Update the cursed rust2rpm patch, add dx executable (#8573)](https://github.com/terrapkg/packages/pull/8573)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)