### PR TITLE
[f43] add: HolyC (#9780)

### DIFF
--- a/anda/langs/holyc/anda.hcl
+++ b/anda/langs/holyc/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "holyc.spec"
+	}
+}

--- a/anda/langs/holyc/holyc.spec
+++ b/anda/langs/holyc/holyc.spec
@@ -1,0 +1,41 @@
+%global ver 0.0.10
+
+Name:          holyc
+Version:       %{ver}~beta
+Release:       1%{?dist}
+Summary:       HolyC compiler and transpiler
+License:       BSD-2-Clause
+URL:           https://holyc-lang.com
+Source0:       https://github.com/Jamesbarford/holyc-lang/archive/refs/tags/beta-v%{ver}.tar.gz
+BuildRequires: cmake
+BuildRequires: cmake-rpm-macros
+BuildRequires: gcc
+BuildRequires: gcc-c++
+BuildRequires: sqlite-devel
+Packager:      Gilver E. <roachy@fyralabs.com>
+
+%description
+HolyC is a fun recreational programming language designed by Terry A. Davis.
+Originally implemented in TempleOS as a general purpose programming language and scripting language for all manner of tasks.
+
+%prep
+%autosetup -n %{name}-lang-beta-v%{ver}/src
+
+%build
+%cmake \
+  -DCMAKE_BUILD_TYPE="Release" \
+  -DHCC_LINK_SQLITE3="1"
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%license ../COPYING
+%doc ../README.md
+%{_bindir}/hcc
+%{_includedir}/tos.HH
+
+%changelog
+* Tue Feb 10 2026 Gilver E. <roachy@fyralabs.com> - 0.0.10~beta-1
+- Initial package

--- a/anda/langs/holyc/update.rhai
+++ b/anda/langs/holyc/update.rhai
@@ -1,0 +1,7 @@
+let v = gh("Jamesbarford/holyc-lang");
+v.crop(6);
+rpm.global("ver", v);
+
+if rpm.changed() {
+  rpm.release()
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: HolyC (#9780)](https://github.com/terrapkg/packages/pull/9780)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)