### PR TITLE
[el10] chore: Update subrepo install steps in README (#9613)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ If you are using immutable/atomic editions of Fedora, run the following commands
 curl -fsSL https://github.com/terrapkg/subatomic-repos/raw/main/terra.repo | pkexec tee /etc/yum.repos.d/terra.repo
 sudo rpm-ostree install terra-release
 ```
+#### Subrepos
 
-Optionally, you can install `terra-release-extra` to use the Extras repository. This also installs the Nvidia, and Mesa streams but does not enable them.
+On Fedora, you can optionally install the Terra subrepos. Extra care and caution may be needed as some of these packages may conflict with other repositories such as RPM Fusion.
+
+Install `terra-release-extras` to enable the Extras subrepo. This repo contains packages which conflict with Fedora packages in some way, such as being a patched version of the same package.
+Install `terra-release-mesa` to install the Mesa subrepo which contains a patched and codec complete Mesa.
+Install `terra-release-nvidia` to install the NVIDIA subrepo which contains NVIDIA drivers.
+Install `terra-release-multimedia` for mutltimedia packages in Terra. This repository is currently considered a work in progress.
 
 ### Enterprise Linux (EL)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: Update subrepo install steps in README (#9613)](https://github.com/terrapkg/packages/pull/9613)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)