### PR TITLE
[f44] chore: bump swayVersion (#9951)

### DIFF
--- a/anda/desktops/swayfx/swayfx.spec
+++ b/anda/desktops/swayfx/swayfx.spec
@@ -1,8 +1,8 @@
-%global swayVersion 1.10.1
+%global swayVersion 1.11
 
 Name:           swayfx
 Version:        0.5.2
-Release:        1%?dist
+Release:        2%?dist
 
 Summary:        SwayFX: Sway, but with eye candy!
 URL:            https://github.com/WillPower3309/swayfx


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore: bump swayVersion (#9951)](https://github.com/terrapkg/packages/pull/9951)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)