### PR TITLE
[el10] fix: Remove extra require from coolercontrol.spec (#10071)

### DIFF
--- a/anda/apps/coolercontrol/coolercontrol.spec
+++ b/anda/apps/coolercontrol/coolercontrol.spec
@@ -32,7 +32,6 @@ BuildRequires:  cmake(Qt6WebEngineWidgets)
 
 %package -n coolercontrold
 Summary:        Monitor and control your cooling devices.
-Requires:       coolercontrol-liqctld
 BuildRequires:  pkgconfig(webkit2gtk-4.1) pkgconfig(openssl) pkgconfig(librsvg-2.0)
 BuildRequires:  libappindicator-gtk3-devel
 %description -n coolercontrold %_desc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: Remove extra require from coolercontrol.spec (#10071)](https://github.com/terrapkg/packages/pull/10071)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)