### PR TITLE
Version bump crystal

### DIFF
--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -1,8 +1,8 @@
-%bcond bootstrap 1
+%bcond bootstrap 0
 %global bootstrap_version 1.17.1
 
 Name:          crystal
-Version:       1.17.1
+Version:       1.19.0
 Release:       1%?dist
 Summary:       A general-purpose, object-oriented programming language
 License:       Apache-2.0

--- a/anda/langs/crystal/crystal/update.rhai
+++ b/anda/langs/crystal/crystal/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("crystal-lang/crystal"));
+rpm.version(gh("crystal-lang/crystal"));


### PR DESCRIPTION
Now that crystal is already in the repo there's no need to bootstrap it using the alpine static compiler by default.