### PR TITLE
[el10] fix (openbangla-keyboard): track master branch (#9535)

### DIFF
--- a/anda/misc/openbangla-keyboard/openbangla-keyboard-nightly.spec
+++ b/anda/misc/openbangla-keyboard/openbangla-keyboard-nightly.spec
@@ -29,7 +29,6 @@ Summary:    OpenBangla Keyboard for IBus
 Requires:   ibus
 Requires:   openbangla-keyboard = %version-%release
 Provides:   openbangla-im = %version-%release
-Conflicts:  openbangla-im
 
 %description -n ibus-openbangla
 OpenBangla Keyboard for IBus.
@@ -40,28 +39,26 @@ Summary:    OpenBangla Keyboard for Fcitx5
 Requires:   fcitx5
 Requires:   openbangla-keyboard = %version-%release
 Provides:   openbangla-im = %version-%release
-Conflicts:  openbangla-im
 
 %description -n fcitx5-openbangla
 OpenBangla Keyboard for Fcitx5.
 
 
 %prep
-%autosetup -n OpenBangla-Keyboard-%commit
-rmdir src/engine/riti
-tar xf %SOURCE1 -C src/engine/
-mv src/engine/riti-master src/engine/riti
+%git_clone https://github.com/OpenBangla/OpenBangla-Keyboard.git %{commit}
+%cargo_prep_online
 
 %build
 if [[ -d build ]]; then rm -rf build; fi
-%cmake -DENABLE_FCITX=YES -DENABLE_IBUS=YES
+%cmake -DENABLE_FCITX=YES -DENABLE_IBUS=YES -DBUILD_SHARED_LIBS:BOOL=OFF
 %cmake_build
 
 %install
 %cmake_install
 
 %files
-%doc README.adoc
+%lang(bn) %doc README.bn.adoc
+%lang(en) %doc README.adoc
 %license LICENSE
 %_bindir/openbangla-gui
 %_datadir/applications/openbangla-keyboard.desktop

--- a/anda/misc/openbangla-keyboard/update.rhai
+++ b/anda/misc/openbangla-keyboard/update.rhai
@@ -1,8 +1,6 @@
-if filters.contains("nightly") {
-	rpm.global("commit", get("https://api.github.com/repos/OpenBangla/OpenBangla-Keyboard/commits/develop").json().sha);
-	if rpm.changed() {
-		rpm.global("ver", gh("OpenBangla/OpenBangla-Keyboard"));
-		rpm.global("commit_date", date());
-		rpm.release();
-	}
+rpm.global("commit", get("https://api.github.com/repos/OpenBangla/OpenBangla-Keyboard/commits/develop").json().sha);
+if rpm.changed() {
+	rpm.global("ver", gh("OpenBangla/OpenBangla-Keyboard"));
+	rpm.global("commit_date", date());
+	rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (openbangla-keyboard): track master branch (#9535)](https://github.com/terrapkg/packages/pull/9535)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)