### PR TITLE
[f42] feat(ci): Explicitly set default Python to python3 (#9786)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -55,7 +55,7 @@ jobs:
         run: anda build -D "vendor Terra" -rrpmbuild anda/terra/release/pkg
 
       - name: Build terra-appstream-helper
-        run: anda build -D "vendor Terra" -rrpmbuild anda/terra/appstream-helper/pkg
+        run: anda build -D "vendor Terra" -D "__python %{__python3}" -rrpmbuild anda/terra/appstream-helper/pkg
 
       - name: Build Subatomic
         run: anda build -D "vendor Terra" -rrpmbuild anda/tools/buildsys/subatomic/pkg

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -65,7 +65,7 @@ jobs:
           dnf5 builddep -y ${dir}/*.spec
 
       - name: Build with Andaman
-        run: anda build -D "vendor Terra" ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
+        run: anda build -D "vendor Terra" -D "__python %{__python3}" ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
 
       - name: Generating artifact name
         id: art


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat(ci): Explicitly set default Python to python3 (#9786)](https://github.com/terrapkg/packages/pull/9786)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)