### PR TITLE
[f42] gamescope-session-opengamepadui: init package (#9653)

### DIFF
--- a/anda/games/gamescope-session-opengamepadui/anda.hcl
+++ b/anda/games/gamescope-session-opengamepadui/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+    arches = ["x86_64"]
+    rpm {
+        spec = "gamescope-session-opengamepadui.spec"
+    }
+    labels {
+        nightly = 1
+    }
+}

--- a/anda/games/gamescope-session-opengamepadui/gamescope-session-opengamepadui.spec
+++ b/anda/games/gamescope-session-opengamepadui/gamescope-session-opengamepadui.spec
@@ -1,0 +1,42 @@
+%global commit 88087a086ab732211c466b41f5d64229ce51c050
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20260204
+
+Name:           gamescope-session-opengamepadui
+Version:        0~%{commit_date}git.%{shortcommit}
+Release:        1%?dist
+Summary:        Gamescope session for OpenGamepadUI
+License:        GPL-3.0-only
+URL:            https://github.com/OpenGamingCollective/gamescope-session-opengamepadui
+Source0:        %url/archive/%commit.tar.gz
+Packager:       Tulip Blossom <tulilirockz@outlook.com>
+Requires:       opengamepadui
+BuildArch:      noarch
+
+%description
+%summary.
+
+%prep
+%autosetup -n %name-%commit
+
+%build
+
+%install
+install -Dpm0755 -t "%buildroot%_bindir/" ".%_bindir/opengamepadui-session-select"
+install -Dpm0755 -t "%buildroot%_datadir/gamescope-session-plus/sessions.d/" ".%_datadir/gamescope-session-plus/sessions.d/opengamepadui"
+install -Dpm0644 -t "%buildroot%_datadir/polkit-1/actions/" ".%_datadir/polkit-1/actions/org.shadowblip.opengamepadui-session.policy"
+install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session-opengamepadui.desktop"
+install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/opengamepadui-session.desktop"
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/opengamepadui-session-select
+%{_datadir}/gamescope-session-plus/sessions.d/opengamepadui
+%{_datadir}/polkit-1/actions/org.shadowblip.opengamepadui-session.policy
+%{_datadir}/wayland-sessions/gamescope-session-opengamepadui.desktop
+%{_datadir}/wayland-sessions/opengamepadui-session.desktop
+
+%changelog
+* Wed Feb 04 2026 Tulip Blossom <tulilirockz@outlook.com> - 20260204.88087a08-1
+- Initial package

--- a/anda/games/gamescope-session-opengamepadui/update.rhai
+++ b/anda/games/gamescope-session-opengamepadui/update.rhai
@@ -1,0 +1,7 @@
+if filters.contains("nightly") {
+    rpm.global("commit", gh_commit("OpenGamingCollective/gamescope-session-steam"));
+    if rpm.changed() {
+        rpm.release();
+        rpm.global("commit_date", date());
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [gamescope-session-opengamepadui: init package (#9653)](https://github.com/terrapkg/packages/pull/9653)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)