### PR TITLE
[el10] add: gradle-completions (#9600)

### DIFF
--- a/anda/misc/gradle-completions/anda.hcl
+++ b/anda/misc/gradle-completions/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+    rpm {
+        spec = "gradle-completions.spec"
+    }
+}

--- a/anda/misc/gradle-completions/gradle-completions.spec
+++ b/anda/misc/gradle-completions/gradle-completions.spec
@@ -1,0 +1,54 @@
+Name:           gradle-completions
+Version:        9.3.1
+Release:        1%?dist
+Summary:        Gradle tab completion for bash and zsh
+License:        MIT
+URL:            https://github.com/gradle/gradle-completion
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+Requires:       gradle-bash-completion = %{evr}
+Requires:       gradle-zsh-completion = %{evr}
+BuildArch:      noarch
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%summary.
+
+%package -n gradle-bash-completion
+Summary:    Bash completion for Gradle
+Recommends: gradle
+%description -n gradle-bash-completion
+%summary.
+
+%package -n gradle-zsh-completion
+Summary:    zsh completion for Gradle
+Recommends: gradle
+%description -n gradle-zsh-completion
+%summary.
+
+%prep
+%autosetup -n gradle-completion-%{version}
+
+%build
+
+%install
+install -Dm644 gradle-completion.bash       %{buildroot}%{bash_completions_dir}/gradle
+install -Dm644 gradle-completion.plugin.zsh %{buildroot}%{zsh_completions_dir}/gradle-completion.plugin.zsh
+install -Dm644 _gradle                      %{buildroot}%{zsh_completions_dir}/_gradle
+
+%files
+%doc README.md CONTRIBUTING.md
+%license LICENSE
+
+%files -n gradle-bash-completion
+%license LICENSE
+%{bash_completions_dir}/gradle
+
+%files -n gradle-zsh-completion
+%license LICENSE
+%{zsh_completions_dir}/gradle-completion.plugin.zsh
+%{zsh_completions_dir}/_gradle
+
+%changelog
+* Mon Feb 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/misc/gradle-completions/update.rhai
+++ b/anda/misc/gradle-completions/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("gradle/gradle-completion"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: gradle-completions (#9600)](https://github.com/terrapkg/packages/pull/9600)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)