### PR TITLE
[f44] fix(kde-material-you-colors): cmake(KF6CoreAddons) (#9821)

### DIFF
--- a/anda/themes/kde-material-you-colors/kde-material-you-colors.spec
+++ b/anda/themes/kde-material-you-colors/kde-material-you-colors.spec
@@ -23,6 +23,8 @@ BuildRequires:  python-rpm-macros
 BuildRequires:  python3dist(pip)
 BuildRequires:  python3dist(setuptools) >= 61.0
 BuildRequires:  python3dist(wheel) >= 0.37.1
+BuildRequires:  cmake(KF6CoreAddons)
+BuildRequires:  cmake(KF6Service)
 BuildRequires:  cmake(KF6KirigamiPlatform)
 BuildRequires:  cmake(Plasma)
 BuildRequires:  cmake(Plasma5Support)
@@ -67,15 +69,12 @@ DESTDIR="%{buildroot}" %cmake_install
 sed -Ei "s:^(#!.*)env (python.*)$:\1python3:" %{buildroot}%{python3_sitelib}/kde_material_you_colors/main.py
 %fdupes %{buildroot}%{python3_sitelib}/%{name}/
 
-%terra_appstream
-
 %files
 %doc CHANGELOG.md
 %doc README.md
 %license LICENSE
 %{_bindir}/%{name}-screenshot-helper
 %{_datadir}/applications/%{name}-screenshot-helper.desktop
-%{_metainfodir}/luisbocanegra.kdematerialyou.colors.metainfo.xml
 %{_datadir}/plasma/plasmoids/luisbocanegra.kdematerialyou.colors/
 
 %files -n python3-%{name}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(kde-material-you-colors): cmake(KF6CoreAddons) (#9821)](https://github.com/terrapkg/packages/pull/9821)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)