### PR TITLE
[el10] chore: Add 44 to update-branch.yml (#9982)

### DIFF
--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         branch:
           - frawhide
+          - f44
           - f43
           - f42
           - el10


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: Add 44 to update-branch.yml (#9982)](https://github.com/terrapkg/packages/pull/9982)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)