### PR TITLE
[f43] fix (powerbuttond): license (#9565)

### DIFF
--- a/anda/games/powerbuttond/powerbuttond.spec
+++ b/anda/games/powerbuttond/powerbuttond.spec
@@ -2,10 +2,10 @@
 
 Name:           powerbuttond
 Version:        4.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Steam Deck power button daemon
 
-License:        BSD
+License:        BSD-2-clause
 URL:            https://gitlab.steamos.cloud/holo/powerbuttond
 Source:		    %{url}/-/archive/v%{version}/powerbuttond-v%{version}.tar.gz
 Packager:       madonuko <mado@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (powerbuttond): license (#9565)](https://github.com/terrapkg/packages/pull/9565)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)