### PR TITLE
[f42] fix (picotool): version (#9393)

### DIFF
--- a/anda/tools/picotool/picotool.spec
+++ b/anda/tools/picotool/picotool.spec
@@ -1,11 +1,14 @@
 %define sdk_version 2.2.0
+%global ver 2.2.0-a4
+%global sanitized_ver %(echo %{ver} | sed 's/-//g')
+
 Name:           picotool
-Version:        2.2.0.a4
+Version:        %sanitized_ver
 Release:        1%?dist
 Summary:        Tool to inspect RP2040 binaries
 License:        BSD-3-Clause
 URL:            https://github.com/raspberrypi/picotool
-Source0:        https://github.com/raspberrypi/picotool/archive/%version.tar.gz#/picotool-%version.tar.gz
+Source0:        https://github.com/raspberrypi/picotool/archive/refs/tags/%ver.tar.gz
 Source1:        https://github.com/raspberrypi/pico-sdk/archive/%sdk_version.tar.gz#/pico-sdk-%sdk_version.tar.gz
 BuildRequires:  cmake g++ libusb1-devel
 
@@ -13,7 +16,7 @@ BuildRequires:  cmake g++ libusb1-devel
 Picotool is a tool for inspecting RP2040 binaries, and interacting with RP2040 devices when they are in BOOTSEL mode.
 
 %prep
-%autosetup -a 1
+%autosetup -a 1 -n %name-%ver
 
 %build
 %cmake -DPICO_SDK_PATH="../pico-sdk-%sdk_version"
@@ -28,8 +31,10 @@ mv %buildroot{%_prefix/lib,%_libdir}
 %doc README.md
 %license LICENSE.TXT
 %_bindir/picotool
-%_libdir/cmake/picotool
-%_datadir/picotool
+%dir %_libdir/cmake/picotool
+%_libdir/cmake/picotool/*
+%dir %_datadir/picotool
+%_datadir/picotool/*
 
 %changelog
 * Mon Nov 18 2024 Owen-sz <owen@fyralabs.com>

--- a/anda/tools/picotool/update.rhai
+++ b/anda/tools/picotool/update.rhai
@@ -1,2 +1,2 @@
-rpm.version(gh("raspberrypi/picotool"));
+rpm.global("ver", gh("raspberrypi/picotool"));
 rpm.define("sdk_version", gh("raspberrypi/pico-sdk"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [fix (picotool): version (#9393)](https://github.com/terrapkg/packages/pull/9393)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)