### PR TITLE
[el10] add: stardust-xr-solar-sailer (#8894)

### DIFF
--- a/anda/stardust/solar-sailer/anda.hcl
+++ b/anda/stardust/solar-sailer/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "stardust-solar-sailer.spec"
+    }
+}

--- a/anda/stardust/solar-sailer/stardust-solar-sailer.spec
+++ b/anda/stardust/solar-sailer/stardust-solar-sailer.spec
@@ -1,0 +1,41 @@
+# Exclude input files from mangling
+%global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
+
+Name:           stardust-xr-solar-sailer
+Version:        0.50.0
+Release:        1%?dist
+Summary:        Glide through space! This play space mover allows you to fly by dragging the space with momentum!
+URL:            https://github.com/StardustXR/solar-sailer
+Source0:        %url/archive/refs/tags/%version.tar.gz
+License:        MIT
+BuildRequires:  cargo anda-srpm-macros cargo-rpm-macros mold python3-devel
+
+Provides:       solar-sailer stardust-solar-sailer
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary
+
+%prep
+%autosetup -n solar-sailer-%version
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+mkdir -p %{buildroot}%{_datadir}/%{name}/solar_sailer
+%cargo_install
+install -Dm644 res/solar_sailer/move_icon.glb %{buildroot}%{_datadir}/%{name}/solar_sailer/move_icon.glb
+%{cargo_license_online} > LICENSE.dependencies
+
+%files
+%doc README.md
+%license LICENSE
+%license LICENSE.dependencies
+%_bindir/solar-sailer
+%{_datadir}/%{name}/solar_sailer/move_icon.glb
+
+%changelog
+* Sat Jan 03 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/stardust/solar-sailer/update.rhai
+++ b/anda/stardust/solar-sailer/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("StardustXR/solar-sailer"));

--- a/anda/stardust/telescope/stardust-telescope.spec
+++ b/anda/stardust/telescope/stardust-telescope.spec
@@ -4,7 +4,7 @@
 
 Name:           stardust-xr-telescope
 Version:        %commit_date.git~%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        See the stars! Easy stardust setups to run on your computer
 License:        MIT
 URL:            https://github.com/StardustXR/telescope
@@ -22,6 +22,7 @@ Requires:       stardust-xr-magnetar
 Requires:       stardust-xr-non-spatial-input
 Requires:       stardust-xr-protostar
 Requires:       stardust-xr-server
+Requires:       stardust-xr-solar-sailer
 
 BuildArch:      noarch
 Provides:       telescope stardust-telescope

--- a/comps.xml
+++ b/comps.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
 <comps>
   <group>
@@ -16,7 +16,8 @@
   <group>
     <id>stardust-xr</id>
     <name>Stardust XR</name>
-    <description>All Stardust XR packages needed to run the Stardust server</description>
+    <description
+        >All Stardust XR packages needed to run the Stardust server</description>
     <default>false</default>
     <uservisable>true</uservisable>
     <packagelist>
@@ -30,6 +31,7 @@
       <packagereq type="default">stardust-xr-non-spatial-input</packagereq>
       <packagereq type="default">stardust-xr-protostar</packagereq>
       <packagereq type="default">stardust-xr-server</packagereq>
+      <packagereq type="default">stardust-xr-solar-sailer</packagereq>
       <packagereq type="default">stardust-xr-telescope</packagereq>
     </packagelist>
   </group>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: stardust-xr-solar-sailer (#8894)](https://github.com/terrapkg/packages/pull/8894)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)