### PR TITLE
[el10] chore: switch stardust-telescope to version based (#9034)

### DIFF
--- a/anda/stardust/telescope/anda.hcl
+++ b/anda/stardust/telescope/anda.hcl
@@ -3,7 +3,4 @@ project pkg {
     rpm {
         spec = "stardust-telescope.spec"
     }
-    labels {
-        nightly = 1
-    }
 }

--- a/anda/stardust/telescope/stardust-telescope.spec
+++ b/anda/stardust/telescope/stardust-telescope.spec
@@ -1,14 +1,11 @@
-%global commit 3f6bbbb6bfaf28da8e3635a67a7d9502ae7a7b11
-%global commit_date 20260104
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-
 Name:           stardust-xr-telescope
-Version:        %commit_date.git~%shortcommit
+Version:        0.50.3
 Release:        1%?dist
+Epoch:          1
 Summary:        See the stars! Easy stardust setups to run on your computer
 License:        MIT
 URL:            https://github.com/StardustXR/telescope
-Source0:        %url/archive/%commit.tar.gz
+Source0:        %url/archive/refs/tags/%version.tar.gz
 
 Requires:       bash
 Requires:       xwayland-satellite
@@ -31,7 +28,7 @@ Provides:       telescope stardust-telescope
 See the stars! Easy stardust setups to run on your computer.
 
 %prep
-%autosetup -n telescope-%commit
+%autosetup -n telescope-%version
 
 %build
 
@@ -48,3 +45,7 @@ install -Dm644 org.stardustxr.Telescope.png      %buildroot%_hicolordir/512x512/
 %_bindir/_telescope_startup
 %_appsdir/org.stardustxr.Telescope.desktop
 %_hicolordir/512x512/apps/org.stardustxr.Telescope.png
+
+%changelog
+* Sat Jan 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to version based

--- a/anda/stardust/telescope/update.rhai
+++ b/anda/stardust/telescope/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("StardustXR/telescope"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(gh("StardustXR/telescope"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: switch stardust-telescope to version based (#9034)](https://github.com/terrapkg/packages/pull/9034)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)