### PR TITLE
[f43] fix: add xdg-desktop-portal as a requirement (#8998)

### DIFF
--- a/anda/desktops/noctalia-shell/noctalia-shell.spec
+++ b/anda/desktops/noctalia-shell/noctalia-shell.spec
@@ -2,7 +2,7 @@
 
 Name:           noctalia-shell
 Version:		3.8.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
@@ -14,6 +14,7 @@ Requires:    	dejavu-sans-fonts
 Requires:    	gpu-screen-recorder
 Requires:	    qt6-qtmultimedia
 Requires:       quickshell
+Requires:       xdg-desktop-portal
 
 Recommends: 	cava
 Recommends:	    cliphist


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: add xdg-desktop-portal as a requirement (#8998)](https://github.com/terrapkg/packages/pull/8998)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)