### PR TITLE
[f44] fix: quickshell update script (#10132)

### DIFF
--- a/anda/desktops/quickshell/update.rhai
+++ b/anda/desktops/quickshell/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("https://github.com/quickshell-mirror/quickshell"));
+rpm.version(gh("quickshell-mirror/quickshell"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: quickshell update script (#10132)](https://github.com/terrapkg/packages/pull/10132)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)