### PR TITLE
[el10] fix (stardust-server): add dep licenses (#9155)

### DIFF
--- a/anda/stardust/server/nightly/stardust-server-nightly.spec
+++ b/anda/stardust/server/nightly/stardust-server-nightly.spec
@@ -6,11 +6,11 @@
 
 Name:           stardust-xr-server-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Usable Linux display server that reinvents human-computer interaction for all kinds of XR
 URL:            https://github.com/StardustXR/server
 Source0:        %url/archive/%commit/server-%commit.tar.gz
-License:        GPL-2.0-only
+License:        GPL-2.0-only AND (Apache-2.0 OR MIT) AND BSD-3-Clause AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR GPL-2.0-only) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (BSD-3-Clause OR Apache-2.0) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 GPL-2.0-only AND ISC AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MIT-0 AND MPL-2.0 AND (Unlicense OR MIT) AND Zlib AND (MIT OR Apache-2.0) AND (Zlib OR Apache-2.0 OR MIT)
 
 BuildRequires:  cargo
 BuildRequires:  cmake
@@ -42,7 +42,6 @@ Usable Linux display server that reinvents human-computer interaction for all ki
 
 %install
 install -Dm755 target/rpm/stardust-xr-server %{buildroot}%{_bindir}/stardust-xr-server
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 %files

--- a/anda/stardust/server/stable/stardust-server.spec
+++ b/anda/stardust/server/stable/stardust-server.spec
@@ -3,12 +3,12 @@
 
 Name:           stardust-xr-server
 Version:        0.50.2
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        Usable Linux display server that reinvents human-computer interaction for all kinds of XR
 URL:            https://github.com/StardustXR/server
 Source0:        %url/archive/refs/tags/%version.tar.gz
-License:        GPL-2.0-only
+License:        GPL-2.0-only AND (Apache-2.0 OR MIT) AND BSD-3-Clause AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR GPL-2.0-only) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR MIT OR Apache-2.0) AND BSD-2-Clause AND (BSD-3-Clause OR Apache-2.0) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 GPL-2.0-only AND ISC AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MIT-0 AND MPL-2.0 AND (Unlicense OR MIT) AND Zlib AND (MIT OR Apache-2.0) AND (Zlib OR Apache-2.0 OR MIT)
 
 BuildRequires:  cargo
 BuildRequires:  cmake
@@ -39,7 +39,6 @@ Usable Linux display server that reinvents human-computer interaction for all ki
 
 %install
 install -Dm755 target/rpm/stardust-xr-server %{buildroot}%{_bindir}/stardust-xr-server
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 %files


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (stardust-server): add dep licenses (#9155)](https://github.com/terrapkg/packages/pull/9155)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)