### PR TITLE
[f43] Metainfo: make 8BitDo description more fluid (#9229)

### DIFF
--- a/anda/games/8bitdo-udev-rules/8bitdo-udev-rules.spec
+++ b/anda/games/8bitdo-udev-rules/8bitdo-udev-rules.spec
@@ -3,7 +3,7 @@
 
 Name:           8bitdo-udev-rules
 Version:        1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Udev rules for 8Bitdo controllers
 Provides: 8bitdo-udev = %{version}-%{release}
 License:        Unlicense

--- a/anda/games/8bitdo-udev-rules/com.8bitdo.Udev.metainfo.xml
+++ b/anda/games/8bitdo-udev-rules/com.8bitdo.Udev.metainfo.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="driver">
   <id>com.8bitdo.Udev</id>
-  <name>udev Rules for 8BitDo devices</name>
+  <name>8BitDo Controller Support</name>
   <description>
-    <p>Udev rules for 8BitDo controllers to enable proper functionality and device access on Linux systems.</p>
+    <p>Enables proper functionality and device access for 8BitDo devices.</p>
   </description>
   <developer id="com.8bitdo">
     <name>Shenzhen 8BitDo Tech Co., Ltd.</name>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [Metainfo: make 8BitDo description more fluid (#9229)](https://github.com/terrapkg/packages/pull/9229)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)