### PR TITLE
[f43] fix (geist): use %evr everywhere (#9630)

### DIFF
--- a/anda/fonts/geist/geist.spec
+++ b/anda/fonts/geist/geist.spec
@@ -1,6 +1,6 @@
 Name:		    geist-font
 Version:	    1.7.0
-Release:	    1%?dist
+Release:	    2%?dist
 URL:		    https://vercel.com/font
 Source0:	    https://github.com/vercel/geist-font/archive/refs/tags/%version.tar.gz
 License:	    OFL-1.1
@@ -18,7 +18,7 @@ that is based on the principles of classic Swiss typography. It is designed to b
 headlines, logos, posters, and other large display sizes.
 
 %package        mono
-Requires:       %{name} = %{version}-%{release}
+Requires:       %{name} = %{evr}
 Summary:        Geist Mono is a monospaced typeface that has been crafted to be the perfect partner to Geist Sans
 Provides:       geist-mono = %evr
 Provides:       geist-mono-fonts = %evr


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (geist): use %evr everywhere (#9630)](https://github.com/terrapkg/packages/pull/9630)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)