### PR TITLE
[f43] add: breeze-plus-icon-theme (#10081)

### DIFF
--- a/anda/themes/breeze-plus-icon-theme/anda.hcl
+++ b/anda/themes/breeze-plus-icon-theme/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "breeze-plus-icon-theme.spec"
+	}
+}

--- a/anda/themes/breeze-plus-icon-theme/breeze-plus-icon-theme.spec
+++ b/anda/themes/breeze-plus-icon-theme/breeze-plus-icon-theme.spec
@@ -1,0 +1,30 @@
+Name:           breeze-plus-icon-theme
+Version:        6.19.0
+Release:        1%{?dist}
+Summary:        Breeze icon theme with additional icons
+Packager:       Amy King <amy@amyrom.tech>
+
+License:        LGPL-2.1-only
+URL:            https://github.com/mjkim0727/breeze-plus
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+BuildArch:      noarch
+%description
+%summary.
+
+%prep
+%autosetup -n breeze-plus-%{version}
+%build
+
+%install
+mkdir -p %{buildroot}%{_datadir}/icons/
+cp -r src/* %{buildroot}%{_datadir}/icons/
+
+
+%files
+%license LICENSE
+%doc README.md
+%{_datadir}/icons/*
+
+%changelog
+* Wed Feb 25 2026 Amy King <amy@amyrom.tech> - 6.19.0
+- Initial package

--- a/anda/themes/breeze-plus-icon-theme/update.rhai
+++ b/anda/themes/breeze-plus-icon-theme/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("mjkim0727/breeze-plus"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: breeze-plus-icon-theme (#10081)](https://github.com/terrapkg/packages/pull/10081)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)