### PR TITLE
[f43] chore: switch stardust-flatland to version based (#9029)

### DIFF
--- a/anda/stardust/flatland/anda.hcl
+++ b/anda/stardust/flatland/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
 	rpm {
 		spec = "stardust-flatland.spec"
 	}
-	labels {
-	   nightly = 1
-	}
 }

--- a/anda/stardust/flatland/stardust-flatland.spec
+++ b/anda/stardust/flatland/stardust-flatland.spec
@@ -1,15 +1,13 @@
-%global commit add9b3420940a5608116d02d3dbf53fbd3eb7c40
-%global commit_date 20251225
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-flatland
-Version:        %commit_date.%shortcommit
+Version:        0.50.1
 Release:        1%?dist
+Epoch:          1
 Summary:        Flatland for Stardust XR
 URL:            https://github.com/StardustXR/flatland
-Source0:        %url/archive/%commit/flatland-%commit.tar.gz
+Source0:        %url/archive/refs/tags/%version.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
@@ -20,7 +18,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %summary.
 
 %prep
-%autosetup -n flatland-%commit
+%autosetup -n flatland-%version
 %cargo_prep_online
 
 %build
@@ -44,5 +42,8 @@ cp -r res/* %buildroot%_datadir/
 %doc README.md
 
 %changelog
+* Sat Jan 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to version based
+
 * Sat Sep 7 2024 Owen-sz <owen@fyralabs.com>
 - Package StardustXR Flatland

--- a/anda/stardust/flatland/update.rhai
+++ b/anda/stardust/flatland/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("StardustXR/flatland"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(gh_tag("StardustXR/flatland"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: switch stardust-flatland to version based (#9029)](https://github.com/terrapkg/packages/pull/9029)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)