### PR TITLE
[el10] chore: Update Zig specs using %zig_build_target -c (#9499)

### DIFF
--- a/anda/system/falcond/falcond.spec
+++ b/anda/system/falcond/falcond.spec
@@ -2,7 +2,7 @@
 
 Name:           falcond
 Version:        1.2.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Advanced Linux Gaming Performance Daemon
 License:        MIT
 URL:            https://git.pika-os.com/general-packages/falcond
@@ -33,7 +33,7 @@ install -Dm644 debian/%{name}.service -t %{buildroot}%{_unitdir}
 # When DNF supports microarchitectures the fallback option for -c can be used here instead
 DESTDIR="%{buildroot}" \
 %ifarch x86_64
-%{zig_build_target -r fast -c x86_64_v2 -s} \
+%{zig_build_target -r fast -cx86_64_v2 -s} \
 %elifarch aarch64
 %{zig_build_target -r fast -s} \
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: Update Zig specs using %zig_build_target -c (#9499)](https://github.com/terrapkg/packages/pull/9499)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)