### PR TITLE
[f43] add: proton-vpn-api-core (#9276)

### DIFF
--- a/anda/langs/python/proton-vpn-api-core/anda.hcl
+++ b/anda/langs/python/proton-vpn-api-core/anda.hcl
@@ -1,0 +1,6 @@
+  project pkg {
+      arches = ["x86_64"]
+    rpm {
+	spec = "proton-vpn-api-core.spec"
+    }
+  }

--- a/anda/langs/python/proton-vpn-api-core/proton-vpn-api-core.spec
+++ b/anda/langs/python/proton-vpn-api-core/proton-vpn-api-core.spec
@@ -1,0 +1,46 @@
+%global pypi_name proton-vpn-api-core
+%global _desc A facade to the other Proton VPN components, exposing a uniform API to the available Proton VPN services.
+
+Name:			python-%{pypi_name}
+Version:		4.14.1
+Release:		1%?dist
+Summary:		A facade to the other Proton VPN components
+License:		GPL-3.0-Only
+URL:			https://github.com/ProtonVPN/python-proton-vpn-api-core
+Source0:		%url/archive/refs/tags/v%version.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       %{pypi_name}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n python-%{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files proton
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md CODEOWNERS
+%license LICENSE
+
+%changelog
+* Sat Jan 17 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/proton-vpn-api-core/update.rhai
+++ b/anda/langs/python/proton-vpn-api-core/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("proton-vpn-api-core"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: proton-vpn-api-core (#9276)](https://github.com/terrapkg/packages/pull/9276)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)