### PR TITLE
[el10] fix(vesktop): building with new package naming scheme & added metainfo (#9678)

### DIFF
--- a/anda/apps/vesktop/vesktop.spec
+++ b/anda/apps/vesktop/vesktop.spec
@@ -11,7 +11,7 @@ Name:		vesktop
 Obsoletes:  VencordDesktop < 1.5.8-1
 Obsoletes:  vencord-desktop < 1.5.8-1
 Version:	1.6.4
-Release:	1%?dist
+Release:	2%?dist
 License:	GPL-3.0
 Summary:	Vesktop is a cross platform desktop app aiming to give you a snappier Discord experience with Vencord pre-installed
 URL:		https://vesktop.dev

--- a/anda/apps/vesktop/vesktop.spec
+++ b/anda/apps/vesktop/vesktop.spec
@@ -1,5 +1,8 @@
 %define debug_package %nil
 
+%global giturl https://github.com/Vencord/Vesktop
+%global appid dev.vencord.Vesktop
+
 # Exclude private libraries
 %global __requires_exclude libffmpeg.so
 %global __provides_exclude_from %{_datadir}/vesktop/.*\\.so
@@ -11,12 +14,17 @@ Version:	1.6.4
 Release:	1%?dist
 License:	GPL-3.0
 Summary:	Vesktop is a cross platform desktop app aiming to give you a snappier Discord experience with Vencord pre-installed
-URL:		https://github.com/Vencord/Vesktop
+URL:		https://vesktop.dev
 Group:		Applications/Internet
 #Source1:	launch.sh
-Source0:    https://github.com/Vencord/Vesktop/archive/refs/tags/v%{version}.tar.gz
+Source0:    %{giturl}/archive/refs/tags/v%{version}.tar.gz
+Source1:    %{giturl}/releases/download/v%{version}/%{appid}.metainfo.xml
 Requires:   xdg-utils
+%if 0%{?fedora} >= 44
+BuildRequires: nodejs24-npm-bin git
+%else
 BuildRequires:	nodejs-npm git
+%endif
 # Conflicts:	vesktop-bin
 
 %description
@@ -25,7 +33,7 @@ while keeping everything lightweight.
 
 %prep
 git init
-git remote add origin %url || :
+git remote add origin %giturl || :
 git reset --hard
 git fetch
 git checkout v%version
@@ -60,6 +68,7 @@ ln -sf /usr/share/vesktop/vesktop %buildroot/usr/bin/vesktop
 ln -sf /usr/bin/vesktop %buildroot/usr/bin/vencorddesktop
 install -Dm644 vesktop.desktop %{buildroot}%{_datadir}/applications/vesktop.desktop
 install -Dm644 build/icon.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/vesktop.svg
+install -Dm644 %{SOURCE1} %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
 
 %files
 %doc README.md
@@ -69,8 +78,11 @@ install -Dm644 build/icon.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/ves
 %{_datadir}/applications/vesktop.desktop
 %{_iconsdir}/hicolor/scalable/apps/vesktop.svg
 %{_datadir}/vesktop/*
+%{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Wed Feb 04 2026 Kaitlyn <kaitlynyaa@kaitlynyaa.dev> - 1.6.4
+- Added appstream metainfo and fixed buildrequires to adhere to new npm package naming scheme
 * Thu Jul 24 2025 Atmois <info@atmois.com> - 1.5.8-2
 - Rename from vencord-desktop to vesktop and amend the spec file accordingly
 * Tue Nov 07 2023 Cappy Ishihara <cappy@cappuchino.xyz> - 0.4.3-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(vesktop): building with new package naming scheme &amp; added metainfo (#9678)](https://github.com/terrapkg/packages/pull/9678)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)