### PR TITLE
[f42] add: antlr4-python3-runtime (#8987)

### DIFF
--- a/anda/langs/python/antlr4-runtime/anda.hcl
+++ b/anda/langs/python/antlr4-runtime/anda.hcl
@@ -1,0 +1,6 @@
+  project pkg {
+    arches = ["x86_64"]
+    rpm {
+      spec = "antlr4-runtime.spec"
+    }
+  }

--- a/anda/langs/python/antlr4-runtime/antlr4-runtime.spec
+++ b/anda/langs/python/antlr4-runtime/antlr4-runtime.spec
@@ -1,0 +1,64 @@
+%global pypi_name antlr4-python3-runtime
+%global _desc Python 3 runtime libraries for ANTLR 4.
+
+%global commit 23ed92cc6655f7def5d1447f51cb4c9657400f9d
+%global commit_date 20150607
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global ver 4.9.3
+
+Name:			python-%{pypi_name}
+Version:		%{ver}^%{commit_date}git.%{shortcommit}
+Release:		1%?dist
+Summary:		Python 3 runtime libraries for ANTLR 4
+License:		BSD
+URL:			https://www.antlr.org/
+Source0:		https://github.com/parrt/antlr4-python3/archive/%commit/antlr4-python3-%commit.tar.gz
+Source1:        https://github.com/s-a/license/blob/master/_licenses/bsd-3-clause.txt
+Patch0:         shebang.patch
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+
+Conflicts:      python3-antlr4-runtime
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%package -n     python3-%{pypi_name}-doc
+Summary:        documentation for python3-%{pypi_name}
+
+%description -n python3-%{pypi_name}-doc
+documentation for python3-%{pypi_name}.
+
+%prep
+%autosetup -n antlr4-python3-%{commit} -p1
+cp %{SOURCE1} .
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+install -Dm755 bin/pygrun %{buildroot}%{_bindir}/pygrun
+%pyproject_save_files antlr4
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.txt RELEASE-4.5.txt
+%license bsd-3-clause.txt
+%{_bindir}/pygrun
+
+%changelog
+* Thu Jan 08 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/antlr4-runtime/shebang.patch
+++ b/anda/langs/python/antlr4-runtime/shebang.patch
@@ -1,0 +1,10 @@
+diff --git a/bin/pygrun b/bin/pygrun
+index 96f1b40..dd01add 100755
+--- a/bin/pygrun
++++ b/bin/pygrun
+@@ -1,4 +1,4 @@
+-#!python
++#!/usr/bin/env python3
+ __author__ = 'jszheng'
+ import optparse
+ import sys

--- a/anda/langs/python/antlr4-runtime/update.rhai
+++ b/anda/langs/python/antlr4-runtime/update.rhai
@@ -1,0 +1,7 @@
+rpm.global("commit", gh_commit("parrt/antlr4-python3"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+    let v = gh("Winetricks/winetricks");
+    rpm.global("ver", v);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: antlr4-python3-runtime (#8987)](https://github.com/terrapkg/packages/pull/8987)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)