### PR TITLE
[f44] chore (yazi): specify licenses (#10100)

### DIFF
--- a/anda/langs/rust/yazi/yazi.spec
+++ b/anda/langs/rust/yazi/yazi.spec
@@ -2,11 +2,11 @@
 
 Name:           yazi
 Version:        26.1.22
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Blazing fast terminal file manager written in Rust, based on async I/O
 URL:            https://yazi-rs.github.io/
 Source0:        https://github.com/sxyazi/yazi/archive/refs/tags/v%version.tar.gz
-License:        MIT
+License:        MIT AND (MIT OR Apache-2.0) AND NCSA AND Unicode-3.0 AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND ISC AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND BSL-1.0 AND CC0-1.0 AND (CC0-1.0 OR Apache-2.0) AND ISC AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND (MIT OR Apache-2.0 OR CC0-1.0) AND MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
 BuildRequires:  cargo anda-srpm-macros cargo-rpm-macros mold
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (yazi): specify licenses (#10100)](https://github.com/terrapkg/packages/pull/10100)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)