### PR TITLE
[f42] chore(.gitignore): Ignore some more files and archives (#9306)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ anda-build/
 **/*.tar*
 **/*.crate
 **/*.zip
+**/*.minisig
+**/*.nupkg
+**/*.rpm
+**/*.kate-swp


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(.gitignore): Ignore some more files and archives (#9306)](https://github.com/terrapkg/packages/pull/9306)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)