### PR TITLE
[f42] fix(asusctl): update metainfo (#9261)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -3,7 +3,8 @@
 
 Name:           asusctl
 Version:        6.3.0
-Release:        1%?dist
+Release:        2%?dist
+Epoch:          1
 Summary:        A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops
 URL:            https://gitlab.com/asus-linux/asusctl
 Source0:        %url/-/archive/%version/asusctl-%version.tar.gz
@@ -31,6 +32,8 @@ Packager:       Metcya <metcya@gmail.com>
 %package rog-gui
 Summary:    An experimental gui for %name
 Requires:   %name
+Provides:   rog-control-center
+Provides:   rog-gui
 
 %description rog-gui
 A one-stop-shop GUI tool for asusd/asusctl. It aims to provide most controls,
@@ -103,6 +106,9 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.d
 %{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Fri Jan 16 2026 metcya <metcya@gmail.com> - 6.3.0-2
+- Update ROG Control Center metainfo
+
 * Tue Jan 13 2026 Owen Zimmerman <owen@fyralabs.com> - 6.2.0-3
 - Add dependency licenses
 

--- a/anda/system/asusctl/org.asus_linux.rog_control_center.metainfo.xml
+++ b/anda/system/asusctl/org.asus_linux.rog_control_center.metainfo.xml
@@ -3,13 +3,33 @@
   <id>org.asus_linux.rog_control_center</id>
   
   <name>Rog Control Center</name>
-  <summary>A one-stop-shop GUI tool for asusd/asusctl.</summary>
-  <icon type="local">/usr/share/icons/hicolor/512x512/apps/rog-control-center.png</icon>
+  <summary>A one-stop-shop GUI tool for asusd/asusctl</summary>
+  <icon type="remote">https://gitlab.com/asus-linux/asusctl/-/blob/main/rog-control-center/data/rog-control-center.png</icon>
   
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0</project_license>
   
   <url type="homepage">https://asus-linux.org</url>
+  <url type="bugtracker">https://gitlab.com/asus-linux/asusctl/-/issues</url>
+  <url type="faq">https://asus-linux.org/faq/</url>
+  <url type="help">https://asus-linux.org/manual/</url>
+  <url type="vcs-browser">https://gitlab.com/asus-linux</url>
+
+  <categories>
+    <category>System</category>
+    <category>Settings</category>
+  </categories>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>The Rog Control Center main window.</caption>
+      <image type="source" width="1800" height="1000">https://gitlab.com/asus-linux/website/-/blob/main/static/images/guides/gui-main.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Fan curve selections.</caption>
+      <image type="source" width="1800" height="1000">https://gitlab.com/asus-linux/website/-/blob/main/static/images/guides/gui-fancurve.png</image>
+    </screenshot>
+  </screenshots>
 
   <description>
     <p>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(asusctl): update metainfo (#9261)](https://github.com/terrapkg/packages/pull/9261)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)