### PR TITLE
[f43] doc: repology (#8585)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Terra Sources
 
-[![Repository status](https://repology.org/badge/repository-big/terra_42.svg?header=Terra+42)](https://repology.org/repository/terra_42)
-[![Repository status](https://repology.org/badge/repository-big/terra_43.svg?header=Terra+43)](https://repology.org/repository/terra_43)
 [![Repository status](https://repology.org/badge/repository-big/terra_rawhide.svg?header=Terra+Rawhide)](https://repology.org/repository/terra_rawhide)
 
 Terra is a rolling-release Fedora repository for all the software you need.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [doc: repology (#8585)](https://github.com/terrapkg/packages/pull/8585)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)