### PR TITLE
[f43] chore: Set RUSTC_WRAPPER variable to full sccache path for outlier issues (#9664)

### DIFF
--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -36,7 +36,7 @@ on:
         default: true
 
 env:
-  RUSTC_WRAPPER: sccache
+  RUSTC_WRAPPER: "/usr/bin/sccache"
   # SCCACHE_NO_DAEMON: "1"
   # Disable incremental compilation so sccache works better
   CARGO_INCREMENTAL: "false"


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: Set RUSTC_WRAPPER variable to full sccache path for outlier issues (#9664)](https://github.com/terrapkg/packages/pull/9664)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)