### PR TITLE
[f43] add: nwg-look (#8731)

### DIFF
--- a/anda/desktops/sway/nwg-look/anda.hcl
+++ b/anda/desktops/sway/nwg-look/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "nwg-look.spec"
+  }
+}

--- a/anda/desktops/sway/nwg-look/nwg-look.spec
+++ b/anda/desktops/sway/nwg-look/nwg-look.spec
@@ -1,0 +1,55 @@
+%dnl %define debug_package %{nil}
+
+%global goipath github.com/nwg-piotr/nwg-look
+Version:        1.0.6
+
+%gometa -f
+
+Name:           nwg-look
+Release:        1%?dist
+Summary:        GTK3 settings editor adapted to work in the wlroots environment
+
+License:        MIT
+URL:            https://github.com/nwg-piotr/nwg-look
+Source0:        https://github.com/nwg-piotr/nwg-look/archive/refs/tags/v%version.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+BuildRequires:  make
+BuildRequires:  pkgconfig(gio-2.0)
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(gobject-2.0)
+BuildRequires:  pkgconfig(gdk-3.0)
+BuildRequires:  pkgconfig(cairo)
+BuildRequires:  pkgconfig(cairo-gobject)
+Requires:       glibc
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%make_build
+%make_build build
+
+%install
+%make_install
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/%{name}
+%{_appsdir}/%{name}.desktop
+%{_datadir}/%{name}/
+%{_datadir}/pixmaps/%{name}.svg
+
+%changelog
+* Fri Dec 05 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/desktops/sway/nwg-look/update.rhai
+++ b/anda/desktops/sway/nwg-look/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("nwg-piotr/nwg-look"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: nwg-look (#8731)](https://github.com/terrapkg/packages/pull/8731)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)