### PR TITLE
[el10] add: dataclasses-json (#8979)

### DIFF
--- a/anda/langs/python/dataclasses-json/anda.hcl
+++ b/anda/langs/python/dataclasses-json/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "dataclasses-json.spec"
+  }
+}

--- a/anda/langs/python/dataclasses-json/dataclasses-json.spec
+++ b/anda/langs/python/dataclasses-json/dataclasses-json.spec
@@ -1,0 +1,57 @@
+%global pypi_name dataclasses-json
+%global _desc Easily serialize Data Classes to and from JSON.
+
+%define _python_dist_allow_version_zero %{nil}
+
+Name:			python-%{pypi_name}
+Version:		0.6.7
+Release:		1%?dist
+Summary:		Easily serialize Data Classes to and from JSON
+License:		MIT
+URL:			https://github.com/lidatong/dataclasses-json
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-poetry-dynamic-versioning
+
+Requires:       python3-marshmallow
+Requires:       python3-typing-inspect
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%package -n     python3-%{pypi_name}-doc
+Summary:        documentation for python3-%{pypi_name}
+
+%description -n python3-%{pypi_name}-doc
+documentation for python3-%{pypi_name}.
+
+%prep
+%autosetup -n dataclasses-json-%{version}
+sed -i '/\[tool.poetry-dynamic-versioning\]/,+1d' pyproject.toml
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files dataclasses_json
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Wed Jan 07 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/dataclasses-json/update.rhai
+++ b/anda/langs/python/dataclasses-json/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("dataclasses-json"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: dataclasses-json (#8979)](https://github.com/terrapkg/packages/pull/8979)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)