### PR TITLE
[el10] fix: asusctl (#9929)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -1,6 +1,8 @@
 %global debug_package %{nil}
 %global appid org.asus_linux.rog_control_center
 
+%define _unpackaged_files_terminate_build 0
+
 Name:           asusctl
 Version:        6.3.2
 Release:        2%?dist


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: asusctl (#9929)](https://github.com/terrapkg/packages/pull/9929)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)