### PR TITLE
[el10] android-studio-canary: disable aarch64 builds (#9978)

### DIFF
--- a/anda/devs/android-studio/canary/anda.hcl
+++ b/anda/devs/android-studio/canary/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+  arches = ["x86_64"]
   rpm {
     spec = "android-studio-canary.spec"
   }

--- a/anda/devs/android-studio/canary/android-studio-canary.spec
+++ b/anda/devs/android-studio/canary/android-studio-canary.spec
@@ -21,6 +21,7 @@ Release:        1%?dist
 Summary:        Official IDE for Android development (Canary build)
 License:        Apache-2.0
 Packager:       veuxit <erroor234@gmail.com>
+ExclusiveArch:  x86_64
 URL:            https://developer.android.com/studio/preview
 
 %define suffixS panda2-canary4


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [android-studio-canary: disable aarch64 builds (#9978)](https://github.com/terrapkg/packages/pull/9978)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)