### PR TITLE
[f43] fix (signal-desktop): proper license identifier (#10101)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -3,13 +3,13 @@
 Name:			signal-desktop
 %electronmeta -aD
 Version:		8.0.0
-Release:		1%?dist
+Release:		2%?dist
 Summary:		A private messenger for Windows, macOS, and Linux
 URL:			https://signal.org
 Source0:		https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz
 Source1:		signal.desktop
 Source2:        org.signal.Signal.metainfo.xml
-License:		AGPL-3.0 AND %{electron_license}
+License:		AGPL-3.0-only AND %{electron_license}
 
 BuildRequires:	pulseaudio-libs-devel
 BuildRequires:  libX11-devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (signal-desktop): proper license identifier (#10101)](https://github.com/terrapkg/packages/pull/10101)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)