### PR TITLE
[f43] chore: Mass update email in Roachy's specs (#9355)

### DIFF
--- a/anda/apps/falcond-gui/falcond-gui.spec
+++ b/anda/apps/falcond-gui/falcond-gui.spec
@@ -1,6 +1,6 @@
 Name:           falcond-gui
 Version:        1.0.1
-Release:        1%?dist
+Release:        1%{?dist}
 Summary:        A GTK4/LibAdwaita application to control and monitor the Falcond gaming optimization daemon
 SourceLicense:  MIT
 License:        (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND CC0-1.0 AND ISC AND (MIT OR Apache-2.0) AND MIT AND (Unlicense OR MIT)

--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -9,7 +9,7 @@
 
 Name:          %{base_name}-nightly
 Version:       %{ver}%{commit_date}.git.%{shortcommit}
-Release:       1%?dist
+Release:       2%{?dist}
 License:       OSL-3.0
 Summary:       A privacy-minded Legcord fork.
 Group:         Applications/Internet
@@ -17,7 +17,7 @@ URL:           https://github.com/Milkshiift/%{git_name}
 Source0:       %{url}/archive/%{commit}/%{git_name}-%{commit}.tar.gz
 BuildRequires: anda-srpm-macros >= 0.2.26
 BuildRequires: bun-bin
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 A highly configurable and privacy minded Discord client.

--- a/anda/apps/goofcord/stable/goofcord.spec
+++ b/anda/apps/goofcord/stable/goofcord.spec
@@ -3,7 +3,7 @@
 
 Name:          goofcord
 Version:       2.0.1
-Release:       1%?dist
+Release:       2%{?dist}
 License:       OSL-3.0
 Summary:       A privacy-minded Legcord fork.
 Group:         Applications/Internet
@@ -11,7 +11,7 @@ URL:           https://github.com/Milkshiift/%{git_name}
 Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires: anda-srpm-macros >= 0.3.0
 BuildRequires: bun-bin
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %electronmeta -D
 

--- a/anda/devs/backport/nodejs-backport.spec
+++ b/anda/devs/backport/nodejs-backport.spec
@@ -4,7 +4,7 @@
 
 Name:          node-%{module}
 Version:       10.2.0
-Release:       1%?dist
+Release:       2%{?dist}
 Summary:       Backport GitHub commits
 SourceLicense: Apache-2.0
 License:       Apache-2.0 AND
@@ -17,7 +17,7 @@ BuildRequires: nodejs-devel
 BuildRequires: nodejs-packaging
 BuildRequires: nodejs-npm
 ExclusiveArch: %{nodejs_arches} noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 A simple CLI tool that automates the process of backporting commits on a GitHub repo.

--- a/anda/devs/edit/edit.spec
+++ b/anda/devs/edit/edit.spec
@@ -8,7 +8,7 @@ An editor that pays homage to the classic MS-DOS Editor, but with a modern inter
 
 Name:          %{crate}
 Version:       1.2.1
-Release:       2%?dist
+Release:       3%{?dist}
 Summary:       A simple editor for simple needs.
 SourceLicense: MIT
 License:       MIT AND (MIT OR Apache-2.0)
@@ -21,7 +21,7 @@ BuildRequires: cargo-rpm-macros
 BuildRequires: rustup
 %endif
 BuildRequires: mold
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -9,7 +9,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif
@@ -55,7 +55,7 @@ Provides:       %{base_name}-tip = %{ver}^%{commit_date}git%{shortcommit}
 Provides:       %{name} = %{commit_date}.%{shortcommit}
 %endif
 Obsoletes:      %{name} = 20250130.04d3636
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 👻 Ghostty is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration.
@@ -318,10 +318,10 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 - Updated for Zig 0.14.0
 - Updated for ncurses-term compatibility in Fedora 42 and Rawhide
 * Wed Mar 05 2025 Gilver E. <rockgrub@disroot.org>
-- Update to 1.1.3~tip^20250305git66e8d91-2%{?dist}
+- Update to 1.1.3~tip^20250305git66e8d91-2
  * Ghostty now has localization support via gettext as well as corresponding localization files
 * Fri Jan 31 2025 Gilver E. <rockgrub@disroot.org>
-- Update to 1.1.1~tip^20250131git5508e7-1%{?dist}
+- Update to 1.1.1~tip^20250131git5508e7-1
  * Low GHSA-98wc-794w-gjx3: Ghostty leaked file descriptors allowing the shell and any of its child processes to impact other Ghostty terminal instances
  * Better Git versioning scheme
  * Ghostty terminfo source files are now a subpackage

--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -4,7 +4,7 @@
 
 Name:           ghostty
 Version:        1.2.3
-Release:        3%?dist
+Release:        4%{?dist}
 Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
 URL:            https://ghostty.org/
@@ -41,7 +41,7 @@ Requires:       gtk4
 Requires:       gtk4-layer-shell
 Requires:       libadwaita
 Conflicts:      ghostty-nightly
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 👻 Ghostty is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration.
@@ -254,7 +254,7 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{name}
  * This is necessary to address licensing issues in the themes repo Ghostty uses
  * See: https://github.com/mbadolato/iTerm2-Color-Schemes/issues/638
 * Fri Jan 31 2025 Gilver E. <rockgrub@disroot.org>
-- Update to 1.1.0-1%{?dist}
+- Update to 1.1.0-1
  * Low GHSA-98wc-794w-gjx3: Ghostty leaked file descriptors allowing the shell and any of its child processes to impact other Ghostty terminal instances
  * Ghostty terminfo source files are now a subpackage
  * Shell integration and completion and terminfo subpackages are now properly noarch

--- a/anda/devs/powershell/powershell.spec
+++ b/anda/devs/powershell/powershell.spec
@@ -19,7 +19,7 @@
 
 Name:          powershell
 Version:       7.5.4
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       A cross-platform automation and configuration tool/framework
 SourceLicense: MIT
 License:       Apache-2.0 AND BSD-2-Clause AND MIT
@@ -44,7 +44,7 @@ Requires:      dotnet-hostfxr-%{dotnet_version}
 Requires:      dotnet-runtime-%{dotnet_version}
 # .NET versioning
 Provides:      mono(pwsh) = %{version}.0
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 %{git_name} is a cross-platform automation and configuration tool/framework.

--- a/anda/devs/rio/rio.spec
+++ b/anda/devs/rio/rio.spec
@@ -5,7 +5,7 @@ A hardware-accelerated terminal emulator focusing to run in desktops and browser
 
 Name:          rio
 Version:       0.2.37
-Release:       1%?dist
+Release:       2%{?dist}
 Summary:       A hardware-accelerated terminal written in Rust.
 SourceLicense: MIT
 License:       ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND BSD-2-Clause AND BSL-1.0 AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CC0-1.0 AND ISC AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR GPL-3.0-only) AND MPL-2.0+ AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT) AND Zlib
