### PR TITLE
add: wooting-udev-rules

### DIFF
--- a/anda/games/wooting-udev-rules/70-wooting.rules
+++ b/anda/games/wooting-udev-rules/70-wooting.rules
@@ -1,0 +1,35 @@
+# Wooting One Legacy
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff01", MODE:="0660", GROUP="input", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff01", MODE:="0660", GROUP="input", TAG+="uaccess"
+# Wooting One update mode
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", MODE:="0660", GROUP="input", TAG+="uaccess"
+
+# Wooting Two Legacy
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", MODE:="0660", GROUP="input", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", MODE:="0660", GROUP="input", TAG+="uaccess"
+# Wooting Two update mode
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", MODE:="0660", GROUP="input", TAG+="uaccess"
+
+# Generic Wootings
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", MODE:="0660", GROUP="input", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="31e3", MODE:="0660", GROUP="input", TAG+="uaccess"
+
+# Wooting One Legacy for snap Chromium (Ubuntu)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff01", TAG+="snap_chromium_chromedriver"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff01", TAG+="snap_chromium_chromium"
+
+# Wooting One update mode for snap Chromium (Ubuntu)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="snap_chromium_chromedriver"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="snap_chromium_chromium"
+
+# Wooting Two Legacy for snap Chromium (Ubuntu)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", TAG+="snap_chromium_chromedriver"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", TAG+="snap_chromium_chromium"
+
+# Wooting Two update mode for snap Chromium (Ubuntu)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", TAG+="snap_chromium_chromedriver"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", TAG+="snap_chromium_chromium"
+
+# Generic Wootings for snap Chromium (Ubuntu)
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", TAG+="snap_chromium_chromedriver"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", TAG+="snap_chromium_chromium"

--- a/anda/games/wooting-udev-rules/70-wooting.rules
+++ b/anda/games/wooting-udev-rules/70-wooting.rules
@@ -1,35 +1,7 @@
-# Wooting One Legacy
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff01", MODE:="0660", GROUP="input", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff01", MODE:="0660", GROUP="input", TAG+="uaccess"
-# Wooting One update mode
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", MODE:="0660", GROUP="input", TAG+="uaccess"
-
-# Wooting Two Legacy
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", MODE:="0660", GROUP="input", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", MODE:="0660", GROUP="input", TAG+="uaccess"
-# Wooting Two update mode
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", MODE:="0660", GROUP="input", TAG+="uaccess"
+# Legacy Wootings
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", MODE:="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", MODE:="0660", TAG+="uaccess"
 
 # Generic Wootings
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", MODE:="0660", GROUP="input", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="31e3", MODE:="0660", GROUP="input", TAG+="uaccess"
-
-# Wooting One Legacy for snap Chromium (Ubuntu)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff01", TAG+="snap_chromium_chromedriver"
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff01", TAG+="snap_chromium_chromium"
-
-# Wooting One update mode for snap Chromium (Ubuntu)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="snap_chromium_chromedriver"
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2402", TAG+="snap_chromium_chromium"
-
-# Wooting Two Legacy for snap Chromium (Ubuntu)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", TAG+="snap_chromium_chromedriver"
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="ff02", TAG+="snap_chromium_chromium"
-
-# Wooting Two update mode for snap Chromium (Ubuntu)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", TAG+="snap_chromium_chromedriver"
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2403", TAG+="snap_chromium_chromium"
-
-# Generic Wootings for snap Chromium (Ubuntu)
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", TAG+="snap_chromium_chromedriver"
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", TAG+="snap_chromium_chromium"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", MODE:="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="31e3", MODE:="0660", TAG+="uaccess"

--- a/anda/games/wooting-udev-rules/anda.hcl
+++ b/anda/games/wooting-udev-rules/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	rpm {
+		spec = "wooting-udev-rules.spec"
+	}
+	arches = ["x86_64"]
+}

--- a/anda/games/wooting-udev-rules/wooting-udev-rules.spec
+++ b/anda/games/wooting-udev-rules/wooting-udev-rules.spec
@@ -1,0 +1,41 @@
+%global appid io.wooting.Udev
+
+
+Name:           wooting-udev-rules
+Version:        1.1
+Release:        1%{?dist}
+Summary:        Udev rules for wooting keyboards
+Provides: 8bitdo-udev = %{version}-%{release}
+License:        Unlicense
+Source0:        70-wooting.rules
+BuildArch:      noarch
+BuildRequires:  systemd
+BuildRequires:  anda-srpm-macros
+Requires:       systemd-udev
+
+%global udev_order 70
+
+%description
+Udev rules for Wooting keyboards to enable device access for use with the Wootility AppImage on Linux systems.
+
+%prep
+
+%build
+
+%install
+install -D -p -m 644 %SOURCE0 %{buildroot}%{_udevrulesdir}/%{udev_order}-wooting.rules
+%terra_appstream -o %{SOURCE1}
+
+%post
+%udev_rules_update
+
+%postun
+%udev_rules_update
+
+%files
+%_udevrulesdir/%{udev_order}-wooting.rules
+
+
+%changelog
+* Mon Jan 05 2026 Roice Young <dekodx@proton.me>
+- Initial release

--- a/anda/games/wooting-udev-rules/wooting-udev-rules.spec
+++ b/anda/games/wooting-udev-rules/wooting-udev-rules.spec
@@ -2,10 +2,10 @@
 
 
 Name:           wooting-udev-rules
-Version:        1.1
+Version:        1
 Release:        1%{?dist}
 Summary:        Udev rules for wooting keyboards
-Provides: 8bitdo-udev = %{version}-%{release}
+Provides:       wooting-udev = %{version}-%{release}
 License:        Unlicense
 Source0:        70-wooting.rules
 BuildArch:      noarch
@@ -24,8 +24,7 @@ Udev rules for Wooting keyboards to enable device access for use with the Wootil
 
 %install
 install -D -p -m 644 %SOURCE0 %{buildroot}%{_udevrulesdir}/%{udev_order}-wooting.rules
-%terra_appstream -o %{SOURCE1}
-
+#
 %post
 %udev_rules_update
 


### PR DESCRIPTION
This pr adds support for configuring Wooting analog keyboards in their keyboard configuration software called "Wootility" which is available as an Appimage at https://wooting.io/wootility. This package contains the chromium snap support rules solely to match upstream documentation.
