### PR TITLE
[f42] fix (copyparty): suggest golang-github-cloudflare-cfssl (#9035)

### DIFF
--- a/anda/tools/copyparty/copyparty.spec
+++ b/anda/tools/copyparty/copyparty.spec
@@ -2,7 +2,7 @@
 
 Name:           %{pypi_name}
 Version:        1.20.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Portable, featureful, and fast file server 
 URL:            https://github.com/9001/copyparty
 Source0:        %{pypi_source}
@@ -13,7 +13,7 @@ BuildRequires:  python3-devel python3-pip pyproject-rpm-macros
 BuildRequires:  python3dist(wheel) python3dist(build) python3dist(jinja2)
 BuildRequires:  python3dist(setuptools) python3dist(installer)
 Requires:       python3-%{name} = %{evr}
-Suggests:       ffmpeg python3dist(fuse)
+Suggests:       ffmpeg python3dist(fuse) golang-github-cloudflare-cfssl
 BuildArch:		noarch
 Packager:       Riley Loo <dev@zackerthescar.com>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (copyparty): suggest golang-github-cloudflare-cfssl (#9035)](https://github.com/terrapkg/packages/pull/9035)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)