### PR TITLE
[el10] fix (arduino-app-lab): add update.rhai (#9036)

### DIFF
--- a/anda/tools/arduino-app-lab-bin/update.rhai
+++ b/anda/tools/arduino-app-lab-bin/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/arduino-app-lab"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (arduino-app-lab): add update.rhai (#9036)](https://github.com/terrapkg/packages/pull/9036)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)