### PR TITLE
[el10] fix(mesa): enable intel-rt if `%with_vulkan_hw` (#8758)

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -34,7 +34,7 @@
 %endif
 %endif
 %ifarch x86_64
-%if !0%{?with_vulkan_hw}
+%if 0%{?with_vulkan_hw}
 %global with_intel_vk_rt 1
 %endif
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(mesa): enable intel-rt if &#x60;%with_vulkan_hw&#x60; (#8758)](https://github.com/terrapkg/packages/pull/8758)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)