### PR TITLE
[f43] gamescope-session-steam: move to OGC sources instead of bazzite sources + minor refactor (#9590)

### DIFF
--- a/anda/games/gamescope-session-steam/anda.hcl
+++ b/anda/games/gamescope-session-steam/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+    arches = ["x86_64"]
     rpm {
         spec = "gamescope-session-steam.spec"
     }

--- a/anda/games/gamescope-session-steam/gamescope-session-steam.spec
+++ b/anda/games/gamescope-session-steam/gamescope-session-steam.spec
@@ -1,16 +1,18 @@
 %define debug_package %nil
 
-%global commit 93859eaa6056c24a9a6e9bc7464951793a54d3d3
+%global commit 1a3fdb7fa15a4bba7204bef69702b7a10a297828
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20251113
+%global commit_date 20241205
 
 Name:           gamescope-session-steam
-Version:        %commit_date.%shortcommit
+Version:        0~%{commit_date}git.%{shortcommit}
 Release:        1%?dist
 Summary:        gamescope-session-steam
 License:        MIT
-URL:            https://github.com/bazzite-org/gamescope-session-steam
+URL:            https://github.com/OpenGamingCollective/gamescope-session-steam
 Source0:        %url/archive/%commit.tar.gz
+Packager:       Tulip Blossom <tulilirockz@outlook.com>
+BuildArch:      noarch
 
 %description
 %summary.
@@ -21,16 +23,15 @@ Source0:        %url/archive/%commit.tar.gz
 %build
 
 %install
-mkdir -p %{buildroot}%{_bindir}/
-mkdir -p %{buildroot}%{_datadir}/
-cp -rv usr/bin/* %{buildroot}%{_bindir}
-cp -rv usr/share/* %{buildroot}%{_datadir}
-rm -rf %{buildroot}%{_bindir}/steamos-polkit-helpers
-rm %{buildroot}%{_bindir}/jupiter-biosupdate
-# We want to actually keep this for drop-in scripts
-# rm %{buildroot}%{_bindir}/steamos-session-select
-rm %{buildroot}%{_bindir}/steamos-update
-
+install -Dpm0755 -t "%buildroot%_bindir/" ".%_bindir/steam-http-loader"
+install -Dpm0755 -t "%buildroot%_bindir/" ".%_bindir/steamos-select-branch"
+install -Dpm0755 -t "%buildroot%_bindir/" ".%_bindir/steamos-session-select"
+install -Dpm0644 -t "%buildroot%_datadir/applications/" ".%_datadir/applications/steam_http_loader.desktop"
+install -Dpm0644 -t "%buildroot%_datadir/applications/" ".%_datadir/applications/gamescope-mimeapps.list"
+install -Dpm0755 -t "%buildroot%_datadir/gamescope-session-plus/sessions.d/" ".%_datadir/gamescope-session-plus/sessions.d/steam"
+install -Dpm0644 -t "%buildroot%_datadir/polkit-1/actions/" ".%_datadir/polkit-1/actions/org.chimeraos.update.policy"
+install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session-steam.desktop"
+install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session.desktop"
 
 %files
 %license LICENSE
@@ -43,3 +44,7 @@ rm %{buildroot}%{_bindir}/steamos-update
 %{_datadir}/polkit-1/actions/org.chimeraos.update.policy
 %{_datadir}/wayland-sessions/gamescope-session-steam.desktop
 %{_datadir}/wayland-sessions/gamescope-session.desktop
+
+%changelog
+* Mon Feb 03 2026 Tulip Blossom <tulilirockz@outlook.com> - 20241205.1a3fdb7f-1
+- Move to OGC source and clean up

--- a/anda/games/gamescope-session-steam/update.rhai
+++ b/anda/games/gamescope-session-steam/update.rhai
@@ -1,5 +1,5 @@
 if filters.contains("nightly") {
-    rpm.global("commit", gh_commit("bazzite-org/gamescope-session-steam"));
+    rpm.global("commit", gh_commit("OpenGamingCollective/gamescope-session-steam"));
     if rpm.changed() {
         rpm.release();
         rpm.global("commit_date", date());


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [gamescope-session-steam: move to OGC sources instead of bazzite sources + minor refactor (#9590)](https://github.com/terrapkg/packages/pull/9590)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)