### PR TITLE
[f42] add: inputtino (#8950)

### DIFF
--- a/anda/lib/inputtino/anda.hcl
+++ b/anda/lib/inputtino/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "inputtino.spec"
+  }
+}

--- a/anda/lib/inputtino/fix-pkgconfig-install-location.patch
+++ b/anda/lib/inputtino/fix-pkgconfig-install-location.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2546b78..c6ca674 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -174,7 +174,7 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+                 @ONLY
+         )
+         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libinputtino.pc
+-                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
++                DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+     endif ()
+ endif ()
+ 

--- a/anda/lib/inputtino/inputtino.spec
+++ b/anda/lib/inputtino/inputtino.spec
@@ -1,0 +1,48 @@
+%global commit 504f0abc7da8ebc351f8300fb2ed98db5438ee48
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20250816
+
+Name:           inputtino
+Version:        0^%{commitdate}.%{shortcommit}
+Release:        1%{?dist}
+License:        MIT
+URL:            https://github.com/games-on-whales/%{name}
+Source:         %{url}/archive/%{commit}.tar.gz
+Patch0:         fix-pkgconfig-install-location.patch
+Summary:        A virtual input library: supports mouse, keyboard, joypad, trackpad and more 
+Packager:       metcya <metcya@gmail.com>
+
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+BuildRequires:  pkgconfig(libevdev)
+BuildRequires:  pkgconfig(libinput)
+BuildRequires:  pkgconfig(sdl2)
+
+%description
+An easy to use virtual input library for Linux built on top of uinput, evdev
+and uhid.
+
+%package devel
+%pkg_devel_files
+
+%prep
+%autosetup -n %{name}-%{commit} -p1
+
+%build
+%cmake -DBUILD_TESTING=OFF \
+       -DLIBINPUTTINO_INSTALL=ON
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%doc README.md
+%license LICENSE
+# huh?
+%{_libdir}/liblib%{name}.so.*
+
+%changelog
+* Mon Jan 05 2026 metcya <metcya@gmail.com> - 0^20250816.504f0ab
+- Initial package 
+

--- a/anda/lib/inputtino/update.rhai
+++ b/anda/lib/inputtino/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("games-on-whales/inputtino"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: inputtino (#8950)](https://github.com/terrapkg/packages/pull/8950)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)