### PR TITLE
[el10] chore(andax/bump_extras.rhai): Bump Rawhide (#9981)

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -45,7 +45,7 @@ fn as_bodhi_ver(branch) {
         }
         return `EPEL-${release}`;
     } else if branch == "frawhide" {
-        return "F44";
+        return "F45";
     } else if branch.starts_with("f") {
         branch.crop(1);
         return branch;


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(andax/bump_extras.rhai): Bump Rawhide (#9981)](https://github.com/terrapkg/packages/pull/9981)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)