### PR TITLE
[f42] chore (arduino-app-lab-bin): add %check, update macros (#8602)

### DIFF
--- a/anda/tools/arduino-app-lab-bin/arduino-app-lab-bin.spec
+++ b/anda/tools/arduino-app-lab-bin/arduino-app-lab-bin.spec
@@ -18,7 +18,7 @@ ExclusiveArch:  x86_64
 
 Requires:       android-tools
 
-BuildRequires:  terra-appstream-helper
+BuildRequires:  terra-appstream-helper desktop-file-utils
 
 Suggests:       arduino-flasher-cli arduino-app-cli  
 
@@ -35,25 +35,30 @@ unzip %{_sourcedir}/source-app-lab-%{version}.zip
 install -dm755 %{buildroot}%{_bindir}
 install -p -m755 ArduinoAppLab_%{version}_Linux_x86-64/arduino-app-lab %{buildroot}%{_bindir}/%{name}
 
-install -dm755 %{buildroot}%{_iconsdir}/hicolor/scalable/apps/
-install -p -m644 source-app-lab/ui-packages/images/assets/round-arduino-logo.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/cc.arduino.AppLab.svg
+install -dm755 %{buildroot}%{_scalableiconsdir}/
+install -p -m644 source-app-lab/ui-packages/images/assets/round-arduino-logo.svg %{buildroot}%{_scalableiconsdir}/cc.arduino.AppLab.svg
 
-install -dm755 %{buildroot}%{_datadir}/applications/
-install -p -m644 %{SOURCE2} %{buildroot}%{_datadir}/applications/%{appid}.desktop
+install -dm755 %{buildroot}%{_appsdir}/
+install -p -m644 %{SOURCE2} %{buildroot}%{_appsdir}/%{appid}.desktop
 
 cp source-app-lab/LICENSE -t .
 cp source-app-lab/dependency_licenses -t .
 
 %terra_appstream -o %{SOURCE3}
 
+%check
+desktop-file-validate %{buildroot}%{_appsdir}/%{appid}.desktop
+
 %files
 %license LICENSE
 %license dependency_licenses
 %{_bindir}/%{name}
-%{_iconsdir}/hicolor/scalable/apps/%{appid}.svg
-%{_datadir}/applications/%{appid}.desktop
+%{_scalableiconsdir}/%{appid}.svg
+%{_appsdir}/%{appid}.desktop
 %{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Thu Dec 25 2025 Owen Zimmerman <owen@fyralabs.com>
+- Add %check, update macros
 * Thu Dec 4 2025 Jaiden Riordan <jade@fyralabs.com>
 - Package arduino-app-lab-bin


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (arduino-app-lab-bin): add %check, update macros (#8602)](https://github.com/terrapkg/packages/pull/8602)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)