### PR TITLE
[f42] fix: improper use of %dir (#9456)

### DIFF
--- a/anda/apps/juce/juce.spec
+++ b/anda/apps/juce/juce.spec
@@ -1,6 +1,6 @@
 Name:           juce
 Version:        8.0.12
-Release:        2%{?dist}
+Release:        3%{?dist}
 License:        AGPL-3.0
 Summary:        framework for audio application and plug-in development
 URL:            https://juce.com
@@ -68,10 +68,7 @@ popd
 %license LICENSE.md
 %{_bindir}/juceaide
 %{_bindir}/juce_lv2_helper
-%dir %{_libdir}/cmake/%{name}
 %{_libdir}/cmake/%{name}/*
-%dir %{_datadir}/%{name}
-%dir %{_datadir}/%{name}/modules
 %{_datadir}/%{name}/modules/*
 
 %files doc
@@ -84,4 +81,3 @@ popd
 
 * Fri Dec 19 2025 metcya <metcya@gmail.com> - 8.0.12
 - Package juce
-

--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -3,7 +3,7 @@
 Name:			signal-desktop
 %electronmeta -aD
 Version:		7.86.0
-Release:		2%?dist
+Release:		3%?dist
 Summary:		A private messenger for Windows, macOS, and Linux
 URL:			https://signal.org
 Source0:		https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz
@@ -87,7 +87,6 @@ done
 %doc README.md CONTRIBUTING.md ACKNOWLEDGMENTS.md
 %license bundled_licenses/*
 %{_bindir}/signal-desktop
-%dir %{_libdir}/signal-desktop
 %{_libdir}/signal-desktop/
 %{_datadir}/polkit-1/rules.d/org.signalapp.view-aep.policy
 %{_datadir}/polkit-1/rules.d/org.signalapp.enable-backups.policy

--- a/anda/devs/tracy/tracy.spec
+++ b/anda/devs/tracy/tracy.spec
@@ -1,6 +1,6 @@
 Name:			tracy
 Version:		0.13.1
-Release:		1%?dist
+Release:		2%?dist
 Summary:		A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications
 License:		BSD-3-Clause
 URL:			https://github.com/wolfpld/tracy
@@ -69,7 +69,6 @@ install -Dm644 icon/application-tracy.svg %buildroot%_iconsdir/hicolor/scalable/
 
 %files devel
 %_libdir/pkgconfig/tracy.pc
-%dir %_includedir/tracy
 %_includedir/tracy/*
 
 %changelog

--- a/anda/misc/click/click.spec
+++ b/anda/misc/click/click.spec
@@ -4,7 +4,7 @@
 
 Name:           click
 Version:        0.5.2
-Release:        1%?dist
+Release:        2%?dist
 Summary:        An app building method
 License:        LGPL-3.0
 URL:            https://gitlab.com/ubports/development/core/click
@@ -84,26 +84,19 @@ mv README %{buildroot}%_pkgdocdir
 %license LICENSE
 %config %{_sysconfdir}/dbus-1/system.d/com.lomiri.click.conf
 %{_libdir}/libclick-0.4.so.*
-%dir %{_libdir}/click
 %{_libdir}/click/libclickpreload.so
-%dir %{_libexecdir}/click
 %{_libexecdir}/click/click-service
 %{_datadir}/dbus-1/system-services/com.lomiri.click.service
 %{_libdir}/girepository-1.0/Click-0.4.typelib
 
 %files devel
-%dir %{_includedir}/click-0.4
 %{_includedir}/click-0.4/click.h
 %{_libdir}/libclick-0.4.so
 %{_libdir}/pkgconfig/click-0.4.pc
 %{_datarootdir}/gir-1.0/Click-0.4.gir
 
 %files -n python3-lomiri-click
-%dir %{_sysconfdir}/click
-%dir %{_sysconfdir}/click/databases
 %config %{_sysconfdir}/click/databases/*.conf
-%dir %{_sysconfdir}/schroot
-%dir %{_sysconfdir}/schroot/click
 %{_sysconfdir}/schroot/click/fstab
 %{_bindir}/dh_click
 %{_bindir}/click
@@ -112,38 +105,25 @@ mv README %{buildroot}%_pkgdocdir
 %{_datarootdir}/perl5/*
 %{_unitdir}/click-system-hooks.service
 %{_userunitdir}/click-user-hooks.service
-%dir %{python3_sitelib}/click_package
 %{python3_sitelib}/click_package/*.py
-%dir %{python3_sitelib}/click_package/tests
 %{python3_sitelib}/click_package/tests/*.py
-%dir %{python3_sitelib}/click_package/tests/integration
 %{python3_sitelib}/click_package/tests/integration/*.py
-%dir %{python3_sitelib}/click_package/tests/integration/__pycache__
 %{python3_sitelib}/click_package/tests/integration/__pycache__/*.pyc
-%dir %{python3_sitelib}/click_package/tests/__pycache__
 %{python3_sitelib}/click_package/tests/__pycache__/*.pyc
-%dir %{python3_sitelib}/click_package/commands
 %{python3_sitelib}/click_package/commands/*.py
-%dir %{python3_sitelib}/click_package/commands/__pycache__
 %{python3_sitelib}/click_package/commands/__pycache__/*.pyc
-%dir %{python3_sitelib}/click_package/__pycache__
 %{python3_sitelib}/click_package/__pycache__/*.pyc
-%dir %{python3_sitelib}/click-%{version}-py%{python3_version}.egg-info
 %{python3_sitelib}/click-%{version}-py%{python3_version}.egg-info/*.txt
 %{python3_sitelib}/click-%{version}-py%{python3_version}.egg-info/PKG-INFO
 
 %files doc
 %{_mandir}/man1/click.1.gz
-%dir %_pkgdocdir
 %_pkgdocdir/README
-%dir %_pkgdocdir/html
 %_pkgdocdir/html/*.html
 %_pkgdocdir/html/.buildinfo
 %_pkgdocdir/html/*inv
 %_pkgdocdir/html/*.js
-%dir %_pkgdocdir/html/_sources
 %_pkgdocdir/html/_sources/*.txt
-%dir %_pkgdocdir/html/_static
 %_pkgdocdir/html/_static/*.png
 %_pkgdocdir/html/_static/*.css
 %_pkgdocdir/html/_static/*.js

--- a/anda/tools/picotool/picotool.spec
+++ b/anda/tools/picotool/picotool.spec
@@ -4,7 +4,7 @@
 
 Name:           picotool
 Version:        %sanitized_ver
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Tool to inspect RP2040 binaries
 License:        BSD-3-Clause
 URL:            https://github.com/raspberrypi/picotool
@@ -33,9 +33,7 @@ mv %buildroot{%_prefix/lib,%_libdir}
 %doc README.md
 %license LICENSE.TXT
 %_bindir/picotool
-%dir %_libdir/cmake/picotool
 %_libdir/cmake/picotool/*
-%dir %_datadir/picotool
 %_datadir/picotool/*
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: improper use of %dir (#9456)](https://github.com/terrapkg/packages/pull/9456)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)