### PR TITLE
[el10] bump(nightly): ghostty-nightly zed-nightly prismlauncher-nightly grabnim nim-nightly types-colorama uwufetch scx-scheds-nightly spotx-bash (#9234)

### DIFF
--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit c90f47f11f5ceaf0f161350c3755db2c50ade3f1
+%global commit 2fd3efd6cdf0629f57572af58dff0ae9115ce919
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2026-01-05
+%global fulldate 2026-01-14
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 20284e4f218081a2c9f90ab78dbb7062e6203725
+%global commit ceecf82287b4f9323b4ecbfb388a147361db7aaf
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260114
-%global ver 0.220.0
+%global commit_date 20260115
+%global ver 0.221.0
 
 %bcond_with check
 %bcond_with debug_no_build

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,10 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-%global commit c2fc0a30b789c63667eb1514b113a2bca6704330
+%global commit 5f8918771940cacbd14837159033901e630ef5ae
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20260114
+%global commit_date 20260115
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 # Change this variables if you want to use custom keys

--- a/anda/langs/nim/grabnim/grabnim.spec
+++ b/anda/langs/nim/grabnim/grabnim.spec
@@ -1,5 +1,5 @@
-%global commit 31433204f9d8721918781c452ee5ed8928e077a3
-%global commit_date 20260114
+%global commit 10a4115ff79ec4f9f40191c76294c4f97f612849
+%global commit_date 20260115
 %global shortcommit %{sub %commit 1 7}
 
 Name:			grabnim

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit b3273e732dd628a0881448bc82ebedf103776ece
+%global commit 40480fe3481cf833ed927f83a177d43046e7c37d
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20260108
+%global commit_date 20260115
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-global commit 82c9b97fef37bda2ab95efef927a93f09ab94a7f
-%global commit_date 20260114
+%global commit cd8b26b0ceef26cd84ab614088140d48680ac7f7
+%global commit_date 20260115
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/misc/uwufetch/uwufetch.spec
+++ b/anda/misc/uwufetch/uwufetch.spec
@@ -1,6 +1,6 @@
-%global commit f3d4503e72fa5b7dff466e527453cfbf2c95cc01
+%global commit fe9c53ffc6570454a3b2bf8431fd713e9953597e
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2024-02-14
+%global fulldate 2026-01-14
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global ver 2.1
 %global debug_package %{nil}

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit c1c77167e53518c81d7ac4819041a1d38c542fae
+%global commit 3777b291b50acde6d2db18c0cbcf3e7c97c3e6c0
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260114
+%global commitdate 20260115
 %global ver 1.0.19
 %undefine __brp_mangle_shebangs
 

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,5 +1,5 @@
-%global commit 63b31200ff28feae474a4898d1e2fd7de04e2969
-%global commit_date 20251231
+%global commit 37ffdc78ba3ded6af6550895bfc687f44f1c4af6
+%global commit_date 20260115
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           spotx-bash


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump(nightly): ghostty-nightly zed-nightly prismlauncher-nightly grabnim nim-nightly types-colorama uwufetch scx-scheds-nightly spotx-bash (#9234)](https://github.com/terrapkg/packages/pull/9234)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)