### PR TITLE
[f44] fix: mise (#9822)

### DIFF
--- a/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
+++ b/anda/tools/buildsys/mise/mise-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- mise-2025.9.15/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ mise-2025.9.15/Cargo.toml	2025-09-22T01:33:34.763933+00:00
-@@ -507,27 +507,6 @@
+--- mise-2026.2.10/Cargo.toml	2006-07-24T01:21:28+00:00
++++ mise-2026.2.10/Cargo.toml	2026-02-12T15:02:18.584012+00:00
+@@ -575,30 +575,6 @@
  optional = true
  default-features = false
  
@@ -25,10 +25,13 @@
 -    "minwindef",
 -]
 -
+-[target."cfg(windows)".dependencies.zipsign-api]
+-version = "0.1"
+-
  [lints.clippy]
  borrowed_box = "allow"
  
-@@ -544,3 +523,4 @@
+@@ -615,3 +591,4 @@
  [profile.serious]
  lto = true
  inherits = "release"

--- a/anda/tools/buildsys/mise/rust-mise.spec
+++ b/anda/tools/buildsys/mise/rust-mise.spec
@@ -91,9 +91,10 @@ Zsh command line completion support for %{crate}.
 %build
 %{cargo_license_summary_online}
 %{cargo_license_online} > LICENSE.dependencies
+%{cargo_build} --locked
 
 %install
-%cargo_install
+%crate_install_bin
 install -Dm644 %SOURCE1 %buildroot%_mandir/man1/mise.1
 install -Dm644 %SOURCE2 %buildroot%bash_completions_dir/mise.bash
 install -Dm644 %SOURCE3 %buildroot%fish_completions_dir/mise.fish


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: mise (#9822)](https://github.com/terrapkg/packages/pull/9822)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)