### PR TITLE
[el10] fix(akmod-nvidia): Requires gcc-c++ (#8890)

### DIFF
--- a/anda/system/nvidia/nvidia-kmod/nvidia-kmod.spec
+++ b/anda/system/nvidia/nvidia-kmod/nvidia-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           nvidia-kmod
 Version:        590.48.01
-Release:        3%?dist
+Release:        4%?dist
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License
@@ -18,6 +18,7 @@ ExclusiveArch:  x86_64 aarch64
 Source0:        https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{version}/open-gpu-kernel-modules-%{version}.tar.gz
 Requires:       nvidia-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       akmods
+Requires:       gcc-c++
 Provides:       akmod-nvidia-open = %{?epoch:%{epoch}:}%{version}
 Obsoletes:      akmod-nvidia-open < %{?epoch:%{epoch}:}%{version}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(akmod-nvidia): Requires gcc-c++ (#8890)](https://github.com/terrapkg/packages/pull/8890)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)