### PR TITLE
[f43] feat: Add create-tauri-app, fix summary on Tauri (#8658)

### DIFF
--- a/anda/devs/create-tauri-app/anda.hcl
+++ b/anda/devs/create-tauri-app/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "create-tauri-app.spec"
+    }
+}

--- a/anda/devs/create-tauri-app/create-tauri-app.spec
+++ b/anda/devs/create-tauri-app/create-tauri-app.spec
@@ -1,0 +1,47 @@
+%global crate create-tauri-app
+
+Name:           rust-create-tauri-app
+Version:        4.6.2
+Release:        1%{?dist}
+Summary:        Rapidly scaffold out a new tauri app project
+License:        Apache-2.0 OR MIT
+URL:            https://crates.io/crates/create-tauri-app
+Source:         %{crates_source}
+BuildRequires:  anda-srpm-macros
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  mold
+Suggests:       tauri
+
+%description
+%{summary}.
+
+%package -n     %{crate}
+Summary:        %{summary}
+License:        Apache-2.0 AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND MIT AND (MIT OR Apache-2.0) AND (Unlicense OR MIT) AND Zlib
+
+%description -n %{crate}
+%{summary}.
+
+%prep
+%autosetup -n %{crate}-%{version} -p1
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+install -Dpm755 target/rpm/cargo-%{crate} %{buildroot}%{_bindir}/%{crate}
+%{cargo_license_online} > LICENSE.dependencies
+
+%files -n %{crate}
+%license LICENSE.spdx
+%license LICENSE_APACHE-2.0
+%license LICENSE_MIT
+%license LICENSE.dependencies
+%doc CHANGELOG.md
+%doc CONTRIBUTING.md
+%doc README.md
+%{_bindir}/%{crate}
+
+%changelog
+%autochangelog

--- a/anda/devs/create-tauri-app/update.rhai
+++ b/anda/devs/create-tauri-app/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(crates("create-tauri-app"));

--- a/anda/tools/tauri/tauri.spec
+++ b/anda/tools/tauri/tauri.spec
@@ -3,26 +3,26 @@
 
 Name:           rust-tauri
 Version:        2.9.6
-Release:        1%{?dist}
-Summary:        Rapidly scaffold out a new tauri app project
+Release:        2%{?dist}
+Summary:        Command line interface for building Tauri apps
 License:        Apache-2.0 OR MIT
 URL:            https://crates.io/crates/create-tauri-app
 Source:         %{crates_source}
 BuildRequires:  anda-srpm-macros
-BuildRequires:  cargo-rpm-macros >= 24
+BuildRequires:  cargo-rpm-macros
 BuildRequires:  mold
 Suggests:       libayatana-appindicator-gtk3
 Packager:       Gilver E. <rockgrub@disroot.org>
 
 %description
-%{summary}.
+Build smaller, faster, and more secure desktop and mobile applications with a web frontend.
 
 %package -n    tauri
 Summary:       %{summary}
 License:       ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-DFS-2016) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSL-1.0 AND BlueOak-1.0.0 AND CC0-1.0 AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND ISC AND MIT AND (MIT AND (MIT OR Apache-2.0)) AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR NCSA) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MIT-0 AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
 
 %description -n tauri
-%{summary}.
+Build smaller, faster, and more secure desktop and mobile applications with a web frontend.
 
 %prep
 %autosetup -n %{crate}-%{version} -p1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Add create-tauri-app, fix summary on Tauri (#8658)](https://github.com/terrapkg/packages/pull/8658)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)