### PR TITLE
[el10] bump(nightly): goofcord-nightly ghostty-nightly zed-nightly gamescope-session-opengamepadui prismlauncher-nightly types-colorama scx-scheds-nightly xone-nightly natscli (#9676)

### DIFF
--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 70738d6b1d4e4ac1992c52f49869c587d062b33b
+%global commit 43fc986a36f10da2fab4924d4e2974b30d53e311
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260128
+%global commit_date 20260205
 %global ver 2.0.1^
 %global base_name goofcord
 %global git_name GoofCord

--- a/anda/devs/ghostty/nightly/ghostty-nightly.spec
+++ b/anda/devs/ghostty/nightly/ghostty-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 51897c0cd51fee61fff824d616fb2901ac41e817
+%global commit b30456d9a8ba432531bb69feb631e5c2955b4db8
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global fulldate 2026-02-03
+%global fulldate 2026-02-04
 %global commit_date %(echo %{fulldate} | sed 's/-//g')
 %global public_key RWQlAjJC23149WL2sEpT/l0QKy7hMIFhYdQOFy0Z7z7PbneUgvlsnYcV
 %global ver 1.3.0

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 555c002499a4676bac4c2e4aae2fa11f0a2bbddd
+%global commit 49c777779a63a0f44abec3ba7bd490c8b1552667
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260204
-%global ver 0.223.0
+%global commit_date 20260205
+%global ver 0.224.0
 
 %bcond_with check
 %bcond_with debug_no_build

--- a/anda/games/gamescope-session-opengamepadui/gamescope-session-opengamepadui.spec
+++ b/anda/games/gamescope-session-opengamepadui/gamescope-session-opengamepadui.spec
@@ -1,6 +1,6 @@
-%global commit 88087a086ab732211c466b41f5d64229ce51c050
+%global commit 1a3fdb7fa15a4bba7204bef69702b7a10a297828
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260204
+%global commit_date 20260205
 
 Name:           gamescope-session-opengamepadui
 Version:        0~%{commit_date}git.%{shortcommit}

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,10 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-%global commit 9e86c44f7c5060e36ef2b67013558fe1c36282fc
+%global commit 620567e4350760df2b5943aa6eae8fff41b98f66
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
-%global commit_date 20260204
+%global commit_date 20260205
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 # Change this variables if you want to use custom keys

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit 11ff7e1126dbf6678b4ac52f3ad5b9c1e1839924
-%global commit_date 20260204
+%global commit e56ab929fdaa7c663a61eab843419e6ede2251d1
+%global commit_date 20260205
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 76f9754053becbc5008e5074608afd3daf7fd65b
+%global commit 48bcca8fd746b11aa0ac8f321fcf55ace7c395b1
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260204
+%global commitdate 20260205
 %global ver 1.0.19
 %undefine __brp_mangle_shebangs
 

--- a/anda/system/xone/nightly/kmod-common/xone-nightly.spec
+++ b/anda/system/xone/nightly/kmod-common/xone-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 17d9b6a8939085d6e13b8c3ad684d28ca3166a02
+%global commit adc17246571adadbc36aa5f168c96662f6ca6b8a
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20251222
-%global ver 0.5.1
+%global commitdate 20260205
+%global ver 0.5.4
 %global modulename xone
 %global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
 %global firmware_hash0 080ce4091e53a4ef3e5fe29939f51fd91f46d6a88be6d67eb6e99a5723b3a223
@@ -11,7 +11,7 @@
 
 Name:           xone-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        1%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -59,7 +59,7 @@ BuildArch:       noarch
 
 %description     firmware
 Proprietary firmware for XBox controller dongles.
- 
+
 %prep
 %autosetup -p1 -n %{modulename}-%{commit}
 /usr/bin/sed -nE '/^BUILT_MODULE_NAME/{s@^.+"(.+)"@\1@; s|-|_|g; p}' dkms.conf > %{modulename}.conf

--- a/anda/tools/natscli/natscli.spec
+++ b/anda/tools/natscli/natscli.spec
@@ -1,7 +1,7 @@
 # https://github.com/nats-io/natscli
 %global goipath         github.com/nats-io/natscli
-%global commit          66f169ff1f1ac0354873f7911758cd3e1fe7af29
-%global commit_date     20260131
+%global commit          c0443926a1072dc49be24215dc3964ff31e1efe0
+%global commit_date     20260205
 %global shortcommit     %{sub %{commit} 1 7}
 
 %gometa -f


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [bump(nightly): goofcord-nightly ghostty-nightly zed-nightly gamescope-session-opengamepadui prismlauncher-nightly types-colorama scx-scheds-nightly xone-nightly natscli (#9676)](https://github.com/terrapkg/packages/pull/9676)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)