### PR TITLE
[el10] fix: rust-deno (#9599)

### DIFF
--- a/anda/devs/deno/deno-fix-metadata-auto.diff
+++ b/anda/devs/deno/deno-fix-metadata-auto.diff
@@ -5,7 +5,7 @@
  version = "=0.1.5"
  
 -[target."cfg(windows)".dependencies.deno_subprocess_windows]
--version = "0.20.0"
+-version = "0.25.0"
 -
 -[target."cfg(windows)".dependencies.winapi]
 -version = "=0.3.9"

--- a/anda/devs/deno/rust-deno.spec
+++ b/anda/devs/deno/rust-deno.spec
@@ -62,7 +62,7 @@ cp %{S:2} gcc
 
 
 %global __cc %_builddir/%buildsubdir/gcc
-sed '/\[env\]/a CC="%__cc"' -i .cargo/config
+%dnl sed '/\[env\]/a CC="%__cc"' -i .cargo/config
 
 %build
 %{cargo_license_summary_online}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: rust-deno (#9599)](https://github.com/terrapkg/packages/pull/9599)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)