### PR TITLE
[el10] add: pyfluidsynth (#9470)

### DIFF
--- a/anda/langs/python/pyfluidsynth/anda.hcl
+++ b/anda/langs/python/pyfluidsynth/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "pyfluidsynth.spec"
+  }
+}

--- a/anda/langs/python/pyfluidsynth/pyfluidsynth.spec
+++ b/anda/langs/python/pyfluidsynth/pyfluidsynth.spec
@@ -1,0 +1,49 @@
+%global pypi_name pyfluidsynth
+%global _desc Python bindings for FluidSynth.
+
+Name:			python-%{pypi_name}
+Version:		1.3.4
+Release:		1%?dist
+Summary:		Python bindings for FluidSynth
+License:		LGPL-2.1
+URL:			https://github.com/nwhitehead/pyfluidsynth
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+BuildRequires:  python3-build
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n pyfluidsynth-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+
+%files -n python3-%{pypi_name}
+%doc README.md
+%license LICENSE
+%{_usr}/lib/python3.14/site-packages/__pycache__/fluidsynth.*.pyc
+%{_usr}/lib/python3.14/site-packages/__pycache__/fluidsynth.*.*.pyc
+%{_usr}/lib/python3.14/site-packages/fluidsynth.py
+%{_usr}/lib/python3.14/site-packages/%{pypi_name}-%{version}.dist-info/*
+
+%changelog
+* Sat Jan 24 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/pyfluidsynth/update.rhai
+++ b/anda/langs/python/pyfluidsynth/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("pyfluidsynth"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: pyfluidsynth (#9470)](https://github.com/terrapkg/packages/pull/9470)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)