### PR TITLE
[el10] add: jade (#8874)

### DIFF
--- a/anda/langs/python/jade/anda.hcl
+++ b/anda/langs/python/jade/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "jade.spec"
+  }
+}

--- a/anda/langs/python/jade/jade.spec
+++ b/anda/langs/python/jade/jade.spec
@@ -1,0 +1,48 @@
+%global pypi_name jade
+%global _desc Exoplanet evolution code.
+
+Name:			python-%{pypi_name}
+Version:		0.1.0
+Release:		1%?dist
+Summary:		Exoplanet evolution code
+License:		LGPL-3.0
+URL:			https://gitlab.unige.ch/spice_dune/jade
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       jade
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n jade-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files jade
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/jade
+
+%changelog
+* Fri Jan 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/jade/update.rhai
+++ b/anda/langs/python/jade/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("jade"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: jade (#8874)](https://github.com/terrapkg/packages/pull/8874)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)