### PR TITLE
[el10] add: veracrypt (#9717)

### DIFF
--- a/anda/system/veracrypt/anda.hcl
+++ b/anda/system/veracrypt/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "veracrypt.spec"
+  }
+}

--- a/anda/system/veracrypt/jp.veracrypt.veracrypt.metainfo.xml
+++ b/anda/system/veracrypt/jp.veracrypt.veracrypt.metainfo.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>jp.veracrypt.veracrypt</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0 AND TrueCrypt-License-version-3.0 AND LGPL-3.0-only AND BSD-2-Clause AND Zlib AND BSD-3-Clause AND Public Domain</project_license>
+  <icon type="remote">https://github.com/veracrypt/VeraCrypt/blob/master/src/Resources/Icons/VeraCrypt.svg</icon>
+
+  <name>Veracrypt</name>
+  <summary>Disk encryption with strong security based on TrueCrypt</summary>
+
+  <description>
+    <p>
+      Free open source disk encryption software for Windows, Mac OSX and Linux. Brought to you by AM Crypto and based on TrueCrypt 7.1a.
+    </p>
+    <p>
+      VeraCrypt main features:
+
+          - Creates a virtual encrypted disk within a file and mounts it as a real disk.
+          - Encrypts an entire partition or storage device such as USB flash drive or hard drive.
+          - Encrypts a partition or drive where Windows is installed (pre-boot authentication).
+          - Encryption is automatic, real-time(on-the-fly) and transparent.
+          - Parallelization and pipelining allow data to be read and written as fast as if the drive was not encrypted.
+          - Encryption can be hardware-accelerated on modern processors.
+          - Provides plausible deniability, in case an adversary forces you to reveal the password: Hidden volume (steganography) and hidden operating system.
+          - More information about the features of VeraCrypt may be found in the documentation
+
+    </p>
+  </description>
+
+  <launchable type="desktop-id">veracrypt.desktop</launchable>
+
+  <url type="homepage">https://veracrypt.jp/en/Home.html</url>
+
+  <keywords>
+    <keyword>Encryption</keyword>
+  </keywords>
+</component>

--- a/anda/system/veracrypt/update.rhai
+++ b/anda/system/veracrypt/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("veracrypt/VeraCrypt"));

--- a/anda/system/veracrypt/veracrypt.spec
+++ b/anda/system/veracrypt/veracrypt.spec
@@ -1,0 +1,79 @@
+%define debug_package %{nil}
+%define _unpackaged_files_terminate_build 0
+%define appid jp.veracrypt.veracrypt
+
+Name:           veracrypt
+Version:        1.26.24
+Release:        1%?dist
+Summary:        Disk encryption with strong security based on TrueCrypt
+URL:            https://veracrypt.jp/en/Home.html
+Source0:        https://github.com/veracrypt/VeraCrypt/archive/refs/tags/VeraCrypt_%version.tar.gz
+Source1:        %{appid}.metainfo.xml
+License:        Apache-2.0 AND TrueCrypt-License-version-3.0 AND LGPL-3.0-only AND BSD-2-Clause AND Zlib AND BSD-3-Clause AND Public Domain
+BuildRequires:  make
+BuildRequires:  yasm
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  clang
+BuildRequires:  pkgconf-pkg-config
+BuildRequires:  wxGTK-devel
+BuildRequires:  pkgconfig(fuse)
+BuildRequires:  pcsc-lite-devel
+Requires:       wxGTK-devel
+
+Provides:       VeraCrypt
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%package        lang
+Summary:        Translations for package %{name}
+Requires:       %{name} = %{evr}
+Supplements:    %{name}
+Provides:       %{name}-lang-all = %{evr}
+BuildArch:      noarch
+
+%description    lang
+%{summary}.
+
+%package        doc
+Summary:        Documentation for %{name}
+Requires:       %{name} = %{evr}
+Supplements:    %{name}
+BuildArch:      noarch
+
+%description    doc
+%{summary}.
+
+%prep
+%autosetup -n VeraCrypt-VeraCrypt_%{version}
+
+%build
+%make_build -C src
+
+%install
+%make_install -C src
+cp -r doc/ %{buildroot}%{_pkgdocdir}/
+%terra_appstream -o %{SOURCE1}
+
+%files
+%doc README.md
+%license License.txt
+%{_bindir}/veracrypt
+%{_bindir}/veracrypt-uninstall.sh
+%{_appsdir}/veracrypt.desktop
+%{_datadir}/mime/packages/veracrypt.xml
+%{_datadir}/pixmaps/veracrypt.xpm
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%files lang
+%{_datadir}/veracrypt/languages/*
+
+%files doc
+%{_pkgdocdir}/
+
+%changelog
+* Sat Feb 07 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: veracrypt (#9717)](https://github.com/terrapkg/packages/pull/9717)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)