### PR TITLE
[el10] fix(goofcord): Use new macros, relock build now that the lockfile is no longer breaking it (#9360)

### DIFF
--- a/anda/apps/goofcord/stable/goofcord.spec
+++ b/anda/apps/goofcord/stable/goofcord.spec
@@ -1,6 +1,5 @@
 %global git_name GoofCord
-
-%electronmeta
+%global appid io.github.milkshiift.GoofCord
 
 Name:          goofcord
 Version:       2.0.1
@@ -10,27 +9,31 @@ Summary:       A privacy-minded Legcord fork.
 Group:         Applications/Internet
 URL:           https://github.com/Milkshiift/%{git_name}
 Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
-BuildRequires: anda-srpm-macros >= 0.2.26
+BuildRequires: anda-srpm-macros >= 0.3.0
 BuildRequires: bun-bin
 Packager:      Gilver E. <rockgrub@disroot.org>
+
+%electronmeta -D
 
 %description
 A highly configurable and privacy minded Discord client.
 
 %prep
 %autosetup -n %{git_name}-%{version}
-
-%build
 %ifarch %{arm64} armv7hl armv7l
 sed -i '/\"x64\",/d' electron-builder.ts
 %endif
-%bun_build -r build -R
+
+%build
+%bun_build
 
 %install
-%electron_install -D -O -U %U -E UseOzonePlatform,WaylandWindowDecorations
+%electron_install -D -O -U %U -E UseOzonePlatform,WaylandWindowDecorations -I
+
+install -Dm644 assetsDev/%{appid}.metainfo.xml -t %{buildroot}%{_metainfodir}
 
 %check
-desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+%desktop_file_validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 %files
 %doc README.md
@@ -38,14 +41,15 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_bindir}/%{name}
 %{_datadir}/applications/%{name}.desktop
 %{_libdir}/%{name}/
-%{_iconsdir}/hicolor/16x16/apps/%{name}.png
-%{_iconsdir}/hicolor/32x32/apps/%{name}.png
-%{_iconsdir}/hicolor/48x48/apps/%{name}.png
-%{_iconsdir}/hicolor/64x64/apps/%{name}.png
-%{_iconsdir}/hicolor/128x128/apps/%{name}.png
-%{_iconsdir}/hicolor/256x256/apps/%{name}.png
-%{_iconsdir}/hicolor/512x512/apps/%{name}.png
-%{_iconsdir}/hicolor/1024x1024/apps/%{name}.png
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_hicolordir}/16x16/apps/%{name}.png
+%{_hicolordir}/32x32/apps/%{name}.png
+%{_hicolordir}/48x48/apps/%{name}.png
+%{_hicolordir}/64x64/apps/%{name}.png
+%{_hicolordir}/128x128/apps/%{name}.png
+%{_hicolordir}/256x256/apps/%{name}.png
+%{_hicolordir}/512x512/apps/%{name}.png
+%{_hicolordir}/1024x1024/apps/%{name}.png
 
 %changelog
 * Sat Jun 28 2025 Gilver E. <rockgrub@disroot.org> - 1.10.1-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(goofcord): Use new macros, relock build now that the lockfile is no longer breaking it (#9360)](https://github.com/terrapkg/packages/pull/9360)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)