### PR TITLE
[f42] bump: coreboot-utils (#8727)

### DIFF
--- a/anda/tools/coreboot-utils/coreboot-utils.spec
+++ b/anda/tools/coreboot-utils/coreboot-utils.spec
@@ -1,7 +1,7 @@
 %define debug_package %nil
 
 Name:           coreboot-utils
-Version:        25.09
+Version:        25.12
 Release:        1%?dist
 Summary:        Various coreboot utilities
 URL:            https://doc.coreboot.org


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [bump: coreboot-utils (#8727)](https://github.com/terrapkg/packages/pull/8727)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)