### PR TITLE
[f42] fix (bitwarden-rofi): license (#9634)

### DIFF
--- a/anda/misc/bitwarden-rofi/bitwarden-rofi.spec
+++ b/anda/misc/bitwarden-rofi/bitwarden-rofi.spec
@@ -1,8 +1,8 @@
 Name:           bitwarden-rofi
 Version:        0.5
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Wrapper for Bitwarden cli and Rofi
-License:        GPL-3.0
+License:        GPL-3.0-only
 URL:            https://github.com/mattydebie/bitwarden-rofi
 Source0:        %url/archive/refs/tags/%version.tar.gz
 Requires:       bash


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (bitwarden-rofi): license (#9634)](https://github.com/terrapkg/packages/pull/9634)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)