### PR TITLE
[f42] fix (proton-vpn-api-core): fix update script (#9290)

### DIFF
--- a/anda/langs/python/proton-vpn-api-core/proton-vpn-api-core.spec
+++ b/anda/langs/python/proton-vpn-api-core/proton-vpn-api-core.spec
@@ -2,7 +2,7 @@
 %global _desc A facade to the other Proton VPN components, exposing a uniform API to the available Proton VPN services.
 
 Name:			python-%{pypi_name}
-Version:		0.0.1
+Version:		4.14.1
 Release:		1%?dist
 Summary:		A facade to the other Proton VPN components
 License:		GPL-3.0-Only

--- a/anda/langs/python/proton-vpn-api-core/update.rhai
+++ b/anda/langs/python/proton-vpn-api-core/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(pypi("proton-vpn-api-core"));
+rpm.version(gh_tag("ProtonVPN/python-proton-vpn-api-core"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (proton-vpn-api-core): fix update script (#9290)](https://github.com/terrapkg/packages/pull/9290)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)