### PR TITLE
[el10] add: gnome-shell-extension-vicinae (#8724)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-vicinae/anda.hcl
+++ b/anda/desktops/gnome/gnome-shell-extension-vicinae/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+  rpm {
+    spec = "gnome-shell-extension-vicinae.spec"
+  }
+  arches = ["x86_64"]
+}

--- a/anda/desktops/gnome/gnome-shell-extension-vicinae/gnome-shell-extension-vicinae.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-vicinae/gnome-shell-extension-vicinae.spec
@@ -1,0 +1,41 @@
+%global uuid vicinae@dagimg-dot.netlify.app
+
+Name:           gnome-shell-extension-vicinae
+Version:        1.5.3
+Release:        1%{?dist}
+License:        MIT
+URL:            https://github.com/dagimg-dot/vicinae-gnome-extension
+Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
+Summary:        Companion GNOME extension for Vicinae launcher
+Packager:       metcya <metcya@gmail.com>
+
+BuildArch:      noarch
+
+BuildRequires:  bun-bin glib2-devel
+Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
+Requires:       vicinae
+Recommends:     gnome-extensions-app
+Provides:       gnome-shell-extension-vicinae-gnome-extension
+
+%description
+Companion GNOME extension for Vicinae launcher with clipboard monitoring,
+window management APIs, and paste-to-active-window capabilities.
+
+%prep
+%autosetup -n vicinae-gnome-extension-%{version}
+
+%build
+%{__bun} i && %{__bun} run build
+
+%install
+mkdir -p %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}
+cp -a src/ %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/
+
+%files
+%license LICENSE
+%doc README.md DEVELOPMENT.md
+%{_datadir}/gnome-shell/extensions/%{uuid}/
+
+%changelog
+* Sat Dec 27 2025 metcya <metcya@gmail.com> - 1.5.3-1
+- Package

--- a/anda/desktops/gnome/gnome-shell-extension-vicinae/update.rhai
+++ b/anda/desktops/gnome/gnome-shell-extension-vicinae/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("dagimg-dot/vicinae-gnome-extension"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: gnome-shell-extension-vicinae (#8724)](https://github.com/terrapkg/packages/pull/8724)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)