### PR TITLE
[f42] add: wooting-udev-rules (#8934)

### DIFF
--- a/anda/games/wooting-udev-rules/70-wooting.rules
+++ b/anda/games/wooting-udev-rules/70-wooting.rules
@@ -1,0 +1,7 @@
+# Legacy Wootings
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="03eb", MODE:="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="03eb", MODE:="0660", TAG+="uaccess"
+
+# Generic Wootings
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="31e3", MODE:="0660", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="31e3", MODE:="0660", TAG+="uaccess"

--- a/anda/games/wooting-udev-rules/anda.hcl
+++ b/anda/games/wooting-udev-rules/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	rpm {
+		spec = "wooting-udev-rules.spec"
+	}
+	arches = ["x86_64"]
+}

--- a/anda/games/wooting-udev-rules/wooting-udev-rules.spec
+++ b/anda/games/wooting-udev-rules/wooting-udev-rules.spec
@@ -1,0 +1,40 @@
+%global appid io.wooting.Udev
+
+
+Name:           wooting-udev-rules
+Version:        1
+Release:        1%{?dist}
+Summary:        Udev rules for wooting keyboards
+Provides:       wooting-udev = %{version}-%{release}
+License:        Unlicense
+Source0:        70-wooting.rules
+BuildArch:      noarch
+BuildRequires:  systemd
+BuildRequires:  anda-srpm-macros
+Requires:       systemd-udev
+
+%global udev_order 70
+
+%description
+Udev rules for Wooting keyboards to enable device access for use with the Wootility AppImage on Linux systems.
+
+%prep
+
+%build
+
+%install
+install -D -p -m 644 %SOURCE0 %{buildroot}%{_udevrulesdir}/%{udev_order}-wooting.rules
+#
+%post
+%udev_rules_update
+
+%postun
+%udev_rules_update
+
+%files
+%_udevrulesdir/%{udev_order}-wooting.rules
+
+
+%changelog
+* Mon Jan 05 2026 Roice Young <dekodx@proton.me>
+- Initial release


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: wooting-udev-rules (#8934)](https://github.com/terrapkg/packages/pull/8934)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)