### PR TITLE
[f42] chore: Bump nightly packages (#9724)

### DIFF
--- a/anda/apps/flameshot/flameshot-nightly.spec
+++ b/anda/apps/flameshot/flameshot-nightly.spec
@@ -1,9 +1,9 @@
 #? https://github.com/flameshot-org/flameshot/blob/master/packaging/rpm/fedora/flameshot.spec
 
 %global ver 13.3.0
-%global commit c4000368c8f48d726d38c3458300e1a4f3fc53a0
+%global commit 739a809557d8be3ee8f3f7d16dffd0cfd391de09
 %global shortcommit %{sub %{commit} 1 7}
-%global commit_date 20260204
+%global commit_date 20260208
 %global devel_name QtColorWidgets
 %global _distro_extra_cflags -fuse-ld=mold
 %global _distro_extra_cxxflags -fuse-ld=mold

--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,5 +1,5 @@
-%global commit df59d55a39662553a8f6f1502272bb4b4991e6f7
-%global commit_date 20260202
+%global commit 08329c25f3344819047b1bddf311df82e953d900
+%global commit_date 20260208
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global debug_package %nil
 %global __strip /bin/true

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,9 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-%global commit 9ccd8899ff28c4f6bdd113026d307af3d46133c5
+%global commit b6512e1f8d5f84ab4fb6cd55027ba91247b025e7
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260207
+%global commit_date 20260208
 %global ver 0.41.0
 
 Name:           mpv-nightly

--- a/anda/desktops/hyprland/hyprwayland-scanner/hyprwayland-scanner.nightly.spec
+++ b/anda/desktops/hyprland/hyprwayland-scanner/hyprwayland-scanner.nightly.spec
@@ -2,9 +2,9 @@
 
 %global realname hyprwayland-scanner
 %global ver 0.4.5
-%global commit b3b0f1f40ae09d4447c20608e5a4faf8bf3c492d
+%global commit 0bd8b6cde9ec27d48aad9e5b4deefb3746909d40
 %global shortcommit %{sub %commit 1 7}
-%global commit_date 20250815
+%global commit_date 20260208
 
 Name:           %realname.nightly
 Version:        %ver^%{commit_date}git.%shortcommit

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 10c3c088fe63525b0301648304f14610cffb4585
+%global commit 35160555da6478945420a45d5ed6482cb9750f70
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260207
+%global commit_date 20260208
 %global ver 0.224.0
 
 %bcond_with check

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,8 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-%global commit 12a2333817ad8864cbb2e36367701c908631c787
+%global commit 513c9aa69a59d4dd414363d518d317b6e614f2ee
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
-%global commit_date 20260206
+%global commit_date 20260208
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/python/types-colorama/types-colorama.spec
+++ b/anda/langs/python/types-colorama/types-colorama.spec
@@ -1,5 +1,5 @@
-%global commit d7595e2b327bc55239b8e6ecc4408d51373c4782
-%global commit_date 20260206
+%global commit c045882babc7d06a5422ffd6d9053c0d4aee8b49
+%global commit_date 20260208
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global pypi_name types-colorama

--- a/anda/lib/tdlib/tdlib-nightly.spec
+++ b/anda/lib/tdlib/tdlib-nightly.spec
@@ -1,6 +1,6 @@
-%global commit cb863c1600082404428f1a84e407b866b9d412a8
-%global ver 1.8.60
-%global commit_date 20260109
+%global commit 6d509061574d684117f74133056aa43df89022fc
+%global ver 1.8.61
+%global commit_date 20260208
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:          tdlib-nightly

--- a/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
+++ b/anda/system/opentabletdriver-nightly/opentabletdriver-nightly.spec
@@ -1,6 +1,6 @@
-%global commit 00e24700a615387153e469c7c7aa5482ac51f2cb
+%global commit a4ac610a2f5e98f878ae3436e3f0e7ea9e41e4a1
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260207
+%global commit_date 20260208
 %global ver 0.6.6.2
 
 # We aren't using Mono but RPM expected Mono

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,7 +1,7 @@
-%global commit 30f3260e94ed975a4ae771f50e2351fa34c597bd
+%global commit a931f9ca47af8178ab18bf341ce9a27049c97b3c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260207
-%global ver 1.0.19
+%global commitdate 20260208
+%global ver 1.0.20
 %undefine __brp_mangle_shebangs
 
 Name:           scx-scheds-nightly

--- a/anda/system/scx-tools/nightly/scx-tools-nightly.spec
+++ b/anda/system/scx-tools/nightly/scx-tools-nightly.spec
@@ -1,14 +1,14 @@
-%global commit 2cced64079cc2d1fbd570746b6bd47e93b99d09e
+%global commit cb5bd4fa620b5f8ec7a31de2a9b60865067b3309
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260114
-%global ver 1.0.19
+%global commitdate 20260208
+%global ver 1.0.20
 %global appid com.sched_ext.scx
 %global developer "sched-ext Contributors"
 %global org "com.sched_ext"
 
 Name:           scx-tools-nightly
 Version:        %{ver}^%{commitdate}.git.%{shortcommit}
-Release:        2%{?dist}
+Release:        1%?dist
 Summary:        Sched_ext Tools
 License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND GPL-2.0-only AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 SourceLicense:  GPL-2.0-only


### PR DESCRIPTION
# Backport

This will backport the following commits from `el10` to `f42`:
 - [chore: Bump nightly packages (#9724)](https://github.com/terrapkg/packages/pull/9724)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)