@@ -29,7 +29,7 @@ Obsoletes:     %{crate} < %{version}-%{release}
 %if %{with docs}
 Suggests:      %{name}-doc = %{version}-%{release}
 %endif
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/devs/shibuya/python-shibuya.spec
+++ b/anda/devs/shibuya/python-shibuya.spec
@@ -6,7 +6,7 @@ A responsive, good looking with modern design documentation theme for Sphinx, wi
 
 Name:           python-%{pypi_name}
 Version:        2026.1.9
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        A clean, responsive, and customizable Sphinx documentation theme with light/dark mode
 License:        BSD-3-Clause
 URL:            https://shibuya.lepture.com
@@ -30,7 +30,7 @@ BuildRequires:  python3dist(sphinx-design)
 BuildRequires:  python3dist(sphinx-togglebutton)
 %endif
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/devs/yarn-berry/yarnpkg-berry.spec
+++ b/anda/devs/yarn-berry/yarnpkg-berry.spec
@@ -2,7 +2,7 @@
 
 Name:          yarnpkg-berry
 Version:       4.12.0
-Release:       4%?dist
+Release:       5%{?dist}
 Summary:       Active development version of Yarn
 License:       BSD-2-Clause
 URL:           https://yarnpkg.com
@@ -19,7 +19,7 @@ BuildRequires: %{name}
 Provides:      yarn-berry
 Conflicts:     yarnpkg
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 The next, actively developed version of Yarn.

--- a/anda/fonts/cleartype/cleartype-fonts.spec
+++ b/anda/fonts/cleartype/cleartype-fonts.spec
@@ -89,7 +89,7 @@ in the PowerPointViewer package, still available on the Microsoft website.
 
 Name:           %{fontname}-fonts
 Version:        1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Package containing ClearType fonts.
 License:        LicenseRef-MS-Core-Fonts
 URL:            https://mscorefonts2.sourceforge.net
@@ -113,7 +113,7 @@ Requires:       %{fontname}-constantia-fonts
 Requires:       %{fontname}-corbel-fonts
 Requires(post): fontconfig
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %fontpkg -a
 

--- a/anda/fonts/ms-core-tahoma/ms-core-tahoma-fonts.spec
+++ b/anda/fonts/ms-core-tahoma/ms-core-tahoma-fonts.spec
@@ -18,7 +18,7 @@ package.
 ### Different name because of font package and setup macro weirdness
 Name:           mscore-tahoma-fonts
 Version:        1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Microsoft core Tahoma fonts for better Windows compatibility
 License:        LicenseRef-MS-Core-Fonts
 URL:            https://mscorefonts2.sourceforge.net
@@ -30,7 +30,7 @@ BuildRequires:  fontpackages-devel
 Requires:       xorg-x11-font-utils
 Requires:       fontconfig
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %fontpkg -a
 

--- a/anda/fonts/ms-core/ms-core-fonts.spec
+++ b/anda/fonts/ms-core/ms-core-fonts.spec
@@ -153,7 +153,7 @@ http://www.microsoft.com/typography/fontpack.
 
 Name:            ms-core-fonts
 Version:         2.2
-Release:         1%{?dist}
+Release:         2%{?dist}
 Summary:         Microsoft core fonts
 License:         LicenseRef-MS-Core-Fonts
 URL:             https://mscorefonts2.sourceforge.net
@@ -192,7 +192,7 @@ Requires:        %{fontname}-webdings-fonts
 Requires:        xorg-x11-font-utils
 Requires(post):  fontconfig
 BuildArch:       noarch
-Packager:        Gilver E. <rockgrub@disroot.org>
+Packager:        Gilver E. <roachy@fyralabs.com>
 
 %fontpkg -a
 

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -9,7 +9,7 @@
 
 Name:          %{shortname}-games-launcher
 Version:       2.18.1
-Release:       1%?dist
+Release:       2%{?dist}
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com
@@ -28,7 +28,7 @@ Provides:      bundled(comet) = %{comet_version}
 Provides:      bundled(gogdl) = %{gogdl_version}
 Provides:      bundled(legendary) = %{legendary_version}
 Provides:      bundled(nile) = %{nile_version}
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %electronmeta -D
 

--- a/anda/games/steamtinkerlaunch/git/steamtinkerlaunch-git.spec
+++ b/anda/games/steamtinkerlaunch/git/steamtinkerlaunch-git.spec
@@ -8,7 +8,7 @@ Steam Tinker Launch is a Linux wrapper tool for use with the Steam client which 
 
 Name:           %{base_name}-git
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Wrapper tool for use with the Steam client for custom launch options
 License:        GPL-3.0-or-later
 URL:            https://github.com/sonic2kk/steamtinkerlaunch
@@ -53,7 +53,7 @@ Recommends:     xdg-utils
 Provides:       %{base_name}.git
 Conflicts:      %{base_name}
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/games/steamtinkerlaunch/stable/steamtinkerlaunch.spec
+++ b/anda/games/steamtinkerlaunch/stable/steamtinkerlaunch.spec
@@ -3,7 +3,7 @@ Steam Tinker Launch is a Linux wrapper tool for use with the Steam client which 
 
 Name:           steamtinkerlaunch
 Version:        12.12
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Wrapper tool for use with the Steam client for custom launch options
 License:        GPL-3.0-or-later
 URL:            https://github.com/sonic2kk/steamtinkerlaunch
