### PR TITLE
[el10] backport: fix (powerbuttond): update script (#9562)

### DIFF
--- a/anda/games/powerbuttond/powerbuttond.spec
+++ b/anda/games/powerbuttond/powerbuttond.spec
@@ -1,7 +1,7 @@
 %define debug_package %nil
 
 Name:           powerbuttond
-Version:        4.0
+Version:        4.1
 Release:        1%?dist
 Summary:        Steam Deck power button daemon
 

--- a/anda/games/powerbuttond/update.rhai
+++ b/anda/games/powerbuttond/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gitlab("gitlab.steamos.cloud", "995"));
+rpm.version(gitlab_tag("gitlab.steamos.cloud", "995"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [backport: fix (powerbuttond): update script (#9562)](https://github.com/terrapkg/packages/pull/9562)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)