### PR TITLE
[f42] chore: Bump nightlies (#9203)

### DIFF
--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,9 +1,9 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
 %global ver 13.3.0
-%global commit bee989ec55e7034a782fd18bd4e694b74a62ac32
+%global commit 042fa5bd1d0e8d4b836a12fa5792d704421c49fe
 %global shortcommit %{sub %{commit} 1 7}
-%global commit_date 20251224
+%global commit_date 20260114
 %global devel_name QtColorWidgets
 %global _distro_extra_cflags -fuse-ld=mold
 %global _distro_extra_cxxflags -fuse-ld=mold

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,9 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-%global commit 39d7bbe2bf3a74e1107b456c2e6b1dd38b521da2
+%global commit 2007f5543ccc2f4ba895e602791d309022aaf174
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260112
+%global commit_date 20260114
 %global ver 0.41.0
 
 Name:           mpv-nightly

--- a/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/gnome-shell-extension-multi-monitors-bar.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/gnome-shell-extension-multi-monitors-bar.spec
@@ -1,5 +1,5 @@
-%global commit fa8a73a208ced4a2376d692552ea6b3694d08d53
-%global commit_date 20260103
+%global commit 5b00b740f0bde0e129a3ad070171d53d97275941
+%global commit_date 20260114
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global extension   multi-monitors-bar

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,4 +1,4 @@
-%global commit bb1c3bce10d0157af0e680a701a07f1a97ca1cdf
+%global commit c90f47f11f5ceaf0f161350c3755db2c50ade3f1
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global fulldate 2026-01-12
 %global commit_date %(echo %{fulldate} | sed 's/-//g')

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit d4f6ca44bc17992b3b88fb687dfe2dd3b52f3aa2
+%global commit 20284e4f218081a2c9f90ab78dbb7062e6203725
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260112
+%global commit_date 20260114
 %global ver 0.220.0
 
 %bcond_with check

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,10 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-%global commit 5a6f94fe795db5fc316d3fab61332034f0612040
+%global commit c2fc0a30b789c63667eb1514b113a2bca6704330
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20260112
+%global commit_date 20260114
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 # Change this variables if you want to use custom keys

--- a/anda/langs/nim/grabnim/grabnim.spec
+++ b/anda/langs/nim/grabnim/grabnim.spec
@@ -1,5 +1,5 @@
-%global commit b6b772ce9e94fc34a8f205392cb8f2d6483022ae
-%global commit_date 20260104
+%global commit 31433204f9d8721918781c452ee5ed8928e077a3
+%global commit_date 20260114
 %global shortcommit %{sub %commit 1 7}
 
 Name:			grabnim

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit 5c5f3eb3907a61596bab6c92781b67bbb051b62a
-%global commit_date 20260112
+%global commit 82c9b97fef37bda2ab95efef927a93f09ab94a7f
+%global commit_date 20260114
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/misc/openbangla-keyboard/openbangla-keyboard-nightly.spec
+++ b/anda/misc/openbangla-keyboard/openbangla-keyboard-nightly.spec
@@ -1,6 +1,6 @@
 %global ver 2.0.0
-%global commit 9befb6fcdb144fd7eacebda726abfd6fc74a65e9
-%global commit_date 20251214
+%global commit 7c19213777cfb43b443f4a57a6b4eab240d21b87
+%global commit_date 20260113
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           openbangla-keyboard-nightly

--- a/anda/stardust/atmosphere/nightly/stardust-atmosphere-nightly.spec
+++ b/anda/stardust/atmosphere/nightly/stardust-atmosphere-nightly.spec
@@ -1,12 +1,12 @@
-%global commit af38adafe7491498c48905b77518f8a6e9541f67
-%global commit_date 20251202
+%global commit 8b160f3bf5b477a2e1a3721b239cdfaef75de35a
+%global commit_date 20260113
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-atmosphere-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Environment, homespace, and setup client for Stardust XR
 URL:            https://github.com/StardustXR/atmosphere
 Source0:        %url/archive/%commit/atmosphere-%commit.tar.gz

--- a/anda/stardust/server/nightly/stardust-server-nightly.spec
+++ b/anda/stardust/server/nightly/stardust-server-nightly.spec
@@ -1,12 +1,12 @@
-%global commit f0545414201aa1c825e2546ee98aae010100bffd
-%global commit_date 20251225
+%global commit bfca9bae08aebd1dc2f2b5f34aecbb7389814c00
+%global commit_date 20260113
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-server-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Usable Linux display server that reinvents human-computer interaction for all kinds of XR
 URL:            https://github.com/StardustXR/server
 Source0:        %url/archive/%commit/server-%commit.tar.gz

--- a/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
+++ b/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 32ec33bc41abdea3b879a9cc29994c9e62b54f79
+%global commit c7ffff086407d6628b7887edd8f99d561c7542d2
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260111
+%global commit_date 20260114
 %global ver 0.6.6.2
 
 # We aren't using Mono but RPM expected Mono

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit c091945fbe1bfacda677c2dd1aa9375286e06751
+%global commit c1c77167e53518c81d7ac4819041a1d38c542fae
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260111
+%global commitdate 20260114
 %global ver 1.0.19
 %undefine __brp_mangle_shebangs
 

--- a/anda/system/scx-tools/nightly/scx-tools-nightly.spec
+++ b/anda/system/scx-tools/nightly/scx-tools-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 122cdb289d09fc960ba7e24dc6bec10326b424e9
+%global commit 2cced64079cc2d1fbd570746b6bd47e93b99d09e
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251209
+%global commitdate 20260114
 %global ver 1.0.19
 %global appid com.sched_ext.scx
 %global developer "sched-ext Contributors"
@@ -8,7 +8,7 @@
 
 Name:           scx-tools-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Sched_ext Tools
 License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND GPL-2.0-only AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 SourceLicense:  GPL-2.0-only

--- a/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
+++ b/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
@@ -1,6 +1,6 @@
 %global _udevrulesdir /usr/lib/udev/rules.d
 
-%global commit      620e69fa8d50134158a57bc8f104840b6d060c17
+%global commit      6fe0cec4f8baeae5e6441489df02c395e39c6ae2
 %global commitdate  20251121
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 

--- a/anda/tools/glasgow/glasgow.spec
+++ b/anda/tools/glasgow/glasgow.spec
@@ -1,5 +1,5 @@
-%global commit f1e5d53259bccf5955394b7b09f0ac3c3b5f4580
-%global commit_date 20260104
+%global commit a7e12be5633308a1bbdee3d2865977bd66e1f309
+%global commit_date 20260114
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name glasgow

--- a/anda/tools/natscli/natscli.spec
+++ b/anda/tools/natscli/natscli.spec
@@ -1,7 +1,7 @@
 # https://github.com/nats-io/natscli
 %global goipath         github.com/nats-io/natscli
-%global commit          b040af29ab96da01f630013806a3666450df4337
-%global commit_date     20260112
+%global commit          29855730ef4dc79047e9382e8f8db64a80942a6c
+%global commit_date     20260113
 %global shortcommit     %{sub %{commit} 1 7}
 
 %gometa -f


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [chore: Bump nightlies (#9203)](https://github.com/terrapkg/packages/pull/9203)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)