### PR TITLE
[f43] fix(wine-staging): files (#7792)

### DIFF
--- a/anda/system/wine/staging/wine-staging.spec
+++ b/anda/system/wine/staging/wine-staging.spec
@@ -369,6 +369,7 @@ done
 %{_mandir}/man?/winepath.?*
 %{_mandir}/man?/wineserver.?*
 %dir %{_datadir}/wine
+%{_datadir}/wine/winmd/
 %{_datadir}/wine/wine.inf
 %{_datadir}/wine/nls/*.nls
 %{_datadir}/applications/*.desktop


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(wine-staging): files (#7792)](https://github.com/terrapkg/packages/pull/7792)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)