### PR TITLE
[el10] add: ttop (#8936)

### DIFF
--- a/anda/apps/ttop/anda.hcl
+++ b/anda/apps/ttop/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "ttop.spec"
+  }
+}

--- a/anda/apps/ttop/ttop.spec
+++ b/anda/apps/ttop/ttop.spec
@@ -1,0 +1,33 @@
+Name:           ttop
+Version:        1.5.7
+Release:        1%?dist
+Summary:        System monitoring tool with historical data service, triggers and top-like TUI
+License:        MIT
+URL:            https://github.com/inv2004/ttop
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildRequires:  anda-srpm-macros
+BuildRequires:  nim
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary.
+
+%prep
+%autosetup -n ttop-%version
+%nim_prep
+
+%build
+%nim_c src/ttop
+
+%install
+install -Dm755 src/ttop.out %{buildroot}%{_bindir}/ttop
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/ttop
+
+%changelog
+* Sun Jan 04 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/apps/ttop/update.rhai
+++ b/anda/apps/ttop/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("inv2004/ttop"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: ttop (#8936)](https://github.com/terrapkg/packages/pull/8936)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)