### PR TITLE
[el10] chore: move needed python packages update scripts to PyPi (#8694)

### DIFF
--- a/anda/langs/python/click-logging/update.rhai
+++ b/anda/langs/python/click-logging/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("Toilal/click-logging"));
+rpm.version(pypi("click-logging"));

--- a/anda/langs/python/dotty-dict/update.rhai
+++ b/anda/langs/python/dotty-dict/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("pawelzny/dotty_dict"));
+rpm.version(pypi("dotty_dict"));

--- a/anda/langs/python/fx2/update.rhai
+++ b/anda/langs/python/fx2/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("whitequark/libfx2"));
+rpm.version(pypi("fx2"));

--- a/anda/langs/python/jellyfin-apiclient-python/update.rhai
+++ b/anda/langs/python/jellyfin-apiclient-python/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("jellyfin/jellyfin-apiclient-python"));
+rpm.version(pypi("jellyfin-apiclient-python"));

--- a/anda/langs/python/jschon/update.rhai
+++ b/anda/langs/python/jschon/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("marksparkza/jschon"));
+rpm.version(pypi("jschon"));

--- a/anda/langs/python/magic-wormhole/update.rhai
+++ b/anda/langs/python/magic-wormhole/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("magic-wormhole/magic-wormhole"));
+rpm.version(pypi("magic-wormhole"));

--- a/anda/langs/python/milc/update.rhai
+++ b/anda/langs/python/milc/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("clueboard/milc"));
+rpm.version(pypi("milc"));

--- a/anda/langs/python/mpv/update.rhai
+++ b/anda/langs/python/mpv/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("jaseg/python-mpv"));
+rpm.version(pypi("mpv"));

--- a/anda/langs/python/numba/update.rhai
+++ b/anda/langs/python/numba/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("numba/numba"));
+rpm.version(pypi("numba"));

--- a/anda/langs/python/pyvcd/update.rhai
+++ b/anda/langs/python/pyvcd/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("SanDisk-Open-Source/pyvcd"));
+rpm.version(pypi("pyvcd"));

--- a/anda/langs/python/superisoupdater/update.rhai
+++ b/anda/langs/python/superisoupdater/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("JoshuaVandaele/SuperISOUpdater"));
+rpm.version(pypi("sisou"));

--- a/anda/langs/python/synapse-s3-storage-provider/update.rhai
+++ b/anda/langs/python/synapse-s3-storage-provider/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("matrix-org/synapse-s3-storage-provider"));
+rpm.version(pypi("synapse-s3-storage-provider"));

--- a/anda/langs/python/west/update.rhai
+++ b/anda/langs/python/west/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("zephyrproject-rtos/west"));
+rpm.version(pypi("west"));

--- a/anda/langs/python/zipstream-ng/update.rhai
+++ b/anda/langs/python/zipstream-ng/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("pR0Ps/zipstream-ng"));
+rpm.version(pypi("zipstream-ng"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: move needed python packages update scripts to PyPi (#8694)](https://github.com/terrapkg/packages/pull/8694)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)