### PR TITLE
[el10] chore: Sync specs (#9616)

### DIFF
--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,9 +1,9 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
 %global ver 13.3.0
-%global commit 6b0427b4466689b3268f7838277455702d7f9691
+%global commit bcf076673e482b05db48a3241e5a8c7890e217d4
 %global shortcommit %{sub %{commit} 1 7}
-%global commit_date 20260125
+%global commit_date 20260129
 %global devel_name QtColorWidgets
 %global _distro_extra_cflags -fuse-ld=mold
 %global _distro_extra_cxxflags -fuse-ld=mold

--- a/anda/devs/micro/micro-nightly.spec
+++ b/anda/devs/micro/micro-nightly.spec
@@ -12,8 +12,8 @@
 
 # Naming variable as something other than "commit" is necessary
 # to stop %%gometa from putting commit hash in release
-%global commit_hash dc2d70bfe127645a11bc791123af7aa01f0a222f
-%global commit_date 20260125
+%global commit_hash 3a7403bde4d508afea93a94d1113ca73cf37c1c1
+%global commit_date 20260129
 %global shortcommit %{sub %{commit_hash} 1 7}
 %global ver 2.0.15
 

--- a/anda/system/nvidia-patch/nvidia-patch.spec
+++ b/anda/system/nvidia-patch/nvidia-patch.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
-%global commit 2836fab5867d7da7e4666957bd7673e47cbb6a18
+%global commit 23c3b8b3d35ae3cd5acdbc42aeb6986472ad28e2
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260131
+%global commit_date 20260201
 
 
 %global patches %{_datadir}/src/nvidia-patch

--- a/anda/tools/qdl/qdl.spec
+++ b/anda/tools/qdl/qdl.spec
@@ -1,13 +1,9 @@
-%global commit eb345dfdfa338dc3626932f8a992423c3f6b3532
-%global commit_date 20260130
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-
 Name:           qdl
-Version:        0^%commit_date.%shortcommit
+Version:        2.4
 Release:        1%?dist
 Summary:        This tool communicates with USB devices of id 05c6:9008 to upload a flash loader and use this to flash images
 URL:            https://github.com/linux-msm/qdl
-Source0:        %{url}/archive/%{commit}/qdl-%{commit}.tar.gz
+Source0:        %url/archive/refs/tags/v%version.tar.gz
 License:        BSD-3-Clause
 BuildRequires:  make
 BuildRequires:  gcc
@@ -21,7 +17,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{summary}.
 
 %prep
-%autosetup -n qdl-%{commit}
+%autosetup -n qdl-%{version}
 
 %build
 %make_build
@@ -48,8 +44,11 @@ install -Dm644 ks.1 %{buildroot}%{_mandir}/man1/ks.1
 %doc README.md
 
 %changelog
+* Mon Feb 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to tagged versions
+
 * Wed Nov 26 2025 metcya <metcya@gmail.com>
 - Package manpages
 
-* Sun Nov 23 2025 Owen-sz <owen@fyralabs.com>
+* Sun Nov 23 2025 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [chore: Sync specs (#9616)](https://github.com/terrapkg/packages/pull/9616)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)