### PR TITLE
chore: Set RUSTC_WRAPPER variable to full sccache path for outlier issues

### DIFF
--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -36,7 +36,7 @@ on:
         default: true
 
 env:
-  RUSTC_WRAPPER: sccache
+  RUSTC_WRAPPER: "/usr/bin/sccache"
   # SCCACHE_NO_DAEMON: "1"
   # Disable incremental compilation so sccache works better
   CARGO_INCREMENTAL: "false"


### PR DESCRIPTION
This is a weird one.