### PR TITLE
[f43] add: socktop (#8929)

### DIFF
--- a/anda/apps/socktop/anda.hcl
+++ b/anda/apps/socktop/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "socktop.spec"
+    }
+}

--- a/anda/apps/socktop/socktop.spec
+++ b/anda/apps/socktop/socktop.spec
@@ -1,0 +1,53 @@
+%global ver 1.55.0-test2
+%global sanitized_ver %(echo %{ver} | sed 's/-//g')
+
+Name:           socktop
+Version:        %sanitized_ver
+Release:        1%?dist
+Summary:        socktop is a remote system monitor with a rich TUI interface
+URL:            https://github.com/jasonwitty/socktop
+Source0:        %{url}/archive/refs/tags/v%{ver}.tar.gz
+License:        MIT
+BuildRequires:  rust libdrm-devel systemd-rpm-macros cargo-rpm-macros
+Requires:       libdrm
+Packager:       lux8149 <julianbashirisasimp@gmail.com>
+
+%description
+socktop is a remote system monitor with a rich TUI interface, inspired by `top` and `btop`,
+that communicates with a lightweight remote agent over WebSockets.
+
+%prep
+%autosetup -n %{name}-%{ver}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+install -Dm 755 target/rpm/socktop %{buildroot}%{_bindir}/socktop
+install -Dm 755 target/rpm/socktop_agent %{buildroot}%{_bindir}/socktop_agent
+install -Dm 644 target/rpm/libsocktop_connector.so %{buildroot}%{_libdir}/libsocktop_connector.so
+install -Dm 644 docs/socktop-agent.service %{buildroot}%{_unitdir}/socktop-agent.service
+%{cargo_license_online} > LICENSE.dependencies
+
+%post
+%systemd_post socktop-agent.service
+
+%preun
+%systemd_preun socktop-agent.service
+
+%postun
+%systemd_postun_with_restart socktop-agent.service
+
+%files
+%doc README.md
+%license LICENSE
+%license LICENSE.dependencies
+%{_bindir}/socktop
+%{_bindir}/socktop_agent
+%{_libdir}/libsocktop_connector.so
+%{_unitdir}/socktop-agent.service
+
+%changelog
+* Sun Jan 04 2026 lux8149 <julianbashirisasimp@gmail.com>
+- Initial Package

--- a/anda/apps/socktop/update.rhai
+++ b/anda/apps/socktop/update.rhai
@@ -1,0 +1,1 @@
+rpm.global("ver", gh("jasonwitty/socktop"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: socktop (#8929)](https://github.com/terrapkg/packages/pull/8929)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)