@@ -46,7 +46,7 @@ Recommends:     winetricks
 Recommends:     xdg-utils
 Conflicts:      %{name}-git
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/games/udev-joystick-blacklist/udev-joystick-blacklist.spec
+++ b/anda/games/udev-joystick-blacklist/udev-joystick-blacklist.spec
@@ -4,7 +4,7 @@
 
 Name:          udev-joystick-blacklist
 Version:       0^%{commit_date}git%{shortcommit}
-Release:       3%{?dist}
+Release:       4%{?dist}
 Summary:       Fix for keyboard/mouse/tablet being detected as joysticks in Linux
 License:       Public Domain
 URL:           https://github.com/denilsonsa/udev-joystick-blacklist
@@ -13,7 +13,7 @@ BuildRequires: systemd-rpm-macros
 Conflicts:     %{name}-rm
 Conflicts:     steam-device-rules <= 1.0.0.85
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 There are several devices that, although recognized by kernel as joysticks, are not joysticks.

--- a/anda/langs/python/bash-kernel/python-bash-kernel.spec
+++ b/anda/langs/python/bash-kernel/python-bash-kernel.spec
@@ -5,7 +5,7 @@
 
 Name:           python-%{real_name}
 Version:        0.10.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Bash kernel for Jupyter
 License:        BSD-3-Clause
 URL:            https://github.com/takluyver/bash_kernel
@@ -21,7 +21,7 @@ BuildRequires:  %{py3_dist docutils}
 # See https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
 ExcludeArch:    %{ix86}
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 This package contains a Jupyter kernel for bash.

--- a/anda/langs/python/colorthief/python-colorthief.spec
+++ b/anda/langs/python/colorthief/python-colorthief.spec
@@ -8,7 +8,7 @@ ExcludeArch: %{ix86}
 
 Name:           python-%{pypi_name}
 Version:        0.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Grabs the dominant color or a representative color palette from an image
 
 # https://gitlab.com/fedora/legal/fedora-license-data/-/issues/382
@@ -23,7 +23,7 @@ BuildRequires:  python3dist(pillow)
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %global _description %{expand:
 A Python module for grabbing the color palette from an image.}

--- a/anda/langs/python/colorz/python-colorz.spec
+++ b/anda/langs/python/colorz/python-colorz.spec
@@ -2,7 +2,7 @@
 
 Name:           python-%{pypi_name}
 Version:        1.0.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Color scheme generator
 License:        MIT
 URL:            https://github.com/metakirby5/colorz
@@ -12,7 +12,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 A k-means color scheme generator.

--- a/anda/langs/python/fast-colorthief/python-fast-colorthief.spec
+++ b/anda/langs/python/fast-colorthief/python-fast-colorthief.spec
@@ -6,7 +6,7 @@
 
 Name:           python-%{pypi_name}
 Version:        0.0.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Faster version of Colorthief
 License:        MIT
 URL:            https://github.com/bedapisl/fast-colorthief
@@ -35,7 +35,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(sphinx)
 BuildRequires:  python3dist(sphinxcontrib-moderncmakedomain)
 BuildRequires:  python3dist(sphinx-copybutton)
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 A Python module for selecting most dominant colors in the image.

--- a/anda/langs/python/haishoku/python-haishoku.spec
+++ b/anda/langs/python/haishoku/python-haishoku.spec
@@ -6,7 +6,7 @@ Haishoku is a development tool for grabbing the dominant color or representative
 
 Name:           python-%{pypi_name}
 Version:        1.1.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A development tool for grabbing the dominant color or representative color palette from an image
 License:        MIT
 URL:            https://github.com/LanceGin/haishoku
@@ -16,7 +16,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description %_description1
 

--- a/anda/langs/python/jupyter-sphinx/python-jupyter-sphinx.spec
+++ b/anda/langs/python/jupyter-sphinx/python-jupyter-sphinx.spec
@@ -7,7 +7,7 @@
 
 Name:           python-jupyter-sphinx
 Version:        0.5.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Jupyter Sphinx extensions
 License:        BSD-3-Clause
 URL:            https://jupyter-sphinx.readthedocs.io/
@@ -31,7 +31,7 @@ BuildRequires:  python3dist(sphinx)
 # See https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
 ExcludeArch:    %{ix86}
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %global _desc %{expand:
 Jupyter-Sphinx enables running code embedded in Sphinx documentation and

--- a/anda/langs/python/materialyoucolor/python-materialyoucolor.spec
+++ b/anda/langs/python/materialyoucolor/python-materialyoucolor.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{pypi_name}
 Version:        2.0.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Material You color generation algorithms in pure python!
 License:        MIT
 URL:            https://github.com/T-Dynamos/materialyoucolor-python
@@ -17,7 +17,7 @@ BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(rich)
 BuildRequires:  python3dist(setuptools)
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Material You color generation algorithms in Python.

--- a/anda/langs/python/pygment-styles/python-pygments-styles.spec
+++ b/anda/langs/python/pygment-styles/python-pygments-styles.spec
@@ -3,7 +3,7 @@
 
 Name:           python-%{real_name}
 Version:        0.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A collection of Pygments styles
 License:        BSD-3-Clause
 URL:            https://pygments-styles.org
@@ -13,7 +13,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools)
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 A curated collection of Pygments styles based on VS Code themes.

--- a/anda/langs/python/pywal16/python-pywal16.spec
+++ b/anda/langs/python/pywal16/python-pywal16.spec
@@ -4,7 +4,7 @@ Pywal is a tool that generates a color palette from the dominant colors in an im
 
 Name:           python-%{pypi_name}
 Version:        3.8.13
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        16 color fork of the original Pywal
 License:        MIT
 URL:            https://github.com/eylles/pywal16
@@ -23,7 +23,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 Obsoletes:      python3-pywal < 3.5.0-1
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 This project is a 16 colors fork of Pywal.

--- a/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
+++ b/anda/langs/python/sphinxcontrib-moderncmakedomain/python-sphinxcontrib-moderncmakedomain.spec
@@ -12,7 +12,7 @@
 
 Name:           python-%{real_name}
 Version:        3.29.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Sphinx domain for modern CMake
 License:        BSD-3-Clause
 URL:            https://github.com/scikit-build/moderncmakedomain
