### PR TITLE
[f43] fix (polycrystal): license and description (#9644)

### DIFF
--- a/anda/system/polycrystal/polycrystal.spec
+++ b/anda/system/polycrystal/polycrystal.spec
@@ -1,15 +1,15 @@
 Name:           polycrystal
 Version:        0.2.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Barebones "automatic" Flatpak installer for distribution-default Flatpak packages.
 URL:            https://github.com/Ultramarine-Linux/polycrystal
 Source0:        %url/archive/refs/tags/v%version.tar.gz
-License:        GPL
+License:        GPL-3.0-only
 BuildRequires:  cargo cmake anda-srpm-macros cargo-rpm-macros systemd-rpm-macros mold glib2-devel flatpak-devel
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
-%summary
+%summary.
 
 %prep
 %autosetup -n polycrystal-%version


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (polycrystal): license and description (#9644)](https://github.com/terrapkg/packages/pull/9644)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)