### PR TITLE
[f42] bump: shadowenv (#9579)

### DIFF
--- a/anda/tools/shadowenv/shadowenv.spec
+++ b/anda/tools/shadowenv/shadowenv.spec
@@ -1,5 +1,5 @@
 Name:           shadowenv
-Version:        3.2.0
+Version:        3.5.0
 Release:        1%?dist
 License:        MIT
 Summary:        Reversible directory-local environment variable manipulations


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [bump: shadowenv (#9579)](https://github.com/terrapkg/packages/pull/9579)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)