### PR TITLE
[f42] fix(quickjs-ng): suppress compiler errors (#9824)

### DIFF
--- a/anda/lib/quickjs-ng/quickjs-ng.spec
+++ b/anda/lib/quickjs-ng/quickjs-ng.spec
@@ -1,4 +1,4 @@
-%global _distro_extra_cflags -Wno-discarded-qualifiers
+%global _distro_extra_cflags -Wno-discarded-qualifiers -Wno-maybe-uninitialized
 
 Name:           quickjs-ng
 Version:        0.12.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(quickjs-ng): suppress compiler errors (#9824)](https://github.com/terrapkg/packages/pull/9824)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)