@@ -28,7 +28,7 @@ BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(sphinx)
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Modern CMake domain entries, originally from Kitware.

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -40,7 +40,7 @@
 
 Name:           zig-master
 Version:        %(echo %{ver} | sed 's/-/~/g')
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Bootstrapped build of Zig from master.
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
@@ -88,7 +88,7 @@ Provides:       bundled(musl) = 1.2.5
 Provides:       bundled(wasi-libc) = d03829489904d38c624f6de9983190f1e5e7c9c5
 Conflicts:      zig
 ExclusiveArch:  %{zig_arches}
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Zig is an open source alternative to C. 

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -14,7 +14,7 @@
 
 Name:           zig-master
 Version:        0.16.0~dev.2261+d6b3dd25a
-Release:        2%?dist
+Release:        3%{?dist}
 Summary:        Master builds of the Zig language
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
@@ -63,7 +63,7 @@ Provides:       bundled(musl) = 1.2.5
 Provides:       bundled(wasi-libc) = d03829489904d38c624f6de9983190f1e5e7c9c5
 Conflicts:      zig
 ExclusiveArch:  %{zig_arches}
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 # Must be defined AFTER the version is
 %global zig_build_options %{shrink: \

--- a/anda/lib/dwarfs/dwarfs.spec
+++ b/anda/lib/dwarfs/dwarfs.spec
@@ -6,7 +6,7 @@ A fast high compression read-only file system for Linux and Windows.}
 
 Name:          dwarfs
 Version:       0.14.1
-Release:       4%?dist
+Release:       5%{?dist}
 Summary:       A fast high compression read-only file system for Linux, Windows and macOS
 License:       GPL-3.0-or-later
 URL:           https://github.com/mhx/%{name}
