### PR TITLE
[f42] chore(ScopeBuddy): move sources to OpenGamingCollective repository instead of HikariKnight (#9679)

### DIFF
--- a/anda/games/ScopeBuddy/ScopeBuddy.spec
+++ b/anda/games/ScopeBuddy/ScopeBuddy.spec
@@ -1,19 +1,17 @@
 Name:           ScopeBuddy
 Version:        1.4.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A manager script to make gamescope easier to use on desktop
 License:        Apache-2.0
-URL:            https://github.com/HikariKnight/ScopeBuddy
+URL:            https://github.com/OpenGamingCollective/ScopeBuddy
 Source0:        %url/archive/refs/tags/%version.tar.gz
 BuildArch:      noarch
 
 Requires:       bash
 Requires:       perl
 Requires:       (gamescope or terra-gamescope)
-
 Suggests:       (kscreen-doctor or gnome-randr)
 Suggests:       jq
-
 Provides:       scopebuddy
 Provides:       scb
 
@@ -26,16 +24,19 @@ A manager script to make gamescope easier to use on the desktop (or if you use i
 %autosetup
 
 %install
-install -Dm 755 bin/scopebuddy %{buildroot}%{_bindir}/scopebuddy
+install -Dpm0755 -t %{buildroot}%{_bindir}/ bin/scopebuddy bin/scb 
 
 %post
-%{__ln_s} -f %{_bindir}/scopebuddy %{_bindir}/scb
 
 %files
 %doc README.md
 %license LICENSE
 %{_bindir}/scopebuddy
+%{_bindir}/scb
 
 %changelog
+* Thu Feb 05 2025 Tulip Blossom <tulilirockz@outlook.com>
+- Move sources to OpenGamingCollective repository instead of personal HikariKnight repo
+
 * Tue Dec 16 2025 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(ScopeBuddy): move sources to OpenGamingCollective repository instead of HikariKnight (#9679)](https://github.com/terrapkg/packages/pull/9679)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)