### PR TITLE
[f42] fix (telescope): put libexec script in proper spot (#9527)

### DIFF
--- a/anda/stardust/telescope/nightly/libexec.patch
+++ b/anda/stardust/telescope/nightly/libexec.patch
@@ -1,0 +1,9 @@
+diff --git a/scripts/telescope b/scripts/telescope
+index bad4436..50f7983 100644
+--- a/scripts/telescope
++++ b/scripts/telescope
+@@ -1,3 +1,3 @@
+ #!/bin/bash
+ 
+-stardust-xr-server -o 6 -e "$(which _telescope_startup)" "$@"
++stardust-xr-server -o 6 -e "/usr/libexec/telescope_startup" "$@"

--- a/anda/stardust/telescope/nightly/stardust-telescope-nightly.spec
+++ b/anda/stardust/telescope/nightly/stardust-telescope-nightly.spec
@@ -4,11 +4,12 @@
 
 Name:           stardust-xr-telescope-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        See the stars! Easy stardust setups to run on your computer
 License:        MIT
 URL:            https://github.com/StardustXR/telescope
 Source0:        %url/archive/%commit.tar.gz
+Patch0:         libexec.patch
 
 Requires:       bash
 Requires:       xwayland-satellite
@@ -28,17 +29,19 @@ BuildArch:      noarch
 Provides:       telescope-nightly stardust-telescope-nightly
 Conflicts:      stardust-xr-telescope
 
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
 %description
 See the stars! Easy stardust setups to run on your computer.
 
 %prep
-%autosetup -n telescope-%commit
+%autosetup -n telescope-%commit -p1
 
 %build
 
 %install
 install -Dm755 scripts/telescope                 %buildroot%_bindir/telescope
-install -Dm755 scripts/_telescope_startup        %buildroot%_bindir/_telescope_startup
+install -Dm755 scripts/_telescope_startup        %buildroot%_libexecdir/telescope_startup
 install -Dm644 org.stardustxr.Telescope.desktop  %buildroot%_appsdir/org.stardustxr.Telescope.desktop
 install -Dm644 org.stardustxr.Telescope.png      %buildroot%_hicolordir/512x512/apps/org.stardustxr.Telescope.png
 
@@ -46,7 +49,7 @@ install -Dm644 org.stardustxr.Telescope.png      %buildroot%_hicolordir/512x512/
 %doc README.md
 %license LICENSE
 %_bindir/telescope
-%_bindir/_telescope_startup
+%_libexecdir/telescope_startup
 %_appsdir/org.stardustxr.Telescope.desktop
 %_hicolordir/512x512/apps/org.stardustxr.Telescope.png
 

--- a/anda/stardust/telescope/stable/libexec.patch
+++ b/anda/stardust/telescope/stable/libexec.patch
@@ -1,0 +1,9 @@
+diff --git a/scripts/telescope b/scripts/telescope
+index bad4436..50f7983 100644
+--- a/scripts/telescope
++++ b/scripts/telescope
+@@ -1,3 +1,3 @@
+ #!/bin/bash
+ 
+-stardust-xr-server -o 6 -e "$(which _telescope_startup)" "$@"
++stardust-xr-server -o 6 -e "/usr/libexec/telescope_startup" "$@"

--- a/anda/stardust/telescope/stable/stardust-telescope.spec
+++ b/anda/stardust/telescope/stable/stardust-telescope.spec
@@ -1,11 +1,12 @@
 Name:           stardust-xr-telescope
 Version:        0.50.3
-Release:        1%?dist
+Release:        2%?dist
 Epoch:          1
 Summary:        See the stars! Easy stardust setups to run on your computer
 License:        MIT
 URL:            https://github.com/StardustXR/telescope
 Source0:        %url/archive/refs/tags/%version.tar.gz
+Patch0:         libexec.patch
 
 Requires:       bash
 Requires:       xwayland-satellite
@@ -24,17 +25,19 @@ Requires:       stardust-xr-solar-sailer
 BuildArch:      noarch
 Provides:       telescope stardust-telescope
 
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
 %description
 See the stars! Easy stardust setups to run on your computer.
 
 %prep
-%autosetup -n telescope-%version
+%autosetup -n telescope-%version -p1
 
 %build
 
 %install
 install -Dm755 scripts/telescope                 %buildroot%_bindir/telescope
-install -Dm755 scripts/_telescope_startup        %buildroot%_bindir/_telescope_startup
+install -Dm755 scripts/_telescope_startup        %buildroot%_libexecdir/telescope_startup
 install -Dm644 org.stardustxr.Telescope.desktop  %buildroot%_appsdir/org.stardustxr.Telescope.desktop
 install -Dm644 org.stardustxr.Telescope.png      %buildroot%_hicolordir/512x512/apps/org.stardustxr.Telescope.png
 
@@ -42,7 +45,7 @@ install -Dm644 org.stardustxr.Telescope.png      %buildroot%_hicolordir/512x512/
 %doc README.md
 %license LICENSE
 %_bindir/telescope
-%_bindir/_telescope_startup
+%_libexecdir/telescope_startup
 %_appsdir/org.stardustxr.Telescope.desktop
 %_hicolordir/512x512/apps/org.stardustxr.Telescope.png
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (telescope): put libexec script in proper spot (#9527)](https://github.com/terrapkg/packages/pull/9527)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)