@@ -61,7 +61,7 @@ Requires:      libattr
 Requires:      libxml2
 Requires:      libzstd
 Requires:      (zlib-ng-compat or zlib)
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
+++ b/anda/lib/ipu6-camera-bins/ipu6-camera-bins.spec
@@ -7,7 +7,7 @@
 Name:           ipu6-camera-bins
 Summary:        Libraries for Intel IPU6
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -36,7 +36,7 @@ Provides:       %{name} = %{?epoch:%{epoch}:}%{commit_date}.%{shortcommit}-%{rel
 Obsoletes:      %{name} < %{?epoch:%{epoch}:}%{commit_date}.%{shortcommit}-2
 %endif
 ExclusiveArch:  x86_64
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Provides binary libraries for Intel IPU6.

--- a/anda/misc/krabby/krabby.spec
+++ b/anda/misc/krabby/krabby.spec
@@ -1,6 +1,6 @@
 Name:          krabby
 Version:       0.3.0
-Release:       1%{?dist}
+Release:       2%{?dist}
 SourceLicense: GPL-3.0-or-later
 License:       (MIT OR Apache-2.0) AND GPL-3.0-or-later AND MIT AND (Unlicense OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND MPL-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT)
 Summary:       Print Pokémon sprites in your terminal
@@ -9,7 +9,7 @@ Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo-rpm-macros
 BuildRequires: mold
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 Krabby is mostly a Rust rewrite of phoney badger's pokemon-colorscripts with some extra features.

--- a/anda/misc/pbcli/pbcli.spec
+++ b/anda/misc/pbcli/pbcli.spec
@@ -3,7 +3,7 @@ pbcli is a command line client which allows to upload and download pastes from p
 
 Name:           pbcli
 Version:        2.8.0
-Release:        3%?dist
+Release:        4%{?dist}
 Summary:        A PrivateBin commandline upload and download utility
 SourceLicense:  Unlicense OR MIT
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND ISC AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
@@ -19,7 +19,7 @@ BuildRequires:  perl-File-Compare
 BuildRequires:  perl-File-Copy
 BuildRequires:  perl-IPC-Cmd
 BuildRequires:  perl-lib
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/misc/pokeget/pokeget.spec
+++ b/anda/misc/pokeget/pokeget.spec
@@ -5,7 +5,7 @@
 
 Name:          %{crate}
 Version:       1.6.7
-Release:       1%?dist
+Release:       2%{?dist}
 SourceLicense: MIT
 License:       (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 Summary:       A better Rust version of pokeget.
@@ -16,7 +16,7 @@ BuildRequires: cargo-rpm-macros
 BuildRequires: mold
 Provides:      bundled(%{pname}) = %{pcommit}
 Obsoletes:     %{crate}-rs < %{version}-%{release}
-Packager:      Gilver E. <rockgrub@disroot.org>, madonuko <mado@fyralabs.com>
+Packager:      Gilver E. <roachy@fyralabs.com>, madonuko <mado@fyralabs.com>
 
 %description
 Successor to pokeget, written in Rust.

--- a/anda/misc/pokemon-colorscripts/pokemon-colorscripts.spec
+++ b/anda/misc/pokemon-colorscripts/pokemon-colorscripts.spec
@@ -4,14 +4,14 @@
 
 Name:          pokemon-colorscripts
 Version:       0^%{commit_date}git.%{shortcommit}
-Release:       1%{?dist}
+Release:       2%{?dist}
 License:       MIT
 Summary:       CLI utility to print out images of Pokémon to the terminal
 URL:           https://gitlab.com/phoneybadger/%{name}
 Source0:       %{url}/-/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
 BuildArch:     noarch
 Requires:      python3
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 A utility that prints unicode sprites of images of Pokémon to the terminal.

--- a/anda/misc/pokeshell/pokeshell.spec
+++ b/anda/misc/pokeshell/pokeshell.spec
@@ -6,7 +6,7 @@
 
 Name:          pokeshell
 Version:       %{ver}^%{date}git.%{shortcommit}
-Release:       3%{?dist}
+Release:       4%{?dist}
 Summary:       A shell program to show Pokémon sprites in the terminal.
 License:       GPL-3.0-or-later
 URL:           https://github.com/acxz/pokeshell
@@ -20,7 +20,7 @@ Requires:      python3
 Requires:      chafa
 Recommends:    timg
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 A featureful shell program to show Pokémon sprites in the terminal.
@@ -31,7 +31,7 @@ Requires:      bash
 Requires:      %{name}
 Requires:      uv
 Recommends:    hyperfine
-Recommends:    pokeget-rs
+Recommends:    pokeget
 Recommends:    pokemon-colorscripts
 
 %description helper-scripts

--- a/anda/system/epsonscan2/epsonscan2.spec
+++ b/anda/system/epsonscan2/epsonscan2.spec
@@ -2,7 +2,7 @@
 
 Name:          epsonscan2
 Version:       6.7.82.0
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Package for Epson scanner drivers and software
 # This was a licensing determination nightmare
 License:       LGPL-2.1-or-later AND MIT AND Zlib AND LicenseRef-SHA1
@@ -37,7 +37,7 @@ BuildRequires: rapidjson-devel
 BuildRequires: sane-backends-devel
 BuildRequires: systemd-rpm-macros
 Requires:      qt5-qtbase
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 This package contains all essential software to use Epson scanners.

--- a/anda/system/falcond-profiles/falcond-profiles.spec
+++ b/anda/system/falcond-profiles/falcond-profiles.spec
@@ -4,7 +4,7 @@
 
 Name:           falcond-profiles
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Profiles for falcond
 License:        MIT
 URL:            https://github.com/PikaOS-Linux/falcond-profiles

--- a/anda/system/falcond/falcond.spec
+++ b/anda/system/falcond/falcond.spec
@@ -2,7 +2,7 @@
 
 Name:           falcond
 Version:        1.2.3
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Advanced Linux Gaming Performance Daemon
 License:        MIT
 URL:            https://git.pika-os.com/general-packages/falcond

--- a/anda/system/ipu6-camera-hal/ipu6-camera-hal.spec
+++ b/anda/system/ipu6-camera-hal/ipu6-camera-hal.spec
@@ -9,7 +9,7 @@
 Name:           ipu6-camera-hal
 Summary:        Hardware abstraction layer for Intel IPU6
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%{?dist}
 License:        Apache-2.0
 URL:            https://github.com/intel/ipu6-camera-hal
 Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz
@@ -33,7 +33,7 @@ Requires:       ipu6-camera-bins >= 0.0-11
 Provides:       %{name} = %{commit_date}.%{shortcommit}-%{release}
 %endif
 ExclusiveArch:  x86_64
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 This package provides the basic Hardware Avstraction Layer (HAL) access APIs for IPU6.

--- a/anda/system/ipu6-drivers/dkms/dkms-intel-ipu6.spec
+++ b/anda/system/ipu6-drivers/dkms/dkms-intel-ipu6.spec
@@ -9,7 +9,7 @@
 Name:           dkms-%{modulename}
 Summary:        DKMS module for %{modulename}
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 License:        GPL-2.0-or-later
 URL:            https://github.com/intel/ipu6-drivers
 Source0:        %{url}/archive/%{commit}.tar.gz#/ipu6-drivers-%{shortcommit}.tar.gz
@@ -22,7 +22,7 @@ Requires:       %{modulename}-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
 Requires:       dkms-usbio-drivers
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 This package enables the Intel IPU6 image processor.

--- a/anda/system/ipu6-drivers/kmod-common/intel-ipu6-drivers.spec
+++ b/anda/system/ipu6-drivers/kmod-common/intel-ipu6-drivers.spec
@@ -9,7 +9,7 @@
 Name:           intel-ipu6-drivers
 Summary:        Common files for Intel IPU6 drivers
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 License:        GPL-2.0-or-later
 URL:            https://github.com/intel/ipu6-drivers
 Source0:        https://github.com/intel/ipu6-drivers/archive/%{commit}/ipu6-drivers-%{shortcommit}.tar.gz
@@ -17,7 +17,7 @@ Requires:       ipu6-camera-bins
 Requires:       intel-ipu6-kmod = %{?epoch:%{epoch}:}%{version}
 Provides:       intel-ipu6-kmod-common = %{?epoch:%{epoch}:}%{version}-%{release}
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Common files for the Intel IPU6 camera drivers.

--- a/anda/system/rtl8821cu/akmod/rtl8821cu-kmod.spec
+++ b/anda/system/rtl8821cu/akmod/rtl8821cu-kmod.spec
@@ -11,7 +11,7 @@ Linux Driver for USB Wi-Fi Adapters that are based on the RTL8811CU, RTL8821CU, 
 
 Name:          %{modulename}-kmod
 Version:       %{ver}^%{commit_date}git.%{shortcommit}
-Release:       2%?dist
+Release:       3%{?dist}
 Summary:       Linux Driver for USB Wi-Fi Adapters using RTL8821 chipsets
 License:       GPL-2.0-only
 URL:           https://github.com/morrownr/8821cu-20210916
@@ -21,7 +21,7 @@ BuildRequires: systemd-rpm-macros
 Requires:      %{modulename}-kmod-common = %{version}
 Requires:      akmods
 Conflicts:     dkms-%{modulename}
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 

--- a/anda/system/rtl8821cu/dkms/dkms-rtl8821cu.spec
+++ b/anda/system/rtl8821cu/dkms/dkms-rtl8821cu.spec
@@ -10,7 +10,7 @@ Linux Driver for USB Wi-Fi Adapters that are based on the RTL8811CU, RTL8821CU, 
 
 Name:          dkms-%{modulename}
 Version:       %{ver}^%{commit_date}git.%{shortcommit}
-Release:       1%?dist
+Release:       2%{?dist}
 Summary:       Linux Driver for USB Wi-Fi Adapters using RTL8821 chipsets
 License:       GPL-2.0-only
 URL:           https://github.com/morrownr/8821cu-20210916
@@ -26,7 +26,7 @@ Requires:      bc
 Requires:      make
 Provides:      %{modulename}-kmod
 Conflicts:     akmod-%{modulename}
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec
+++ b/anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-kmod-common
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Common files and documentation for the rtl8821cu driver
 License:        GPL-2.0-only
 URL:            https://github.com/morrownr/8821cu-20210916
@@ -16,7 +16,7 @@ Source0:        %{url}/archive/%{commit}.tar.gz#/%{git_name}-%{shortcommit}.tar.
 BuildRequires:  systemd-rpm-macros
 Requires:       rtl8821cu-kmod = %{version}
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Necessary files for the %{modulename} driver.

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -6,7 +6,7 @@
 
 Name:           scx-scheds-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Nightly builds of sched_ext schedulers and tools
 SourceLicense:  GPL-2.0-only
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (LGPL-2.1-only OR BSD-2-Clause) AND LGPL-2.1 AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR MIT OR Apache-2.0) AND MPL-2.0-only and MPL-2.0-or-later AND (Unlicense OR MIT) AND Zlib
@@ -53,7 +53,7 @@ Provides:       scx_layered
 Provides:       scx_rustland
 Provides:       scx_rusty
 Obsoletes:      scxctl <= 0.3.4
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 sched_ext is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them.

--- a/anda/system/scx-scheds/stable/scx-scheds.spec
+++ b/anda/system/scx-scheds/stable/scx-scheds.spec
@@ -2,7 +2,7 @@
 
 Name:           scx-scheds
 Version:        1.0.19
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        sched_ext schedulers
 SourceLicense:  GPL-2.0-only
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (LGPL-2.1-only OR BSD-2-Clause) AND LGPL-2.1 AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR MIT OR Apache-2.0) AND MPL-2.0-only and MPL-2.0-or-later AND (Unlicense OR MIT) AND Zlib
@@ -50,7 +50,7 @@ Provides:       scx_layered
 Provides:       scx_rustland
 Provides:       scx_rusty
 Obsoletes:      scxctl <= 0.3.4
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 sched_ext is a Linux kernel feature which enables implementing kernel thread schedulers in BPF and dynamically loading them.

