### PR TITLE
[f42] fix(codium): more req excl (#8763)

### DIFF
--- a/anda/devs/codium/codium.spec
+++ b/anda/devs/codium/codium.spec
@@ -2,7 +2,7 @@
 %global _build_id_links none
 
 # Exclude private libraries
-%global __requires_exclude libffmpeg.so
+%global __requires_exclude libffmpeg.so|libcurl.so|libmsalruntime.so
 %global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
 
 %ifarch x86_64
@@ -11,9 +11,11 @@
 %define a arm64
 %endif
 
+%global appid com.vscodium.VSCodium
+
 Name:			codium
 Version:		1.107.18627
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Code editing. Redefined.
 License:		MIT
 URL:			https://vscodium.com/
@@ -21,11 +23,14 @@ Source0:		https://github.com/VSCodium/vscodium/releases/download/%version/VSCodi
 Source1:		https://raw.githubusercontent.com/VSCodium/vscodium/%version/README.md
 Source2:		https://raw.githubusercontent.com/VSCodium/vscodium/%version/LICENSE
 Requires:		at-spi2-atk cairo expat gtk3 xrandr mesa-libgbm nspr nss nss-util xdg-utils
+Provides:       vscodium = %evr
 BuildRequires:	rpm_macro(fdupes)
 
 %description
 VSCodium is a new choice of tool that combines the simplicity of a code editor
 with what developers need for the core edit-build-debug cycle.
+
+%pkg_completion -Bz
 
 %prep
 mkdir stuff
@@ -95,6 +100,7 @@ ln -s %_datadir/%name/resources/completions/bash/codium %buildroot%_datadir/bash
 
 %fdupes %_datadir/%name/resources/app/extensions/
 
+#terra_appstream
 
 %files
 %doc README.md
@@ -105,8 +111,7 @@ ln -s %_datadir/%name/resources/completions/bash/codium %buildroot%_datadir/bash
 %_datadir/applications/codium.desktop
 %_datadir/applications/codium-uri-handler.desktop
 %_datadir/pixmaps/vscodium.png
-%_datadir/zsh/site-functions/_codium
-%_datadir/bash-completion/completions/codium
+%dnl %_metainfodir/%appid.metainfo.xml
 
 %changelog
 * Sat Jun 17 2023 windowsboy111 <windowsboy111@fyralabs.com> - 1.79.2.23166-2
@@ -115,4 +120,3 @@ ln -s %_datadir/%name/resources/completions/bash/codium %buildroot%_datadir/bash
 
 * Sun Apr 2 2023 windowsboy111 <windowsboy111@fyralabs.com> - 1.77.3.23102-1
 - Initial package.
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(codium): more req excl (#8763)](https://github.com/terrapkg/packages/pull/8763)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)