### PR TITLE
[el10] fix: add appstream-helper to bootstrap (#9738)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build terra-release
         run: anda build -D "vendor Terra" -rrpmbuild anda/terra/release/pkg
 
+      - name: Build terra-appstream-helper
+        run: anda build -D "vendor Terra" -rrpmbuild anda/terra/appstream-helper/pkg
+
       - name: Build Subatomic
         run: anda build -D "vendor Terra" -rrpmbuild anda/tools/buildsys/subatomic/pkg
       - name: Install Subatomic and anda-srpm-macros


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: add appstream-helper to bootstrap (#9738)](https://github.com/terrapkg/packages/pull/9738)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)