### PR TITLE
[f43] add: praat (#9699)

### DIFF
--- a/anda/tools/praat/anda.hcl
+++ b/anda/tools/praat/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	rpm {
+		spec = "praat.spec"
+	}
+}
+

--- a/anda/tools/praat/org.praat.praat.metainfo.xml
+++ b/anda/tools/praat/org.praat.praat.metainfo.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component>
+  <id>org.praat.praat</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later AND BSD-3-Clause AND Unicode-3.0 AND BSL-1.0</project_license>
+  <icon type="local">/usr/share/icons/hicolor/16x16/praat.png</icon>
+
+  <name>Praat</name>
+  <summary>Praat: Doing Phonetics By Computer</summary>
+
+  <description>
+    <p>
+        Praat: Doing Phonetics By Computer
+    </p>
+  </description>
+
+  <launchable type="desktop-id">praat.desktop</launchable>
+
+  <url type="homepage">https://www.praat.org</url>
+
+  <releases>
+    <release version="6.4.59"/>
+  </releases>
+
+  <keywords>
+    <keyword>audio</keyword>
+    <keyword>sound</keyword>
+    <keyword>speech</keyword>
+    <keyword>phonetics</keyword>
+  </keywords>
+
+  <developer id="paul.boersma@uva.nl">
+    <name>Paul Boersma</name>
+  </developer>
+
+  <developer id="dweenink@xs4all.nl">
+    <name>David Weenink</name>
+  </developer>
+</component>

--- a/anda/tools/praat/praat.spec
+++ b/anda/tools/praat/praat.spec
@@ -1,0 +1,76 @@
+%global appid org.praat.praat
+%global name_pretty Praat
+%global appstream_component desktop-application
+%global org "org.praat"
+
+Name:             praat
+Version:          6.4.59
+Release:          1%{?dist}
+URL:              https://www.praat.org
+Source0:          https://github.com/praat/praat.github.io/archive/refs/tags/v%{version}.tar.gz
+Source1:          %appid.metainfo.xml
+License:          GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later AND BSD-3-Clause AND Unicode-3.0 AND BSL-1.0
+
+Requires:         gtk3 pulseaudio-libs alsa-lib pipewire-jack-audio-connection-kit
+BuildRequires:    gcc g++ gtk3-devel pulseaudio-libs-devel alsa-lib-devel pipewire-jack-audio-connection-kit-devel
+# for lscpu check below
+BuildRequires:    util-linux 
+# to install desktop file
+BuildRequires:    desktop-file-utils
+# to generate the icon files
+BuildRequires:    libicns-utils
+# to generate the appstream metadata
+BuildRequires:    terra-appstream-helper
+
+Summary:          Praat: Doing Phonetics By Computer 
+
+Packager:         june-fish <june@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n praat.github.io-%{version}
+
+%build
+# .LE makefile hardcodes little endian
+if [[ "$(lscpu | grep Endian)" == *"Little Endian"* ]]
+then
+  cp makefiles/makefile.defs.linux.pulse-gcc.LE ./makefile.defs
+elif [[ "%{lscpu | grep Endian}" == *"Big Endian"* ]]
+then
+  cp makefiles/makefile.defs.linux.pulse-gcc.BE ./makefile.defs
+fi
+
+%make_build
+
+%install
+install -pDm755 praat %{buildroot}%{_bindir}/praat
+%__desktop_file_install main/praat.desktop
+
+# https://build.opensuse.org/projects/openSUSE:Factory/packages/praat/files/praat.spec?expand=1
+icns2png -x -d32 main/Praat.icns
+for s in 16 32 48 128; do
+   if [ -f Praat_${s}x${s}x32.png ]; then
+      install -Dm0644 Praat_${s}x${s}x32.png %{buildroot}%{_hicolordir}/${s}x${s}/apps/%{name}.png
+   fi
+done
+
+%terra_appstream -o %{SOURCE1}
+
+%files
+%license docs/LICENSE.txt
+%license external/*/LICENSE*
+%license external/*/COPYING*
+%doc README.md
+%{_bindir}/praat
+%{_datadir}/applications/praat.desktop
+%{_hicolordir}/16x16/apps/%{name}.png
+%{_hicolordir}/32x32/apps/%{name}.png
+%{_hicolordir}/48x48/apps/%{name}.png
+%{_hicolordir}/128x128/apps/%{name}.png
+%{_metainfodir}/%appid.metainfo.xml
+
+%changelog
+* Fri Feb 06 2026 june-fish <git@june.fish> - 6.4.59
+- Initial Package

--- a/anda/tools/praat/update.rhai
+++ b/anda/tools/praat/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("praat/praat.github.io"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: praat (#9699)](https://github.com/terrapkg/packages/pull/9699)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)