### PR TITLE
[f42] fix: topgrade (#9875)

### DIFF
--- a/anda/tools/topgrade/topgrade-fix-metadata-auto.diff
+++ b/anda/tools/topgrade/topgrade-fix-metadata-auto.diff
@@ -1,6 +1,6 @@
---- topgrade-16.8.0/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ topgrade-16.8.0/Cargo.toml	2026-01-26T14:29:43.890964+00:00
-@@ -258,26 +258,3 @@
+--- topgrade-16.9.0/Cargo.toml	2006-07-24T01:21:28+00:00
++++ topgrade-16.9.0/Cargo.toml	2026-02-13T07:55:20.141538+00:00
+@@ -255,29 +255,6 @@
  default-features = false
  package = "self_update"
  
@@ -27,3 +27,7 @@
 -
 -[target."cfg(windows)".dependencies.windows-registry]
 -version = "~0.6"
+-
+ [profile.release]
+ lto = true
++


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: topgrade (#9875)](https://github.com/terrapkg/packages/pull/9875)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)