### PR TITLE
[f42] add: uxn (debug) (#8809)

### DIFF
--- a/anda/misc/uxn/stable/anda.hcl
+++ b/anda/misc/uxn/stable/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "uxn.spec"
+	}
+}

--- a/anda/misc/uxn/stable/uxn.spec
+++ b/anda/misc/uxn/stable/uxn.spec
@@ -1,0 +1,48 @@
+# uxn stable has no update script because this version
+# is permanently frozen. A nightly will be added once the
+# sourcehut versioning script is done.
+
+Name:           uxn
+Version:        1.0
+Release:        1%?dist
+Summary:        An emulator for the Varvara virtual machine
+URL:            https://100r.ca/site/%{name}.html
+Source0:        https://git.sr.ht/~rabbits/%{name}/archive/%{version}.tar.gz
+License:        MIT
+BuildRequires:  SDL2-devel gcc
+
+Packager:       arbormoss <arbormoss@woodsprite.dev>
+
+%description
+%summary.
+
+%prep
+%autosetup -n %name-%version
+
+%build
+# credit: based on the build script for uxn
+# https://git.sr.ht/~rabbits/uxn/tree/1.0/item/build.sh
+
+mkdir -p bin
+UXNEMU_LDFLAGS="-L/usr/local/lib $(sdl2-config --cflags --libs)"
+CFLAGS="%{build_cflags}"
+
+%{__cc} ${CFLAGS} src/%{name}asm.c %{build_ldflags} -o bin/%{name}asm
+%{__cc} ${CFLAGS} src/%{name}.c src/devices/system.c src/devices/console.c src/devices/file.c src/devices/datetime.c src/devices/mouse.c src/devices/controller.c src/devices/screen.c src/devices/audio.c src/%{name}emu.c ${UXNEMU_LDFLAGS} ${FILE_LDFLAGS} %{build_ldflags} -o bin/%{name}emu
+%{__cc} ${CFLAGS} src/%{name}.c src/devices/system.c src/devices/console.c src/devices/file.c src/devices/datetime.c src/%{name}cli.c ${FILE_LDFLAGS} %{build_ldflags} -o bin/%{name}cli
+
+%install
+install -Dm755 bin/%{name}asm %{buildroot}%{_bindir}/%{name}asm
+install -Dm755 bin/%{name}cli %{buildroot}%{_bindir}/%{name}cli
+install -Dm755 bin/%{name}emu %{buildroot}%{_bindir}/%{name}emu
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}asm
+%{_bindir}/%{name}cli
+%{_bindir}/%{name}emu
+
+%changelog
+* Sun Dec 21 2025 arbormoss <arbormoss@woodsprite.dev>
+- Intial Commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: uxn (debug) (#8809)](https://github.com/terrapkg/packages/pull/8809)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)