### PR TITLE
[f42] bump: noctalia-shell (#8909)

### DIFF
--- a/anda/desktops/noctalia-shell/noctalia-shell.spec
+++ b/anda/desktops/noctalia-shell/noctalia-shell.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           noctalia-shell
-Version:		3.8.0
+Version:		3.8.2
 Release:        1%?dist
 Summary:        A Quickshell-based custom shell setup
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [bump: noctalia-shell (#8909)](https://github.com/terrapkg/packages/pull/8909)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)