### PR TITLE
[el10] fix(breakpad): Static files (#8862)

### DIFF
--- a/anda/lib/breakpad/breakpad.spec
+++ b/anda/lib/breakpad/breakpad.spec
@@ -1,6 +1,6 @@
 Name:               breakpad
 Version:            2024.02.16
-Release:            1%?dist
+Release:            2%?dist
 Summary:            Google Breakpad crash-reporting system
 License:            BSD-3-Clause
 Group:		        System
@@ -22,8 +22,9 @@ A set of client and server components which implement a crash-reporting system.
 %package devel
 Requires:	%{name} = %{evr}
 %pkg_devel_files
-%{_libdir}/libbreakpad.a
-%{_libdir}/libbreakpad_client.a
+
+%package static
+%pkg_static_files
 
 %prep
 %autosetup -n breakpad-%{version}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(breakpad): Static files (#8862)](https://github.com/terrapkg/packages/pull/8862)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)