### PR TITLE
[f44] fix: TH Sarabun New PSK font files (#10118)

### DIFF
--- a/anda/fonts/sipa/sipa-fonts.spec
+++ b/anda/fonts/sipa/sipa-fonts.spec
@@ -5,7 +5,7 @@
 # namespace
 %global fontorg th.or.sipa
 Version:		20200217
-Release:		7%{?dist}
+Release:		8%{?dist}
 URL:			https://www.nstda.or.th/home/news_post/thai-font/
 %global fontlicense       LicenseRef-DIP-SIPA AND OFL-1.1-RFN
 %global fontlicenses      LICENSE
@@ -59,7 +59,7 @@ BuildArch:		noarch
 
 %global fontfamily1        TH Sarabun PSK
 %global foundry1           Suppakit Chalermlarp
-%global fonts1             'TH Sarabun'*.ttf
+%global fonts1             'TH Sarabun'.ttf 'TH Sarabun Italic.ttf' 'TH Sarabun Bold.ttf' 'TH Sarabun BoldItalic.ttf'
 %global fontsummary1       %{fontfamily1} font family
 %global fontdescription1   %{common_description}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: TH Sarabun New PSK font files (#10118)](https://github.com/terrapkg/packages/pull/10118)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)