### PR TITLE
[f42] bump: codium rust-television (#8622)

### DIFF
--- a/anda/devs/codium/codium.spec
+++ b/anda/devs/codium/codium.spec
@@ -12,7 +12,7 @@
 %endif
 
 Name:			codium
-Version:		1.106.37938
+Version:		1.107.18627
 Release:		1%?dist
 Summary:		Code editing. Redefined.
 License:		MIT

--- a/anda/langs/rust/television/rust-television.spec
+++ b/anda/langs/rust/television/rust-television.spec
@@ -5,7 +5,7 @@
 %global crate television
 
 Name:           rust-television
-Version:        0.14.1
+Version:        0.14.2
 Release:        1%?dist
 Summary:        Cross-platform, fast and extensible general purpose fuzzy finder TUI
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [bump: codium rust-television (#8622)](https://github.com/terrapkg/packages/pull/8622)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)