### PR TITLE
osu-lazer.spec: use EOF in quotes to escape shell variables

### DIFF
--- a/anda/games/osu-lazer/osu-lazer.spec
+++ b/anda/games/osu-lazer/osu-lazer.spec
@@ -4,7 +4,7 @@
 
 Name:			osu-lazer
 Version:		2026.119.0
-Release:		1%?dist
+Release:		2%?dist
 Summary:		The future of osu! and the beginning of an open era! Commonly known by the codename osu!lazer. Pew pew.
 ExclusiveArch:	x86_64
 URL:			https://osu.ppy.sh/

--- a/anda/games/osu-lazer/osu-lazer.spec
+++ b/anda/games/osu-lazer/osu-lazer.spec
@@ -21,7 +21,7 @@ Source4:		osu-lazer-uri-handler.desktop
 %{summary}
 
 %prep
-cat <<EOF > osu-lazer
+cat <<'EOF' > osu-lazer
 #!/bin/sh
 env OSU_EXTERNAL_UPDATE_PROVIDER=1 /opt/osu-lazer/osu.AppImage "$@"
 EOF


### PR DESCRIPTION
So for osu-lazer, the spec file is broken and it looked like this previously:
```
#!/bin/sh
env OSU_EXTERNAL_UPDATE_PROVIDER=1 /opt/osu-lazer/osu.AppImage ""
```

but it should be `env OSU_EXTERNAL_UPDATE_PROVIDER=1 /opt/osu-lazer/osu.AppImage "$@"` to accept files.

This is because `EOF` in cat needs to be quoted (`'EOF'`) to prevent variable expansion. See https://stackoverflow.com/a/27921346