### PR TITLE
[f43] add: standard-chunk (#8670)

### DIFF
--- a/anda/langs/python/standard-chunk/anda.hcl
+++ b/anda/langs/python/standard-chunk/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "standard-chunk.spec"
+  }
+}

--- a/anda/langs/python/standard-chunk/standard-chunk.spec
+++ b/anda/langs/python/standard-chunk/standard-chunk.spec
@@ -1,0 +1,52 @@
+%global pypi_name standard-chunk
+%global _desc Standard library chunk redistribution.
+
+Name:			python-%{pypi_name}
+Version:		3.13.0
+Release:		1%?dist
+Summary:		Standard library chunk redistribution
+License:		PSF-2.0
+URL:			https://github.com/youknowone/python-deadlib
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       standard-chunk
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n python-deadlib-%{version}
+
+%build
+pushd chunk
+%pyproject_wheel
+popd
+
+%install
+pushd chunk
+%pyproject_install
+%pyproject_save_files chunk
+popd
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc chunk/Doc/chunk.rst
+%doc chunk/README.rst
+%license chunk/LICENSE
+
+%changelog
+* Fri Dec 26 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/standard-chunk/update.rhai
+++ b/anda/langs/python/standard-chunk/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("standard-chunk"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: standard-chunk (#8670)](https://github.com/terrapkg/packages/pull/8670)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)