### PR TITLE
[f42] fix: socktop version weirdness (#9394)

### DIFF
--- a/anda/apps/socktop/socktop.spec
+++ b/anda/apps/socktop/socktop.spec
@@ -1,4 +1,5 @@
 %global ver v1.55.0-test2
+%global download_ver %(echo %{ver} | sed 's/v//g')
 %global sanitized_ver %(echo %{ver} | sed 's/-//g')
 
 Name:           socktop
@@ -6,7 +7,7 @@ Version:        %sanitized_ver
 Release:        1%?dist
 Summary:        socktop is a remote system monitor with a rich TUI interface
 URL:            https://github.com/jasonwitty/socktop
-Source0:        %{url}/archive/refs/tags/v%{ver}.tar.gz
+Source0:        %{url}/archive/refs/tags/%{ver}.tar.gz
 License:        MIT
 BuildRequires:  rust libdrm-devel systemd-rpm-macros cargo-rpm-macros
 Requires:       libdrm
@@ -17,7 +18,7 @@ socktop is a remote system monitor with a rich TUI interface, inspired by `top` 
 that communicates with a lightweight remote agent over WebSockets.
 
 %prep
-%autosetup -n %{name}-%{ver}
+%autosetup -n %{name}-%{download_ver}
 %cargo_prep_online
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: socktop version weirdness (#9394)](https://github.com/terrapkg/packages/pull/9394)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)