### PR TITLE
[f44] add: surge (#10098)

### DIFF
--- a/anda/tools/surge/anda.hcl
+++ b/anda/tools/surge/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "surge.spec"
+    }
+}

--- a/anda/tools/surge/surge.spec
+++ b/anda/tools/surge/surge.spec
@@ -1,0 +1,41 @@
+%global goipath github.com/surge-downloader/surge
+Version:        0.6.9
+
+%gometa
+
+Name:           surge
+Release:        1%?dist
+Summary:        Blazing fast TUI download manager built in Go for power users
+
+License:        MIT
+URL:            https://github.com/surge-downloader/Surge
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang gcc go-rpm-macros
+Requires:       glibc
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%autosetup -n Surge-%{version}
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/surge %{goipath}
+
+%install
+install -Dm755 %{gobuilddir}/bin/surge %{buildroot}%{_bindir}/surge
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/surge
+
+%changelog
+* Tue Feb 24 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/surge/update.rhai
+++ b/anda/tools/surge/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("surge-downloader/Surge"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: surge (#10098)](https://github.com/terrapkg/packages/pull/10098)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)