### PR TITLE
[el10] chore(falcond): Add group (#8846)

### DIFF
--- a/anda/system/falcond/falcond.spec
+++ b/anda/system/falcond/falcond.spec
@@ -2,7 +2,7 @@
 
 Name:           falcond
 Version:        1.2.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Advanced Linux Gaming Performance Daemon
 License:        MIT
 URL:            https://git.pika-os.com/general-packages/falcond
@@ -15,6 +15,7 @@ Requires:       %{name}-profiles
 Requires:       (scx-scheds or scx-scheds-nightly)
 Suggests:       %{name}-gui
 Conflicts:      gamemode
+Provides:       group(falcond)
 Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
@@ -36,6 +37,13 @@ DESTDIR="%{buildroot}" \
 %elifarch aarch64
 %{zig_build_target -r fast -s} \
 %endif
+
+%pre
+# Create falcond group if it doesn't exist
+getent group 'falcond' >/dev/null || groupadd -f -r 'falcond' || :
+
+# Root must be a member of the group
+usermod -aG 'falcond' root || :
 
 %post
 %systemd_post %{name}.service


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(falcond): Add group (#8846)](https://github.com/terrapkg/packages/pull/8846)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)