### PR TITLE
[el10] add: gnome-shell-extension-battery_time (#8954)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-battery_time/anda.hcl
+++ b/anda/desktops/gnome/gnome-shell-extension-battery_time/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+    rpm {
+        spec = "gnome-shell-extension-battery_time.spec"
+    }
+}

--- a/anda/desktops/gnome/gnome-shell-extension-battery_time/gnome-shell-extension-battery_time.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-battery_time/gnome-shell-extension-battery_time.spec
@@ -1,0 +1,45 @@
+%global commit 0df5f952843a296bf9f9b61b36c5fae5d851700b
+%global commit_date 20250925
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global extension   battery_time
+%global uuid        %{extension}@pomoke
+
+Name:           gnome-shell-extension-%{extension}
+Version:        0~%{commit_date}git.%{shortcommit}
+Release:        1%?dist
+Summary:        Battery remaining time extension for GNOME Shell
+License:        GPL-2.0-only
+URL:            https://github.com/pomoke/battery_time
+
+BuildArch:      noarch
+
+Source0:        %url/archive/%commit/battery_time-%commit.tar.gz
+# License declared in README
+Source1:        https://scancode-licensedb.aboutcode.org/gpl-2.0.LICENSE
+
+Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
+Recommends:     gnome-extensions-app
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+This extension serves as a replacement of battery remaining time, last seen in GNOME 42.
+Remaining time is shown inline, so no additional menu item is created (currently).
+
+%prep
+%autosetup -n %{extension}-%{commit}
+
+%install
+install -Dm644 metadata.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/metadata.json
+install -Dm644 extension.js %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/extension.js
+cp %{SOURCE1} LICENSE
+
+%files
+%doc README.md
+%license LICENSE
+%{_datadir}/gnome-shell/extensions/%{uuid}
+
+%changelog
+* Mon Jan 05 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/desktops/gnome/gnome-shell-extension-battery_time/update.rhai
+++ b/anda/desktops/gnome/gnome-shell-extension-battery_time/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("pomoke/battery_time"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: gnome-shell-extension-battery_time (#8954)](https://github.com/terrapkg/packages/pull/8954)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)