### PR TITLE
[f43] add: PyMusicLooper (#8693)

### DIFF
--- a/anda/langs/python/PyMusicLooper/PyMusicLooper.spec
+++ b/anda/langs/python/PyMusicLooper/PyMusicLooper.spec
@@ -1,0 +1,53 @@
+%global pypi_name pymusiclooper
+%global _desc A python program for repeating music endlessly and creating seamless music loops, with play/export/tagging support.
+
+Name:			python-%{pypi_name}
+Version:		3.6.0
+Release:		1%?dist
+Summary:		A python program for repeating music endlessly and creating seamless music loops, with play/export/tagging support
+License:		MIT
+URL:			https://github.com/arkrow/PyMusicLooper
+Source0:		%{pypi_source}
+# Fedora doesn't yet carry pytaglib >=3.0.0
+Patch0:         make-dep-installable.patch
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+BuildRequires:  python3-hatchling
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       pymusiclooper
+Provides:       python3-pymusiclooper
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n pymusiclooper-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files pymusiclooper
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md CLI_README.md CHANGELOG.md
+%license LICENSE
+%{_bindir}/pymusiclooper
+%python3_sitelib/pymusiclooper-%version.dist-info/*
+
+%changelog
+* Fri Dec 26 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/PyMusicLooper/anda.hcl
+++ b/anda/langs/python/PyMusicLooper/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "PyMusicLooper.spec"
+  }
+}

--- a/anda/langs/python/PyMusicLooper/make-dep-installable.patch
+++ b/anda/langs/python/PyMusicLooper/make-dep-installable.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 9b37b98..9cb6ad3 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -27,7 +27,7 @@ dependencies = [
+   "sounddevice>=0.5.0",
+   "rich-click>=1.8.0,<2",
+   "rich>= 13.4.2",
+-  "pytaglib>=3.0.0,<4",
++  "pytaglib>=2.0.0,<4",
+   "numba>=0.59.1",
+   "yt-dlp>=2025.01.26",
+   "click-params>=0.5.0,<0.6",

--- a/anda/langs/python/PyMusicLooper/updatet.rhai
+++ b/anda/langs/python/PyMusicLooper/updatet.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("pymusiclooper"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: PyMusicLooper (#8693)](https://github.com/terrapkg/packages/pull/8693)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)