### PR TITLE
[el10] fix: topgrade (#9503)

### DIFF
--- a/anda/tools/topgrade/rust-topgrade.spec
+++ b/anda/tools/topgrade/rust-topgrade.spec
@@ -19,14 +19,11 @@ BuildRequires:  rust
 BuildRequires:  rpm_macro(cargo_install)
 BuildRequires:  anda-srpm-macros mold
 
-%description
+%global _description %{expand:
 Keeping your system up to date usually involves invoking multiple package managers.
 This results in big, non-portable shell one-liners saved in your shell.
 To remedy this, Topgrade detects which tools you use and
-runs the appropriate commands to update them.
-
-%global _description %{expand:
-Upgrade all the things.}
+runs the appropriate commands to update them.}
 
 %description %{_description}
 

--- a/anda/tools/topgrade/topgrade-fix-metadata-auto.diff
+++ b/anda/tools/topgrade/topgrade-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- topgrade-16.2.1/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ topgrade-16.2.1/Cargo.toml	2025-11-11T08:14:26.891440+00:00
-@@ -246,26 +246,3 @@
+--- topgrade-16.8.0/Cargo.toml	1970-01-01T00:00:01+00:00
++++ topgrade-16.8.0/Cargo.toml	2026-01-26T14:29:43.890964+00:00
+@@ -258,26 +258,3 @@
  default-features = false
  package = "self_update"
  
@@ -11,7 +11,7 @@
 -version = "~0.1"
 -
 -[target."cfg(windows)".dependencies.self_update_crate]
--version = "~0.40"
+-version = "~0.42"
 -features = [
 -    "archive-zip",
 -    "compression-zip-deflate",


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: topgrade (#9503)](https://github.com/terrapkg/packages/pull/9503)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)