### PR TITLE
[el10] fix(gnome-shell-extension-multi-monitors-bar): Nightly (#8882)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/anda.hcl
+++ b/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
     rpm {
         spec = "gnome-shell-extension-multi-monitors-bar.spec"
     }
+    labels {
+        nightly = 1
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(gnome-shell-extension-multi-monitors-bar): Nightly (#8882)](https://github.com/terrapkg/packages/pull/8882)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)