### PR TITLE
[el10] chore: add/fix needed packager fields (#9391)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
@@ -3,7 +3,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        9
-Release:        1%?dist
+Release:        2%?dist
 Summary:        GNOME extension that removes the 'Window is ready' notification and brings the window into focus instead
 License:        AGPL-3.0-only
 URL:            https://github.com/zalckos/GrandTheftFocus
@@ -14,6 +14,8 @@ Source0:        https://github.com/zalckos/GrandTheftFocus/archive/refs/tags/v%v
 
 Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
 Recommends:     gnome-extensions-app
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 GNOME extension. Removes the 'Window is ready' notification and brings the window into focus instead.

--- a/anda/misc/signal-cli/signal-cli.spec
+++ b/anda/misc/signal-cli/signal-cli.spec
@@ -4,7 +4,7 @@
 
 Name:             signal-cli
 Version:          0.13.22
-Release:          1%?dist
+Release:          2%?dist
 Summary:          signal-cli provides an unofficial commandline, JSON-RPC and dbus interface for the Signal messenger
 License:          GPL-3.0-only
 URL:              https://github.com/AsamK/signal-cli
@@ -21,6 +21,8 @@ BuildRequires:    make
 BuildRequires:    asciidoc
 
 Recommends:       java-21-openjdk
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 signal-cli is a commandline interface for the Signal messenger.

--- a/anda/system/chromebook-usbc-fix/chromebook-usbc-fix.spec
+++ b/anda/system/chromebook-usbc-fix/chromebook-usbc-fix.spec
@@ -46,7 +46,8 @@ install -Dm755 chromebook-usbc.service %buildroot%{_unitdir}/chromebook-usbc.ser
 %{_unitdir}/chromebook-usbc.service
 
 %changelog
-* Sat Oct 12 2024 Owen-sz <owen@fyralabs.com>
+* Sat Oct 12 2024 Owen Zimmerman <owen@fyralabs.com>
 - Fix the systemd preset application
-* Sat Oct 5 2024 Owen-sz <owen@fyralabs.com>
+
+* Sat Oct 5 2024 Owen Zimmerman <owen@fyralabs.com>
 - Initial package.

--- a/anda/system/cros-keyboard-map/cros-keyboard-map.spec
+++ b/anda/system/cros-keyboard-map/cros-keyboard-map.spec
@@ -11,7 +11,7 @@
 
 Name:           cros-keyboard-map
 Version:        %commit_date.%tree_shortcommit.%um_shortcommit
-Release:        1%?dist
+Release:        2%?dist
 
 License:        BSD-3-Clause and GPLv3
 Summary:        Utility to generate keyd configurations for use on Chromebooks
@@ -22,6 +22,8 @@ Source1:        https://github.com/Ultramarine-Linux/cros-keyboard-map/archive/%
 %{?systemd_requires}
 BuildRequires:  systemd-rpm-macros
 Requires:       keyd python3 python3-libfdt
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 Bash script and systemd service to apply WeirdTreeThing's Chromebook keyboard maps.
@@ -59,9 +61,11 @@ chmod +x %buildroot%{_bindir}/um-generate-cros-keymap
 %{_bindir}/um-generate-cros-keymap
 
 %changelog
-* Sat Oct 12 2024 Owen-sz <owen@fyralabs.com>
+* Sat Oct 12 2024 Owen Zimmerman <owen@fyralabs.com>
 - Fix the systemd preset application
+
 * Sat Aug 24 2024 junefish <june@fyralabs.com>
 - Split off into seperate git repo.
-* Sat May 4 2024 Owen-sz <owen@fyralabs.com>
+
+* Sat May 4 2024 Owen Zimmerman <owen@fyralabs.com>
 - Initial package.

--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -4,7 +4,7 @@
 
 Name:           readymade-git
 Version:        %commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Install ready-made distribution images!
 License:        GPL-3.0-or-later
 URL:            https://github.com/FyraLabs/readymade
@@ -23,6 +23,8 @@ Conflicts:      readymade
 Obsoletes:      readymade-nightly < 20250502.4dc78ec-3
 
 Requires:  efibootmgr
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 Readymade is a simple Linux Distribution installer.

--- a/anda/tools/bmpblk_utility/bmpblk_utility.spec
+++ b/anda/tools/bmpblk_utility/bmpblk_utility.spec
@@ -6,7 +6,7 @@
 
 Name:           bmpblk_utility
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A utility to create/modify the bmpfv in the GBB of chromebooks running old stock firmware
 
 License:        BSD-3-Clause
@@ -22,7 +22,7 @@ BuildRequires:  xz-devel
 BuildRequires:  libyaml
 BuildRequires:  libyaml-devel
 
-packager:       Owen Zimmerman <owen@fyralabs.com>
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 %summary.

--- a/anda/tools/gsctool/gsctool.spec
+++ b/anda/tools/gsctool/gsctool.spec
@@ -2,7 +2,7 @@
 %define shortcommit %(c=%{commit}; echo ${c:0:12})
 Name:           gsctool
 Version:        git+%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Chromium OS EC utilities
 
 License:      BSD-3-Clause
@@ -14,6 +14,8 @@ BuildRequires:  pkgconfig
 BuildRequires:  pkgconfig(libusb-1.0)
 BuildRequires:  pkgconfig(openssl)
 BuildRequires:  gcc
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 Chromium OS EC utilities

--- a/anda/tools/piclone/piclone.spec
+++ b/anda/tools/piclone/piclone.spec
@@ -4,7 +4,7 @@
 
 Name:           piclone
 Version:        %commit_date.git~%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Utility to back up Pi to an SD card reader
 License:        BSD-3-Clause
 URL:            https://github.com/raspberrypi-ui/piclone
@@ -20,6 +20,8 @@ BuildRequires: pkgconfig
 BuildRequires: gcc
 
 Requires: parted dosfstools e2fsprogs coreutils util-linux-core uuid dbus-x11 gtk3
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 SD Card backup program for Raspberry Pi.

--- a/anda/tools/picotool/picotool.spec
+++ b/anda/tools/picotool/picotool.spec
@@ -4,13 +4,15 @@
 
 Name:           picotool
 Version:        %sanitized_ver
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Tool to inspect RP2040 binaries
 License:        BSD-3-Clause
 URL:            https://github.com/raspberrypi/picotool
 Source0:        https://github.com/raspberrypi/picotool/archive/refs/tags/%ver.tar.gz
 Source1:        https://github.com/raspberrypi/pico-sdk/archive/%sdk_version.tar.gz#/pico-sdk-%sdk_version.tar.gz
 BuildRequires:  cmake g++ libusb1-devel
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 Picotool is a tool for inspecting RP2040 binaries, and interacting with RP2040 devices when they are in BOOTSEL mode.

--- a/anda/tools/rpi-update/rpi-update.spec
+++ b/anda/tools/rpi-update/rpi-update.spec
@@ -6,13 +6,15 @@
 
 Name:           rpi-update
 Version:        %commit_date.git~%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        An easier way to update the firmware of your Raspberry Pi. 
 License:        MIT
 URL:            https://github.com/raspberrypi/rpi-update
 Source0:        %url/archive/%commit.tar.gz
 Requires:       bash
 ExclusiveArch:  aarch64
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 %summary

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -26,6 +26,8 @@ Requires:       %{name}-vcgencmd = %{evr}
 Requires:       %{name}-vclog = %{evr}
 Requires:       %{name}-vcmailbox = %{evr}
 
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
 %description
 %{summary}.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: add/fix needed packager fields (#9391)](https://github.com/terrapkg/packages/pull/9391)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)