### PR TITLE
[f43] add: kopia (#9450)

### DIFF
--- a/anda/apps/kopia/anda.hcl
+++ b/anda/apps/kopia/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "kopia.spec"
+  }
+}

--- a/anda/apps/kopia/fix-electron-output-dir.patch
+++ b/anda/apps/kopia/fix-electron-output-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/app/package.json b/app/package.json
+index bd3a699a..df05befa 100644
+--- a/app/package.json
++++ b/app/package.json
+@@ -45,7 +45,7 @@
+     ],
+     "directories": {
+       "buildResources": "assets",
+-      "output": "../dist/kopia-ui"
++      "output": "./dist"
+     },
+     "nsis": {
+       "oneClick": false,

--- a/anda/apps/kopia/io.kopia.ui.desktop
+++ b/anda/apps/kopia/io.kopia.ui.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Terminal=false
+Name=KopiaUI
+Comment=Fast and secure open-source backup/restore tool
+Exec=kopia-ui
+Icon=kopia

--- a/anda/apps/kopia/io.kopia.ui.metainfo.xml
+++ b/anda/apps/kopia/io.kopia.ui.metainfo.xml
@@ -1,0 +1,13 @@
+<component>
+    <name>KopiaUI</name>
+    <summary>
+        A backup/restore tool that allows you to create encrypted snapshots
+    </summary>
+    <categories>
+        <category>System</category>
+        <category>Network</category>
+    </categories>
+    <provides>
+        <binary>kopia-ui</binary>
+    </provides>
+</component>

--- a/anda/apps/kopia/kopia.spec
+++ b/anda/apps/kopia/kopia.spec
@@ -1,0 +1,84 @@
+%global appid io.kopia.ui
+%global appstream_component desktop-application
+
+Name:           kopia
+%electronmeta -D
+Version:        0.22.3
+Release:        1%{?dist}
+Summary:        A backup/restore tool that allows you to create encrypted snapshots
+
+License:        Apache-2.0 AND CC0-1.0 AND %{electron_license}
+URL:            https://kopia.io/
+Source0:        https://github.com/kopia/kopia/archive/v%{version}.tar.gz
+Source1:        io.kopia.ui.desktop
+Source2:        io.kopia.ui.metainfo.xml
+Patch0:         fix-electron-output-dir.patch
+ExclusiveArch:  %{golang_arches_future}
+Packager:       metcya <metcya@gmail.com>
+
+BuildRequires:  go-rpm-macros
+BuildRequires:  terra-appstream-helper
+
+%global gui_name %{name}-ui
+
+%package -n %{gui_name}
+Summary:        GUI for %{name}
+Requires:       %{name} = %{evr}
+ExclusiveArch:  %{electron_arches}
+
+%description
+Kopia is a fast and secure open-source backup/restore tool that allows you to
+create encrypted snapshots of your data and save the snapshots to remote or
+cloud storage of your choice, to network-attached storage or server, or locally
+on your machine. Kopia does not 'image' your whole machine. Rather, Kopia
+allows you to backup/restore any and all files/directories that you deem are
+important or critical.
+
+%description -n %{gui_name}
+A graphical user interface for %{name}.
+
+%prep
+%autosetup -p1
+
+%build
+%global gomodulesmode GO111MODULE=on
+%gobuild -o %{name} .
+
+pushd app
+%npm_build -B
+popd
+
+%install
+install -Dm 755 %{name} -t %{buildroot}%{_bindir}
+
+pushd app
+%electron_install -b %{gui_name} -d %{gui_name} -s %{gui_name} -I ../icons
+popd
+
+# the offical package for kopia-ui includes a bundled copy of the kopia binary
+# but we'll just symlink it
+mkdir -p %{buildroot}%{_libdir}/%{gui_name}/resources/server
+%{__ln_s} %{_bindir}/%{name} %{buildroot}%{_libdir}/%{gui_name}/resources/server/%{name}
+
+%desktop_file_install %{S:1}
+
+%terra_appstream -o %{S:2}
+
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/%{appid}.desktop
+
+%files
+%license README.md
+%doc LICENSE
+%{_bindir}/%{name}
+
+%files -n %{gui_name}
+%{_bindir}/%{gui_name}
+%{_libdir}/%{gui_name}/
+%{_appsdir}/%{appid}.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_hicolordir}/*/apps/kopia.png
+
+%changelog
+* Thu Jan 22 2026 metcya <metcya@gmail.com> - 0.22.3-1
+- Initial package

--- a/anda/apps/kopia/update.rhai
+++ b/anda/apps/kopia/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("kopia/kopia"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: kopia (#9450)](https://github.com/terrapkg/packages/pull/9450)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)