### PR TITLE
fix (mesa): Use tags instead of branches for patches from OGC

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -119,8 +119,8 @@ Source15:       https://crates.io/api/v1/crates/rustc-hash/%{rustc_hash_ver}/dow
 Patch12:        mesa-38532.patch
 
 # Open Gaming Collective Patches
-Patch30:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/heads/%{ver}/limiter.patch
-Patch31:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/heads/%{ver}/radv-defaults.patch
+Patch30:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/tags/%{ver}/limiter.patch
+Patch31:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/tags/%{ver}/radv-defaults.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc


### PR DESCRIPTION
No change to release because this is a non-op build, no code change from last one.