### PR TITLE
[f43] chore: Remove %config from files that shouldn't have this (#8899)

### DIFF
--- a/anda/langs/go/zrepl/golang-github-zrepl.spec
+++ b/anda/langs/go/zrepl/golang-github-zrepl.spec
@@ -75,7 +75,7 @@ cp -a   config/samples                                  %{buildroot}%{_datadir}/
 %license LICENSE
 %doc README.md
 %{_bindir}/*
-%config %{_unitdir}/zrepl.service
+%{_unitdir}/zrepl.service
 %dir %{_sysconfdir}/zrepl
 %config(noreplace) %{_sysconfdir}/zrepl/zrepl.yml
 %{_datadir}/bash-completion/completions/zrepl

--- a/anda/system/broadcom-wl/broadcom-wl.spec
+++ b/anda/system/broadcom-wl/broadcom-wl.spec
@@ -6,7 +6,7 @@
 
 Name:       broadcom-wl
 Version:    6.30.223.271
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    Common files for Broadcom 802.11 STA driver
 Group:      System Environment/Kernel
 License:    Redistributable, no modification permitted
@@ -61,9 +61,9 @@ grep -q Copyright ${fn} >/dev/null || sed -i "s%\(^<?xml.*$\)%\1\n${copyright_st
 %doc README_6.30.223.271.txt fedora.readme
 %license lib/LICENSE.txt
 %{_metainfodir}/com.broadcom.wireless.hybrid.driver.metainfo.xml
-%config %{_nmlibdir_conf_d}/90-broadcom-wl.conf
-%config(noreplace) %{_modprobe_d}/broadcom-wl-blacklist.conf
-%config(noreplace) %{_dracut_conf_d}/20-wl.conf
+%{_nmlibdir_conf_d}/90-broadcom-wl.conf
+%{_modprobe_d}/broadcom-wl-blacklist.conf
+%{_dracut_conf_d}/20-wl.conf
 
 %changelog
 %autochangelog

--- a/anda/system/falcond-profiles/falcond-profiles.spec
+++ b/anda/system/falcond-profiles/falcond-profiles.spec
@@ -4,7 +4,7 @@
 
 Name:           falcond-profiles
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        4%?dist
+Release:        5%?dist
 Summary:        Profiles for falcond
 License:        MIT
 URL:            https://github.com/PikaOS-Linux/falcond-profiles
@@ -35,10 +35,10 @@ install -dm2775 %{buildroot}%{_datadir}/falcond/profiles/user
 %doc README.md
 %license LICENSE
 %dir %{_datadir}/falcond
-%config %{_datadir}/falcond/system.conf
-%config %{_datadir}/falcond/profiles/*.conf
-%config %{_datadir}/falcond/profiles/handheld/*.conf
-%config %{_datadir}/falcond/profiles/htpc/*.conf
+%{_datadir}/falcond/system.conf
+%{_datadir}/falcond/profiles/*.conf
+%{_datadir}/falcond/profiles/handheld/*.conf
+%{_datadir}/falcond/profiles/htpc/*.conf
 %attr(2775, root, falcond) %dir %{_datadir}/falcond/profiles/user
 
 %changelog

--- a/anda/system/scx-tools/nightly/scx-tools-nightly.spec
+++ b/anda/system/scx-tools/nightly/scx-tools-nightly.spec
@@ -8,7 +8,7 @@
 
 Name:           scx-tools-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Sched_ext Tools
 License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND GPL-2.0-only AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 SourceLicense:  GPL-2.0-only
@@ -80,7 +80,7 @@ install -Dm755 target/rpm/*.so -t %{buildroot}%{_libdir} || :
 %{_datadir}/dbus-1/system-services/org.scx.Loader.service
 %{_datadir}/dbus-1/system.d/org.scx.Loader.conf
 %{_datadir}/polkit-1/actions/org.scx.Loader.policy
-%config(noreplace) %{_datadir}/scx_loader/config.toml
+%{_datadir}/scx_loader/config.toml
 %{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog

--- a/anda/system/scx-tools/stable/scx-tools.spec
+++ b/anda/system/scx-tools/stable/scx-tools.spec
@@ -4,7 +4,7 @@
 
 Name:           scx-tools
 Version:        1.0.19
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Sched_ext Tools
 License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND GPL-2.0-only AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 SourceLicense:  GPL-2.0-only
@@ -73,10 +73,11 @@ install -Dm755 target/rpm/*.so -t %{buildroot}%{_libdir} || :
 %doc README.md
 %{_bindir}/scx*
 %{_unitdir}/scx_loader.service
+%{_datadir}/dbus-1/interfaces/org.scx.Loader.xml
 %{_datadir}/dbus-1/system-services/org.scx.Loader.service
 %{_datadir}/dbus-1/system.d/org.scx.Loader.conf
 %{_datadir}/polkit-1/actions/org.scx.Loader.policy
-%config(noreplace) %{_datadir}/scx_loader/config.toml
+%{_datadir}/scx_loader/config.toml
 %{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: Remove %config from files that shouldn&#x27;t have this (#8899)](https://github.com/terrapkg/packages/pull/8899)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)