### PR TITLE
[el10] Remove unnecessary dependencies in throne.spec (#8913)

### DIFF
--- a/anda/apps/throne/throne.spec
+++ b/anda/apps/throne/throne.spec
@@ -24,12 +24,6 @@ BuildRequires: rpm_macro(cmake_build)
 BuildRequires: rpm_macro(cmake_install)
 BuildRequires: cmake
 BuildRequires: gcc-c++
-BuildRequires: pkgconfig(protobuf)
-BuildRequires: pkgconfig(libcurl)
-BuildRequires: cmake(yaml-cpp)
-BuildRequires: cmake(ZXing)
-BuildRequires: cmake(absl)
-BuildRequires: cmake(cpr)
 BuildRequires: cmake(Qt6)
 BuildRequires: cmake(Qt6Svg)
 BuildRequires: cmake(Qt6Linguist)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Remove unnecessary dependencies in throne.spec (#8913)](https://github.com/terrapkg/packages/pull/8913)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)