--- a/anda/system/scx-tools/nightly/scx-tools-nightly.spec
+++ b/anda/system/scx-tools/nightly/scx-tools-nightly.spec
@@ -8,7 +8,7 @@
 
 Name:           scx-tools-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Sched_ext Tools
 License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND GPL-2.0-only AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 SourceLicense:  GPL-2.0-only
@@ -34,7 +34,7 @@ Suggests:       scx-scheds-nightly
 Obsoletes:      scxctl <= 0.3.4
 Provides:       scxctl = %{evr}
 Conflicts:      scx-tools
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 scx_loader: A D-Bus interface for managing sched_ext schedulers

--- a/anda/system/scx-tools/stable/scx-tools.spec
+++ b/anda/system/scx-tools/stable/scx-tools.spec
@@ -4,7 +4,7 @@
 
 Name:           scx-tools
 Version:        1.0.19
-Release:        2%?dist
+Release:        3%{?dist}
 Summary:        Sched_ext Tools
 License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND GPL-2.0-only AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 SourceLicense:  GPL-2.0-only
@@ -31,7 +31,7 @@ Obsoletes:      scxctl <= 0.3.4
 Provides:       scxctl = %{evr}
 Conflicts:      scx-tools-git
 Conflicts:      scx-tools-nightly
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 scx_loader: A D-Bus interface for managing sched_ext schedulers

--- a/anda/system/si-cik-amdgpu/si-cik-amdgpu.spec
+++ b/anda/system/si-cik-amdgpu/si-cik-amdgpu.spec
@@ -4,7 +4,7 @@
 
 Name:             si-cik-amdgpu
 Version:          0^%{commit_date}git.%{shortcommit}
-Release:          1%{?dist}
+Release:          2%{?dist}
 Summary:          Modprobe config to enable the amdgpu drivers on Southern Islands (SI) and CIK (Sea Islands)
 License:          GPL-3.0-only
 URL:              https://github.com/terrapkg/pkg-si-cik-amdgpu
@@ -13,7 +13,7 @@ BuildRequires:    systemd-rpm-macros
 Requires(post):   dracut
 Requires(postun): dracut
 BuildArch:        noarch
-Packager:         Gilver E. <rockgrub@disroot.org>
+Packager:         Gilver E. <roachy@fyralabs.com>
 
 %description
 %{summary}.

--- a/anda/system/usbio-drivers/akmod/intel-usbio-kmod.spec
+++ b/anda/system/usbio-drivers/akmod/intel-usbio-kmod.spec
@@ -8,7 +8,7 @@
 Name:           %{modulename}-kmod
 Summary:        Kernel drivers for the USBIO Extension
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%{?dist}
 License:        GPL-2.0-only
 URL:            https://github.com/intel/usbio-drivers
 Source0:        %{url}/archive/%{commit}.tar.gz#/usbio-drivers-%{shortcommit}.tar.gz
@@ -18,7 +18,7 @@ BuildRequires:  kmodtool
 Requires:       %{modulename}-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       akmods
 Requires:       akmod-intel-ipu6
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 

--- a/anda/system/usbio-drivers/dkms/dkms-intel-usbio.spec
+++ b/anda/system/usbio-drivers/dkms/dkms-intel-usbio.spec
@@ -6,7 +6,7 @@
 
 Name:       dkms-%{modulename}
 Version:    0^%{commit_date}git.%{shortcommit}
-Release:    1%?dist
+Release:    2%{?dist}
 Summary:    Kernel drivers for the USBIO Extension
 License:    GPL-2.0-only
 URL:        https://github.com/intel/usbio-drivers
@@ -16,7 +16,7 @@ Provides:   %{modulename}-kmod = %{version}
 Requires:   dkms
 Requires:   dkms-intel-ipu6
 BuildArch:  noarch
-Packager:   Gilver E. <rockgrub@disroot.org>
+Packager:   Gilver E. <roachy@fyralabs.com>
 
 %description
 This package enables USBIO Extension drivers on Intel Alder Lake, Raptor Lake, Meteor Lake and Lunar Lake platforms.

--- a/anda/system/usbio-drivers/kmod-common/intel-usbio-drivers.spec
+++ b/anda/system/usbio-drivers/kmod-common/intel-usbio-drivers.spec
@@ -5,7 +5,7 @@
 
 Name:          intel-usbio
 Version:       0^%{commit_date}git.%{shortcommit}
