### PR TITLE
[el10] add: proton-core and make proton-vpn dep on it (#9796)

### DIFF
--- a/anda/apps/proton-vpn/proton-vpn.spec
+++ b/anda/apps/proton-vpn/proton-vpn.spec
@@ -1,6 +1,6 @@
 Name:			proton-vpn-gtk-app
 Version:		4.14.1
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Official ProtonVPN Linux app
 License:		GPL-3.0-only
 URL:			https://protonvpn.com/download-linux
@@ -27,6 +27,7 @@ Requires:       python3-gobject
 Requires:       python3-dbus
 Requires:       python3-packaging
 Requires:       python3-proton-vpn-api-core
+Requires:       python3-proton-core >= 0.7.0
 Requires:       librsvg2
 
 Provides:       protonvpn

--- a/anda/langs/python/proton-core/anda.hcl
+++ b/anda/langs/python/proton-core/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "proton-core.spec"
+  }
+  labels {
+    subrepo = "extras"
+  }
+}

--- a/anda/langs/python/proton-core/proton-core.spec
+++ b/anda/langs/python/proton-core/proton-core.spec
@@ -1,0 +1,46 @@
+%define unmangled_name proton-core
+%define github_repo_name python-proton-core
+%global _desc The proton-core component contains core logic used by the other Proton components.
+
+Name:       python-proton-core
+Version:    0.7.0
+Release:    1%?dist
+Summary:    %{unmangled_name} library
+License:    GPL-3.0-or-later
+URL:        https://github.com/ProtonVPN/%{github_repo_name}
+Source:     %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildArch:      noarch
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n python3-%{unmangled_name}
+Summary: %{summary}
+%{?python_provide:%python_provide python3-%{unmangled_name}}
+
+%description -n python3-%{unmangled_name}
+%_desc
+
+%prep
+%autosetup
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files proton
+
+%files -n python3-%{unmangled_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Tue Feb 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/proton-core/update.rhai
+++ b/anda/langs/python/proton-core/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("ProtonVPN/python-proton-core"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: proton-core and make proton-vpn dep on it (#9796)](https://github.com/terrapkg/packages/pull/9796)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)