### PR TITLE
[el10] fix (app-bricks-py): version (#9446)

### DIFF
--- a/anda/tools/arduino-app-bricks-py/arduino-app-bricks-py.spec
+++ b/anda/tools/arduino-app-bricks-py/arduino-app-bricks-py.spec
@@ -1,8 +1,11 @@
 %global pypi_name app-bricks-py
 %global _desc The code of the Arduino App Lab Bricks
 
+%global ver release/0.6.3
+%global sanitized_ver %(echo %{ver} | sed 's|release/||')
+
 Name:			%{pypi_name}
-Version:		release/0.6.3
+Version:		%sanitized_ver
 Release:		1%?dist
 Summary:		The code of the Arduino App Lab Bricks
 License:		MPL-2.0

--- a/anda/tools/arduino-app-bricks-py/update.rhai
+++ b/anda/tools/arduino-app-bricks-py/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("arduino/app-bricks-py"));
+rpm.global("ver", gh("arduino/app-bricks-py"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (app-bricks-py): version (#9446)](https://github.com/terrapkg/packages/pull/9446)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)