### PR TITLE
[el10] bump: proton-vpn-api-core (#9284)

### DIFF
--- a/anda/langs/python/proton-vpn-api-core/proton-vpn-api-core.spec
+++ b/anda/langs/python/proton-vpn-api-core/proton-vpn-api-core.spec
@@ -2,7 +2,7 @@
 %global _desc A facade to the other Proton VPN components, exposing a uniform API to the available Proton VPN services.
 
 Name:			python-%{pypi_name}
-Version:		4.14.1
+Version:		0.0.1
 Release:		1%?dist
 Summary:		A facade to the other Proton VPN components
 License:		GPL-3.0-Only


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [bump: proton-vpn-api-core (#9284)](https://github.com/terrapkg/packages/pull/9284)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)