### PR TITLE
[f43] fix(heroic-games-launcher): Remove improper %dir macro (#9517)

### DIFF
--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -9,7 +9,7 @@
 
 Name:          %{shortname}-games-launcher
 Version:       2.19.1
-Release:       1%?dist
+Release:       2%?dist
 Summary:       A games launcher for GOG, Amazon, and Epic Games
 License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com
@@ -64,8 +64,7 @@ install -Dpm644 flatpak/templates/%{appid}.metainfo.xml.template %{buildroot}%{_
 %doc     CODE_OF_CONDUCT.md
 %license COPYING
 %license bundled_licenses/*
-%dir %{_libdir}/%{shortname}
-%{_libdir}/%{shortname}/*
+%{_libdir}/%{shortname}/
 %{_bindir}/%{shortname}
 %{_bindir}/%{name}
 %{_appsdir}/%{appid}.desktop


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(heroic-games-launcher): Remove improper %dir macro (#9517)](https://github.com/terrapkg/packages/pull/9517)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)