### PR TITLE
[f42] fix: fix taidan_proc_macros clone in readymade (#9107)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -44,7 +44,7 @@ This package contains the configuration files for Readymade to install Ultramari
 %prep
 %autosetup -n readymade-%commit
 tar xf %{S:1}
-rmdir taidan_proc_macros && mv rdms_proc_macros* taidan_proc_macros
+rmdir crates/taidan_proc_macros && mv rdms_proc_macros* crates/taidan_proc_macros
 %cargo_prep_online
 
 %build

--- a/anda/system/readymade/stable/readymade.spec
+++ b/anda/system/readymade/stable/readymade.spec
@@ -32,7 +32,7 @@ This package contains the configuration files for Readymade to install Ultramari
 %prep
 %autosetup
 tar xf %{S:1}
-rmdir taidan_proc_macros && mv rdms_proc_macros* taidan_proc_macros
+rmdir crates/taidan_proc_macros && mv rdms_proc_macros* crates/taidan_proc_macros
 %cargo_prep_online
 
 %build
@@ -56,4 +56,3 @@ ln -sf %{_datadir}/applications/com.fyralabs.Readymade.desktop %{buildroot}%{_da
 %_datadir/applications/liveinst.desktop
 %ghost %_datadir/readymade
 %_datadir/icons/hicolor/scalable/apps/com.fyralabs.Readymade.svg
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: fix taidan_proc_macros clone in readymade (#9107)](https://github.com/terrapkg/packages/pull/9107)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)