### PR TITLE
[f42] fix (geteltorito): license and description (#9578)

### DIFF
--- a/anda/tools/geteltorito/geteltorito.spec
+++ b/anda/tools/geteltorito/geteltorito.spec
@@ -4,9 +4,9 @@
 
 Name:          geteltorito
 Version:       %{commit_date}.%{shortcommit}
-Release:       1%?dist
+Release:       2%?dist
 Summary:       An El Torito boot image extractor
-License:       GPLv3
+License:       GPL-3.0-only
 Packager:      Owen Zimmerman <owen@fyralabs.com>
 Url:           https://github.com/rainer042/geteltorito
 Source0:       %{url}/archive/%{commit}.tar.gz
@@ -14,7 +14,7 @@ BuildArch:     noarch
 Requires:      perl
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n geteltorito-%commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (geteltorito): license and description (#9578)](https://github.com/terrapkg/packages/pull/9578)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)