### PR TITLE
[f42] chore: switch stardust-comet to version based (#9028)

### DIFF
--- a/anda/stardust/comet/anda.hcl
+++ b/anda/stardust/comet/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
 	rpm {
 		spec = "stardust-comet.spec"
 	}
-	labels {
-	   nightly = 1
-	}
 }

--- a/anda/stardust/comet/stardust-comet.spec
+++ b/anda/stardust/comet/stardust-comet.spec
@@ -1,15 +1,13 @@
-%global commit 52b442c42d8b2938f16adfe42ab1ac0b5d29a137
-%global commit_date 20251218
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-comet
-Version:        %commit_date.%shortcommit
+Version:        0.50.0
 Release:        1%?dist
+Epoch:          1
 Summary:        Annotate things in Stardust XR
 URL:            https://github.com/StardustXR/comet
-Source0:        %url/archive/%commit/comet-%commit.tar.gz
+Source0:        %url/archive/refs/tags/%version.tar.gz
 License:        MIT
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
@@ -20,7 +18,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %summary.
 
 %prep
-%autosetup -n comet-%commit
+%autosetup -n comet-%version
 %cargo_prep_online
 
 %build
@@ -38,5 +36,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %doc README.md
 
 %changelog
+* Sat Jan 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to version based
+
 * Sat Sep 7 2024 Owen-sz <owen@fyralabs.com>
 - Package StardustXR comet

--- a/anda/stardust/comet/update.rhai
+++ b/anda/stardust/comet/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("StardustXR/comet"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(gh_tag("StardustXR/comet"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: switch stardust-comet to version based (#9028)](https://github.com/terrapkg/packages/pull/9028)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)