### PR TITLE
[f43] chore: update issue templates (#8769)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,63 @@
+name: Package Bug Report
+description: Report an issue with a package.
+title: "[BUG] "
+labels: ["bug", "triage"]
+#projects: ["octo-org/1", "octo-org/44"]
+assignees:
+  - hamachitan
+#type: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: pkg
+    attributes:
+      label: Full Package Name
+      description: If you report multiple packages, only the main package is needed if applicable, or separate them with spaces otherwise. Obtain the full package name using `rpm -qa pkg-name`.
+      placeholder: anda-0.4.14-1.fc43.x86_64
+    validations:
+      required: true
+  - type: dropdown
+    id: releasever
+    attributes:
+      label: Release Version
+      description: Which version of Terra are you using?
+      options:
+        - frawhide
+        - f43
+        - f42
+        - el10
+      default: 1
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is. Please only report issues with packaging or Terra itself, report upstream bugs to the respective project.
+      placeholder: A bug happened!
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: To Reproduce
+      description: How can the bug be reproduced?
+      placeholder: |
+        1. `dnf install this-package`
+        2. run `this-package`
+        3. see error
+    validations:
+      required: true
+  - type: textarea
+    id: expect
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: Running it should show hello world!
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/incident.md
+++ b/.github/ISSUE_TEMPLATE/incident.md
@@ -1,14 +1,14 @@
 ---
-name: Bug report
-about: Report an issue with a package (or Terra itself)
-title: '[BUG] '
-labels: bug
-assignees: ''
+name: Incident Report
+about: Report an issue with Terra itself
+title: '[INCIDENT] '
+labels: incident
+assignees: ['madonuko', 'korewaChino', 'lleyton']
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is. Please only report issues with packaging or Terra itself, report upstream bugs to the respective project.
+**Describe the Incident**
+A clear and concise description of what is going on. **If you want to report a problem with a package, please use the Package Bug Report option instead.**
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -23,7 +23,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Affected (please complete the following information):**
  - Distro [e.g. Fedora]
- - Package [e.g. melody, srpm-macros]
+ - Other relevant environments
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: update issue templates (#8769)](https://github.com/terrapkg/packages/pull/8769)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)