### PR TITLE
[f43] add: standard-sunau (#8684)

### DIFF
--- a/anda/langs/python/standard-sunau/anda.hcl
+++ b/anda/langs/python/standard-sunau/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "standard-sunau.spec"
+  }
+}

--- a/anda/langs/python/standard-sunau/standard-sunau.spec
+++ b/anda/langs/python/standard-sunau/standard-sunau.spec
@@ -1,0 +1,52 @@
+%global pypi_name standard-sunau
+%global _desc Standard library sunau redistribution.
+
+Name:			python-%{pypi_name}
+Version:		3.13.0
+Release:		1%?dist
+Summary:		Standard library sunau redistribution
+License:		PSF-2.0
+URL:			https://github.com/youknowone/python-deadlib
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       standard-sunau
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n python-deadlib-%{version}
+
+%build
+pushd sunau
+%pyproject_wheel
+popd
+
+%install
+pushd sunau
+%pyproject_install
+%pyproject_save_files sunau
+popd
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc sunau/Doc/sunau.rst
+%doc sunau/README.rst
+%license sunau/LICENSE
+
+%changelog
+* Sat Dec 27 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/standard-sunau/update.rhai
+++ b/anda/langs/python/standard-sunau/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("standard-sunau"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: standard-sunau (#8684)](https://github.com/terrapkg/packages/pull/8684)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)