### PR TITLE
[frawhide] chore(sync): frawhide -> f43 (#10091)

### DIFF
--- a/anda/apps/bazzite-portal/bazzite-portal.spec
+++ b/anda/apps/bazzite-portal/bazzite-portal.spec
@@ -1,6 +1,6 @@
 Name:           bazzite-portal
 Version:        0.1.6
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Bazzite Portal is a tabbed frontend for curated script execution, with a focus on distro specific QOL shortcuts
 URL:            https://github.com/ublue-os/yafti-gtk
 Source0:        https://github.com/ublue-os/yafti-gtk/archive/refs/tags/v%{version}.tar.gz

--- a/anda/apps/bitwarden/cli.bin/bitwarden-cli.bin.spec
+++ b/anda/apps/bitwarden/cli.bin/bitwarden-cli.bin.spec
@@ -1,6 +1,6 @@
 Name:           bitwarden-cli.bin
 Version:        2026.1.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Bitwarden command-line client
 License:        GPL-3.0-only
 URL:            https://bitwarden.com

--- a/anda/devs/devpod/golang-github-loft-sh-devpod.spec
+++ b/anda/devs/devpod/golang-github-loft-sh-devpod.spec
@@ -17,7 +17,7 @@ and lets you use any cloud, kubernetes or just localhost docker.}
                         loadtest/README.md
 
 Name:           devpod
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Spin up dev environments in any infra
 Provides:       golang-github-loft-sh-devpod
 BuildRequires:  anda-srpm-macros mold

--- a/anda/system/veracrypt/veracrypt.spec
+++ b/anda/system/veracrypt/veracrypt.spec
@@ -6,7 +6,7 @@
 
 Name:           veracrypt
 Version:        %{sanitized_ver}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Disk encryption with strong security based on TrueCrypt
 URL:            https://veracrypt.jp/en/Home.html
 Source0:        https://github.com/veracrypt/VeraCrypt/archive/refs/tags/VeraCrypt_%version.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `frawhide`:
 - [chore(sync): frawhide -&gt; f43 (#10091)](https://github.com/terrapkg/packages/pull/10091)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)