### PR TITLE
[f42] fix(goofcord-nightly): Update build (#8548)

### DIFF
--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -4,8 +4,7 @@
 %global ver 2.0.1^
 %global base_name goofcord
 %global git_name GoofCord
-
-%electronmeta
+%global appid io.github.milkshiift.GoofCord
 
 Name:          %{base_name}-nightly
 Version:       %{ver}%{commit_date}.git.%{shortcommit}
@@ -19,23 +18,26 @@ BuildRequires: anda-srpm-macros >= 0.2.26
 BuildRequires: bun-bin
 Packager:      Gilver E. <rockgrub@disroot.org>
 
+%electronmeta -D
+
 %description
 A highly configurable and privacy minded Discord client.
 
 %prep
 %autosetup -n %{git_name}-%{commit}
-
-%build
-%ifarch %{arm64} armv7hl armv7l
+%ifarch %{arm64} armv7l armv7hl armv7hnl
 sed -i '/\"x64\",/d' electron-builder.ts
 %endif
-%bun_build -r build -R
+
+%build
+%bun_build
 
 %install
-%electron_install -d %{base_name} -s %{base_name} -i %{base_name} -D -O -U %U -E UseOzonePlatform,WaylandWindowDecorations
+%electron_install -d %{base_name} -s %{base_name} -i %{base_name} -D -O -U %U -E UseOzonePlatform,WaylandWindowDecorations -I
+install -Dm644 assetsDev/%{appid}.metainfo.xml -t %{buildroot}%{_metainfodir}
 
 %check
-desktop-file-validate %{buildroot}%{_datadir}/applications/%{base_name}.desktop
+%desktop_file_validate %{buildroot}%{_datadir}/applications/%{base_name}.desktop
 
 %files
 %doc README.md
@@ -43,14 +45,15 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{base_name}.desktop
 %{_bindir}/%{base_name}
 %{_datadir}/applications/%{base_name}.desktop
 %{_libdir}/%{base_name}/
-%{_iconsdir}/hicolor/16x16/apps/%{base_name}.png
-%{_iconsdir}/hicolor/32x32/apps/%{base_name}.png
-%{_iconsdir}/hicolor/48x48/apps/%{base_name}.png
-%{_iconsdir}/hicolor/64x64/apps/%{base_name}.png
-%{_iconsdir}/hicolor/128x128/apps/%{base_name}.png
-%{_iconsdir}/hicolor/256x256/apps/%{base_name}.png
-%{_iconsdir}/hicolor/512x512/apps/%{base_name}.png
-%{_iconsdir}/hicolor/1024x1024/apps/%{base_name}.png
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_hicolordir}/16x16/apps/%{base_name}.png
+%{_hicolordir}/32x32/apps/%{base_name}.png
+%{_hicolordir}/48x48/apps/%{base_name}.png
+%{_hicolordir}/64x64/apps/%{base_name}.png
+%{_hicolordir}/128x128/apps/%{base_name}.png
+%{_hicolordir}/256x256/apps/%{base_name}.png
+%{_hicolordir}/512x512/apps/%{base_name}.png
+%{_hicolordir}/1024x1024/apps/%{base_name}.png
 
 %changelog
 * Sat Jun 28 2025 Gilver E. <rockgrub@disroot.org> - 1.10.1^20250615.git.3f5eda1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(goofcord-nightly): Update build (#8548)](https://github.com/terrapkg/packages/pull/8548)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)