### PR TITLE
[el10] chore (arduino-lab-micropython-installer): add %check (#8618)

### DIFF
--- a/anda/tools/arduino-lab-micropython-installer/arduino-lab-micropython-installer.spec
+++ b/anda/tools/arduino-lab-micropython-installer/arduino-lab-micropython-installer.spec
@@ -11,8 +11,10 @@ Source1:        micropython-installer.desktop
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 Requires:       libdrm libxcb
 BuildRequires:  anda-srpm-macros
+BuildRequires:  desktop-file-utils
 BuildRequires:  pnpm
 Provides:       arduino-lab-micropython-installer
+
 %description
 MicroPython Installer for Arduino is a cross-platform tool that streamlines the process of downloading
 and installing MicroPython firmware on compatible Arduino boards. It is compatible with macOS, Linux,
@@ -26,7 +28,10 @@ and Windows and is built using the Electron framework.
 
 %install
 %electron_install -i micropython-installer -s micropython-installer -d micropython-installer -b micropython-installer
-install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/applications/micropython-installer.desktop
+install -Dm644 %{SOURCE1} %{buildroot}%{_appsdir}/micropython-installer.desktop
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/micropython-installer.desktop
 
 %files
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (arduino-lab-micropython-installer): add %check (#8618)](https://github.com/terrapkg/packages/pull/8618)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)