### PR TITLE
[f43] add: Tauri (#8623)

### DIFF
--- a/anda/tools/tauri/anda.hcl
+++ b/anda/tools/tauri/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "tauri.spec"
+    }
+}

--- a/anda/tools/tauri/tauri.spec
+++ b/anda/tools/tauri/tauri.spec
@@ -1,0 +1,47 @@
+%global crate tauri-cli
+%undefine __brp_mangle_shebangs
+
+Name:           rust-tauri
+Version:        2.9.6
+Release:        1%{?dist}
+Summary:        Rapidly scaffold out a new tauri app project
+License:        Apache-2.0 OR MIT
+URL:            https://crates.io/crates/create-tauri-app
+Source:         %{crates_source}
+BuildRequires:  anda-srpm-macros
+BuildRequires:  cargo-rpm-macros >= 24
+BuildRequires:  mold
+Suggests:       libayatana-appindicator-gtk3
+Packager:       Gilver E. <rockgrub@disroot.org>
+
+%description
+%{summary}.
+
+%package -n    tauri
+Summary:       %{summary}
+License:       ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-DFS-2016) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSL-1.0 AND BlueOak-1.0.0 AND CC0-1.0 AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND ISC AND MIT AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MIT-0 AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
+
+%description -n tauri
+%{summary}.
+
+%prep
+%autosetup -n %{crate}-%{version} -p1
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+install -Dpm755 target/rpm/cargo-tauri %{buildroot}%{_bindir}/tauri
+%{cargo_license_online} > LICENSE.dependencies
+
+%files -n tauri
+%license LICENSE_APACHE-2.0
+%license LICENSE_MIT
+%license LICENSE.dependencies
+%doc README.md
+%{_bindir}/tauri
+
+%changelog
+* Thu Dec 25 2025 Gilver E. <rockgrub@disroot.org> - 4.6.2-1
+- Initial package

--- a/anda/tools/tauri/update.rhai
+++ b/anda/tools/tauri/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(crates("tauri-cli"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: Tauri (#8623)](https://github.com/terrapkg/packages/pull/8623)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)