### PR TITLE
[el10] bump(nightly): mpv-nightly zed-nightly prismlauncher-nightly nim-nightly stardust-black-hole-nightly readymade-git scx-scheds-nightly natscli rpi-utils (#9884)

### DIFF
--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,10 +1,6 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
-<<<<<<< HEAD
-%global commit 3847a8157f6e44d7788dea2d1c172bc20bc50120
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260210
 %global commit 102e693f49ce40fa10361d166392068c24fe5f15
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260214

--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -1,9 +1,13 @@
 # Disable X11 for RHEL 10+
 %bcond x11 %[%{undefined rhel} || 0%{?rhel} < 10]
 
+<<<<<<< HEAD
 %global commit 3847a8157f6e44d7788dea2d1c172bc20bc50120
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260210
+%global commit 102e693f49ce40fa10361d166392068c24fe5f15
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20260214
 %global ver 0.41.0
 
 Name:           mpv-nightly

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,6 +1,10 @@
+<<<<<<< HEAD
 %global commit ee3f40fe25d206ca363b753e5b86e09ac6181eca
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260212
+%global commit b90a370c864a76dc53bc19b650a2a07fbb36b043
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20260214
 %global ver 0.225.0
 
 %bcond_with check

--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-%global commit ee3f40fe25d206ca363b753e5b86e09ac6181eca
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260212
 %global commit b90a370c864a76dc53bc19b650a2a07fbb36b043
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260214

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,11 +3,6 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
-<<<<<<< HEAD
-%global commit 157ae6fb72592492ef9269588f58ddb0ca87e4d2
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-
-%global commit_date 20260212
 %global commit 4f128148932452fbff5b1e2b07382180ed7c8041
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 

--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -3,10 +3,15 @@
 %global name_pretty %{quote:Prism Launcher (Nightly)}
 %global appid org.prismlauncher.PrismLauncher-nightly
 
+<<<<<<< HEAD
 %global commit 157ae6fb72592492ef9269588f58ddb0ca87e4d2
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global commit_date 20260212
+%global commit 4f128148932452fbff5b1e2b07382180ed7c8041
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global commit_date 20260214
 %global snapshot_info %{commit_date}.%{shortcommit}
 
 # Change this variables if you want to use custom keys

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,8 +1,13 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
+<<<<<<< HEAD
 %global commit 5fa11c5686f652772472639b5c761cfea91055eb
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1
 %global commit_date 20260212
+%global commit 97fed258ed3287a17c6b798fd7ffe16508bd69d9
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global ver 2.3.1
+%global commit_date 20260214
 %global debug_package %nil
 
 Name:			nim-nightly

--- a/anda/langs/nim/nim-nightly/nim-nightly.spec
+++ b/anda/langs/nim/nim-nightly/nim-nightly.spec
@@ -1,9 +1,4 @@
 %global csrc_commit 561b417c65791cd8356b5f73620914ceff845d10
-<<<<<<< HEAD
-%global commit 5fa11c5686f652772472639b5c761cfea91055eb
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global ver 2.3.1
-%global commit_date 20260212
 %global commit 97fed258ed3287a17c6b798fd7ffe16508bd69d9
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global ver 2.3.1

--- a/anda/stardust/black-hole/nightly/stardust-black-hole-nightly.spec
+++ b/anda/stardust/black-hole/nightly/stardust-black-hole-nightly.spec
@@ -1,5 +1,8 @@
+<<<<<<< HEAD
 %global commit 5abca9d613fac7861803319b3191061b2d8ce067
 %global commit_date 20251130
+%global commit 49fbf32f330b324c9b9d8582e80582378fc57e3c
+%global commit_date 20260214
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # Exclude input files from mangling
 %global __brp_mangle_shebangs_exclude_from ^/usr/src/.*$

--- a/anda/stardust/black-hole/nightly/stardust-black-hole-nightly.spec
+++ b/anda/stardust/black-hole/nightly/stardust-black-hole-nightly.spec
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-%global commit 5abca9d613fac7861803319b3191061b2d8ce067
-%global commit_date 20251130
 %global commit 49fbf32f330b324c9b9d8582e80582378fc57e3c
 %global commit_date 20260214
 %global shortcommit %(c=%{commit}; echo ${c:0:7})

--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-%global commit 40d07f6d1e34c5ecaf958d01a5ddee8d9e1fefcf
-%global commit_date 20251111
 %global commit 02ac25638105d17d822500b735cd5cb2ac8d2414
 %global commit_date 20260214
 %global shortcommit %(c=%{commit}; echo ${c:0:7})

--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -1,5 +1,8 @@
+<<<<<<< HEAD
 %global commit 40d07f6d1e34c5ecaf958d01a5ddee8d9e1fefcf
 %global commit_date 20251111
+%global commit 02ac25638105d17d822500b735cd5cb2ac8d2414
+%global commit_date 20260214
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:           readymade-git

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-%global commit 88fe0d0be3626218b1e47fffeebe812e6bd78e20
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260212
 %global commit 56483858768257405947d5f43a765770368fa416
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commitdate 20260214

--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -1,6 +1,10 @@
+<<<<<<< HEAD
 %global commit 88fe0d0be3626218b1e47fffeebe812e6bd78e20
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commitdate 20260212
+%global commit 56483858768257405947d5f43a765770368fa416
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260214
 %global ver 1.0.20
 %undefine __brp_mangle_shebangs
 

--- a/anda/tools/natscli/natscli.spec
+++ b/anda/tools/natscli/natscli.spec
@@ -1,8 +1,5 @@
 # https://github.com/nats-io/natscli
 %global goipath         github.com/nats-io/natscli
-<<<<<<< HEAD
-%global commit          dbc03310ec4be56f9e93871fd5940ff8eed21a3c
-%global commit_date     20260211
 %global commit          2ceb7ec4c190ea026bb4e9cfe49f489c67eb515d
 %global commit_date     20260214
 %global shortcommit     %{sub %{commit} 1 7}

--- a/anda/tools/natscli/natscli.spec
+++ b/anda/tools/natscli/natscli.spec
@@ -1,7 +1,10 @@
 # https://github.com/nats-io/natscli
 %global goipath         github.com/nats-io/natscli
+<<<<<<< HEAD
 %global commit          dbc03310ec4be56f9e93871fd5940ff8eed21a3c
 %global commit_date     20260211
+%global commit          2ceb7ec4c190ea026bb4e9cfe49f489c67eb515d
+%global commit_date     20260214
 %global shortcommit     %{sub %{commit} 1 7}
 
 %gometa -f

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -1,6 +1,3 @@
-<<<<<<< HEAD
-%global commit bdbc6f88cbc917b4ddf33b440aff36c36370d467
-%global commit_date 20260211
 %global commit 58d5da926965ad78fb863abacdd73a00dea022a1
 %global commit_date 20260214
 %global shortcommit %(c=%{commit}; echo ${c:0:7})

--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -1,5 +1,8 @@
+<<<<<<< HEAD
 %global commit bdbc6f88cbc917b4ddf33b440aff36c36370d467
 %global commit_date 20260211
+%global commit 58d5da926965ad78fb863abacdd73a00dea022a1
+%global commit_date 20260214
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 Name:			rpi-utils


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `el10`:
 - [bump(nightly): mpv-nightly zed-nightly prismlauncher-nightly nim-nightly stardust-black-hole-nightly readymade-git scx-scheds-nightly natscli rpi-utils (#9884)](https://github.com/terrapkg/packages/pull/9884)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)