### PR TITLE
[f43] fix (gnome-shell-extension-appmenu-is-back): only use x86_64 runners (#8955)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/anda.hcl
+++ b/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+  arches = ["x86_64"]
     rpm {
         spec = "gnome-shell-extension-appmenu-is-back.spec"
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (gnome-shell-extension-appmenu-is-back): only use x86_64 runners (#8955)](https://github.com/terrapkg/packages/pull/8955)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)