### PR TITLE
[f42] chore (throne): add %check, update macros (#8593)

### DIFF
--- a/anda/apps/throne/throne.spec
+++ b/anda/apps/throne/throne.spec
@@ -39,6 +39,7 @@ BuildRequires: sed
 BuildRequires: golang
 BuildRequires: rpm_macro(gobuildflags)
 BuildRequires: protobuf-compiler
+BuildRequires: desktop-file-utils
 Requires: %{name}-core
 %define core Core
 
@@ -86,17 +87,20 @@ popd
 install -Dm755 %__cmake_builddir/Throne %buildroot%_libdir/%name/%name
 install -Dm755 %__cmake_builddir/%core %buildroot%_libdir/%name/%core
 install -Dpm755 %{SOURCE4} %{buildroot}%{_bindir}/%{name}
-install -Dpm644 %{SOURCE3} %{buildroot}%{_datadir}/applications/%{name}.desktop
+install -Dpm644 %{SOURCE3} %{buildroot}%{_appsdir}/%{name}.desktop
 install -Dpm644 res/Throne.ico -t %buildroot%_iconsdir/
 install -Dpm644 res/public/Throne.png -t %buildroot%_datadir/pixmaps/
 patchelf --remove-rpath %{buildroot}%{_libdir}/%{name}/%{name}
 patchelf --remove-rpath %{buildroot}%{_libdir}/%{name}/%{core}
 
+%check
+desktop-file-validate %{buildroot}%{_appsdir}/%{name}.desktop
+
 %files
 %attr(0755, -, -) %{_bindir}/%{name}
 %attr(0755, -, -) %{_libdir}/%{name}/%{name}
-%attr(0644, -, -) %{_datadir}/icons/Throne.ico
-%attr(0644, -, -) %{_datadir}/applications/%{name}.desktop
+%attr(0644, -, -) %{_iconsdir}/Throne.ico
+%attr(0644, -, -) %{_appsdir}/%{name}.desktop
 %_datadir/pixmaps/Throne.png
 
 %files core


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (throne): add %check, update macros (#8593)](https://github.com/terrapkg/packages/pull/8593)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)