### PR TITLE
[el10] add: tokenizers (#9083)

### DIFF
--- a/anda/langs/python/tokenizers/anda.hcl
+++ b/anda/langs/python/tokenizers/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+	spec = "tokenizers.spec"
+  }
+}

--- a/anda/langs/python/tokenizers/tokenizers.spec
+++ b/anda/langs/python/tokenizers/tokenizers.spec
@@ -1,0 +1,51 @@
+%global pypi_name tokenizers
+%global _desc Fast State-of-the-Art Tokenizers optimized for Research and Production.
+
+Name:			python-%{pypi_name}
+Version:		0.22.2
+Release:		1%?dist
+Summary:		Fast State-of-the-Art Tokenizers optimized for Research and Production
+License:		Apache-2.0
+URL:			https://github.com/huggingface/tokenizers
+Source0:		%{pypi_source}
+Source1:        https://github.com/huggingface/tokenizers/blob/main/LICENSE
+Source2:        https://github.com/huggingface/tokenizers/blob/main/README.md
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+BuildRequires:  maturin
+BuildRequires:  gcc-c++
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n tokenizers-%{version}
+cp %{SOURCE1} .
+cp %{SOURCE2} .
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files tokenizers
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Sat Jan 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/tokenizers/update.rhai
+++ b/anda/langs/python/tokenizers/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("tokenizers"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: tokenizers (#9083)](https://github.com/terrapkg/packages/pull/9083)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)