### PR TITLE
[f43] feat: Toggleable sccache (#9773)

### DIFF
--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -35,6 +35,7 @@ on:
         type: boolean
         default: true
 
+<<<<<<< HEAD
 env:
   RUSTC_WRAPPER: "/usr/bin/sccache"
   # SCCACHE_NO_DAEMON: "1"
@@ -43,6 +44,8 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_RECACHE: "${{ inputs.bust_cache == 'true' && 'true' || '' }}"
 
+=======
+>>>>>>> 05feb6592 (feat: Toggleable sccache (#9773))
 jobs:
   build:
     strategy:
@@ -77,8 +80,16 @@ jobs:
           dir=$(dirname ${{ matrix.pkg.pkg }})
           dnf5 builddep -y ${dir}/*.spec
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Configure sccache
+        if: ${{ !contains(matrix.pkg.labels, 'sccache') }}
+        run: |
+          set -euo pipefail
+          echo "RUSTC_WRAPPER=/usr/bin/sccache" >> $GITHUB_ENV
+          echo "CARGO_INCREMENTAL=false" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          if [ "${{ inputs.bust_cache }}" = "true" ]; then
+            echo "SCCACHE_BUST_CACHE=true" >> $GITHUB_ENV
+          fi
 
       - name: Build with Andaman
         run: anda build -D "vendor Terra" ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Toggleable sccache (#9773)](https://github.com/terrapkg/packages/pull/9773)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)