### PR TITLE
[f42] fix(openutau): no autoreqprov? (#8500)

### DIFF
--- a/anda/multimedia/openutau/openutau.bin.spec
+++ b/anda/multimedia/openutau/openutau.bin.spec
@@ -2,7 +2,7 @@
 
 Name:			openutau.bin
 Version:		%(echo %ver | sed -E 's@^build/@@')
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Open singing synthesis platform / Open source UTAU successor
 License:		MIT
 URL:			http://www.openutau.com
@@ -12,6 +12,7 @@ Source2:		https://github.com/stakira/OpenUtau/raw/refs/tags/%ver/OpenUtau/Assets
 Packager:		madonuko <mado@fyralabs.com>
 Provides:		openutau = %evr
 Provides:		OpenUtau = %evr
+AutoReqProv:	0
 
 %description
 OpenUtau is a free, open-source editor made for the UTAU community.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(openutau): no autoreqprov? (#8500)](https://github.com/terrapkg/packages/pull/8500)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)