### PR TITLE
[f43] chore: Add 44 to comps (#9980)

### DIFF
--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - frawhide
+      - f44
       - f43
       - f42
       - el10


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: Add 44 to comps (#9980)](https://github.com/terrapkg/packages/pull/9980)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)