### PR TITLE
[el10] add: diffq (#8984)

### DIFF
--- a/anda/langs/python/diffq/anda.hcl
+++ b/anda/langs/python/diffq/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "diffq.spec"
+  }
+}

--- a/anda/langs/python/diffq/diffq.spec
+++ b/anda/langs/python/diffq/diffq.spec
@@ -1,0 +1,52 @@
+%global pypi_name diffq
+%global _desc DiffQ performs differentiable quantization using pseudo quantization noise.
+
+Name:			python-%{pypi_name}
+Version:		0.2.4
+Release:		1%?dist
+Summary:		DiffQ performs differentiable quantization using pseudo quantization noise
+License:		CC-BY-NC-4.0
+URL:			https://github.com/facebookresearch/diffq
+Source0:		%{pypi_source}
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildRequires:  cython
+BuildRequires:  gcc
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%package -n     python3-%{pypi_name}-doc
+Summary:        documentation for python3-%{pypi_name}
+
+%description -n python3-%{pypi_name}-doc
+documentation for python3-%{pypi_name}.
+
+%prep
+%autosetup -n diffq-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files diffq
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Thu Jan 08 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/diffq/update.rhai
+++ b/anda/langs/python/diffq/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("diffq"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: diffq (#8984)](https://github.com/terrapkg/packages/pull/8984)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)