### PR TITLE
[f43] chore: switch stardust-gravity to version based (#9030)

### DIFF
--- a/anda/stardust/gravity/anda.hcl
+++ b/anda/stardust/gravity/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
     rpm {
         spec = "stardust-gravity.spec"
     }
-    labels {
-       nightly = 1
-    }
 }

--- a/anda/stardust/gravity/stardust-gravity.spec
+++ b/anda/stardust/gravity/stardust-gravity.spec
@@ -1,15 +1,13 @@
-%global commit 3283bf8b352cdcb04ef3e0edb5155c4ca8c5c97c
-%global commit_date 20251130
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-gravity
-Version:        %commit_date.%shortcommit
-Release:        2%?dist
+Version:        0.50.0
+Release:        1%?dist
+Epoch:          1
 Summary:        Utility to launch apps and Stardust XR clients spatially
 URL:            https://github.com/StardustXR/gravity
-Source0:        %url/archive/%commit/gravity-%commit.tar.gz
+Source0:        %url/archive/refs/tags/%version.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
@@ -20,7 +18,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %summary.
 
 %prep
-%autosetup -n gravity-%commit
+%autosetup -n gravity-%version
 %cargo_prep_online
 
 %build
@@ -38,5 +36,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %doc README.md
 
 %changelog
+* Sat Jan 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to version based
+
 * Wed Sep 11 2024 Owen-sz <owen@fyralabs.com>
 - Package StardustXR gravity

--- a/anda/stardust/gravity/update.rhai
+++ b/anda/stardust/gravity/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("StardustXR/gravity"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(gh_tag("StardustXR/gravity"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: switch stardust-gravity to version based (#9030)](https://github.com/terrapkg/packages/pull/9030)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)