### PR TITLE
[el10] fix (proton-vpn-local-agent): Provides (#9508)

### DIFF
--- a/anda/langs/python/proton-vpn-local-agent/proton-vpn-local-agent.spec
+++ b/anda/langs/python/proton-vpn-local-agent/proton-vpn-local-agent.spec
@@ -5,7 +5,7 @@
 
 Name:			python-%{pypi_name}
 Version:		1.6.0
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Proton VPN local agent written in Rust
 License:		GPL-3.0-only
 URL:			https://github.com/ProtonVPN/local-agent-rs
@@ -13,6 +13,9 @@ Source0:		%url/archive/refs/tags/%version.tar.gz
 
 BuildRequires:  python3-devel
 BuildRequires:  cargo-rpm-macros
+
+# Really cursed but there is no pyproject.toml or setup.py in this package to auto-provide this, and proton-vpn needs this
+Provides:       python3.14dist(proton-vpn-local-agent)
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
@@ -40,12 +43,11 @@ popd
 
 %install
 pushd %{name}
-install -Dm0644 target/rpm/libpython_proton_vpn_local_agent.so %{buildroot}%{_libdir}/proton/local_agent.so
+install -Dm0644 target/release/libpython_proton_vpn_local_agent.so %{buildroot}%{_libdir}/proton/local_agent.so
 popd
 
 %files -n python3-%{pypi_name}
 %doc README.md CODEOWNERS
-%dir %{_libdir}/proton
 %{_libdir}/proton/local_agent.so
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (proton-vpn-local-agent): Provides (#9508)](https://github.com/terrapkg/packages/pull/9508)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)