### PR TITLE
[f43] fix (veracrypt): update script (#9730)

### DIFF
--- a/anda/system/veracrypt/update.rhai
+++ b/anda/system/veracrypt/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("veracrypt/VeraCrypt"));
+rpm.global("ver", gh("veracrypt/VeraCrypt"));

--- a/anda/system/veracrypt/veracrypt.spec
+++ b/anda/system/veracrypt/veracrypt.spec
@@ -3,7 +3,7 @@
 %define appid jp.veracrypt.veracrypt
 
 Name:           veracrypt
-Version:        VeraCrypt_1.26.24
+Version:        %{sanitized_ver}
 Release:        1%?dist
 Summary:        Disk encryption with strong security based on TrueCrypt
 URL:            https://veracrypt.jp/en/Home.html


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (veracrypt): update script (#9730)](https://github.com/terrapkg/packages/pull/9730)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)