### PR TITLE
[f43] chore (qdl): switch to tagged versions (#9577)

### DIFF
--- a/anda/tools/qdl/anda.hcl
+++ b/anda/tools/qdl/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
 	rpm {
 		spec = "qdl.spec"
 	}
- labels {
-    nightly = 1
-  }
 }

--- a/anda/tools/qdl/qdl.spec
+++ b/anda/tools/qdl/qdl.spec
@@ -1,13 +1,9 @@
-%global commit eb345dfdfa338dc3626932f8a992423c3f6b3532
-%global commit_date 20260130
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-
 Name:           qdl
-Version:        0^%commit_date.%shortcommit
+Version:        2.4
 Release:        1%?dist
 Summary:        This tool communicates with USB devices of id 05c6:9008 to upload a flash loader and use this to flash images
 URL:            https://github.com/linux-msm/qdl
-Source0:        %{url}/archive/%{commit}/qdl-%{commit}.tar.gz
+Source0:        %url/archive/refs/tags/v%version.tar.gz
 License:        BSD-3-Clause
 BuildRequires:  make
 BuildRequires:  gcc
@@ -21,7 +17,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{summary}.
 
 %prep
-%autosetup -n qdl-%{commit}
+%autosetup -n qdl-%{version}
 
 %build
 %make_build
@@ -48,8 +44,11 @@ install -Dm644 ks.1 %{buildroot}%{_mandir}/man1/ks.1
 %doc README.md
 
 %changelog
+* Mon Feb 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to tagged versions
+
 * Wed Nov 26 2025 metcya <metcya@gmail.com>
 - Package manpages
 
-* Sun Nov 23 2025 Owen-sz <owen@fyralabs.com>
+* Sun Nov 23 2025 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit

--- a/anda/tools/qdl/update.rhai
+++ b/anda/tools/qdl/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("linux-msm/qdl"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(gh_tag("linux-msm/qdl"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (qdl): switch to tagged versions (#9577)](https://github.com/terrapkg/packages/pull/9577)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)