### PR TITLE
[f43] fix (stardust-flatland): add dep licenses (#9147)

### DIFF
--- a/anda/stardust/flatland/nightly/stardust-flatland-nightly.spec
+++ b/anda/stardust/flatland/nightly/stardust-flatland-nightly.spec
@@ -6,11 +6,11 @@
 
 Name:           stardust-xr-flatland-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Flatland for Stardust XR
 URL:            https://github.com/StardustXR/flatland
 Source0:        %url/archive/%commit/flatland-%commit.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
 Provides:       flatland-nightly stardust-flatland-nightly
@@ -33,7 +33,6 @@ export STARDUST_RES_PREFIXES=%_datadir
 
 mkdir -p %buildroot%_datadir
 cp -r res/* %buildroot%_datadir/
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 

--- a/anda/stardust/flatland/stable/stardust-flatland.spec
+++ b/anda/stardust/flatland/stable/stardust-flatland.spec
@@ -3,12 +3,12 @@
 
 Name:           stardust-xr-flatland
 Version:        0.50.1
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        Flatland for Stardust XR
 URL:            https://github.com/StardustXR/flatland
 Source0:        %url/archive/refs/tags/%version.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros mold
 
 Provides:       flatland stardust-flatland
@@ -30,7 +30,6 @@ export STARDUST_RES_PREFIXES=%_datadir
 
 mkdir -p %buildroot%_datadir
 cp -r res/* %buildroot%_datadir/
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (stardust-flatland): add dep licenses (#9147)](https://github.com/terrapkg/packages/pull/9147)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)