### PR TITLE
[f42] fix (omegaconf): dep on latest java version (#9956)

### DIFF
--- a/anda/langs/python/omegaconf/omegaconf.spec
+++ b/anda/langs/python/omegaconf/omegaconf.spec
@@ -14,7 +14,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-wheel
-BuildRequires:  java-21-openjdk-devel
+BuildRequires:  java-latest-openjdk-devel
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (omegaconf): dep on latest java version (#9956)](https://github.com/terrapkg/packages/pull/9956)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)