### PR TITLE
[el10] gamescope-session: move sources to opengamingcollective instead of bazzite-org (#9588)

### DIFF
--- a/anda/games/gamescope-session/anda.hcl
+++ b/anda/games/gamescope-session/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+    arches = ["x86_64"]
     rpm {
         spec = "gamescope-session.spec"
     }

--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,17 +1,19 @@
 %define debug_package %nil
 
-%global commit df099b31451531a2bb5a1dc29c93f76bbbab79d0
+%global commit b5c2d0d3ebcefa7450d9d4336dd5802aa96d8513
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251109
+%global commit_date 20260202
 
 Name:           gamescope-session
-Version:        %commit_date.%shortcommit
+Version:        0~%{commit_date}git.%{shortcommit}
 Release:        1%?dist
 Summary:        Gamescope session based on Valve's gamescope
 License:        MIT
-URL:            https://github.com/bazzite-org/gamescope-session
+URL:            https://github.com/OpenGamingCollective/gamescope-session
 Source0:        %url/archive/%commit.tar.gz
 BuildRequires:  systemd-rpm-macros
+Packager:       Tulip Blossom <tulilirockz@outlook.com>
+BuildArch:      noarch
 
 %description
 Gamescope session plus based on Valve's gamescope.
@@ -22,8 +24,13 @@ Gamescope session plus based on Valve's gamescope.
 %build
 
 %install
-mkdir -p %buildroot
-cp -r usr %buildroot/
+install -Dpm0755 -t "%buildroot%_bindir/" ".%_bindir/export-gpu"
+install -Dpm0755 -t "%buildroot%_bindir/" ".%_bindir/gamescope-session-plus"
+install -Dpm0644 -t "%buildroot%_userunitdir/" ".%_userunitdir/gamescope-session-plus@.service"
+install -Dpm0644 -t "%buildroot%_userunitdir/" ".%_userunitdir/gamescope-session.target"
+install -Dpm0644 -t "%buildroot%_datadir/gamescope-session-plus/" ".%_datadir/gamescope-session-plus/device-quirks"
+install -Dpm0644 -t "%buildroot%_datadir/gamescope-session-plus/" ".%_datadir/gamescope-session-plus/gamescope-session-plus"
+install -Dpm0644 -t "%buildroot%_datadir/gamescope/scripts/50-custom/50-disable-explicit-sync.lua" ".%_datadir/gamescope/scripts/50-custom/50-disable-explicit-sync.lua"
 
 %files
 %doc README.md
@@ -32,9 +39,9 @@ cp -r usr %buildroot/
 %{_bindir}/gamescope-session-plus
 %{_datadir}/gamescope-session-plus/device-quirks
 %{_datadir}/gamescope-session-plus/gamescope-session-plus
+%{_datadir}/gamescope/scripts/50-custom/50-disable-explicit-sync.lua
 %{_userunitdir}/gamescope-session-plus@.service
 %{_userunitdir}/gamescope-session.target
-
 
 %changelog
 %autochangelog

--- a/anda/games/gamescope-session/update.rhai
+++ b/anda/games/gamescope-session/update.rhai
@@ -1,5 +1,5 @@
 if filters.contains("nightly") {
-    rpm.global("commit", gh_commit("bazzite-org/gamescope-session"));
+    rpm.global("commit", gh_commit("OpenGamingCollective/gamescope-session"));
     if rpm.changed() {
         rpm.release();
         rpm.global("commit_date", date());


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [gamescope-session: move sources to opengamingcollective instead of bazzite-org (#9588)](https://github.com/terrapkg/packages/pull/9588)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)