### PR TITLE
[f42] fix: geist (#9828)

### DIFF
--- a/anda/fonts/geist/geist.spec
+++ b/anda/fonts/geist/geist.spec
@@ -1,8 +1,10 @@
+%global ver geist@1.7.0
+
 Name:		    geist-font
-Version:	    geist@1.7.0
+Version:	    %(echo %ver | sed 's/^geist@//')
 Release:	    1%?dist
 URL:		    https://vercel.com/font
-Source0:	    https://github.com/vercel/geist-font/archive/refs/tags/%version.tar.gz
+Source0:	    https://github.com/vercel/geist-font/archive/refs/tags/%ver.tar.gz
 License:	    OFL-1.1
 Summary:	    Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio
 BuildRequires:  make python3 python3.10 python3.10-devel meson cairo cairo-devel gcc
@@ -28,7 +30,7 @@ Geist Mono is a monospaced typeface that has been crafted to be the perfect part
 It is designed to be used in code editors, diagrams, terminals, and other textbased interfaces where code is represented.
 
 %prep
-%autosetup -n %name-%version
+%autosetup -n %name-geist-%version
 
 %build
 %make_build

--- a/anda/fonts/geist/update.rhai
+++ b/anda/fonts/geist/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("vercel/geist-font"));
+rpm.global("ver", gh("vercel/geist-font"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: geist (#9828)](https://github.com/terrapkg/packages/pull/9828)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)