### PR TITLE
[el10] fix (alsa-ucm-cros): remove provides and conflicts (#9325)

### DIFF
--- a/anda/misc/alsa-ucm-cros/alsa-ucm-cros.spec
+++ b/anda/misc/alsa-ucm-cros/alsa-ucm-cros.spec
@@ -2,14 +2,12 @@
 
 Name:			alsa-ucm-cros
 Version:		0.8
-Release:		1%?dist
+Release:		2%?dist
 Summary:		ALSA Use Case Manager configuration
 License:		BSD-3-Clause
 URL:			https://github.com/WeirdTreeThing/alsa-ucm-conf-cros/tree/standalone
 Source0:		https://github.com/WeirdTreeThing/alsa-ucm-conf-cros/archive/refs/tags/%version.tar.gz
 BuildArch:		noarch
-Provides:     alsa-ucm
-Conflicts:    alsa-ucm
 
 %description
 %summary for chromebooks.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (alsa-ucm-cros): remove provides and conflicts (#9325)](https://github.com/terrapkg/packages/pull/9325)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)