### PR TITLE
[el10] fix (framework-system): add dep licenses (#9225)

### DIFF
--- a/anda/tools/framework-system/framework-system.spec
+++ b/anda/tools/framework-system/framework-system.spec
@@ -1,10 +1,10 @@
 Name:           framework-system
 Version:        0.4.5
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Rust libraries and tools to interact with the Framework Computer systems
 URL:            https://github.com/FrameworkComputer/framework-system
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
-License:        BSD-3-Clause
+License:        BSD-3-Clause AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND BSD-2-Clause AND MIT AND MPL-2.0 AND (Unlicense OR MIT)
 BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  mold


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (framework-system): add dep licenses (#9225)](https://github.com/terrapkg/packages/pull/9225)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)