### PR TITLE
[f42] add: hydra-colorlog (#9022)

### DIFF
--- a/anda/langs/python/hydra-colorlog/anda.hcl
+++ b/anda/langs/python/hydra-colorlog/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "hydra-colorlog.spec"
+  }
+}

--- a/anda/langs/python/hydra-colorlog/hydra-colorlog.spec
+++ b/anda/langs/python/hydra-colorlog/hydra-colorlog.spec
@@ -1,0 +1,53 @@
+%global pypi_name hydra-colorlog
+%global _desc Hydra is a framework for elegantly configuring complex applications.
+
+%define debug_package %{nil}
+
+Name:			python-%{pypi_name}
+Version:		1.3.2
+Release:		1%?dist
+Summary:		Hydra is a framework for elegantly configuring complex applications
+License:		MIT
+URL:			https://github.com/facebookresearch/hydra
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildRequires:  java-21-openjdk-devel
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%package -n     python3-%{pypi_name}-doc
+Summary:        documentation for python3-%{pypi_name}
+
+%description -n python3-%{pypi_name}-doc
+documentation for python3-%{pypi_name}.
+
+%prep
+%autosetup -n hydra-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files hydra
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Fri Jan 09 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/hydra-colorlog/update.rhai
+++ b/anda/langs/python/hydra-colorlog/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("hydra-colorlog"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: hydra-colorlog (#9022)](https://github.com/terrapkg/packages/pull/9022)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)