### PR TITLE
[f43] fix(kde-material-you-colors): Use file-magic instead of magic (#9303)

### DIFF
--- a/anda/themes/kde-material-you-colors/kde-material-you-colors.spec
+++ b/anda/themes/kde-material-you-colors/kde-material-you-colors.spec
@@ -4,7 +4,7 @@
 
 Name:           kde-material-you-colors
 Version:        2.0.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Automatic Material You Colors Generator from your wallpaper for the Plasma Desktop
 License:        GPL-3.0-only
 URL:            https://github.com/luisbocanegra/%{name}
@@ -17,15 +17,17 @@ BuildRequires:  cmake >= 3.16
 BuildRequires:  extra-cmake-modules >= 6.0.0
 BuildRequires:  fdupes
 BuildRequires:  generic-logos
-BuildRequires:  libplasma-devel
-BuildRequires:  plasma5support-devel
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-devel
 BuildRequires:  python-rpm-macros
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools) >= 61.0
 BuildRequires:  python3dist(wheel) >= 0.37.1
-BuildRequires:  qt5-qtbase-devel
+BuildRequires:  cmake(KF6KirigamiPlatform)
+BuildRequires:  cmake(Plasma)
+BuildRequires:  cmake(Plasma5Support)
+BuildRequires:  cmake(Qt5Core)
+BuildRequires:  pkgconfig(ocl-icd)
 Requires:       qt5-qtbase
 Requires:       kf6-filesystem >= 6.0.0
 Requires:       python3-%{name} = %{version}-%{release}
@@ -49,6 +51,7 @@ Python files for KDE Material You Colors.
 
 %prep
 %autosetup -p1 -n %{name}-%{version}
+sed -iE 's:\"python-magic.*\":\"file-magic\":' pyproject.toml
 
 %build
 %pyproject_wheel
@@ -61,7 +64,7 @@ Python files for KDE Material You Colors.
 %pyproject_install
 DESTDIR="%{buildroot}" %cmake_install
 
-sed -i "1{/^#!\/usr\/bin\/env python3/d}" %{buildroot}%{python3_sitelib}/kde_material_you_colors/main.py
+sed -Ei "s:^(#!.*)env (python.*)$:\1python3:" %{buildroot}%{python3_sitelib}/kde_material_you_colors/main.py
 %fdupes %{buildroot}%{python3_sitelib}/%{name}/
 
 %terra_appstream


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(kde-material-you-colors): Use file-magic instead of magic (#9303)](https://github.com/terrapkg/packages/pull/9303)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)