### PR TITLE
[f42] add: xapp-symbolic-icons (#8815)

### DIFF
--- a/anda/misc/xapp-symbolic-icons/anda.hcl
+++ b/anda/misc/xapp-symbolic-icons/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "xapp-symbolic-icons.spec"
+  }
+}

--- a/anda/misc/xapp-symbolic-icons/update.rhai
+++ b/anda/misc/xapp-symbolic-icons/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("xapp-project/xapp-symbolic-icons"));

--- a/anda/misc/xapp-symbolic-icons/xapp-symbolic-icons.spec
+++ b/anda/misc/xapp-symbolic-icons/xapp-symbolic-icons.spec
@@ -1,0 +1,51 @@
+Name:           xapp-symbolic-icons
+Version:        1.0.7
+Release:        1%{?dist}
+Summary:        A set of symbolic icons which replaces the GNOME-specific Adwaita set
+License:        GPL-3.0-only AND LGPL-3.0-only
+URL:            https://github.com/xapp-project/xapp-symbolic-icons
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  meson
+Requires:       hicolor-icon-theme
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+A set of symbolic icons which replaces the GNOME-specific Adwaita set.
+All provided icons are prefixed with xsi-.
+Icon names loosely follow the Adwaita names.
+
+%prep
+%autosetup
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+
+%transfiletriggerin -- %{_hicolordir}
+gtk-update-icon-cache --force %{_hicolordir} &>/dev/null || :
+
+%transfiletriggerpostun -- %{_hicolordir}
+gtk-update-icon-cache --force %{_hicolordir} &>/dev/null || :
+
+%files
+%license COPYING COPYING.LESSER
+%doc AUTHORS README.md
+%{_bindir}/xsi-replace-adwaita-symbolic
+%{_hicolordir}/scalable/actions/xsi-*.svg
+%{_datadir}/xapp/
+
+%changelog
+* Thu Jan 01 2026 Owen Zimmerman <owen@fyralabs.com>
+- Port to Terra from Fedora Rawhide
+
+* Fri Dec 12 2025 Leigh Scott <leigh123linux@gmail.com> - 1.0.6-1
+- Update to 1.0.6
+
+* Thu Nov 27 2025 Leigh Scott <leigh123linux@gmail.com> - 1.0.5-1
+- Update to 1.0.5


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [add: xapp-symbolic-icons (#8815)](https://github.com/terrapkg/packages/pull/8815)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)