### PR TITLE
[f42] chore (bazzite-portal): make noarch (#9589)

### DIFF
--- a/anda/apps/bazzite-portal/anda.hcl
+++ b/anda/apps/bazzite-portal/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+        arches = ["x86_64"]
     rpm {
         spec = "bazzite-portal.spec"
     }

--- a/anda/apps/bazzite-portal/bazzite-portal.spec
+++ b/anda/apps/bazzite-portal/bazzite-portal.spec
@@ -1,7 +1,6 @@
-%define debug_package %{nil}
 Name:           bazzite-portal
 Version:        0.1.6
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Bazzite Portal is a tabbed frontend for curated script execution, with a focus on distro specific QOL shortcuts
 URL:            https://github.com/ublue-os/yafti-gtk
 Source0:        https://github.com/ublue-os/yafti-gtk/archive/refs/tags/v%{version}.tar.gz
@@ -10,6 +9,7 @@ Requires:       python3-gobject
 Requires:       python3-PyYAML
 Requires:       gtk3
 Provides:       Bazzite-Portal
+BuildArch:      noarch
 Packager:       Zacharias Xenakis <xarishark@outlook.com>
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (bazzite-portal): make noarch (#9589)](https://github.com/terrapkg/packages/pull/9589)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)