### PR TITLE
[f43] fix: typst (#8650)

### DIFF
--- a/anda/langs/rust/typst/rust-typst.spec
+++ b/anda/langs/rust/typst/rust-typst.spec
@@ -35,8 +35,10 @@ Provides:       %crate-cli = %version-%release
 %doc README.md
 %_bindir/typst
 %_mandir/man1/typst-compile.1.gz
+%_mandir/man1/typst-completions.1.gz
 %_mandir/man1/typst-fonts.1.gz
 %_mandir/man1/typst-init.1.gz
+%_mandir/man1/typst-info.1.gz
 %_mandir/man1/typst-query.1.gz
 %_mandir/man1/typst-update.1.gz
 %_mandir/man1/typst-watch.1.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: typst (#8650)](https://github.com/terrapkg/packages/pull/8650)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)