### PR TITLE
[f42] fix (stardust-protostar): add dep licenses (#9154)

### DIFF
--- a/anda/stardust/protostar/nightly/stardust-protostar-nightly.spec
+++ b/anda/stardust/protostar/nightly/stardust-protostar-nightly.spec
@@ -6,11 +6,11 @@
 
 Name:           stardust-xr-protostar-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Prototype application launcher for Stardust XR
 URL:            https://github.com/StardustXR/protostar
 Source0:        %url/archive/%commit/protostar-%commit.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause-Patent AND BSD-2-Clause AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND ISC AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
 Provides:       protostar-nightly stardust-protostar-nightly
@@ -39,7 +39,6 @@ wait
 mkdir -p %buildroot%_datadir
 cp -r res/* %buildroot%_datadir/
 
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 %files

--- a/anda/stardust/protostar/stable/stardust-protostar.spec
+++ b/anda/stardust/protostar/stable/stardust-protostar.spec
@@ -3,12 +3,12 @@
 
 Name:           stardust-xr-protostar
 Version:        0.50.0
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        Prototype application launcher for Stardust XR
 URL:            https://github.com/StardustXR/protostar
 Source0:        %url/archive/refs/tags/%version.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause-Patent AND BSD-2-Clause AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND ISC AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold libudev-devel g++ libinput-devel libxkbcommon-x11-devel
 
 Provides:       protostar stardust-protostar
@@ -36,7 +36,6 @@ wait
 mkdir -p %buildroot%_datadir
 cp -r res/* %buildroot%_datadir/
 
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 %files


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (stardust-protostar): add dep licenses (#9154)](https://github.com/terrapkg/packages/pull/9154)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)