### PR TITLE
[f43] fix(create-tauri-app): Packager and changelog (#9356)

### DIFF
--- a/anda/devs/create-tauri-app/create-tauri-app.spec
+++ b/anda/devs/create-tauri-app/create-tauri-app.spec
@@ -2,7 +2,7 @@
 
 Name:           rust-create-tauri-app
 Version:        4.7.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Rapidly scaffold out a new tauri app project
 License:        Apache-2.0 OR MIT
 URL:            https://crates.io/crates/create-tauri-app
@@ -11,6 +11,7 @@ BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  mold
 Suggests:       tauri
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 %{summary}.
@@ -44,4 +45,5 @@ install -Dpm755 target/rpm/cargo-%{crate} %{buildroot}%{_bindir}/%{crate}
 %{_bindir}/%{crate}
 
 %changelog
-%autochangelog
+* Fri Dec 26 2025 Gilver E. <roachy@fyralabs.com> - 4.6.2-1
+- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(create-tauri-app): Packager and changelog (#9356)](https://github.com/terrapkg/packages/pull/9356)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)