### PR TITLE
[f42] fix (stardust-solar-sailer): add dep licenses (#9156)

### DIFF
--- a/anda/stardust/solar-sailer/nightly/stardust-solar-sailer-nightly.spec
+++ b/anda/stardust/solar-sailer/nightly/stardust-solar-sailer-nightly.spec
@@ -7,11 +7,11 @@
 
 Name:           stardust-xr-solar-sailer-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Glide through space! This play space mover allows you to fly by dragging the space with momentum!
 URL:            https://github.com/StardustXR/solar-sailer
 Source0:        %url/archive/%commit.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT)
 BuildRequires:  cargo anda-srpm-macros cargo-rpm-macros mold python3-devel
 
 Provides:       solar-sailer-nightly stardust-solar-sailer-nightly

--- a/anda/stardust/solar-sailer/stable/stardust-solar-sailer.spec
+++ b/anda/stardust/solar-sailer/stable/stardust-solar-sailer.spec
@@ -3,11 +3,11 @@
 
 Name:           stardust-xr-solar-sailer
 Version:        0.50.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Glide through space! This play space mover allows you to fly by dragging the space with momentum!
 URL:            https://github.com/StardustXR/solar-sailer
 Source0:        %url/archive/refs/tags/%version.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT)
 BuildRequires:  cargo anda-srpm-macros cargo-rpm-macros mold python3-devel
 
 Provides:       solar-sailer stardust-solar-sailer


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (stardust-solar-sailer): add dep licenses (#9156)](https://github.com/terrapkg/packages/pull/9156)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)