-Release:       1%?dist
+Release:       2%{?dist}
 Summary:       Common files for the USBIO drivers
 License:       GPL-2.0-only
 URL:           https://github.com/intel/usbio-drivers
@@ -14,7 +14,7 @@ BuildRequires: anda-srpm-macros
 Provides:      intel-usbio-kmod-common = %{evr}
 Requires:      intel-ipu6-kmod-common
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 This package contains the common files for the UBSIO kernel modules.

--- a/anda/system/v4l2loopback/dkms/dkms-v4l2loopback.spec
+++ b/anda/system/v4l2loopback/dkms/dkms-v4l2loopback.spec
@@ -5,7 +5,7 @@ This module allows you to create \"virtual video devices.\" Normal \(v4l2\) appl
 
 Name:           dkms-%{modulename}
 Version:        0.15.3
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Utils for V4L2 loopback devices
 License:        GPL-2.0-or-later
 URL:            https://github.com/v4l2loopback/v4l2loopback
@@ -17,7 +17,7 @@ Requires:       dkms
 Requires:       help2man
 Conflicts:      akmod-%{modulename}
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/system/xone/nightly/akmod/xone-nightly-kmod.spec
+++ b/anda/system/xone/nightly/akmod/xone-nightly-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-nightly-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -26,7 +26,7 @@ Conflicts:      %{modulename}-kmod
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Obsoletes:      %{name} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
 %endif
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 

--- a/anda/system/xone/nightly/dkms/dkms-xone-nightly.spec
+++ b/anda/system/xone/nightly/dkms/dkms-xone-nightly.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -27,7 +27,7 @@ Provides:       %{modulename}-nightly-kmod = %{?epoch:%{epoch}:}%{version}
 Obsoletes:      dkms-%{modulename} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
 %endif
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Linux kernel driver for Xbox One and Xbox Series X|S accessories.

--- a/anda/system/xone/nightly/kmod-common/xone-nightly.spec
+++ b/anda/system/xone/nightly/kmod-common/xone-nightly.spec
@@ -11,7 +11,7 @@
 
 Name:           xone-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -38,7 +38,7 @@ Conflicts:      %{modulename}
 Conflicts:      xow <= 0.5
 Obsoletes:      xow <= 0.5
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.

--- a/anda/system/xone/stable/akmod/xone-kmod.spec
+++ b/anda/system/xone/stable/akmod/xone-kmod.spec
@@ -4,7 +4,7 @@
 
 Name:           %{modulename}-kmod
 Version:        0.5.2
-Release:        1%?dist
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif
@@ -22,7 +22,7 @@ Conflicts:      %{modulename}-nightly-kmod
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Obsoletes:      %{name} < %{?epoch:%{epoch}:}0.3.4
 %endif
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 

--- a/anda/system/xone/stable/dkms/dkms-xone.spec
+++ b/anda/system/xone/stable/dkms/dkms-xone.spec
@@ -3,7 +3,7 @@
 
 Name:           dkms-%{modulename}
 Version:        0.5.2
-Release:        1%?dist
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif
@@ -23,7 +23,7 @@ Provides:       %{modulename}-kmod
 Obsoletes:      %{name} < %{?epoch:%{epoch}:}0.3.4
 %endif
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Linux kernel driver for Xbox One and Xbox Series X|S accessories.

--- a/anda/system/xone/stable/kmod-common/xone.spec
+++ b/anda/system/xone/stable/kmod-common/xone.spec
@@ -6,7 +6,7 @@
 
 Name:           xone
 Version:        0.5.2
-Release:        1%?dist
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif
@@ -37,7 +37,7 @@ Obsoletes:      xow <= 0.5
 Obsoletes:      %{name} < %{?epoch:%{epoch}:}0.3.4
 %endif
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.
@@ -132,7 +132,7 @@ install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
 %changelog
 * Wed Dec 10 2025 Gilver E. <rockgrub@disroot.org> - 0.5.0-2
 - Added new firmware files
-* Thu Apr 17 2025 Gilver E. <rockgrub@disroot.org> - 0.3^20250418git.ecdd59e-2%{?dist}
+* Thu Apr 17 2025 Gilver E. <rockgrub@disroot.org> - 0.3^20250418git.ecdd59e-2
 - Added additional firmware needed for dongle pairing on some controllers
 * Thu Feb 27 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
+++ b/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
@@ -10,7 +10,7 @@ This is the original upstream xpad driver from the Linux kernel with support for
 
 Name:          %{modulename}-kmod
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       3%?dist
+Release:       4%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
 URL:           https://github.com/medusalix/xpad-noone
@@ -26,7 +26,7 @@ Requires:      %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:      %{modulename}-akmod-modules
 Requires:      akmods
 Conflicts:     dkms-%{modulename}
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 

--- a/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
+++ b/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
@@ -8,7 +8,7 @@ This is the original upstream xpad driver from the Linux kernel with support for
 
 Name:          dkms-%{modulename}
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       2%?dist
+Release:       3%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
 URL:           https://github.com/medusalix/xpad-noone
@@ -21,7 +21,7 @@ Requires:      %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:      dkms
 Conflicts:     akmod-%{modulename}
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/system/xpad-noone/kmod-common/xpad-noone.spec
+++ b/anda/system/xpad-noone/kmod-common/xpad-noone.spec
@@ -7,7 +7,7 @@ This is the original upstream xpad driver from the Linux kernel with support for
 
 Name:          xpad-noone
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       1%{?dist}
+Release:       2%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
 URL:           https://github.com/medusalix/xpad-noone
