### PR TITLE
[f43] add: python-soxr (#8668)

### DIFF
--- a/anda/langs/python/python-soxr/anda.hcl
+++ b/anda/langs/python/python-soxr/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+	spec = "python-soxr.spec"
+  }
+}

--- a/anda/langs/python/python-soxr/python-soxr.spec
+++ b/anda/langs/python/python-soxr/python-soxr.spec
@@ -1,0 +1,55 @@
+%define debug_package %{nil}
+
+%global pypi_name soxr
+%global _desc Fast and high quality sample-rate conversion library for Python.
+
+Name:			python-%{pypi_name}
+Version:		1.0.0
+Release:		1%?dist
+Summary:		Fast and high quality sample-rate conversion library for Python
+License:		LGPL-2.1
+URL:			https://github.com/dofuuz/python-soxr
+Source0:		https://github.com/dofuuz/python-soxr/archive/refs/tags/v%version.tar.gz
+# This package is intentionally not noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-setuptools_scm
+BuildRequires:  python3-pip
+BuildRequires:  python3-scikit-build-core
+BuildRequires:  python3-pybind11
+BuildRequires:  python3-nanobind
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%git_clone
+
+%build
+export SETUPTOOLS_SCM_PRETEND_VERSION=%version
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files soxr
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md BUILDING.md
+%license LICENSE.txt COPYING.LGPL
+
+%changelog
+* Fri Dec 26 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/python-soxr/update.rhai
+++ b/anda/langs/python/python-soxr/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("soxr"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: python-soxr (#8668)](https://github.com/terrapkg/packages/pull/8668)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)