### PR TITLE
[el10] fix(heroic-games-launcher): Exec path (#9483)

### DIFF
--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -9,7 +9,7 @@
 
 Name:          %{shortname}-games-launcher
 Version:       2.19.0
-Release:       1%?dist
+Release:       2%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com
@@ -52,7 +52,7 @@ rm -rf dist/linux-unpacked/resources/app.asar.unpacked/build/bin/arm64
 %endif
 
 %electron_install -d heroic -b heroic -S heroic -I -i %{appid} -l
-%desktop_file_install -k Exec -v /usr/share/%{shortname}/%{shortname} -u %u flatpak/%{appid}.desktop
+%desktop_file_install -k Exec -v %{_libdir}/%{shortname}/%{shortname} -u %u flatpak/%{appid}.desktop
 
 install -Dpm644 flatpak/templates/%{appid}.metainfo.xml.template %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(heroic-games-launcher): Exec path (#9483)](https://github.com/terrapkg/packages/pull/9483)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)