### PR TITLE
[f43] chore (asusctl): add dependency licenses (#9198)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -3,12 +3,12 @@
 
 Name:           asusctl
 Version:        6.2.0
-Release:        2%?dist
+Release:        3%?dist
 Summary:        A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops
 URL:            https://gitlab.com/asus-linux/asusctl
 Source0:        %url/-/archive/%version/asusctl-%version.tar.gz
 Source1:        %{appid}.metainfo.xml
-License:        MPL-2.0
+License:        MPL-2.0 AND (MIT OR Apache-2.0) AND NCSA AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND MIT AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 OR Zlib) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND BSD-3-Clause AND BSL-1.0 AND (CC0-1.0 OR Apache-2.0) AND (GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0) AND ISC AND MIT AND Zlib AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND Unlicense AND (Zlib OR Apache-2.0 OR MIT)
 BuildRequires:  anda-srpm-macros cargo-rpm-macros systemd-rpm-macros mold rust-udev-devel clang-devel
 BuildRequires:  desktop-file-utils
 BuildRequires:  cmake
@@ -51,10 +51,13 @@ install -D -m 0644 rog-anime/README.md %{buildroot}/%{_docdir}/%{name}/README-an
 install -D -m 0644 rog-anime/data/diagonal-template.png %{buildroot}/%{_docdir}/%{name}/diagonal-template.png
 %terra_appstream -o %{S:1}
 
+%{cargo_license_online} > LICENSE.dependencies
+
 desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.desktop
 
 %files
 %license LICENSE
+%license LICENSE.dependencies
 %{_datadir}/asusctl/LICENSE
 %{_bindir}/asusd
 %{_bindir}/asusd-user
@@ -100,6 +103,9 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.d
 %{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Tue Jan 13 2026 Owen Zimmerman <owen@fyralabs.com> - 6.2.0-3
+- Add dependency licenses
+
 * Tue Dec 9 2025 Metcya <metcya@gmail.com> - 6.2.0
 - Add metainfo
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (asusctl): add dependency licenses (#9198)](https://github.com/terrapkg/packages/pull/9198)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)