### PR TITLE
[el10] chore: Bump nightly packages (#9614)

### DIFF
--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,9 +1,9 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
 %global ver 13.3.0
-%global commit 042fa5bd1d0e8d4b836a12fa5792d704421c49fe
+%global commit 6b0427b4466689b3268f7838277455702d7f9691
 %global shortcommit %{sub %{commit} 1 7}
-%global commit_date 20260114
+%global commit_date 20260125
 %global devel_name QtColorWidgets
 %global _distro_extra_cflags -fuse-ld=mold
 %global _distro_extra_cxxflags -fuse-ld=mold

--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -8,7 +8,7 @@
 
 Name:          %{base_name}-nightly
 Version:       %{ver}%{commit_date}.git.%{shortcommit}
-Release:       3%{?dist}
+Release:       1%?dist
 License:       OSL-3.0
 Summary:       A privacy-minded Legcord fork.
 Group:         Applications/Internet

--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,10 +1,5 @@
-<<<<<<< HEAD
-%global commit 4104aea0b89e600203e3b3d189649714877bcd70
-%global commit_date 20260109
-=======
-%global commit d679a0ac9ca1b2cc0c7814ee6fb93c7824fb72c5
-%global commit_date 20260128
->>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
+%global commit df59d55a39662553a8f6f1502272bb4b4991e6f7
+%global commit_date 20260202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global debug_package %nil
 %global __strip /bin/true

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,15 +1,9 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-<<<<<<< HEAD
-%global commit 00774f5b85d78b87007f9b88beef90550951e6f1
+%global commit db22a4528ff4ca77253c0dbc80fb96908c8c48f1
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260116
-=======
-%global commit d1743b641b5b8a51115a9828124c7a9b527115e3
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260128
->>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
+%global commit_date 20260202
 %global ver 0.41.0
 
 Name:           mpv-nightly

--- a/anda/apps/rpcc/rpcc.spec
+++ b/anda/apps/rpcc/rpcc.spec
@@ -1,5 +1,5 @@
-%global commit 6ae576bee3ca42f0aea597e76d2e0df0e1184bad
-%global commit_date 20251030
+%global commit 353e04bf0bc1866cba1f599cd76050890d33ba23
+%global commit_date 20260123
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           rpcc

--- a/anda/apps/winetricks/git/winetricks-git.spec
+++ b/anda/apps/winetricks/git/winetricks-git.spec
@@ -1,9 +1,9 @@
 # Fedora sometimes sources the snapshots under stable versions and just bumps release
 # For user clarity I have separated these into different packages
-%global commit  3483ce867ee10aa084843e97b8f31c9489d6e93d
+%global commit  c9ec7e27eb01e8f0e46a2d4803c405c38a27cc75
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 20260125
-%global commit_date 20260128
+%global commit_date 20260130
 
 Name:           winetricks-git
 Version:        %{ver}^%{commit_date}git.%{shortcommit}

--- a/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/gnome-shell-extension-multi-monitors-bar.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/gnome-shell-extension-multi-monitors-bar.spec
@@ -1,5 +1,5 @@
-%global commit 95678dd702dd91a8f0f37c9d3e217ea6edb89300
-%global commit_date 20260116
+%global commit a6a8b8a717f2255c3c1b3af4ce205ebc3a65e0af
+%global commit_date 20260130
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global extension   multi-monitors-bar

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,12 +1,6 @@
-<<<<<<< HEAD
-%global commit 26e243a9194f8653e0b44cf00b600629fcee8f46
+%global commit e06742b36ec971c32fffd4b890cf83746c3a9bf7
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2026-01-15
-=======
-%global commit 685daee01bbd18dc50c066ccfa85828509068a99
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2026-01-27
->>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
+%global fulldate 2026-02-03
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0
@@ -15,7 +9,7 @@
 
 Name:           %{base_name}-nightly
 Version:        %{ver}~tip^%{commit_date}git%{shortcommit}
-Release:        2%{?dist}
+Release:        1%?dist
 %if 0%{?fedora} <= 41
 Epoch:          1
 %endif

--- a/anda/devs/micro/micro-nightly.spec
+++ b/anda/devs/micro/micro-nightly.spec
@@ -12,8 +12,8 @@
 
 # Naming variable as something other than "commit" is necessary
 # to stop %%gometa from putting commit hash in release
-%global commit_hash 6a62575bcfdf4965f187eedafceb3400316e612b
-%global commit_date 20260101
+%global commit_hash dc2d70bfe127645a11bc791123af7aa01f0a222f
+%global commit_date 20260125
 %global shortcommit %{sub %{commit_hash} 1 7}
 %global ver 2.0.15
 

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,14 +1,7 @@
-<<<<<<< HEAD
-%global commit d183902dc7d8e55c58a85bbc3e2f0607b6571e82
+%global commit 81c65414ca36bdf4fd0b9cc2612d7d1180258589
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260116
-%global ver 0.221.0
-=======
-%global commit 06b5ec4664562505ab7a070c3d412ace635bb25d
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260128
-%global ver 0.222.0
->>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
+%global commit_date 20260203
+%global ver 0.223.0
 
 %bcond_with check
 %bcond_with debug_no_build

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,17 +3,10 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-<<<<<<< HEAD
-%global commit 5f8918771940cacbd14837159033901e630ef5ae
+%global commit f476b2b726d6de0575fa1c56f6bbef0d1d101148
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20260115
-=======
-%global commit 301d978d9c73067e21a4f8688a42efc8a00de364
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-
-%global commit_date 20260128
->>>>>>> 93ea6f333 (chore: Bump out of sync packages (#9513))
+%global commit_date 20260203
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 # Change this variables if you want to use custom keys
@@ -27,7 +20,7 @@
 %global build_platform terra
 
 Name:             prismlauncher-nightly
-Version:          10.0^%{snapshot_info}
+Version:          11.0^%{snapshot_info}
 Release:          1%?dist
 Summary:          Minecraft launcher with ability to manage multiple instances
 License:          GPL-3.0-only AND Apache-2.0 AND LGPL-3.0-only AND GPL-3.0-or-later AND GPL-2.0-or-later AND ISC AND OFL-1.1 AND LGPL-2.1-only AND MIT AND BSD-2-Clause-FreeBSD AND BSD-3-Clause AND LGPL-3.0-or-later

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit abf434a3362811b3b86558c70b846da664f6841b
+%global commit bfc27867187e28dd3b5f2a887450cfc2c465da98
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20260128
+%global commit_date 20260202
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit 7f3ec0016092743c1d6738e61bed560614d4def8
-%global commit_date 20260128
+%global commit dd78db84765d908c6eac58e7fc2473edacf3e056
+%global commit_date 20260203
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/lib/astal/astal/astal.spec
+++ b/anda/lib/astal/astal/astal.spec
@@ -1,7 +1,7 @@
 
-%global commit 7d1fac8a4b2a14954843a978d2ddde86168c75ef
+%global commit eb235f8813bdea2a4a38ac228f2efc4e2a8a90af
 %global shortcommit %{sub %commit 1 7}
-%global commit_date 20251127
+%global commit_date 20260131
 
 Name:			astal
 Version:		0^%commit_date.%shortcommit

--- a/anda/misc/openbangla-keyboard/openbangla-keyboard-nightly.spec
+++ b/anda/misc/openbangla-keyboard/openbangla-keyboard-nightly.spec
@@ -1,6 +1,6 @@
 %global ver 2.0.0
-%global commit 7c19213777cfb43b443f4a57a6b4eab240d21b87
-%global commit_date 20260113
+%global commit b29dce323f3e14e32a7f341f0e2a74f329753fc2
+%global commit_date 20260131
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           openbangla-keyboard-nightly

--- a/anda/stardust/comet/nightly/stardust-comet-nightly.spec
+++ b/anda/stardust/comet/nightly/stardust-comet-nightly.spec
@@ -1,12 +1,12 @@
-%global commit 52b442c42d8b2938f16adfe42ab1ac0b5d29a137
-%global commit_date 20251218
+%global commit 310fafa22ef1ae7c26d0ba83e0ae152de4d8afb5
+%global commit_date 20260203
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-comet-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Annotate things in Stardust XR
 URL:            https://github.com/StardustXR/comet
 Source0:        %url/archive/%commit/comet-%commit.tar.gz

--- a/anda/stardust/flatland/nightly/stardust-flatland-nightly.spec
+++ b/anda/stardust/flatland/nightly/stardust-flatland-nightly.spec
@@ -1,12 +1,12 @@
-%global commit add9b3420940a5608116d02d3dbf53fbd3eb7c40
-%global commit_date 20251225
+%global commit b2031190cd241292289bfd4f6dd33d1950761e9a
+%global commit_date 20260203
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$
 
 Name:           stardust-xr-flatland-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Flatland for Stardust XR
 URL:            https://github.com/StardustXR/flatland
 Source0:        %url/archive/%commit/flatland-%commit.tar.gz

--- a/anda/stardust/server/nightly/stardust-server-nightly.spec
+++ b/anda/stardust/server/nightly/stardust-server-nightly.spec
@@ -1,5 +1,5 @@
-%global commit bfca9bae08aebd1dc2f2b5f34aecbb7389814c00
-%global commit_date 20260113
+%global commit 6c3206b7a7f5241fbd12bfe30cc78a4593e582cd
+%global commit_date 20260203
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/stardust/solar-sailer/nightly/stardust-solar-sailer-nightly.spec
+++ b/anda/stardust/solar-sailer/nightly/stardust-solar-sailer-nightly.spec
@@ -1,5 +1,5 @@
-%global commit 40ca9fc446756a5151275dcbac914cee399dbc4c
-%global commit_date 20251218
+%global commit e9ff298d261d13c69b560a3993a8cd00b3da56ee
+%global commit_date 20260125
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 # Exclude input files from mangling
@@ -7,7 +7,7 @@
 
 Name:           stardust-xr-solar-sailer-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Glide through space! This play space mover allows you to fly by dragging the space with momentum!
 URL:            https://github.com/StardustXR/solar-sailer
 Source0:        %url/archive/%commit.tar.gz

--- a/anda/system/ipu6-camera-hal/ipu6-camera-hal.spec
+++ b/anda/system/ipu6-camera-hal/ipu6-camera-hal.spec
@@ -1,15 +1,15 @@
-%global commit c933525a6efe8229a7129b7b0b66798f19d2bef7
-%global commit_date 20250627
+%global commit 9899efa70921906ee6dd23c9f83aff343968f164
+%global commit_date 20260121
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global build_cflags %{__build_flags_lang_c} %{?_distro_extra_cflags} -Wno-alloc-size-larger-than
 %global build_cxxflags %{__build_flags_lang_cxx} %{?_distro_extra_cxxflags} -Wno-alloc-size-larger-than
 %global __cmake_in_source_build 1
-%global ver 1.0.0
+%global ver 1.0.1
 
 Name:           ipu6-camera-hal
 Summary:        Hardware abstraction layer for Intel IPU6
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        3%{?dist}
+Release:        1%?dist
 License:        Apache-2.0
 URL:            https://github.com/intel/ipu6-camera-hal
 Source0:        %{url}/archive/%{commit}/%{name}-%{shortcommit}.tar.gz

--- a/anda/system/ipu6-drivers/kmod-common/intel-ipu6-drivers.spec
+++ b/anda/system/ipu6-drivers/kmod-common/intel-ipu6-drivers.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
-%global commit 9766e218112f4173be9b0f06dfae27cb40c54f40
+%global commit d0252e41bc871dad5eeb89e875ce1abd92eab87b
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251113
+%global commit_date 20260123
 # Actual "release" version, currently unused as the release versions are back and forth on if on if they use 1.0.0 or 1.0.1
 # Use this if they ever stop doing that I guess
 %global ver 1.0.1
@@ -9,7 +9,7 @@
 Name:           intel-ipu6-drivers
 Summary:        Common files for Intel IPU6 drivers
 Version:        0^%{commit_date}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        1%?dist
 License:        GPL-2.0-or-later
 URL:            https://github.com/intel/ipu6-drivers
 Source0:        https://github.com/intel/ipu6-drivers/archive/%{commit}/ipu6-drivers-%{shortcommit}.tar.gz

--- a/anda/system/nvidia-patch/nvidia-patch.spec
+++ b/anda/system/nvidia-patch/nvidia-patch.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
-%global commit 2b16ade220d42021b32f7c9129a756fa246a7567
+%global commit 2836fab5867d7da7e4666957bd7673e47cbb6a18
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260128
+%global commit_date 20260131
 
 
 %global patches %{_datadir}/src/nvidia-patch

--- a/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
+++ b/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
@@ -1,6 +1,6 @@
-%global commit e0ca73a3e0e4475c2cd20aa772ca3d6bbcf8b9e4
+%global commit 6a6afe29e94417315378c6d1b791fec3dbe45d6c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260128
+%global commit_date 20260202
 %global ver 0.6.6.2
 
 # We aren't using Mono but RPM expected Mono

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,12 +1,12 @@
-%global commit 62335207134f05a521f54fd2eb8a2068915bad80
+%global commit ab261a97392f8e1c6fc34f2c9ad274bd1b2cbe0a
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260128
+%global commitdate 20260203
 %global ver 1.0.19
 %undefine __brp_mangle_shebangs
 
 Name:           scx-scheds-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}
-Release:        2%{?dist}
+Release:        1%?dist
 Summary:        Nightly builds of sched_ext schedulers and tools
 SourceLicense:  GPL-2.0-only
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only AND ISC AND (LGPL-2.1-only OR BSD-2-Clause) AND LGPL-2.1 AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (MPL-2.0 OR MIT OR Apache-2.0) AND MPL-2.0-only and MPL-2.0-or-later AND (Unlicense OR MIT) AND Zlib

--- a/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
+++ b/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
@@ -1,6 +1,6 @@
 %global _udevrulesdir /usr/lib/udev/rules.d
 
-%global commit      6fe0cec4f8baeae5e6441489df02c395e39c6ae2
+%global commit      b627b4b3ea950dd861673d6ebf0ff186e00521f7
 %global commitdate  20251121
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 

--- a/anda/tools/glasgow/glasgow.spec
+++ b/anda/tools/glasgow/glasgow.spec
@@ -1,5 +1,5 @@
-%global commit 2b3953f1c4bea0fe38f06627fc4ff96f9c40c8ec
-%global commit_date 20260128
+%global commit 5c935bc2b8ba931ac1f7022f86214526442126d6
+%global commit_date 20260202
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name glasgow

--- a/anda/tools/graftcp/nightly/graftcp-nightly.spec
+++ b/anda/tools/graftcp/nightly/graftcp-nightly.spec
@@ -1,5 +1,5 @@
-%global commit 7f1a44c4886c64c4708c5f2e88f787768801bb7a
-%global commit_date 20251226
+%global commit 214f8b82ef78f2c3d54b3dc37075aadfc2da2bdf
+%global commit_date 20260121
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:			graftcp-nightly

--- a/anda/tools/natscli/natscli.spec
+++ b/anda/tools/natscli/natscli.spec
@@ -1,7 +1,7 @@
 # https://github.com/nats-io/natscli
 %global goipath         github.com/nats-io/natscli
-%global commit          29855730ef4dc79047e9382e8f8db64a80942a6c
-%global commit_date     20260113
+%global commit          66f169ff1f1ac0354873f7911758cd3e1fe7af29
+%global commit_date     20260131
 %global shortcommit     %{sub %{commit} 1 7}
 
 %gometa -f

--- a/anda/tools/qdl/qdl.spec
+++ b/anda/tools/qdl/qdl.spec
@@ -1,5 +1,5 @@
-%global commit aa77dfc23e3e4f2122633ed6599d208d3c44791d
-%global commit_date 20260128
+%global commit eb345dfdfa338dc3626932f8a992423c3f6b3532
+%global commit_date 20260130
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           qdl

--- a/anda/tools/raindrop/raindrop.spec
+++ b/anda/tools/raindrop/raindrop.spec
@@ -1,5 +1,5 @@
-%global commit 2e3859fe3afd65c89eeacb63bdaf7c432f2df30d
-%global commit_date 20251202
+%global commit 9d5396972bb5557c427a79309ce5c00f91bc9211
+%global commit_date 20260130
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           raindrop


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [chore: Bump nightly packages (#9614)](https://github.com/terrapkg/packages/pull/9614)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)