### PR TITLE
[f42] fix (anda-srpm-macros): remove terra-appstream-helper dep (#9695)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -1,6 +1,6 @@
 Name:           anda-srpm-macros
 Version:        0.3.3
-Release:        1%?dist
+Release:        2%?dist
 Summary:        SRPM macros for extra Fedora packages
 
 License:        MIT
@@ -9,7 +9,6 @@ Source0:        %url/archive/refs/tags/v%{version}.tar.gz
 
 Recommends:     rust-packaging
 Requires:       git-core
-Requires:       terra-appstream-helper
 Obsoletes:      fyra-srpm-macros < 0.1.1-1
 Provides:       fyra-srpm-macros = %{version}-%{release}
 BuildArch:      noarch


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (anda-srpm-macros): remove terra-appstream-helper dep (#9695)](https://github.com/terrapkg/packages/pull/9695)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)