### PR TITLE
[el10] fix (stardust-non-spatial-input): add dep licenses (#9153)

### DIFF
--- a/anda/stardust/non-spatial-input/nightly/stardust-non-spatial-input-nightly.spec
+++ b/anda/stardust/non-spatial-input/nightly/stardust-non-spatial-input-nightly.spec
@@ -6,11 +6,11 @@
 
 Name:           stardust-xr-non-spatial-input-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Tools you can easily snap together to get non-spatial input into Stardust XR
 URL:            https://github.com/StardustXR/non-spatial-input
 Source0:        %url/archive/%commit/non-spatial-input-%commit.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND BSD-3-Clause AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
 Provides:       non-spatial-input-nightly stardust-non-spatial-input-nightly
@@ -35,7 +35,6 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 wait
 
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 %files

--- a/anda/stardust/non-spatial-input/stable/stardust-non-spatial-input.spec
+++ b/anda/stardust/non-spatial-input/stable/stardust-non-spatial-input.spec
@@ -3,12 +3,12 @@
 
 Name:           stardust-xr-non-spatial-input
 Version:        0.50.0
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        Tools you can easily snap together to get non-spatial input into Stardust XR
 URL:            https://github.com/StardustXR/non-spatial-input
 Source0:        %url/archive/refs/tags/%version.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND BSD-3-Clause AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
 Provides:       non-spatial-input stardust-non-spatial-input
@@ -32,7 +32,6 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 wait
 
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 %files


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (stardust-non-spatial-input): add dep licenses (#9153)](https://github.com/terrapkg/packages/pull/9153)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)