### PR TITLE
[f44] add: termflix (#10099)

### DIFF
--- a/anda/tools/termflix/anda.hcl
+++ b/anda/tools/termflix/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "termflix.spec"
+  }
+}

--- a/anda/tools/termflix/termflix.spec
+++ b/anda/tools/termflix/termflix.spec
@@ -1,0 +1,35 @@
+Name:           termflix
+Version:        0.4.1
+Release:        1%?dist
+Summary:        Terminal animation player with 43 procedurally generated animations, multiple render modes, and true color support
+
+License:        MIT AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND MPL-2.0
+URL:            https://github.com/paulrobello/termflix
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires:  cargo-rpm-macros >= 24
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+install -Dm 755 target/rpm/%{name} -t %{buildroot}%{_bindir}
+
+%files
+%doc README.md
+%license LICENSE LICENSE.dependencies
+%{_bindir}/%{name}
+
+%changelog
+* Thu Feb 26 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/termflix/update.rhai
+++ b/anda/tools/termflix/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(crates("termflix"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: termflix (#10099)](https://github.com/terrapkg/packages/pull/10099)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)