### PR TITLE
[el10]  fix(cmark-gfm): fix cmake install directories  (#8639)

### DIFF
--- a/anda/lib/cmark-gfm/cmark-gfm.spec
+++ b/anda/lib/cmark-gfm/cmark-gfm.spec
@@ -1,9 +1,10 @@
 Name:           cmark-gfm
 Version:        0.29.0.gfm.13
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        BSD-2-Clause AND MIT
 URL:            https://github.com/github/cmark-gfm
 Source:         %{url}/archive/refs/tags/%{version}.tar.gz
+Patch0:         fix-cmake-dir.patch
 Summary:        GitHub's fork of cmark, a CommonMark parsing and rendering library and program in C
 Packager:       metcya <metcya@gmail.com>
 
@@ -39,7 +40,7 @@ Requires:       %{name}-libs = %{evr}
 Development files for %{name}.
 
 %prep
-%autosetup
+%autosetup -p1
 
 %build
 %cmake
@@ -56,10 +57,12 @@ Development files for %{name}.
 %{_mandir}/man3/%{name}.3.*
 
 %files devel
-%{_libdir}/cmake/*.cmake
-%dir %{_libdir}/cmake-gfm-extensions
-%{_libdir}/cmake-gfm-extensions/*.cmake
+%{_libdir}/cmake/cmark-gfm/
+%{_libdir}/cmake-gfm-extensions/
 
 %changelog
-* Wed Dec 24 2025 metcya <metcya@gmail.com> - 0.29.0.gfm.13
+* Thu Dec 25 2025 metcya <metcya@gmail.com> - 0.29.0.gfm.13-2
+- Fix cmake install directories
+
+* Wed Dec 24 2025 metcya <metcya@gmail.com> - 0.29.0.gfm.13-1
 - Package cmark-gfm

--- a/anda/lib/cmark-gfm/fix-cmake-dir.patch
+++ b/anda/lib/cmark-gfm/fix-cmake-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 84dd2a0..d8f5ffa 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -175,7 +175,7 @@ if(CMARK_SHARED OR CMARK_STATIC)
+     DESTINATION include
+     )
+ 
+-  install(EXPORT cmark-gfm DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
++  install(EXPORT cmark-gfm DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm)
+ endif()
+ 
+ # Feature tests


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [ fix(cmark-gfm): fix cmake install directories  (#8639)](https://github.com/terrapkg/packages/pull/8639)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)