### PR TITLE
[el10] fix (anda-srpm-macros): install new files (#9326)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -38,7 +38,8 @@ install -Dpm755 *.sh -t %buildroot%_libexecdir/%name/
 %{_rpmmacrodir}/macros.nim_extra
 %{_rpmmacrodir}/macros.nodejs_extra
 %{_rpmmacrodir}/macros.zig_extra
-
+%{_rpmmacrodir}/macros.tauri
+%{_rpmmacrodir}/macros.webapps
 
 %changelog
 * Wed Aug 14 2024 madonuko <mado@fyralabs.com> - 0.1.7-2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (anda-srpm-macros): install new files (#9326)](https://github.com/terrapkg/packages/pull/9326)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)