### PR TITLE
[el10] bump: terra-mock-configs (#9940)

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,5 +1,5 @@
 Name:           terra-mock-configs
-Version:        2.2.2
+Version:        2.2.3
 Release:        1%?dist
 Epoch:          1
 Summary:        Mock configs for Terra repos


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [bump: terra-mock-configs (#9940)](https://github.com/terrapkg/packages/pull/9940)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)