### PR TITLE
[f42] bump: rust-bottom (#8626)

### DIFF
--- a/anda/langs/rust/bottom/rust-bottom.spec
+++ b/anda/langs/rust/bottom/rust-bottom.spec
@@ -5,7 +5,7 @@
 %global crate bottom
 
 Name:           rust-bottom
-Version:        0.11.2
+Version:        0.12.1
 Release:        1%?dist
 Summary:        Customizable cross-platform graphical process/system monitor for the terminal
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [bump: rust-bottom (#8626)](https://github.com/terrapkg/packages/pull/8626)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)