### PR TITLE
[f42] fix (antlr4): update script (#9188)

### DIFF
--- a/anda/langs/python/antlr4-runtime/update.rhai
+++ b/anda/langs/python/antlr4-runtime/update.rhai
@@ -2,6 +2,6 @@ rpm.global("commit", gh_commit("parrt/antlr4-python3"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commit_date", date());
-    let v = gh("Winetricks/winetricks");
+    let v = gh("parrt/antlr4-python3");
     rpm.global("ver", v);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (antlr4): update script (#9188)](https://github.com/terrapkg/packages/pull/9188)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)