### PR TITLE
[f42] fix: inputplumber (#9566)

### DIFF
--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -51,3 +51,10 @@ keyboards) and translate their input to a variety of virtual device formats.
 %_udevrulesdir/90-inputplumber-autostart.rules
 %_datadir/dbus-1/system.d/org.shadowblip.InputPlumber.conf
 %_datadir/inputplumber/
+%{_udevrulesdir}/99-inputplumber-device-setup.rules
+%{_datadir}/polkit-1/actions/org.shadowblip.InputPlumber.policy
+%{_datadir}/polkit-1/rules.d/org.shadowblip.InputPlumber.rules
+
+%changelog
+* Sun Feb 01 2026 Owen Zimmerman <owen@fyralabs.com>
+- Add more files from 0.73.0 release


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: inputplumber (#9566)](https://github.com/terrapkg/packages/pull/9566)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)