### PR TITLE
[f43] chore(falcond-profiles): Update for falcond group (#8842)

### DIFF
--- a/anda/system/falcond-profiles/falcond-profiles.spec
+++ b/anda/system/falcond-profiles/falcond-profiles.spec
@@ -4,7 +4,7 @@
 
 Name:           falcond-profiles
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Profiles for falcond
 License:        MIT
 URL:            https://github.com/PikaOS-Linux/falcond-profiles
@@ -29,16 +29,17 @@ install -Dm644 usr/share/falcond/profiles/*.conf -t %{buildroot}%{_datadir}/falc
 install -Dm644 usr/share/falcond/profiles/handheld/* -t %{buildroot}%{_datadir}/falcond/profiles/handheld/
 install -Dm644 usr/share/falcond/profiles/htpc/* -t %{buildroot}%{_datadir}/falcond/profiles/htpc/
 
-install -dm755 %{buildroot}%{_datadir}/falcond/profiles/user
+install -dm2755 %{buildroot}%{_datadir}/falcond/profiles/user
 
 %files
 %doc README.md
 %license LICENSE
-%{_datadir}/falcond/system.conf
-%{_datadir}/falcond/profiles/*.conf
-%{_datadir}/falcond/profiles/handheld/*.conf
-%{_datadir}/falcond/profiles/htpc/*.conf
-%dir %{_datadir}/falcond/profiles/user/
+%dir %{_datadir}/falcond
+%config %{_datadir}/falcond/system.conf
+%config %{_datadir}/falcond/profiles/*.conf
+%config %{_datadir}/falcond/profiles/handheld/*.conf
+%config %{_datadir}/falcond/profiles/htpc/*.conf
+%attr(2755, root, falcond) %dir %{_datadir}/falcond/profiles/user
 
 %changelog
 * Thu Jan 1 2026 Gilver E. <roachy@fyralabs.com> - 0^20260101git.0f87c74-2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore(falcond-profiles): Update for falcond group (#8842)](https://github.com/terrapkg/packages/pull/8842)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)