### PR TITLE
[f42] fix: halloy (#9854)

### DIFF
--- a/anda/apps/halloy/halloy.spec
+++ b/anda/apps/halloy/halloy.spec
@@ -33,14 +33,13 @@ BuildRequires: pkgconfig(xcb)
 %cargo_build
 
 %install
-%crate_install_bin
+install -Dm755 target/rpm/halloy %{buildroot}%{_bindir}/halloy
 desktop-file-install assets/linux/%{appid}.desktop
 install -Dpm644 assets/linux/%{appid}.appdata.xml -t %{buildroot}%{_datadir}/metainfo
 
 mkdir -p %{buildroot}%{_datadir}
 cp -r assets/linux/icons -t %{buildroot}%{_datadir}
 
-%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
 
 %if %{with check}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: halloy (#9854)](https://github.com/terrapkg/packages/pull/9854)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)