### PR TITLE
[f43] fix (shadowenv): update script (#9592)

### DIFF
--- a/anda/tools/shadowenv/update.rhai
+++ b/anda/tools/shadowenv/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("Shopify/shadowenv"));
+rpm.version(gh("Shopify/shadowenv"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (shadowenv): update script (#9592)](https://github.com/terrapkg/packages/pull/9592)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)