### PR TITLE
[f43] add: darkdetect (#8972)

### DIFF
--- a/anda/langs/python/darkdetect/anda.hcl
+++ b/anda/langs/python/darkdetect/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "darkdetect.spec"
+  }
+}

--- a/anda/langs/python/darkdetect/darkdetect.spec
+++ b/anda/langs/python/darkdetect/darkdetect.spec
@@ -1,0 +1,51 @@
+%global pypi_name darkdetect
+%global _desc Detect OS Dark Mode from Python.
+
+Name:			python-%{pypi_name}
+Version:		0.8.0
+Release:		1%?dist
+Summary:		Detect OS Dark Mode from Python
+License:		BSD-3-Clause
+URL:			https://github.com/albertosottile/darkdetect
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%package -n     python3-%{pypi_name}-doc
+Summary:        documentation for python3-%{pypi_name}
+
+%description -n python3-%{pypi_name}-doc
+documentation for python3-%{pypi_name}.
+
+%prep
+%autosetup -n darkdetect-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files darkdetect
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Wed Jan 07 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/darkdetect/update.rhai
+++ b/anda/langs/python/darkdetect/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("darkdetect"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: darkdetect (#8972)](https://github.com/terrapkg/packages/pull/8972)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)