### PR TITLE
[f43] add: gnome-shell-extension-grand-theft-focus (#8777)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/anda.hcl
+++ b/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+    rpm {
+        spec = "gnome-shell-extension-grand-theft-focus.spec"
+    }
+}

--- a/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
@@ -1,0 +1,35 @@
+%global extension   grand-theft-focus
+%global uuid        %{extension}@zalckos
+
+Name:           gnome-shell-extension-%{extension}
+Version:        9
+Release:        1%?dist
+Summary:        GNOME extension that removes the 'Window is ready' notification and brings the window into focus instead
+License:        AGPL-3.0-only
+URL:            https://github.com/zalckos/GrandTheftFocus
+
+BuildArch:      noarch
+
+Source0:        https://github.com/zalckos/GrandTheftFocus/archive/refs/tags/v%version.tar.gz
+
+Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
+Recommends:     gnome-extensions-app
+
+%description
+GNOME extension. Removes the 'Window is ready' notification and brings the window into focus instead.
+
+%prep
+%autosetup -n GrandTheftFocus-%version
+
+%install
+install -Dm644 grand-theft-focus@zalckos.github.com/metadata.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/metadata.json
+install -Dm644 grand-theft-focus@zalckos.github.com/extension.js %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/extension.js
+
+%files
+%license LICENSE
+%doc README.md
+%{_datadir}/gnome-shell/extensions/%{uuid}
+
+%changelog
+* Tue Dec 30 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/update.rhai
+++ b/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("zalckos/GrandTheftFocus"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: gnome-shell-extension-grand-theft-focus (#8777)](https://github.com/terrapkg/packages/pull/8777)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)