### PR TITLE
[f42] Version bump crystal (#9259)

### DIFF
--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -1,8 +1,8 @@
-%bcond bootstrap 1
+%bcond bootstrap 0
 %global bootstrap_version 1.17.1
 
 Name:          crystal
-Version:       1.17.1
+Version:       1.19.0
 Release:       1%?dist
 Summary:       A general-purpose, object-oriented programming language
 License:       Apache-2.0

--- a/anda/langs/crystal/crystal/update.rhai
+++ b/anda/langs/crystal/crystal/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("crystal-lang/crystal"));
+rpm.version(gh("crystal-lang/crystal"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Version bump crystal (#9259)](https://github.com/terrapkg/packages/pull/9259)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)