### PR TITLE
[f43] chore: use %{_gnomeextensionsdir} (#10080)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
@@ -3,7 +3,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        12
-Release:        2%?dist
+Release:        3%?dist
 Summary:        GNOME Shell extension to bring back the app menu
 License:        GPL-3.0-only
 URL:            https://github.com/fthx/appmenu-is-back
@@ -22,12 +22,12 @@ This extension brings back the app menu in the top panel, for GNOME 45 and later
 %autosetup -n appmenu-is-back-%{version} -p1
 
 %install
-install -Dm644 metadata.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/metadata.json
-install -Dm644 extension.js %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/extension.js
+install -Dm644 metadata.json %{buildroot}%{_gnomeextensionsdir}/metadata.json
+install -Dm644 extension.js %{buildroot}%{_gnomeextensionsdir}/extension.js
 
 %files
 %license LICENSE
-%{_datadir}/gnome-shell/extensions/%{uuid}
+%{_gnomeextensionsdir}
 
 %changelog
 * Thu Nov 16 2023 Lleyton Gray <lleyton@fyralabs.com> - 2-1

--- a/anda/desktops/gnome/gnome-shell-extension-battery_time/gnome-shell-extension-battery_time.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-battery_time/gnome-shell-extension-battery_time.spec
@@ -7,7 +7,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Battery remaining time extension for GNOME Shell
 License:        GPL-2.0-only
 URL:            https://github.com/pomoke/battery_time
@@ -31,14 +31,14 @@ Remaining time is shown inline, so no additional menu item is created (currently
 %autosetup -n %{extension}-%{commit}
 
 %install
-install -Dm644 metadata.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/metadata.json
-install -Dm644 extension.js %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/extension.js
+install -Dm644 metadata.json %{buildroot}%{_gnomeextensionsdir}/metadata.json
+install -Dm644 extension.js %{buildroot}%{_gnomeextensionsdir}/extension.js
 cp %{SOURCE1} LICENSE
 
 %files
 %doc README.md
 %license LICENSE
-%{_datadir}/gnome-shell/extensions/%{uuid}
+%{_gnomeextensionsdir}
 
 %changelog
 * Mon Jan 05 2026 Owen Zimmerman <owen@fyralabs.com>

--- a/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/gnome-shell-extension-gpu-supergfxctl-switch.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/gnome-shell-extension-gpu-supergfxctl-switch.spec
@@ -7,7 +7,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        %ver^%commit_date.%shortcommit
-Release:        1%?dist
+Release:        2%?dist
 Summary:        GPU Profile switcher Gnome-Shell-Extension for ASUS laptops using Supergfxctl
 License:        GPL-3.0-only
 URL:            https://github.com/chikobara/GPU-Switcher-Supergfxctl
@@ -26,13 +26,13 @@ GPU Profile switcher Gnome-Shell-Extension for ASUS laptops using Supergfxctl
 %autosetup -n GPU-Switcher-Supergfxctl-%{commit} -p1
 
 %install
-install -Dm644 metadata.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/metadata.json
-install -Dm644 extension.js %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/extension.js
+install -Dm644 metadata.json %{buildroot}%{_gnomeextensionsdir}/metadata.json
+install -Dm644 extension.js %{buildroot}%{_gnomeextensionsdir}/extension.js
 
 %files
 %license LICENSE
 %doc README.md
-%{_datadir}/gnome-shell/extensions/%{uuid}
+%{_gnomeextensionsdir}
 
 %changelog
 * Mon Oct 27 2025 june-fish <june@fyralabs.com> - 11

--- a/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
@@ -3,7 +3,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        9
-Release:        2%?dist
+Release:        3%?dist
 Summary:        GNOME extension that removes the 'Window is ready' notification and brings the window into focus instead
 License:        AGPL-3.0-only
 URL:            https://github.com/zalckos/GrandTheftFocus
@@ -24,13 +24,13 @@ GNOME extension. Removes the 'Window is ready' notification and brings the windo
 %autosetup -n GrandTheftFocus-%version
 
 %install
-install -Dm644 grand-theft-focus@zalckos.github.com/metadata.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/metadata.json
-install -Dm644 grand-theft-focus@zalckos.github.com/extension.js %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/extension.js
+install -Dm644 grand-theft-focus@zalckos.github.com/metadata.json %{buildroot}%{_gnomeextensionsdir}/metadata.json
+install -Dm644 grand-theft-focus@zalckos.github.com/extension.js %{buildroot}%{_gnomeextensionsdir}/extension.js
 
 %files
 %license LICENSE
 %doc README.md
-%{_datadir}/gnome-shell/extensions/%{uuid}
+%{_gnomeextensionsdir}
 
 %changelog
 * Tue Dec 30 2025 Owen Zimmerman <owen@fyralabs.com>

--- a/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/gnome-shell-extension-multi-monitors-bar.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/gnome-shell-extension-multi-monitors-bar.spec
@@ -7,7 +7,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Add multiple monitors overview and panel for GNOME Shell. This is an updated fork with GNOME 46 compatibility
 License:        GPL-2.0-or-later
 URL:            https://github.com/FrederykAbryan/multi-monitors-bar_fapv2
@@ -32,10 +32,10 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %install
 find . -name "*.gschema.xml"
-mkdir -p %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}
-install -Dm644 *.json %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/
-install -Dm644 *.js %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/
-install -Dm644 *.css %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/
+mkdir -p %{buildroot}%{_gnomeextensionsdir}
+install -Dm644 *.json %{buildroot}%{_gnomeextensionsdir}/
+install -Dm644 *.js %{buildroot}%{_gnomeextensionsdir}/
+install -Dm644 *.css %{buildroot}%{_gnomeextensionsdir}/
 install -Dm644 schemas/*.gschema.xml -t %{buildroot}%{_datadir}/glib-2.0/schemas/
 
 %post
@@ -47,7 +47,7 @@ glib-compile-schemas %{_datadir}/glib-2.0/schemas/ &> /dev/null || :
 %files
 %license LICENSE
 %doc README.md
-%{_datadir}/gnome-shell/extensions/%{uuid}
+%{_gnomeextensionsdir}
 %{_datadir}/glib-2.0/schemas/*.gschema.xml
 
 %changelog

--- a/anda/desktops/gnome/gnome-shell-extension-vicinae/gnome-shell-extension-vicinae.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-vicinae/gnome-shell-extension-vicinae.spec
@@ -2,7 +2,7 @@
 
 Name:           gnome-shell-extension-vicinae
 Version:        1.5.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 URL:            https://github.com/dagimg-dot/vicinae-gnome-extension
 Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
@@ -28,13 +28,13 @@ window management APIs, and paste-to-active-window capabilities.
 %{__bun} i && %{__bun} run build
 
 %install
-mkdir -p %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}
-cp -a src/ %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/
+mkdir -p %{buildroot}%{_gnomeextensionsdir}
+cp -a src/ %{buildroot}%{_gnomeextensionsdir}/
 
 %files
 %license LICENSE
 %doc README.md DEVELOPMENT.md
-%{_datadir}/gnome-shell/extensions/%{uuid}/
+%{_gnomeextensionsdir}/
 
 %changelog
 * Sat Dec 27 2025 metcya <metcya@gmail.com> - 1.5.3-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: use %{_gnomeextensionsdir} (#10080)](https://github.com/terrapkg/packages/pull/10080)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)