### PR TITLE
[f42] add: posthog (#9039)

### DIFF
--- a/anda/langs/python/posthog/anda.hcl
+++ b/anda/langs/python/posthog/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "posthog.spec"
+  }
+}

--- a/anda/langs/python/posthog/posthog.spec
+++ b/anda/langs/python/posthog/posthog.spec
@@ -1,0 +1,46 @@
+%global pypi_name posthog
+%global _desc Send usage data from your Python code to PostHog.
+
+Name:			python-%{pypi_name}
+Version:		7.5.1
+Release:		1%?dist
+Summary:		Send usage data from your Python code to PostHog
+License:		MIT
+URL:			https://posthog.com/docs/libraries/python
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       %{pypi_name}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Sat Jan 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/posthog/update.rhai
+++ b/anda/langs/python/posthog/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("posthog"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: posthog (#9039)](https://github.com/terrapkg/packages/pull/9039)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)