### PR TITLE
[f43] fix (zola): remove period in summary tag (#8796)

### DIFF
--- a/anda/tools/zola/zola.spec
+++ b/anda/tools/zola/zola.spec
@@ -1,7 +1,7 @@
 Name:           zola
 Version:        0.21.0
-Release:        1%?dist
-Summary:        A fast static site generator in a single binary with everything built-in.
+Release:        2%?dist
+Summary:        A fast static site generator in a single binary with everything built-in
 URL:            https://www.getzola.org
 Source0:        https://github.com/getzola/%{name}/archive/refs/tags/v%{version}.tar.gz
 License:        MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (zola): remove period in summary tag (#8796)](https://github.com/terrapkg/packages/pull/8796)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)