### PR TITLE
[f43] fix (kmonad): add missing directory, switch to hackage update function (#9963)

### DIFF
--- a/anda/tools/kmonad/kmonad.spec
+++ b/anda/tools/kmonad/kmonad.spec
@@ -73,7 +73,7 @@ install -Dm644 startup/kmonad@.service -t %{buildroot}%{_unitdir}
 %doc doc/faq.md doc/quick-reference.md
 %{_bindir}/%{name}
 %{_unitdir}/%{name}@.service
-
+%doc %{_docdir}/ghc/html/libraries/kmonad-%{version}/
 
 %files -n ghc-%{name} -f ghc-%{name}.files
 %license LICENSE

--- a/anda/tools/kmonad/update.rhai
+++ b/anda/tools/kmonad/update.rhai
@@ -1,4 +1,1 @@
-rpm.version(gh("kmonad/kmonad"));
-if rpm.changed() {
-  rpm.release();
-}
+print(hackage("kmonad"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (kmonad): add missing directory, switch to hackage update function (#9963)](https://github.com/terrapkg/packages/pull/9963)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)