### PR TITLE
[el10] chore: Bump out of sync packages (#9513)

### DIFF
--- a/anda/apps/discord-canary-openasar/discord-canary-openasar.spec
+++ b/anda/apps/discord-canary-openasar/discord-canary-openasar.spec
@@ -6,7 +6,7 @@
 %global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
 
 Name:           discord-canary-openasar
-Version:        0.0.857
+Version:        0.0.858
 Release:        1%?dist
 Summary:        A snappier Discord rewrite with features like further customization and theming
 License:        MIT AND https://discord.com/terms

--- a/anda/apps/discord-canary/discord-canary.spec
+++ b/anda/apps/discord-canary/discord-canary.spec
@@ -6,7 +6,7 @@
 %global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
 
 Name:           discord-canary
-Version:        0.0.857
+Version:        0.0.858
 Release:        1%?dist
 Summary:        Free Voice and Text Chat for Gamers
 URL:            discord.com

--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 7764acf34f511c37652e8995723b1b92d825a9a3
+%global commit 70738d6b1d4e4ac1992c52f49869c587d062b33b
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260106
-%global ver 1.11.4^
+%global commit_date 20260128
+%global ver 2.0.1^
 %global base_name goofcord
 %global git_name GoofCord
 %global appid io.github.milkshiift.GoofCord

--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 %global commit 4104aea0b89e600203e3b3d189649714877bcd70
 %global commit_date 20260109
+=======
+%global commit d679a0ac9ca1b2cc0c7814ee6fb93c7824fb72c5
+%global commit_date 20260128
+>>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global debug_package %nil
 %global __strip /bin/true

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,15 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
+<<<<<<< HEAD
 %global commit 00774f5b85d78b87007f9b88beef90550951e6f1
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260116
+=======
+%global commit d1743b641b5b8a51115a9828124c7a9b527115e3
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20260128
+>>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
 %global ver 0.41.0
 
 Name:           mpv-nightly

--- a/anda/apps/rasputin/rasputin.spec
+++ b/anda/apps/rasputin/rasputin.spec
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 %global commit b3f3f1da2fa59a2cbdea73c75b7d67bc312ce2bc
 %global commit_date 20251115
+=======
+%global commit 605d9dd8c825b650deeaa614e1b83e8dbb41e87d
+%global commit_date 20260128
+>>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           rasputin

--- a/anda/apps/rp-appset/rp-appset.spec
+++ b/anda/apps/rp-appset/rp-appset.spec
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 %global commit b3f3f1da2fa59a2cbdea73c75b7d67bc312ce2bc
 %global commit_date 20251115
+=======
+%global commit 605d9dd8c825b650deeaa614e1b83e8dbb41e87d
+%global commit_date 20260128
+>>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           appset

--- a/anda/apps/winetricks/git/winetricks-git.spec
+++ b/anda/apps/winetricks/git/winetricks-git.spec
@@ -1,9 +1,9 @@
 # Fedora sometimes sources the snapshots under stable versions and just bumps release
 # For user clarity I have separated these into different packages
-%global commit  81a692e2ee6b311367f18a17a9a61a0ef1c0ad18
+%global commit  3483ce867ee10aa084843e97b8f31c9489d6e93d
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global ver 20250102
-%global commit_date 20251224
+%global ver 20260125
+%global commit_date 20260128
 
 Name:           winetricks-git
 Version:        %{ver}^%{commit_date}git.%{shortcommit}

--- a/anda/devs/bun/bun-bin.spec
+++ b/anda/devs/bun/bun-bin.spec
@@ -8,7 +8,7 @@
 %global appid sh.oven.bun
 
 Name:			bun-bin
-Version:		1.3.6
+Version:		1.3.7
 Release:		1%?dist
 Summary:		Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one
 License:		MIT

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,12 @@
+<<<<<<< HEAD
 %global commit 26e243a9194f8653e0b44cf00b600629fcee8f46
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global fulldate 2026-01-15
+=======
+%global commit 685daee01bbd18dc50c066ccfa85828509068a99
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global fulldate 2026-01-27
+>>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,14 @@
+<<<<<<< HEAD
 %global commit d183902dc7d8e55c58a85bbc3e2f0607b6571e82
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260116
 %global ver 0.221.0
+=======
+%global commit 06b5ec4664562505ab7a070c3d412ace635bb25d
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20260128
+%global ver 0.222.0
+>>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
 
 %bcond_with check
 %bcond_with debug_no_build

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,17 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
+<<<<<<< HEAD
 %global commit 5f8918771940cacbd14837159033901e630ef5ae
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global commit_date 20260115
+=======
+%global commit 301d978d9c73067e21a4f8688a42efc8a00de364
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global commit_date 20260128
+>>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 # Change this variables if you want to use custom keys

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit 40480fe3481cf833ed927f83a177d43046e7c37d
+%global commit abf434a3362811b3b86558c70b846da664f6841b
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20260115
+%global commit_date 20260128
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit ee1e94d4309f30e9a6e169da4e4db72aa6a98cc0
-%global commit_date 20260116
+%global commit 7f3ec0016092743c1d6738e61bed560614d4def8
+%global commit_date 20260128
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/multimedia/gpu-screen-recorder/gpu-screen-recorder.spec
+++ b/anda/multimedia/gpu-screen-recorder/gpu-screen-recorder.spec
@@ -1,7 +1,7 @@
 %global snapshot r1245.8e82100
 
 Name:           gpu-screen-recorder
-Version:        5.12.0
+Version:        5.12.3
 Release:        1%?dist
 Summary:        A shadowplay-like screen recorder for Linux
 

--- a/anda/system/nvidia-patch/nvidia-patch.spec
+++ b/anda/system/nvidia-patch/nvidia-patch.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
-%global commit be3f1616b976c47d33b0abf2956f4129d759824a
+%global commit 2b16ade220d42021b32f7c9129a756fa246a7567
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260107
+%global commit_date 20260128
 
 
 %global patches %{_datadir}/src/nvidia-patch

--- a/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
+++ b/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
@@ -1,6 +1,6 @@
-%global commit c7ffff086407d6628b7887edd8f99d561c7542d2
+%global commit e0ca73a3e0e4475c2cd20aa772ca3d6bbcf8b9e4
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260114
+%global commit_date 20260128
 %global ver 0.6.6.2
 
 # We aren't using Mono but RPM expected Mono

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit b3146cbbe9d0368edab10bae8528f3fd57f4898f
+%global commit 62335207134f05a521f54fd2eb8a2068915bad80
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260116
+%global commitdate 20260128
 %global ver 1.0.19
 %undefine __brp_mangle_shebangs
 

--- a/anda/tools/glasgow/glasgow.spec
+++ b/anda/tools/glasgow/glasgow.spec
@@ -1,5 +1,5 @@
-%global commit 5d8876e448480b2d593823fc43c958e687841315
-%global commit_date 20260116
+%global commit 2b3953f1c4bea0fe38f06627fc4ff96f9c40c8ec
+%global commit_date 20260128
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name glasgow

--- a/anda/tools/qdl/qdl.spec
+++ b/anda/tools/qdl/qdl.spec
@@ -1,5 +1,5 @@
-%global commit 6eeb866b1503a9219258edbdb72fcd478c20b2d7
-%global commit_date 20251220
+%global commit aa77dfc23e3e4f2122633ed6599d208d3c44791d
+%global commit_date 20260128
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           qdl

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -1,10 +1,10 @@
-%global commit 230d67ad28e74b17a42064453b2163991cb51a5e
-%global commit_date 20251218
+%global commit f0ceb02829c3f8349b53633747527f4e2e5c0ae7
+%global commit_date 20260128
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:			rpi-utils
 Version:		%{commit_date}.%{shortcommit}
-Release:		2%?dist
+Release:		1%?dist
 Summary:		A collection of scripts and simple applications for Raspberry Pi devices
 License:		BSD-3-Clause
 URL:			https://github.com/raspberrypi/utils

--- a/anda/tools/spotx-bash/spotx-bash.spec
+++ b/anda/tools/spotx-bash/spotx-bash.spec
@@ -1,10 +1,10 @@
-%global commit 37ffdc78ba3ded6af6550895bfc687f44f1c4af6
-%global commit_date 20260115
+%global commit ca98eef240cd26b90ff423a836229275d4a1594f
+%global commit_date 20260128
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           spotx-bash
 Version:        %commit_date.git~%shortcommit
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Adblock for the Spotify desktop client on Linux.
 License:        MIT
 URL:            https://github.com/SpotX-Official/SpotX-Bash

--- a/anda/tools/yt-dlp/yt-dlp-git.spec
+++ b/anda/tools/yt-dlp/yt-dlp-git.spec
@@ -2,7 +2,7 @@
 %global oldpkgname yt-dlp-nightly
 
 Name:           yt-dlp-git
-Version:        2026.01.27.165355
+Version:        2026.01.28.035725
 Release:        1%?dist
 Summary:        A command-line program to download videos from online video platforms
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [chore: Bump out of sync packages (#9513)](https://github.com/terrapkg/packages/pull/9513)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)