### PR TITLE
[el10] add: proton-vpn-local-agent (#9296)

### DIFF
--- a/anda/langs/python/proton-vpn-local-agent/anda.hcl
+++ b/anda/langs/python/proton-vpn-local-agent/anda.hcl
@@ -1,0 +1,5 @@
+  project pkg {
+    rpm {
+	    spec = "proton-vpn-local-agent.spec"
+    }
+  }

--- a/anda/langs/python/proton-vpn-local-agent/proton-vpn-local-agent.spec
+++ b/anda/langs/python/proton-vpn-local-agent/proton-vpn-local-agent.spec
@@ -1,0 +1,53 @@
+%define debug_package %{nil}
+
+%global pypi_name proton-vpn-local-agent
+%global _desc Proton VPN local agent written in Rust.
+
+Name:			python-%{pypi_name}
+Version:		1.6.0
+Release:		1%?dist
+Summary:		Proton VPN local agent written in Rust
+License:		GPL-3.0-only
+URL:			https://github.com/ProtonVPN/local-agent-rs
+Source0:		%url/archive/refs/tags/%version.tar.gz
+
+BuildRequires:  python3-devel
+BuildRequires:  cargo-rpm-macros
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       %{pypi_name}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n local-agent-rs-%{version}
+pushd %{name}
+%{cargo_prep_online}
+popd
+
+%build
+pushd %{name}
+%{cargo_build}
+popd
+
+%install
+pushd %{name}
+install -Dm0644 target/rpm/libpython_proton_vpn_local_agent.so %{buildroot}%{_libdir}/proton/local_agent.so
+popd
+
+%files -n python3-%{pypi_name}
+%doc README.md CODEOWNERS
+%dir %{_libdir}/proton
+%{_libdir}/proton/local_agent.so
+
+%changelog
+* Sun Jan 18 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/proton-vpn-local-agent/update.rhai
+++ b/anda/langs/python/proton-vpn-local-agent/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("ProtonVPN/local-agent-rs"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: proton-vpn-local-agent (#9296)](https://github.com/terrapkg/packages/pull/9296)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)