@@ -19,7 +19,7 @@ Requires:      (akmod-%{name} = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = 
 Conflicts:     xow <= 0.5
 Obsoletes:     xow <= 0.5
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description %_description
 

--- a/anda/system/xpadneo/akmod/xpadneo-kmod.spec
+++ b/anda/system/xpadneo/akmod/xpadneo-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/xpadneo
@@ -21,7 +21,7 @@ Requires:       bluez-tools
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:       %{modulename}-akmod-modules = %{?epoch:%{epoch}:}%{version}
 Conflicts:      dkms-%{modulename}
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 

--- a/anda/system/xpadneo/dkms/dkms-xpadneo.spec
+++ b/anda/system/xpadneo/dkms/dkms-xpadneo.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/%{modulename}
@@ -21,7 +21,7 @@ Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
 Conflicts:      akmod-%{modulename}
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Advanced Linux Driver for Xbox One Wireless Gamepad.

--- a/anda/system/xpadneo/kmod-common/xpadneo.spec
+++ b/anda/system/xpadneo/kmod-common/xpadneo.spec
@@ -5,7 +5,7 @@
 
 Name:           xpadneo
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad common files
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/%{name}
@@ -15,9 +15,9 @@ BuildRequires:  sed
 BuildRequires:  systemd-rpm-macros
 Requires:       (akmod-%{name} = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = %{?epoch:%{epoch}:}%{version})
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
-Obsoletes:      %{name}-kmod-common < %{?epoch:%{epoch}:}0.9.7^20241224git.8d20a23-4%{?dist}
+Obsoletes:      %{name}-kmod-common < %{?epoch:%{epoch}:}0.9.7^20241224git.8d20a23-5%{?dist}
 BuildArch:      noarch
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Advanced Linux Driver for Xbox One Wireless Gamepad common files.

--- a/anda/themes/kde-material-you-colors/kde-material-you-colors.spec
+++ b/anda/themes/kde-material-you-colors/kde-material-you-colors.spec
@@ -4,7 +4,7 @@
 
 Name:           kde-material-you-colors
 Version:        2.0.0
-Release:        2%?dist
+Release:        3%{?dist}
 Summary:        Automatic Material You Colors Generator from your wallpaper for the Plasma Desktop
 License:        GPL-3.0-only
 URL:            https://github.com/luisbocanegra/%{name}
@@ -31,7 +31,7 @@ BuildRequires:  pkgconfig(ocl-icd)
 Requires:       qt5-qtbase
 Requires:       kf6-filesystem >= 6.0.0
 Requires:       python3-%{name} = %{version}-%{release}
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Automatic Material You Colors Generator from your wallpaper for the Plasma Desktop

--- a/anda/tools/java-binfmt/java-binfmt.spec
+++ b/anda/tools/java-binfmt/java-binfmt.spec
@@ -5,7 +5,7 @@
 
 Name:           java-binfmt
 Version:        1.0.0^%{commit_date}git%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Binfmt wrappers and utilities for Java and Jar files.
 ### License for the C file used in the binary.
 License:        GPL-2.0-or-later
@@ -18,7 +18,7 @@ Source5:        https://raw.githubusercontent.com/terrapkg/pkg-java-binfmt/%{com
 Source6:        https://raw.githubusercontent.com/terrapkg/pkg-java-binfmt/%{commit}/Applet-lib64.conf
 BuildRequires:  gcc
 BuildRequires:  systemd-rpm-macros
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 This package installs binfmt files for use with Java wrappers.

--- a/anda/tools/license-checker/nodejs-license-checker.spec
+++ b/anda/tools/license-checker/nodejs-license-checker.spec
@@ -5,7 +5,7 @@
 
 Name:          nodejs-license-checker
 Version:       4.4.2
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Check NPM package licenses
 SourceLicense: BSD-3-Clause
 License:       Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND CC-BY-3.0 AND ISC AND (MIT AND CC-BY-3.0) AND MIT
@@ -16,7 +16,7 @@ BuildRequires: nodejs-npm
 BuildRequires: nodejs-packaging
 ExclusiveArch: %{nodejs_arches} noarch
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 Extract NPM package licenses.

--- a/anda/tools/micro-default-editor/micro-default-editor.spec
+++ b/anda/tools/micro-default-editor/micro-default-editor.spec
@@ -19,7 +19,7 @@ Requires:      micro
 # All default editor packages MUST provide this
 Provides:      system-default-editor
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 This package ensures the EDITOR shell variable

--- a/anda/tools/neovim-default-editor/neovim-default-editor.spec
+++ b/anda/tools/neovim-default-editor/neovim-default-editor.spec
@@ -3,7 +3,7 @@
 Name:          neovim-default-editor
 # Version, release, and epoch are inherited from the editor package just like other default editors
 Version:       0.11.5
-Release:       1%?dist
+Release:       1%{?dist}
 Epoch: 0
 # Inherited from Neovim itself
 License:       Apache-2.0 AND Vim AND MIT
@@ -19,7 +19,7 @@ Requires:      neovim
 # All default editor packages MUST provide this
 Provides:      system-default-editor
 BuildArch:     noarch
-Packager:      Gilver E. <rockgrub@disroot.org>
+Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description
 This package ensures the EDITOR shell variable

--- a/anda/tools/nvm/nvm.spec
+++ b/anda/tools/nvm/nvm.spec
@@ -1,6 +1,6 @@
 Name:     nvm
 Version:  0.40.3
-Release:  5%{?dist}
+Release:  6%{?dist}
 Summary:  Node Version Manager
 License:  MIT
 URL:      https://github.com/nvm-sh/nvm
@@ -11,7 +11,7 @@ Patch0:   nvm-always-use-default-dir.patch
 # Only works with POSIX compliant shells
 Requires: bash
 BuildArch: noarch
-Packager:  Gilver E. <rockgrub@disroot.org>
+Packager:  Gilver E. <roachy@fyralabs.com>
 
 %description
 POSIX-compliant script to manage multiple active Node.js versions.

--- a/anda/tools/tauri/tauri.spec
+++ b/anda/tools/tauri/tauri.spec
@@ -3,7 +3,7 @@
 
 Name:           rust-tauri
 Version:        2.9.6
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Command line interface for building Tauri apps
 License:        Apache-2.0 OR MIT
 URL:            https://crates.io/crates/create-tauri-app
@@ -12,7 +12,7 @@ BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  mold
 Suggests:       libayatana-appindicator-gtk3
-Packager:       Gilver E. <rockgrub@disroot.org>
+Packager:       Gilver E. <roachy@fyralabs.com>
 
 %description
 Build smaller, faster, and more secure desktop and mobile applications with a web frontend.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: Mass update email in Roachy&#x27;s specs (#9355)](https://github.com/terrapkg/packages/pull/9355)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)