### PR TITLE
[el10] chore(gurk): Let the CI handle sccache (#10004)

### DIFF
--- a/anda/apps/gurk/gurk.spec
+++ b/anda/apps/gurk/gurk.spec
@@ -2,7 +2,7 @@
 
 Name:           gurk
 Version:        0.8.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Signal Messenger client for terminal
 License:        AGPL-3.0-or-later AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND ISC AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND (BSD-3-Clause OR Apache-2.0) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND BSL-1.0 AND CDLA-Permissive-2.0 AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
 URL:            https://github.com/boxdot/gurk-rs
@@ -26,7 +26,6 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %install
 export LC_ALL=C.UTF-8
 export LANG=C
-unset RUSTC_WRAPPER
 %cargo_install
 %{cargo_license_online} > LICENSE.dependencies
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(gurk): Let the CI handle sccache (#10004)](https://github.com/terrapkg/packages/pull/10004)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)