### PR TITLE
[el10] add: hf-xet (#9016)

### DIFF
--- a/anda/langs/python/hf-xet/anda.hcl
+++ b/anda/langs/python/hf-xet/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "xf-xet.spec"
+  }
+}

--- a/anda/langs/python/hf-xet/update.rhai
+++ b/anda/langs/python/hf-xet/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("hf-xet"));

--- a/anda/langs/python/hf-xet/xf-xet.spec
+++ b/anda/langs/python/hf-xet/xf-xet.spec
@@ -1,0 +1,58 @@
+%global pypi_name hf-xet
+%global _desc xet client tech, used in huggingface_hub.
+
+Name:			python-%{pypi_name}
+Version:		1.2.0
+Release:		1%?dist
+Summary:		xet client tech, used in huggingface_hub
+License:		Apache-2.0
+URL:			https://github.com/huggingface/xet-core
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+
+BuildRequires: python
+BuildRequires: gdb
+BuildRequires: cargo
+BuildRequires: rust-src
+BuildRequires: pkgconfig(libssh2)
+BuildRequires: lmdb-devel
+BuildRequires: maturin
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%package -n     python3-%{pypi_name}-doc
+Summary:        documentation for python3-%{pypi_name}
+
+%description -n python3-%{pypi_name}-doc
+documentation for python3-%{pypi_name}.
+
+%prep
+%autosetup -n xet-core-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files hf_xet
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc *.md
+%license LICENSE
+
+%changelog
+* Fri Jan 09 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: hf-xet (#9016)](https://github.com/terrapkg/packages/pull/9016)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)