### PR TITLE
[el10] fix (praat): metainfo (#9704)

### DIFF
--- a/anda/tools/praat/org.praat.praat.metainfo.xml
+++ b/anda/tools/praat/org.praat.praat.metainfo.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<component>
+<component type="desktop-application">
   <id>org.praat.praat</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later AND BSD-3-Clause AND Unicode-3.0 AND BSL-1.0</project_license>
-  <icon type="local">/usr/share/icons/hicolor/16x16/praat.png</icon>
+  <project_license
+    >GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT AND GPL-2.0-or-later AND BSD-3-Clause AND Unicode-3.0 AND BSL-1.0</project_license>
+  <icon
+        type="remote"
+    >https://github.com/praat/praat.github.io/blob/master/main/praat-480.svg</icon>
 
   <name>Praat</name>
   <summary>Praat: Doing Phonetics By Computer</summary>
 
   <description>
     <p>
-        Praat: Doing Phonetics By Computer
+    A speech analysis tool used for doing phonetics by computer. Praat can analyse,
+    synthesize, and manipulate speech, and create high-quality pictures for your publications.
+    Praat was created by Paul Boersma and David Weenink of the Institute of Phonetics Sciences of the University of Amsterdam.
     </p>
   </description>
 
@@ -19,7 +24,7 @@
   <url type="homepage">https://www.praat.org</url>
 
   <releases>
-    <release version="6.4.59"/>
+    <release version="6.4.59" date="2026-02-05" type="stable" />
   </releases>
 
   <keywords>
@@ -29,11 +34,7 @@
     <keyword>phonetics</keyword>
   </keywords>
 
-  <developer id="paul.boersma@uva.nl">
-    <name>Paul Boersma</name>
-  </developer>
-
-  <developer id="dweenink@xs4all.nl">
-    <name>David Weenink</name>
+  <developer id="org.praat">
+    <name>Paul Boersma and David Weenink</name>
   </developer>
 </component>

--- a/anda/tools/praat/praat.spec
+++ b/anda/tools/praat/praat.spec
@@ -5,7 +5,7 @@
 
 Name:             praat
 Version:          6.4.59
-Release:          1%{?dist}
+Release:          2%{?dist}
 URL:              https://www.praat.org
 Source0:          https://github.com/praat/praat.github.io/archive/refs/tags/v%{version}.tar.gz
 Source1:          %appid.metainfo.xml
@@ -14,7 +14,7 @@ License:          GPL-3.0-or-later AND LGPL-2.1-or-later AND MIT AND GPL-2.0-or-
 Requires:         gtk3 pulseaudio-libs alsa-lib pipewire-jack-audio-connection-kit
 BuildRequires:    gcc g++ gtk3-devel pulseaudio-libs-devel alsa-lib-devel pipewire-jack-audio-connection-kit-devel
 # for lscpu check below
-BuildRequires:    util-linux 
+BuildRequires:    util-linux
 # to install desktop file
 BuildRequires:    desktop-file-utils
 # to generate the icon files
@@ -22,7 +22,7 @@ BuildRequires:    libicns-utils
 # to generate the appstream metadata
 BuildRequires:    terra-appstream-helper
 
-Summary:          Praat: Doing Phonetics By Computer 
+Summary:          Praat: Doing Phonetics By Computer
 
 Packager:         june-fish <june@fyralabs.com>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (praat): metainfo (#9704)](https://github.com/terrapkg/packages/pull/9704)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)