### PR TITLE
[f42] Update file copy command in rtl8821cu-kmod.spec (#9708)

### DIFF
--- a/anda/system/rtl8821cu/akmod/rtl8821cu-kmod.spec
+++ b/anda/system/rtl8821cu/akmod/rtl8821cu-kmod.spec
@@ -44,7 +44,7 @@ sed -i 's/CONFIG_PLATFORM_ARM64_RPI = n/CONFIG_PLATFORM_ARM64_RPI = y/g' Makefil
 
 for kernel_version in %{?kernel_versions}; do
     mkdir _kmod_build_${kernel_version%%___*}
-    cp -fr core hal include os_dep platform Kconfig Makefile halmac.mk _kmod_build_${kernel_version%%___*}
+    cp -fr core hal include os_dep platform Kconfig Makefile halmac.mk rtl8821c.mk _kmod_build_${kernel_version%%___*}
 done
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Update file copy command in rtl8821cu-kmod.spec (#9708)](https://github.com/terrapkg/packages/pull/9708)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)