### PR TITLE
[el10] fix (spotx-bash): track symlink (#9403)

### DIFF
--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -4,7 +4,7 @@
 
 Name:           spotx-bash
 Version:        %commit_date.git~%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Adblock for the Spotify desktop client on Linux.
 License:        MIT
 URL:            https://github.com/SpotX-Official/SpotX-Bash
@@ -21,15 +21,14 @@ Provides:       spotx spotx-linux spot-x spotx.sh
 
 %install
 mkdir -p %{buildroot}%{_bindir}
-install -Dm 755 spotx.sh %buildroot%{_bindir}/spotx
-
-%post
-%{__ln_s} -f %{_bindir}/spotx %{_bindir}/spotx.sh
+install -Dm 755 spotx.sh %{buildroot}%{_bindir}/spotx
+%{__ln_s} -f %{_bindir}/spotx %{buildroot}%{_bindir}/spotx.sh
 
 %files
 %doc README.md
 %license LICENSE
-%_bindir/spotx
+%{_bindir}/spotx.sh
+%{_bindir}/spotx
 
 %changelog
 * Sat Dec 14 2024 Its-J


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (spotx-bash): track symlink (#9403)](https://github.com/terrapkg/packages/pull/9403)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)