### PR TITLE
[el10] chore: switch stardust-atmosphere to version based (#9026)

### DIFF
--- a/anda/stardust/atmosphere/anda.hcl
+++ b/anda/stardust/atmosphere/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
     rpm {
         spec = "stardust-atmosphere.spec"
     }
-    labels {
-       nightly = 1
-    }
 }

--- a/anda/stardust/atmosphere/stardust-atmosphere.spec
+++ b/anda/stardust/atmosphere/stardust-atmosphere.spec
@@ -1,15 +1,13 @@
-%global commit af38adafe7491498c48905b77518f8a6e9541f67
-%global commit_date 20251202
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-atmosphere
-Version:        %commit_date.%shortcommit
-Release:        2%?dist
+Version:        0.5.0
+Release:        1%?dist
+Epoch:          1
 Summary:        Environment, homespace, and setup client for Stardust XR
 URL:            https://github.com/StardustXR/atmosphere
-Source0:        %url/archive/%commit/atmosphere-%commit.tar.gz
+Source0:        %url/archive/refs/tags/%version.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
@@ -20,7 +18,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %summary.
 
 %prep
-%autosetup -n atmosphere-%commit
+%autosetup -n atmosphere-%version
 %cargo_prep_online
 
 %build
@@ -38,5 +36,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %doc README.md
 
 %changelog
+* Sat Jan 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to version based
+
 * Tue Sep 10 2024 Owen-sz <owen@fyralabs.com>
 - Package StardustXR atmosphere

--- a/anda/stardust/atmosphere/update.rhai
+++ b/anda/stardust/atmosphere/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("StardustXR/atmosphere"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(gh_tag("StardustXR/atmosphere"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: switch stardust-atmosphere to version based (#9026)](https://github.com/terrapkg/packages/pull/9026)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)