### PR TITLE
[f44] bump: android-studio (#9968)

### DIFF
--- a/anda/devs/android-studio/stable/anda.hcl
+++ b/anda/devs/android-studio/stable/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+  arches = ["x86_64"]
   rpm {
     spec = "android-studio.spec"
   }

--- a/anda/devs/android-studio/stable/android-studio.spec
+++ b/anda/devs/android-studio/stable/android-studio.spec
@@ -1,16 +1,32 @@
+%undefine __brp_add_determinism
+# disable debuginfo subpackage
 %global debug_package %{nil}
+# Disable build-id symlinks to avoid conflicts
+%global _build_id_links none
+# don't strip bundled binaries because pycharm checks length (!!!) of binary fsnotif
+# and if you strip debug stuff from it, it will complain
+%global __strip /bin/true
+# dont repack jars
+%global __jar_repack %{nil}
+# disable rpath checks
+%define __brp_check_rpaths %{nil}
+
 %define __requires_exclude_from ^/usr/libexec/android-studio/.*$
 %define __provides_exclude_from ^/usr/libexec/android-studio/.*|libedit\\so.*$
 %global __requires_exclude ^libaaudio\\.so.*|^libandroid\\.so.*|^libmediandk\\.so.*|^liblog\\.so.*|^libc\\.so.*|^libm\\.so.*|^libdl\\.so.*|^libcrypt\\.so.*|^libstdc\\+\\+\\.so.*|^libncursesw\\.so.*|^libtinfo\\.so.*|^libnsl\\.so.*|^libpanelw\\.so.*$
 
 Name:           android-studio
-Version:        2025.2.2.8
+Version:        2025.3.1.8
 Release:        1%?dist
 Summary:        Official IDE for Android development
 License:        Apache-2.0
-Packager:       like-engels <higashikataengels@icloud.com>
+Packager:       veuxit <erroor234@gmail.com>, like-engels <higashikataengels@icloud.com>
+ExclusiveArch:  x86_64
 URL:            https://developer.android.com/studio
-Source0:        https://dl.google.com/dl/android/studio/ide-zips/%{version}/android-studio-%{version}-linux.tar.gz
+
+%define suffixS panda1-patch1
+
+Source0:        https://dl.google.com/dl/android/studio/ide-zips/%{version}/android-studio-%{suffixS}-linux.tar.gz
 
 Requires:       alsa-lib
 Requires:       freetype
@@ -20,11 +36,13 @@ Requires:       libXtst
 Requires:       glibc
 Requires:       libsecret
 
+BuildRequires:  desktop-file-utils
+
 %description
 Android Studio is the official IDE for Android development, and includes everything you need to build Android apps.
 
 %prep
-%setup -q -n android-studio
+%autosetup -n android-studio
 
 %install
 mkdir -p %{buildroot}%{_libexecdir}/%{name}
@@ -37,7 +55,10 @@ ln -s %{_libexecdir}/%{name}/bin/studio %{buildroot}%{_bindir}/%{name}
 mkdir -p %{buildroot}%{_licensedir}/%{name}
 install -Dm644 LICENSE.txt %{buildroot}%{_licensedir}/%{name}/LICENSE.txt
 
-install -Dm644 bin/studio.png %{buildroot}%{_datadir}/pixmaps/%{name}.png
+install -d %{buildroot}%{_datadir}/pixmaps
+install -m 0644 -p bin/studio.png %{buildroot}%{_datadir}/pixmaps/%{name}.png
+install -d %{buildroot}%{_datadir}/icons/hicolor/scalable/apps
+install -m 0644 -p bin/studio.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
 
 mkdir -p %{buildroot}%{_datadir}/applications
 cat > %{buildroot}%{_datadir}/applications/%{name}.desktop << 'EOF'
@@ -45,9 +66,9 @@ cat > %{buildroot}%{_datadir}/applications/%{name}.desktop << 'EOF'
 Version=1.0
 Type=Application
 Name=Android Studio
-Exec=android-studio %f
+Exec=android-studio
 Icon=android-studio
-Comment=The official Android IDE
+Comment=Official IDE for Android development
 Categories=Development;IDE;
 Terminal=false
 StartupNotify=true
@@ -55,12 +76,17 @@ StartupWMClass=jetbrains-studio
 MimeType=application/x-extension-iml;
 EOF
 
+%check
+%desktop_file_validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+
 %files
 %license %{_licensedir}/%{name}/LICENSE.txt
 %{_libexecdir}/%{name}
 %{_bindir}/%{name}
-%{_datadir}/pixmaps/%{name}.png
+%{_datadir}/pixmaps/android-studio.png
+%{_datadir}/icons/hicolor/scalable/apps/android-studio.svg
 %{_datadir}/applications/%{name}.desktop
 
 %changelog
-%autochangelog
+* Fri Feb 20 2026 veuxit <erroor234@gmail.com> - 2025.3.1.8
+- Package update to 2025.3.1.8 panda1-patch1

--- a/anda/devs/android-studio/stable/update.rhai
+++ b/anda/devs/android-studio/stable/update.rhai
@@ -1,1 +1,10 @@
-rpm.version(find(`https://redirector.gvt1.com/edgedl/android/studio/ide-zips/([\d.]+)/android-studio-[\d.]+-linux.tar.gz`, get("https://developer.android.com/studio"), 1));
+let html = get("https://developer.android.com/studio");
+let pattern = `ide-zips/([^/]+)/android-studio-(.*?)-linux\.tar\.gz`;
+let nofilter = find(pattern, html, 0);
+let version = find(pattern, html, 1);
+let suffixS = find(pattern, html, 2);
+print(nofilter);
+print(version);
+print(suffixS);
+rpm.version(version);
+rpm.define("suffixS", suffixS);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [bump: android-studio (#9968)](https://github.com/terrapkg/packages/pull/9968)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)