### PR TITLE
[f43] fix: proton-vpn-local-agent (#9768)

### DIFF
--- a/anda/langs/python/proton-vpn-local-agent/anda.hcl
+++ b/anda/langs/python/proton-vpn-local-agent/anda.hcl
@@ -2,4 +2,7 @@
     rpm {
 	    spec = "proton-vpn-local-agent.spec"
     }
+    labels {
+      sccache = 0
+    }
   }

--- a/anda/langs/python/proton-vpn-local-agent/proton-vpn-local-agent.spec
+++ b/anda/langs/python/proton-vpn-local-agent/proton-vpn-local-agent.spec
@@ -1,11 +1,12 @@
 %define debug_package %{nil}
+%define __python /usr/bin/python3
 
 %global pypi_name proton-vpn-local-agent
 %global _desc Proton VPN local agent written in Rust.
 
 Name:			python-%{pypi_name}
 Version:		1.6.0
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Proton VPN local agent written in Rust
 License:		GPL-3.0-only
 URL:			https://github.com/ProtonVPN/local-agent-rs
@@ -15,7 +16,7 @@ BuildRequires:  python3-devel
 BuildRequires:  cargo-rpm-macros
 
 # Really cursed but there is no pyproject.toml or setup.py in this package to auto-provide this, and proton-vpn needs this
-Provides:       python3.14dist(proton-vpn-local-agent)
+%dnl Provides:       python3.14dist(proton-vpn-local-agent)
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
@@ -43,12 +44,12 @@ popd
 
 %install
 pushd %{name}
-install -Dm0644 target/release/libpython_proton_vpn_local_agent.so %{buildroot}%{_libdir}/proton/local_agent.so
+install -Dm0644 target/release/libpython_proton_vpn_local_agent.so %{buildroot}%{python_sitearch}/proton/vpn/local_agent.so
 popd
 
 %files -n python3-%{pypi_name}
 %doc README.md CODEOWNERS
-%{_libdir}/proton/local_agent.so
+%{python_sitearch}/proton/vpn/local_agent.so
 
 %changelog
 * Sun Jan 18 2026 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: proton-vpn-local-agent (#9768)](https://github.com/terrapkg/packages/pull/9768)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)