### PR TITLE
[f43] add: falcond-gui (#8827)

### DIFF
--- a/anda/apps/falcond-gui/anda.hcl
+++ b/anda/apps/falcond-gui/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "falcond-gui.spec"
+    }
+}

--- a/anda/apps/falcond-gui/falcond-gui.spec
+++ b/anda/apps/falcond-gui/falcond-gui.spec
@@ -1,0 +1,52 @@
+Name:           falcond-gui
+Version:        1.0.0
+Release:        1%{?dist}
+Summary:        A GTK4/LibAdwaita application to control and monitor the Falcond gaming optimization daemon
+SourceLicense:  MIT
+License:        (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND CC0-1.0 AND ISC AND (MIT OR Apache-2.0) AND MIT AND (Unlicense OR MIT)
+URL:            https://git.pika-os.com/general-packages/falcond-gui
+Source0:        %{url}/archive/v%{version}.tar.gz
+BuildRequires:  anda-srpm-macros
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  desktop-file-utils
+BuildRequires:  gtk4-devel
+BuildRequires:  libadwaita-devel
+BuildRequires:  mold
+Requires:       gtk4
+Requires:       falcond
+Requires:       falcond-profiles
+Requires:       libadwaita
+Requires(post): gtk-update-icon-cache
+Packager:      Gilver E. <roachy@fyralabs.com>
+
+%description
+falcond-gui provides a user-friendly graphical interface for managing falcond. It allows users to view the status of the daemon and customize its behavior.
+
+%prep
+%autosetup -n %{name}/%{name}
+%cargo_prep_online
+
+%build
+
+%install
+%cargo_install
+desktop-file-install res/%{name}.desktop
+install -Dm644 res/falcond.png -t %{buildroot}%{_hicolordir}/512x512/apps/
+%{cargo_license_online} > LICENSE.dependencies
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+
+%posttrans
+/usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor/ &>/dev/null || :
+
+%files
+%doc ../README.md
+%license ../LICENSE.md
+%{_bindir}/%{name}
+%{_hicolordir}/512x512/apps/falcond.png
+%{_appsdir}/%{name}.desktop
+
+%changelog
+* Thu Jan 1 2026 Gilver E. <roachy@fyralabs.com> - 1.0.0-1
+- Initial package

--- a/anda/apps/falcond-gui/update.rhai
+++ b/anda/apps/falcond-gui/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(get("https://git.pika-os.com/api/v1/repos/general-packages/falcond-gui/releases").json_arr()[0].tag_name);

--- a/anda/system/falcond-profiles/falcond-profiles.spec
+++ b/anda/system/falcond-profiles/falcond-profiles.spec
@@ -4,14 +4,15 @@
 
 Name:           falcond-profiles
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Profiles for falcond
 License:        MIT
 URL:            https://github.com/PikaOS-Linux/falcond-profiles
 Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
 Requires:       falcond
+Suggests:       falcond-gui
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 This package contains the profiles needed for falcond.
@@ -28,6 +29,8 @@ install -Dm644 usr/share/falcond/profiles/*.conf -t %{buildroot}%{_datadir}/falc
 install -Dm644 usr/share/falcond/profiles/handheld/* -t %{buildroot}%{_datadir}/falcond/profiles/handheld/
 install -Dm644 usr/share/falcond/profiles/htpc/* -t %{buildroot}%{_datadir}/falcond/profiles/htpc/
 
+install -dm755 %{buildroot}%{_datadir}/falcond/profiles/user
+
 %files
 %doc README.md
 %license LICENSE
@@ -35,7 +38,11 @@ install -Dm644 usr/share/falcond/profiles/htpc/* -t %{buildroot}%{_datadir}/falc
 %{_datadir}/falcond/profiles/*.conf
 %{_datadir}/falcond/profiles/handheld/*.conf
 %{_datadir}/falcond/profiles/htpc/*.conf
+%dir %{_datadir}/falcond/profiles/user/
 
 %changelog
+* Thu Jan 1 2026 Gilver E. <roachy@fyralabs.com> - 0^20260101git.0f87c74-2
+- Added new user profiles directory
+- Added weak dep on falcond-gui
 * Thu Jun 19 2025 Gilver E. <rockgrub@disroot.org> - 0^20250613git.96c2cdf-1
 - Initial package

--- a/anda/system/falcond/falcond.preset
+++ b/anda/system/falcond/falcond.preset
@@ -1,1 +1,0 @@
-enable falcond.service

--- a/anda/system/falcond/falcond.spec
+++ b/anda/system/falcond/falcond.spec
@@ -2,20 +2,20 @@
 
 Name:           falcond
 Version:        1.2.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Advanced Linux Gaming Performance Daemon
 License:        MIT
 URL:            https://git.pika-os.com/general-packages/falcond
 Source0:        %{url}/archive/v%{version}.tar.gz
-Source1:        %{name}.preset
 BuildRequires:  anda-srpm-macros >= 0.2.18
 BuildRequires:  systemd-rpm-macros
-BuildRequires:  zig >= 0.14.0
+BuildRequires:  zig >= 0.15.2
 BuildRequires:  zig-rpm-macros
 Requires:       %{name}-profiles
 Requires:       (scx-scheds or scx-scheds-nightly)
+Suggests:       %{name}-gui
 Conflicts:      gamemode
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 falcond is a powerful system daemon designed to automatically optimize your Linux gaming experience.
@@ -29,7 +29,6 @@ This eliminates the need to manually configure settings for each game.
 
 %install
 install -Dm644 debian/%{name}.service -t %{buildroot}%{_unitdir}
-install -Dm644 %{SOURCE1} %{buildroot}%{_presetdir}/60-%{name}.preset
 # When DNF supports microarchitectures the fallback option for -c can be used here instead
 DESTDIR="%{buildroot}" \
 %ifarch x86_64
@@ -52,9 +51,11 @@ DESTDIR="%{buildroot}" \
 %license ../LICENSE
 %{_bindir}/%{name}
 %{_unitdir}/%{name}.service
-%{_presetdir}/60-%{name}.preset
 
 %changelog
+* Thu Jan 1 2026 Gilver E. <roachy@fyralabs.com> - 1.2.1-2
+- Disabled service by default in favor of user enablement via falcond-gui
+- Added weak dep on falcond-gui
 * Fri Jun 20 2025 Gilver E. <rockgrub@disroot.org> - 1.1.5-2
 - Enable service by default
 - Enable aarch64 CPU features


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: falcond-gui (#8827)](https://github.com/terrapkg/packages/pull/8827)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)