### PR TITLE
[el10] chore(rpcs3): Future proofing LLVM stuff (#8810)

### DIFF
--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -1,8 +1,11 @@
+# RPCS3 builds often break with GCC
+%global toolchain clang
 # Define which LLVM/Clang version RPCS3 needs
 %if 0%{?fedora} >= 45
 %global llvm_major 21
+%global __cc clang-%{llvm_major}
+%global __cxx clang++-%{llvm_major}
 %endif
-%global toolchain clang
 # GLIBCXX_ASSERTIONS is known to break RPCS3
 %global build_cflags %(echo "%{__build_flags_lang_c}" | sed 's|-Wp,-D_GLIBCXX_ASSERTIONS ||g') %{?_distro_extra_cflags}
 %global build_cxxflags %(echo "%{__build_flags_lang_cxx}" | sed 's|-Wp,-D_GLIBCXX_ASSERTIONS ||g') %{?_distro_extra_cflags}
@@ -88,8 +91,8 @@ export LLVM_DIR=%{_libdir}/llvm%{?llvm_major}/%{_lib}/cmake
     -DUSE_SYSTEM_FLATBUFFERS=OFF                              \
     -DUSE_SYSTEM_PUGIXML=OFF                                  \
     -DUSE_SYSTEM_WOLFSSL=OFF                                  \
-    -DCMAKE_C_COMPILER=clang%{?llvm_major:-%{llvm_major}}     \
-    -DCMAKE_CXX_COMPILER=clang++%{?llvm_major:-%{llvm_major}} \
+    -DCMAKE_C_COMPILER="$CC"                                  \
+    -DCMAKE_CXX_COMPILER="$CXX"                               \
     -DCMAKE_LINKER=mold                                       \
     -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS -fuse-ld=mold"      \
     -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -fuse-ld=mold"    


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(rpcs3): Future proofing LLVM stuff (#8810)](https://github.com/terrapkg/packages/pull/8810)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)