### PR TITLE
[f42] add: lua-language-server (#8754)

### DIFF
--- a/anda/langs/lua/lua-language-server/anda.hcl
+++ b/anda/langs/lua/lua-language-server/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "lua-language-server.spec"
+  }
+}

--- a/anda/langs/lua/lua-language-server/lua-language-server.spec
+++ b/anda/langs/lua/lua-language-server/lua-language-server.spec
@@ -1,0 +1,47 @@
+%define debug_package %{nil}
+
+Name:           lua-language-server
+Version:        3.16.4
+Release:        1%?dist
+License:        MIT
+URL:            https://luals.github.io/
+Source:         https://github.com/LuaLS/lua-language-server/archive/refs/tags/%version.tar.gz
+Summary:        A language server that offers Lua language support
+
+BuildRequires:  gcc-c++ make ninja-build glibc lua gcc cmake libstdc++-devel libstdc++-static libcxx libcxx-devel
+
+%description
+A language server that offers Lua language support - programmed in Lua.
+
+%prep
+%git_clone https://github.com/LuaLS/lua-language-server.git %{version}
+
+%build
+# The funny
+chmod +x make.sh
+./make.sh
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_libexecdir}/%{name}
+mkdir -p %{buildroot}%{_datadir}/%{name}/
+install -Dm755 bin/lua-language-server %{buildroot}%{_libexecdir}/%{name}/%{name}
+install -Dm644 bin/main.lua            %{buildroot}%{_libexecdir}/%{name}/main.lua
+install -Dm644 debugger.lua            %{buildroot}%{_libexecdir}/%{name}/debugger.lua
+cp -av \
+    debugger.lua \
+    main.lua \
+    locale \
+    script \
+    meta \
+    %{buildroot}%{_datadir}/%{name}/
+
+%files
+%license LICENSE
+%doc README.md
+%{_libexecdir}/%{name}/
+%{_datadir}/%{name}/
+
+%changelog
+* Sun Dec 28 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/lua/lua-language-server/update.rhai
+++ b/anda/langs/lua/lua-language-server/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("LuaLS/lua-language-server"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: lua-language-server (#8754)](https://github.com/terrapkg/packages/pull/8754)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)