### PR TITLE
[el10] fix (crossystem): bump, update patches, update source link (#9307)

### DIFF
--- a/anda/tools/crossystem/crossystem.spec
+++ b/anda/tools/crossystem/crossystem.spec
@@ -1,5 +1,5 @@
-%global commit_date 20221215
-%global commit 	c4102fe4eef8c0539c03d60c7256fd4bc599bf4a
+%global commit_date 20260105
+%global commit 0ee734db27fe06a92b92e0bdc58c8b7f35dfaf16
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           crossystem
@@ -7,14 +7,15 @@ Summary:        Manage ChromeOS firmware
 License:        BSD-3-Clause
 URL:            https://chromium.googlesource.com/chromiumos/platform/vboot_reference
 
-Version:        %shortcommit
+Version:        0~%{commit_date}git.%{shortcommit}
 Release:        1%?dist
-Source0:        %url/+archive/refs/heads/release-R110-15278.B.tar.gz
+Epoch:          1
+Source0:        %url/+archive/refs/heads/firmware-R145-16552.2.B.tar.gz
 Patch0:         use-flashrom-cros.patch
 Patch1:         disable-werror.patch
 
 Requires:       flashrom-cros
-BuildRequires:  make gcc openssl-devel flashrom-devel libuuid-devel
+BuildRequires:  make gcc openssl-devel flashrom-cros-devel libuuid-devel
 
 Packager:       WeirdTreeThing <bradyn127@protonmail.com>
 
@@ -28,6 +29,7 @@ info from a ChromeOS system
 %patch -P1 -p1
 
 %build
+export CFLAGS="$CFLAGS -Wno-implicit-function-declaration"
 %make_build
 
 %install
@@ -38,5 +40,8 @@ install -Dm755 build/utility/crossystem %{buildroot}%{_bindir}/crossystem
 %{_bindir}/crossystem
 
 %changelog
+* Sun Jan 18 2026 Owen Zimmerman <owen@fyralabs.com>
+- Bump, use proper versioning name, update patches and source link
+
 * Fri Oct 25 2024 WeirdTreeThing <bradyn127@protonmail.com>
 - initial release

--- a/anda/tools/crossystem/use-flashrom-cros.patch
+++ b/anda/tools/crossystem/use-flashrom-cros.patch
@@ -11,16 +11,3 @@ index 6a80201..c67a99d 100644
 
  /**
   * Helper to create a temporary file, and optionally write some data
-diff --git a/host/lib/include/flashrom.h b/host/lib/include/flashrom.h
-index 81d6ba9..6b760d6 100644
---- a/host/lib/include/flashrom.h
-+++ b/host/lib/include/flashrom.h
-@@ -10,7 +10,7 @@
- #include "2return_codes.h"
- #include "fmap.h"
-
--#define FLASHROM_PROGRAMMER_INTERNAL_AP "host"
-+#define FLASHROM_PROGRAMMER_INTERNAL_AP "internal"
- #define FLASHROM_PROGRAMMER_INTERNAL_EC "ec"
-
- /* Utilities for firmware images and (FMAP) sections */


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (crossystem): bump, update patches, update source link (#9307)](https://github.com/terrapkg/packages/pull/9307)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)