### PR TITLE
[f43] fix: README formatting (#9620)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ sudo rpm-ostree install terra-release
 
 On Fedora, you can optionally install the Terra subrepos. Extra care and caution may be needed as some of these packages may conflict with other repositories such as RPM Fusion.
 
-Install `terra-release-extras` to enable the Extras subrepo. This repo contains packages which conflict with Fedora packages in some way, such as being a patched version of the same package.
-Install `terra-release-mesa` to install the Mesa subrepo which contains a patched and codec complete Mesa.
-Install `terra-release-nvidia` to install the NVIDIA subrepo which contains NVIDIA drivers.
-Install `terra-release-multimedia` for mutltimedia packages in Terra. This repository is currently considered a work in progress.
+- Install `terra-release-extras` to enable the Extras subrepo. This repo contains packages which conflict with Fedora packages in some way, such as being a patched version of the same package.
+- Install `terra-release-mesa` to install the Mesa subrepo which contains a patched and codec complete Mesa.
+- Install `terra-release-nvidia` to install the NVIDIA subrepo which contains NVIDIA drivers.
+- Install `terra-release-multimedia` for mutltimedia packages in Terra. This repository is currently considered a work in progress.
 
 ### Enterprise Linux (EL)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: README formatting (#9620)](https://github.com/terrapkg/packages/pull/9620)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)