### PR TITLE
[f42] fix(ffmpeg): Catch exceptions in update script when Bodhi returns `nil` (#8520)

### DIFF
--- a/anda/multimedia/ffmpeg/update.rhai
+++ b/anda/multimedia/ffmpeg/update.rhai
@@ -6,15 +6,45 @@ rpm.version(bump::bodhi("ffmpeg", bump::as_bodhi_ver(labels.branch)));
 
 open_file("anda/multimedia/ffmpeg/VERSION_x264.txt", "w").write(bump::madoguchi("x264", labels.branch));
 open_file("anda/multimedia/ffmpeg/VERSION_x265.txt", "w").write(bump::madoguchi("x265", labels.branch));
+try
+{
 open_file("anda/multimedia/ffmpeg/VERSION_tesseract.txt", "w").write(bump::bodhi("tesseract", bump::as_bodhi_ver(labels.branch)));
+}
+catch
+{
+}
+try
+{
 open_file("anda/multimedia/ffmpeg/VERSION_rubberband.txt", "w").write(bump::bodhi("rubberband", bump::as_bodhi_ver(labels.branch)));
+}
+catch
+{
+}
+try
+{
 open_file("anda/multimedia/ffmpeg/VERSION_libbluray.txt", "w").write(bump::bodhi("libbluray", bump::as_bodhi_ver(labels.branch)));
+}
+catch
+{
+}
+try
+{
 open_file("anda/multimedia/ffmpeg/VERSION_libchromaprint.txt", "w").write(bump::bodhi("libchromaprint", bump::as_bodhi_ver(labels.branch)));
+}
+catch
+{
+}
 open_file("anda/multimedia/ffmpeg/VERSION_vvenc.txt", "w").write(bump::madoguchi("vvenc-libs", labels.branch));
 open_file("anda/multimedia/ffmpeg/VERSION_xeve.txt", "w").write(bump::madoguchi("xeve", labels.branch));
 open_file("anda/multimedia/ffmpeg/VERSION_xevd.txt", "w").write(bump::madoguchi("xevd", labels.branch));
 open_file("anda/multimedia/ffmpeg/VERSION_LCEVCdec.txt", "w").write(bump::madoguchi("LCEVCdec", labels.branch));
+try
+{
 open_file("anda/multimedia/ffmpeg/VERSION_svt-av1.txt", "w").write(bump::bodhi("svt-av1", bump::as_bodhi_ver(labels.branch)));
+}
+catch
+{
+}
 
 let dir = sub(`/[^/]+$`, "", __script_path);
 if sh("[[ `git status " + dir + " --porcelain` ]] && exit 1 || exit 0", #{}).ctx.rc == 1 {


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(ffmpeg): Catch exceptions in update script when Bodhi returns &#x60;nil&#x60; (#8520)](https://github.com/terrapkg/packages/pull/8520)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)