### PR TITLE
fix (helium-browser-bin): .desktop file

### DIFF
--- a/anda/apps/helium-browser-bin/helium-browser-bin.spec
+++ b/anda/apps/helium-browser-bin/helium-browser-bin.spec
@@ -12,7 +12,7 @@
 
 Name:           helium-browser-bin
 Version:        0.7.9.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Private, fast, and honest web browser based on Chromium
 
 URL:            https://helium.computer
@@ -39,11 +39,7 @@ Based on ungoogled-chromium with additional privacy and usability improvements.
 %autosetup -n helium-%{version}-%{arch}_linux
 tar --strip-components=1 -zxvf %{SOURCE1}
 
-sed -i \
-    -e 's/Exec=chromium/Exec=%{name}/' \
-    -e 's/Name=Helium$/Name=Helium Browser/' \
-    -e 's/Icon=helium/Icon=%{appid}/' \
-    helium.desktop
+sed -i 's/Exec=helium\b/Exec=helium-browser-bin/g' helium.desktop
 
 %build
 

--- a/anda/apps/helium-browser-bin/helium-browser-bin.spec
+++ b/anda/apps/helium-browser-bin/helium-browser-bin.spec
@@ -49,9 +49,9 @@ cp -a * %{buildroot}%{_libdir}/%{name}/
 sed -i 's/exists_desktop_file || generate_desktop_file/true/' \
     %{buildroot}%{_libdir}/%{name}/chrome-wrapper
 
-desktop-file-install --dir=%{buildroot}%{_datadir}/applications --set-key=Exec --set-value="helium-browser-bin %U" helium-browser-bin.desktop
-
 install -Dm644 helium.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop
+desktop-file-edit --set-key=Exec --set-value="helium-browser-bin %U" %{buildroot}%{_datadir}/applications/%{name}.desktop
+
 install -Dm644 product_logo_256.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/%{appid}.png
 
 rm -f %{buildroot}%{_libdir}/%{name}/helium.desktop

--- a/anda/apps/helium-browser-bin/helium-browser-bin.spec
+++ b/anda/apps/helium-browser-bin/helium-browser-bin.spec
@@ -25,6 +25,7 @@ Source2:        net.imput.helium.metainfo.xml
 ExclusiveArch:  x86_64 aarch64
 
 BuildRequires:  terra-appstream-helper
+BuildRequires:  desktop-file-utils
 
 Requires:       xdg-utils
 Requires:       liberation-fonts
@@ -39,8 +40,6 @@ Based on ungoogled-chromium with additional privacy and usability improvements.
 %autosetup -n helium-%{version}-%{arch}_linux
 tar --strip-components=1 -zxvf %{SOURCE1}
 
-sed -i 's/Exec=helium\b/Exec=helium-browser-bin/g' helium.desktop
-
 %build
 
 %install
@@ -49,6 +48,8 @@ cp -a * %{buildroot}%{_libdir}/%{name}/
 
 sed -i 's/exists_desktop_file || generate_desktop_file/true/' \
     %{buildroot}%{_libdir}/%{name}/chrome-wrapper
+
+desktop-file-install --dir=%{buildroot}%{_datadir}/applications --set-key=Exec --set-value="helium-browser-bin %U" helium.desktop
 
 install -Dm644 helium.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop
 install -Dm644 product_logo_256.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/%{appid}.png

--- a/anda/apps/helium-browser-bin/helium-browser-bin.spec
+++ b/anda/apps/helium-browser-bin/helium-browser-bin.spec
@@ -49,7 +49,7 @@ cp -a * %{buildroot}%{_libdir}/%{name}/
 sed -i 's/exists_desktop_file || generate_desktop_file/true/' \
     %{buildroot}%{_libdir}/%{name}/chrome-wrapper
 
-desktop-file-install --dir=%{buildroot}%{_datadir}/applications --set-key=Exec --set-value="helium-browser-bin %U" helium.desktop
+desktop-file-install --dir=%{buildroot}%{_datadir}/applications --set-key=Exec --set-value="helium-browser-bin %U" helium-browser-bin.desktop
 
 install -Dm644 helium.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop
 install -Dm644 product_logo_256.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/%{appid}.png

--- a/anda/apps/helium-browser-bin/helium-browser-bin.spec
+++ b/anda/apps/helium-browser-bin/helium-browser-bin.spec
@@ -25,7 +25,6 @@ Source2:        net.imput.helium.metainfo.xml
 ExclusiveArch:  x86_64 aarch64
 
 BuildRequires:  terra-appstream-helper
-BuildRequires:  desktop-file-utils
 
 Requires:       xdg-utils
 Requires:       liberation-fonts
@@ -40,6 +39,8 @@ Based on ungoogled-chromium with additional privacy and usability improvements.
 %autosetup -n helium-%{version}-%{arch}_linux
 tar --strip-components=1 -zxvf %{SOURCE1}
 
+sed -i 's/Exec=helium\b/Exec=helium-browser-bin/g' helium.desktop
+
 %build
 
 %install
@@ -50,8 +51,6 @@ sed -i 's/exists_desktop_file || generate_desktop_file/true/' \
     %{buildroot}%{_libdir}/%{name}/chrome-wrapper
 
 install -Dm644 helium.desktop %{buildroot}%{_datadir}/applications/%{name}.desktop
-desktop-file-edit --set-key=Exec --set-value="helium-browser-bin %U" %{buildroot}%{_datadir}/applications/%{name}.desktop
-
 install -Dm644 product_logo_256.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/%{appid}.png
 
 rm -f %{buildroot}%{_libdir}/%{name}/helium.desktop


### PR DESCRIPTION
For some reason the .desktop file doesn't exec the correct binary anymore?

```
[Desktop Entry]
Version=1.0
Name=Helium Browser
GenericName=Web Browser
Comment=Access the Internet
Exec=helium %U
StartupNotify=true
StartupWMClass=helium
Terminal=false
Icon=net.imput.helium
Type=Application
Categories=Network;WebBrowser;
MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/http;x-scheme-handler/https;
Actions=new-window;new-private-window;

[Desktop Action new-window]
Name=New Window
Exec=helium

[Desktop Action new-private-window]
Name=New Incognito Window
Exec=helium --incognito
```

This should fix that