### PR TITLE
[f42] chore(usbio-drivers): Update patches (#9363)

### DIFF
--- a/anda/system/usbio-drivers/akmod/0011-include-linux-mfd-usbio-Fix-missing-prototypes.patch
+++ b/anda/system/usbio-drivers/akmod/0011-include-linux-mfd-usbio-Fix-missing-prototypes.patch
@@ -1,0 +1,34 @@
+From c86e7a74c151304af7393c27f8f3df84d7d005ae Mon Sep 17 00:00:00 2001
+From: Kate Hsuan <hpa@redhat.com>
+Date: Tue, 23 Sep 2025 14:17:05 +0800
+Subject: [PATCH 2/2] include: linux: mfd: usbio: Fix missing-prototypes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix the following missing-prototypes issues
+
+drivers/mfd/usbio.c: At top level:
+drivers/mfd/usbio.c:473:6: warning: no previous prototype for ‘usbio_unregister_event_cb’ [-Wmissing-prototypes]
+  473 | void usbio_unregister_event_cb(struct platform_device *pdev)
+      |      ^~~~~~~~~~~~~~~~~~~~~~~~~
+---
+ include/linux/mfd/usbio.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/linux/mfd/usbio.h b/include/linux/mfd/usbio.h
+index c8024a8..ecf8ac9 100644
+--- a/include/linux/mfd/usbio.h
++++ b/include/linux/mfd/usbio.h
+@@ -45,5 +45,8 @@ int usbio_transfer(struct platform_device *pdev, u8 cmd, const void *obuf,
+ 		  int obuf_len, void *ibuf, int *ibuf_len);
+ int usbio_transfer_noack(struct platform_device *pdev, u8 cmd, const void *obuf,
+ 			int obuf_len);
++int usbio_register_event_cb(struct platform_device *pdev,
++			    usbio_event_cb_t event_cb);
++void usbio_unregister_event_cb(struct platform_device *pdev);
+ 
+ #endif
+-- 
+2.51.0
+

--- a/anda/system/usbio-drivers/akmod/01-387.patch
+++ b/anda/system/usbio-drivers/akmod/01-387.patch
@@ -1,0 +1,69 @@
+From 1e6f315ec4e867fe25da5c6d216bb4757757515e Mon Sep 17 00:00:00 2001
+From: Kate Hsuan <hpa@redhat.com>
+Date: Mon, 15 Sep 2025 17:15:41 +0800
+Subject: [PATCH] patches: remove "u64 dma_mask" for the kernel higher than
+ 6.16
+
+The upstream commits 1284c9693953aed2a9974a5a384ce2a42a1b9ae8 brought the
+kernel crash
+
+[    6.697129] BUG: unable to handle page fault for address: 00000000ff78d008
+[    6.697134] #PF: supervisor read access in kernel mode
+[    6.697135] #PF: error_code(0x0000) - not-present page
+[    6.697137] PGD 0 P4D 0
+[    6.697141] Oops: Oops: 0000 [#1] SMP NOPTI
+[    6.697145] CPU: 12 UID: 0 PID: 1149 Comm: (udev-worker) Tainted: G           OE       6.16.5-200.fc42.x86_64 #1 PREEMPT(lazy)
+[    6.697149] Tainted: [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
+[    6.697150] Hardware name: LENOVO 21HQSIT024/21HQSIT024, BIOS N3XET40W (1.15 ) 05/22/2023
+[    6.697152] RIP: 0010:ipu6_psys_probe+0x384/0x3b0 [intel_ipu6_psys]
+[    6.697164] Code: ff c7 44 24 10 fb fd ff ff e9 f8 fc ff ff c7 44 24 10 f4 ff ff ff eb cb 49 8b 84 24 98 03 00 00 48 c7 c6 cf 51 ad c1 4c 89 e7 <48> 8b 40 08 89 43 18 89 c2 e8 8e a5 e3 e4 80 3d 33 6b f3 ff 00 0f
+[    6.697166] RSP: 0018:ffffcee981177860 EFLAGS: 00010246
+[    6.697169] RAX: 00000000ff78d000 RBX: ffff8bc153c8e028 RCX: 0000000000002000
+[    6.697171] RDX: ffff8bc146d58020 RSI: ffffffffc1ad51cf RDI: ffff8bc14e7d1000
+[    6.697172] RBP: ffff8bc146d58020 R08: 0000000000000002 R09: ffffcee980ba7000
+[    6.697174] R10: ffffcee980ba7000 R11: ffff8bc141b00480 R12: ffff8bc14e7d1000
+[    6.697175] R13: ffff8bc153c8e440 R14: ffff8bc146d5a020 R15: ffff8bc146d5a000
+[    6.697176] FS:  00007feae3a8d3c0(0000) GS:ffff8bc4e565f000(0000) knlGS:0000000000000000
+[    6.697179] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[    6.697180] CR2: 00000000ff78d008 CR3: 0000000104809001 CR4: 0000000000f70ef0
+[    6.697182] PKRU: 55555554
+[    6.697183] Call Trace:
+[    6.697186]  <TASK>
+[    6.697189]  ? __pfx_ipu6_psys_probe+0x10/0x10 [intel_ipu6_psys]
+[    6.697196]  auxiliary_bus_probe+0x46/0x80
+[    6.697202]  really_probe+0xdb/0x340
+
+Since the upstream commit 1284c9693953aed2a9974a5a384ce2a42a1b9ae8
+removed dms_mask from struct ipu6_bus_device, the size of
+struct ipu6_bus_device isn't the same as it is in the upstream kernel.
+"u64 dms_mask" has to be removed when it is built with the upstream kernel
+higher than 6.16.
+
+Resolves: #372
+---
+ patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch b/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch
+index b8eeaae662d3..44c213050d9d 100644
+--- a/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch
++++ b/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch
+@@ -28,7 +28,7 @@ new file mode 100644
+ index 000000000..b26c6aee1
+ --- /dev/null
+ +++ b/drivers/media/pci/intel/ipu6/ipu6-bus.h
+-@@ -0,0 +1,58 @@
++@@ -0,0 +1,60 @@
+ +/* SPDX-License-Identifier: GPL-2.0-only */
+ +/* Copyright (C) 2013 - 2024 Intel Corporation */
+ +
+@@ -59,7 +59,9 @@ index 000000000..b26c6aee1
+ +	struct ipu6_mmu *mmu;
+ +	struct ipu6_device *isp;
+ +	struct ipu6_buttress_ctrl *ctrl;
+++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ +	u64 dma_mask;
+++#endif
+ +	const struct firmware *fw;
+ +	struct sg_table fw_sgt;
+ +	u64 *pkg_dir;

--- a/anda/system/usbio-drivers/akmod/23-38.patch
+++ b/anda/system/usbio-drivers/akmod/23-38.patch
@@ -1,0 +1,49 @@
+From 1e2311383bb5fdc857664d1e30700dd3496a5a11 Mon Sep 17 00:00:00 2001
+From: You-Sheng Yang <vicamo@gmail.com>
+Date: Wed, 13 Aug 2025 14:58:19 +0800
+Subject: [PATCH] backport: fix build against kernel >= 6.17
+
+v6.17-rc1 commit 98ce1eb1fd87e ("gpiolib: introduce gpio_chip setters
+that return values") added two new APIs `set_rv` and `set_multiple_rv`
+to `struct gpio_irq_chip` that duplicate existing `set` and
+`set_multiple` without return values. They then completely replace the
+no-return-value APIs in same v6.17-rc1 commit d9d87d90cc0b1
+("treewide: rename GPIO set callbacks back to their original names").
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2120461
+Signed-off-by: You-Sheng Yang <vicamo@gmail.com>
+---
+ drivers/gpio/gpio-usbio.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpio/gpio-usbio.c b/drivers/gpio/gpio-usbio.c
+index 625558b..9c904e7 100644
+--- a/drivers/gpio/gpio-usbio.c
++++ b/drivers/gpio/gpio-usbio.c
+@@ -175,8 +175,13 @@ static int usbio_gpio_get_value(struct gpio_chip *chip, unsigned int offset)
+ 	return usbio_gpio_read(usbio_gpio, offset);
+ }
+ 
+-static void usbio_gpio_set_value(struct gpio_chip *chip, unsigned int offset,
+-				int val)
++static
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
++void
++#else
++int
++#endif
++usbio_gpio_set_value(struct gpio_chip *chip, unsigned int offset, int val)
+ {
+ 	struct usbio_gpio_dev *usbio_gpio = gpiochip_get_data(chip);
+ 	int ret;
+@@ -186,6 +191,10 @@ static void usbio_gpio_set_value(struct gpio_chip *chip, unsigned int offset,
+ 		dev_err(chip->parent,
+ 			"%s offset:%d val:%d set value failed %d\n", __func__,
+ 			offset, val, ret);
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++	return ret;
++#endif
+ }
+ 
+ static int usbio_gpio_direction_input(struct gpio_chip *chip,

--- a/anda/system/usbio-drivers/akmod/intel-usbio-kmod.spec
+++ b/anda/system/usbio-drivers/akmod/intel-usbio-kmod.spec
@@ -12,9 +12,6 @@ Release:        2%?dist
 License:        GPL-2.0-only
 URL:            https://github.com/intel/usbio-drivers
 Source0:        %{url}/archive/%{commit}.tar.gz#/usbio-drivers-%{shortcommit}.tar.gz
-Patch0:         https://github.com/jwrdegoede/usbio-drivers/commit/d5f08986936a7fda0cce543c73fb8d9bab76eae2.patch
-Patch1:         https://github.com/jwrdegoede/usbio-drivers/commit/47b34a6f467eebb4e9fc59f5e25618fe760fbf33.patch
-Patch2:         https://github.com/jwrdegoede/usbio-drivers/commit/0eae85556558b410635ad03ed5eccb9648e11fce.patch
 BuildRequires:  elfutils-libelf-devel
 BuildRequires:  gcc
 BuildRequires:  kmodtool

--- a/anda/system/usbio-drivers/dkms/0011-include-linux-mfd-usbio-Fix-missing-prototypes.patch
+++ b/anda/system/usbio-drivers/dkms/0011-include-linux-mfd-usbio-Fix-missing-prototypes.patch
@@ -1,0 +1,34 @@
+From c86e7a74c151304af7393c27f8f3df84d7d005ae Mon Sep 17 00:00:00 2001
+From: Kate Hsuan <hpa@redhat.com>
+Date: Tue, 23 Sep 2025 14:17:05 +0800
+Subject: [PATCH 2/2] include: linux: mfd: usbio: Fix missing-prototypes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix the following missing-prototypes issues
+
+drivers/mfd/usbio.c: At top level:
+drivers/mfd/usbio.c:473:6: warning: no previous prototype for ‘usbio_unregister_event_cb’ [-Wmissing-prototypes]
+  473 | void usbio_unregister_event_cb(struct platform_device *pdev)
+      |      ^~~~~~~~~~~~~~~~~~~~~~~~~
+---
+ include/linux/mfd/usbio.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/linux/mfd/usbio.h b/include/linux/mfd/usbio.h
+index c8024a8..ecf8ac9 100644
+--- a/include/linux/mfd/usbio.h
++++ b/include/linux/mfd/usbio.h
+@@ -45,5 +45,8 @@ int usbio_transfer(struct platform_device *pdev, u8 cmd, const void *obuf,
+ 		  int obuf_len, void *ibuf, int *ibuf_len);
+ int usbio_transfer_noack(struct platform_device *pdev, u8 cmd, const void *obuf,
+ 			int obuf_len);
++int usbio_register_event_cb(struct platform_device *pdev,
++			    usbio_event_cb_t event_cb);
++void usbio_unregister_event_cb(struct platform_device *pdev);
+ 
+ #endif
+-- 
+2.51.0
+

--- a/anda/system/usbio-drivers/dkms/01-387.patch
+++ b/anda/system/usbio-drivers/dkms/01-387.patch
@@ -1,0 +1,69 @@
+From 1e6f315ec4e867fe25da5c6d216bb4757757515e Mon Sep 17 00:00:00 2001
+From: Kate Hsuan <hpa@redhat.com>
+Date: Mon, 15 Sep 2025 17:15:41 +0800
+Subject: [PATCH] patches: remove "u64 dma_mask" for the kernel higher than
+ 6.16
+
+The upstream commits 1284c9693953aed2a9974a5a384ce2a42a1b9ae8 brought the
+kernel crash
+
+[    6.697129] BUG: unable to handle page fault for address: 00000000ff78d008
+[    6.697134] #PF: supervisor read access in kernel mode
+[    6.697135] #PF: error_code(0x0000) - not-present page
+[    6.697137] PGD 0 P4D 0
+[    6.697141] Oops: Oops: 0000 [#1] SMP NOPTI
+[    6.697145] CPU: 12 UID: 0 PID: 1149 Comm: (udev-worker) Tainted: G           OE       6.16.5-200.fc42.x86_64 #1 PREEMPT(lazy)
+[    6.697149] Tainted: [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
+[    6.697150] Hardware name: LENOVO 21HQSIT024/21HQSIT024, BIOS N3XET40W (1.15 ) 05/22/2023
+[    6.697152] RIP: 0010:ipu6_psys_probe+0x384/0x3b0 [intel_ipu6_psys]
+[    6.697164] Code: ff c7 44 24 10 fb fd ff ff e9 f8 fc ff ff c7 44 24 10 f4 ff ff ff eb cb 49 8b 84 24 98 03 00 00 48 c7 c6 cf 51 ad c1 4c 89 e7 <48> 8b 40 08 89 43 18 89 c2 e8 8e a5 e3 e4 80 3d 33 6b f3 ff 00 0f
+[    6.697166] RSP: 0018:ffffcee981177860 EFLAGS: 00010246
+[    6.697169] RAX: 00000000ff78d000 RBX: ffff8bc153c8e028 RCX: 0000000000002000
+[    6.697171] RDX: ffff8bc146d58020 RSI: ffffffffc1ad51cf RDI: ffff8bc14e7d1000
+[    6.697172] RBP: ffff8bc146d58020 R08: 0000000000000002 R09: ffffcee980ba7000
+[    6.697174] R10: ffffcee980ba7000 R11: ffff8bc141b00480 R12: ffff8bc14e7d1000
+[    6.697175] R13: ffff8bc153c8e440 R14: ffff8bc146d5a020 R15: ffff8bc146d5a000
+[    6.697176] FS:  00007feae3a8d3c0(0000) GS:ffff8bc4e565f000(0000) knlGS:0000000000000000
+[    6.697179] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+[    6.697180] CR2: 00000000ff78d008 CR3: 0000000104809001 CR4: 0000000000f70ef0
+[    6.697182] PKRU: 55555554
+[    6.697183] Call Trace:
+[    6.697186]  <TASK>
+[    6.697189]  ? __pfx_ipu6_psys_probe+0x10/0x10 [intel_ipu6_psys]
+[    6.697196]  auxiliary_bus_probe+0x46/0x80
+[    6.697202]  really_probe+0xdb/0x340
+
+Since the upstream commit 1284c9693953aed2a9974a5a384ce2a42a1b9ae8
+removed dms_mask from struct ipu6_bus_device, the size of
+struct ipu6_bus_device isn't the same as it is in the upstream kernel.
+"u64 dms_mask" has to be removed when it is built with the upstream kernel
+higher than 6.16.
+
+Resolves: #372
+---
+ patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch b/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch
+index b8eeaae662d3..44c213050d9d 100644
+--- a/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch
++++ b/patches/0001-v6.10-IPU6-headers-used-by-PSYS.patch
+@@ -28,7 +28,7 @@ new file mode 100644
+ index 000000000..b26c6aee1
+ --- /dev/null
+ +++ b/drivers/media/pci/intel/ipu6/ipu6-bus.h
+-@@ -0,0 +1,58 @@
++@@ -0,0 +1,60 @@
+ +/* SPDX-License-Identifier: GPL-2.0-only */
+ +/* Copyright (C) 2013 - 2024 Intel Corporation */
+ +
+@@ -59,7 +59,9 @@ index 000000000..b26c6aee1
+ +	struct ipu6_mmu *mmu;
+ +	struct ipu6_device *isp;
+ +	struct ipu6_buttress_ctrl *ctrl;
+++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 16, 0)
+ +	u64 dma_mask;
+++#endif
+ +	const struct firmware *fw;
+ +	struct sg_table fw_sgt;
+ +	u64 *pkg_dir;

--- a/anda/system/usbio-drivers/dkms/23-38.patch
+++ b/anda/system/usbio-drivers/dkms/23-38.patch
@@ -1,0 +1,49 @@
+From 1e2311383bb5fdc857664d1e30700dd3496a5a11 Mon Sep 17 00:00:00 2001
+From: You-Sheng Yang <vicamo@gmail.com>
+Date: Wed, 13 Aug 2025 14:58:19 +0800
+Subject: [PATCH] backport: fix build against kernel >= 6.17
+
+v6.17-rc1 commit 98ce1eb1fd87e ("gpiolib: introduce gpio_chip setters
+that return values") added two new APIs `set_rv` and `set_multiple_rv`
+to `struct gpio_irq_chip` that duplicate existing `set` and
+`set_multiple` without return values. They then completely replace the
+no-return-value APIs in same v6.17-rc1 commit d9d87d90cc0b1
+("treewide: rename GPIO set callbacks back to their original names").
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2120461
+Signed-off-by: You-Sheng Yang <vicamo@gmail.com>
+---
+ drivers/gpio/gpio-usbio.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpio/gpio-usbio.c b/drivers/gpio/gpio-usbio.c
+index 625558b..9c904e7 100644
+--- a/drivers/gpio/gpio-usbio.c
++++ b/drivers/gpio/gpio-usbio.c
+@@ -175,8 +175,13 @@ static int usbio_gpio_get_value(struct gpio_chip *chip, unsigned int offset)
+ 	return usbio_gpio_read(usbio_gpio, offset);
+ }
+ 
+-static void usbio_gpio_set_value(struct gpio_chip *chip, unsigned int offset,
+-				int val)
++static
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
++void
++#else
++int
++#endif
++usbio_gpio_set_value(struct gpio_chip *chip, unsigned int offset, int val)
+ {
+ 	struct usbio_gpio_dev *usbio_gpio = gpiochip_get_data(chip);
+ 	int ret;
+@@ -186,6 +191,10 @@ static void usbio_gpio_set_value(struct gpio_chip *chip, unsigned int offset,
+ 		dev_err(chip->parent,
+ 			"%s offset:%d val:%d set value failed %d\n", __func__,
+ 			offset, val, ret);
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++	return ret;
++#endif
+ }
+ 
+ static int usbio_gpio_direction_input(struct gpio_chip *chip,

--- a/anda/system/usbio-drivers/dkms/dkms-intel-usbio.spec
+++ b/anda/system/usbio-drivers/dkms/dkms-intel-usbio.spec
@@ -12,9 +12,6 @@ License:    GPL-2.0-only
 URL:        https://github.com/intel/usbio-drivers
 Source0:    %{url}/archive/%{commit}.tar.gz#/usbio-drivers-%{shortcommit}.tar.gz
 Source2:    %{name}.conf
-Patch0:     https://github.com/jwrdegoede/usbio-drivers/commit/d5f08986936a7fda0cce543c73fb8d9bab76eae2.patch
-Patch1:     https://github.com/jwrdegoede/usbio-drivers/commit/47b34a6f467eebb4e9fc59f5e25618fe760fbf33.patch
-Patch2:     https://github.com/jwrdegoede/usbio-drivers/commit/0eae85556558b410635ad03ed5eccb9648e11fce.patch
 Provides:   %{modulename}-kmod = %{version}
 Requires:   dkms
 Requires:   dkms-intel-ipu6

--- a/anda/system/usbio-drivers/kmod-common/intel-usbio-drivers.spec
+++ b/anda/system/usbio-drivers/kmod-common/intel-usbio-drivers.spec
@@ -3,7 +3,7 @@
 %global commit_date 20251031
 %global debug_package %{nil}
 
-Name:          dkms-%{modulename}
+Name:          intel-usbio
 Version:       0^%{commit_date}git.%{shortcommit}
 Release:       1%?dist
 Summary:       Common files for the USBIO drivers
@@ -29,10 +29,8 @@ This package contains the common files for the UBSIO kernel modules.
 # Hi, I'm also empty!
 
 %files
-%doc CODE_OF_CONDUCT.md
 %doc README.md
 %doc SECURITY.md
-%doc security.md
 %license LICENSE.txt
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(usbio-drivers): Update patches (#9363)](https://github.com/terrapkg/packages/pull/9363)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)