### PR TITLE
[el10] add: snakeoil (#9344)

### DIFF
--- a/anda/langs/python/snakeoil/anda.hcl
+++ b/anda/langs/python/snakeoil/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+	rpm {
+		spec = "snakeoil.spec"
+	}
+}

--- a/anda/langs/python/snakeoil/snakeoil.spec
+++ b/anda/langs/python/snakeoil/snakeoil.spec
@@ -1,0 +1,45 @@
+%global pypi_name snakeoil
+%global _desc A python library that implements optimized versions of common functionality.
+
+Name:			python-%{pypi_name}
+Version:		0.11.0
+Release:		1%?dist
+Summary:		Implements optimized versions of common functionality
+License:		BSD-3-Clause
+URL:			https://pkgcore.github.io/snakeoil
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-flit-core
+BuildRequires:  python3-pip
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n snakeoil-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files snakeoil
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+* Mon Jan 19 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/snakeoil/update.rhai
+++ b/anda/langs/python/snakeoil/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("snakeoil"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: snakeoil (#9344)](https://github.com/terrapkg/packages/pull/9344)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)