### PR TITLE
[el10] chore: switch stardust-protostar to version based (#9032)

### DIFF
--- a/anda/stardust/protostar/anda.hcl
+++ b/anda/stardust/protostar/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
     rpm {
         spec = "stardust-protostar.spec"
     }
-    labels {
-       nightly = 1
-    }
 }

--- a/anda/stardust/protostar/stardust-protostar.spec
+++ b/anda/stardust/protostar/stardust-protostar.spec
@@ -1,15 +1,13 @@
-%global commit 7609cbfc07121b3b68d91bf2124b9c0afa57363d
-%global commit_date 20251218
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-protostar
-Version:        %commit_date.%shortcommit
+Version:        0.50.0
 Release:        1%?dist
+Epoch:          1
 Summary:        Prototype application launcher for Stardust XR
 URL:            https://github.com/StardustXR/protostar
-Source0:        %url/archive/%commit/protostar-%commit.tar.gz
+Source0:        %url/archive/refs/tags/%version.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
@@ -20,7 +18,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 Prototype application launcher for StardustXR, providing an easy to use crate to write applications launchers.
 
 %prep
-%autosetup -n protostar-%commit
+%autosetup -n protostar-%version
 %cargo_prep_online
 
 %build
@@ -51,5 +49,8 @@ cp -r res/* %buildroot%_datadir/
 %_datadir/protostar/
 
 %changelog
+* Sat Jan 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to version based
+
 * Tue Sep 10 2024 Owen-sz <owen@fyralabs.com>
 - Package StardustXR protostar

--- a/anda/stardust/protostar/update.rhai
+++ b/anda/stardust/protostar/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("StardustXR/protostar"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(gh_tag("StardustXR/protostar"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: switch stardust-protostar to version based (#9032)](https://github.com/terrapkg/packages/pull/9032)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)