### PR TITLE
[f42] chore (README): remove policy page and add guidelines page (#8637)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ First of all, thanks for being interested in contributing to Terra! If you have 
 
 - [Contribution Guide](https://developer.fyralabs.com/terra/contributing)
 - [FAQ](https://developer.fyralabs.com/terra/faq)
-- [Policy](https://developer.fyralabs.com/terra/policy)
-
+- [Guidelines](https://developer.fyralabs.com/terra/guidelines)
 
 ## Documentation
 
@@ -67,4 +66,4 @@ Feel free to reach out by [joining our community](https://wiki.ultramarine-linux
 
 - [Contribution Guide](https://developer.fyralabs.com/terra/contributing)
 - [FAQ](https://developer.fyralabs.com/terra/faq)
-- [Policy](https://developer.fyralabs.com/terra/policy)
+- [Guidelines](https://developer.fyralabs.com/terra/guidelines)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (README): remove policy page and add guidelines page (#8637)](https://github.com/terrapkg/packages/pull/8637)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)