### PR TITLE
[f44] bump: readymade-git (#9853)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,10 +1,10 @@
-%global commit 3ad158ad7ab2f36e104d93378c2938d572cec92d
-%global commit_date 20251216
+%global commit c35a86ddd3a9a673276111f02a6b1f36cfddce0d
+%global commit_date 20260212
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global crate readymade
 Name:           readymade-git
 Version:        %commit_date.%shortcommit
-Release:        2%?dist
+Release:        1%?dist
 Summary:        Install ready-made distribution images!
 License:        GPL-3.0-or-later
 URL:            https://github.com/FyraLabs/readymade
@@ -12,6 +12,7 @@ Source0:        %url/archive/%commit.tar.gz
 Source1:        https://github.com/FyraLabs/rdms_proc_macros/archive/HEAD.tar.gz
 BuildRequires:	anda-srpm-macros rust-packaging mold
 BuildRequires:  pkgconfig(libhelium-1)
+BuildRequires:  pkgconfig(openssl)
 BuildRequires:  clang-devel
 BuildRequires:  gcc
 BuildRequires:  cmake


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [bump: readymade-git (#9853)](https://github.com/terrapkg/packages/pull/9853)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)