### PR TITLE
[el10] add: libfiber (#8795)

### DIFF
--- a/anda/lib/libfiber/add-missing-header.patch
+++ b/anda/lib/libfiber/add-missing-header.patch
@@ -1,0 +1,12 @@
+diff --git a/cpp/include/fiber/go_fiber.hpp b/cpp/include/fiber/go_fiber.hpp
+index 5e1df06..8d6ad2a 100644
+--- a/cpp/include/fiber/go_fiber.hpp
++++ b/cpp/include/fiber/go_fiber.hpp
+@@ -15,6 +15,7 @@
+ #include <utility>
+ #include "fiber.hpp"
+ #include "fiber_tbox.hpp"
++#include <memory>
+ 
+ struct ACL_FIBER;
+ 

--- a/anda/lib/libfiber/anda.hcl
+++ b/anda/lib/libfiber/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "libfiber.spec"
+  }
+}

--- a/anda/lib/libfiber/libfiber.spec
+++ b/anda/lib/libfiber/libfiber.spec
@@ -1,0 +1,42 @@
+%define debug_package %{nil}
+
+%global _description %{expand:
+libfiber is a high-performance coroutine library designed for building efficient network applications across multiple platforms.
+Originating from the coroutine module in the acl project, libfiber supports Linux, FreeBSD, macOS, and Windows operating systems.
+The library enables developers to write highly concurrent applications using synchronous programming paradigms while achieving performance comparable to or better than asynchronous frameworks.}
+
+Name:           libfiber-devel
+Version:        1.1.0
+Release:        1%?dist
+URL:            https://deepwiki.com/iqiyi/libfiber
+Source0:        https://github.com/iqiyi/libfiber/archive/refs/tags/v%version.tar.gz
+Patch0:         add-missing-header.patch
+Summary:        The high performance c/c++ coroutine/fiber library for Linux/FreeBSD/MacOS/Windows, supporting select/poll/epoll/kqueue/iouring/iocp/windows GUI
+License:        LGPL-3.0
+ExclusiveArch:  x86_64
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  gcc-c++ make
+
+%description %_description
+
+%prep
+%autosetup -n libfiber-%{version} -p1
+
+%build
+%make_build
+
+%install
+mkdir -p %{buildroot}%{_includedir}/fiber/
+install -Dm644 c/include/fiber/*.h %{buildroot}%{_includedir}/fiber/
+install -Dm644 cpp/include/fiber/*.hpp %{buildroot}%{_includedir}/fiber/
+
+%files
+%license LICENSE.txt
+%doc README.md README_cn.md changes.txt
+%{_includedir}/fiber/
+
+%changelog
+* Wed Dec 31 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/lib/libfiber/update.rhai
+++ b/anda/lib/libfiber/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("iqiyi/libfiber"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: libfiber (#8795)](https://github.com/terrapkg/packages/pull/8795)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)