### PR TITLE
[f43] fix(falcond-profiles): 2775 (#8883)

### DIFF
--- a/anda/system/falcond-profiles/falcond-profiles.spec
+++ b/anda/system/falcond-profiles/falcond-profiles.spec
@@ -4,7 +4,7 @@
 
 Name:           falcond-profiles
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        3%?dist
+Release:        4%?dist
 Summary:        Profiles for falcond
 License:        MIT
 URL:            https://github.com/PikaOS-Linux/falcond-profiles
@@ -29,7 +29,7 @@ install -Dm644 usr/share/falcond/profiles/*.conf -t %{buildroot}%{_datadir}/falc
 install -Dm644 usr/share/falcond/profiles/handheld/* -t %{buildroot}%{_datadir}/falcond/profiles/handheld/
 install -Dm644 usr/share/falcond/profiles/htpc/* -t %{buildroot}%{_datadir}/falcond/profiles/htpc/
 
-install -dm2755 %{buildroot}%{_datadir}/falcond/profiles/user
+install -dm2775 %{buildroot}%{_datadir}/falcond/profiles/user
 
 %files
 %doc README.md
@@ -39,7 +39,7 @@ install -dm2755 %{buildroot}%{_datadir}/falcond/profiles/user
 %config %{_datadir}/falcond/profiles/*.conf
 %config %{_datadir}/falcond/profiles/handheld/*.conf
 %config %{_datadir}/falcond/profiles/htpc/*.conf
-%attr(2755, root, falcond) %dir %{_datadir}/falcond/profiles/user
+%attr(2775, root, falcond) %dir %{_datadir}/falcond/profiles/user
 
 %changelog
 * Thu Jan 1 2026 Gilver E. <roachy@fyralabs.com> - 0^20260101git.0f87c74-2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(falcond-profiles): 2775 (#8883)](https://github.com/terrapkg/packages/pull/8883)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)