### PR TITLE
[el10] fix (glasgow): update patch (#8627)

### DIFF
--- a/anda/tools/glasgow/remove-dep-versions.patch
+++ b/anda/tools/glasgow/remove-dep-versions.patch
@@ -9,7 +9,7 @@ index c1151748..c3302e60 100644
 -  "typing_extensions>=4.8,<5",
 +  "typing_extensions",
    # Amaranth is the core of the Glasgow software/gateware interoperability layer. It uses SemVer.
--  "amaranth>=0.5.7,<0.6",
+-  "amaranth>=0.5.8,<0.6",
 +  "amaranth",
    # `packaging` is used in the plugin system, `support.plugin`. It uses CalVer: the major version
    # is the two last digits of the year and the minor version is the release within that year.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (glasgow): update patch (#8627)](https://github.com/terrapkg/packages/pull/8627)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)