### PR TITLE
[el10] fix (asusctl): broken metainfo (#9338)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -3,7 +3,7 @@
 
 Name:           asusctl
 Version:        6.3.1
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops
 URL:            https://gitlab.com/asus-linux/asusctl

--- a/anda/system/asusctl/org.asus_linux.rog_control_center.metainfo.xml
+++ b/anda/system/asusctl/org.asus_linux.rog_control_center.metainfo.xml
@@ -23,33 +23,25 @@
   <screenshots>
     <screenshot type="default">
       <caption>The Rog Control Center main window.</caption>
-      <image type="source" width="1800" height="1000">https://gitlab.com/asus-linux/website/-/blob/main/static/images/guides/gui-main.png</image>
+      <image type="source" width="1800" height="1000">https://gitlab.com/asus-linux/website/-/raw/main/static/images/guides/gui-main.png</image>
     </screenshot>
-    <screenshot type="default">
+    <screenshot>
       <caption>Fan curve selections.</caption>
-      <image type="source" width="1800" height="1000">https://gitlab.com/asus-linux/website/-/blob/main/static/images/guides/gui-fancurve.png</image>
+      <image type="source" width="1800" height="1000">https://gitlab.com/asus-linux/website/-/raw/main/static/images/guides/gui-fancurve.png</image>
     </screenshot>
   </screenshots>
 
   <description>
     <p>
-      A one-stop-shop GUI tool for asusd/asusctl. It aims to provide most controls, a notification service, and ability to run in the background.
+      Rog Control Center aims to provide most controls, a notification service, and ability to run in the background.
     </p>
   </description>
-
-  <releases>
-    <release version="6.2.0" date="2025-12-13" />
-  </releases>
 
   <keywords>
     <keyword>ASUS</keyword>
     <keyword>ROG</keyword>
     <keyword>asusctl</keyword>
   </keywords>
-
-  <provides>
-    <binary>rog-control-center</binary>
-  </provides>
 
   <launchable type="desktop-id">rog-control-center.desktop</launchable>
 </component>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (asusctl): broken metainfo (#9338)](https://github.com/terrapkg/packages/pull/9338)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)