### PR TITLE
[f42] fix (snow): metainfo (#8835)

### DIFF
--- a/anda/apps/snow/com.github.snow.metainfo.xml
+++ b/anda/apps/snow/com.github.snow.metainfo.xml
@@ -22,9 +22,6 @@
   <launchable type="desktop-id">snow.desktop</launchable>
 
   <url type="homepage">https://github.com/twvd/snow</url>
-  <provides>
-    <binary>snowemu</binary>
-  </provides>
 
   <keywords>
     <keyword>macintosh</keyword>

--- a/anda/apps/snow/snow.spec
+++ b/anda/apps/snow/snow.spec
@@ -2,7 +2,7 @@
 
 Name:           snow
 Version:        1.2.0
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Classic Macintosh emulator
 URL:            https://github.com/twvd/snow
 Source0:        %url/archive/refs/tags/v%version.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (snow): metainfo (#8835)](https://github.com/terrapkg/packages/pull/8835)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)