### PR TITLE
[f42] add: noctalia-qs (#10131)

### DIFF
--- a/anda/desktops/noctalia-qs/anda.hcl
+++ b/anda/desktops/noctalia-qs/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "noctalia-qs.spec"
+  }
+}

--- a/anda/desktops/noctalia-qs/noctalia-qs.spec
+++ b/anda/desktops/noctalia-qs/noctalia-qs.spec
@@ -1,0 +1,71 @@
+Name:		noctalia-qs
+Version:	0.0.4
+Release:	1%?dist
+Summary:	Flexible QtQuick based desktop shell toolkit
+License:	LGPL-3.0-only AND GPL-3.0-only
+URL:		https://github.com/noctalia-dev/noctalia-qs
+Source0:	https://github.com/noctalia-dev/noctalia-qs/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Willow C Reed (willow@willowidk.dev)
+
+BuildRequires: cmake
+BuildRequires: cmake(Qt6Core)
+BuildRequires: cmake(Qt6Qml)
+BuildRequires: cmake(Qt6ShaderTools)
+BuildRequires: cmake(Qt6WaylandClient)
+BuildRequires: gcc-c++
+BuildRequires: ninja-build
+BuildRequires: qt6-qtbase-private-devel
+BuildRequires: spirv-tools
+BuildRequires: anda-srpm-macros
+BuildRequires: breakpad-devel
+BuildRequires: breakpad-static
+BuildRequires: pkgconfig
+BuildRequires: pkgconfig(jemalloc)
+BuildRequires: pkgconfig(libpipewire-0.3)
+BuildRequires: pkgconfig(wayland-client)
+BuildRequires: pkgconfig(wayland-protocols)
+BuildRequires: pkgconfig(xcb)
+BuildRequires: pkgconfig(pam)
+BuildRequires: pkgconfig(libdrm)
+BuildRequires: pkgconfig(gbm)
+BuildRequires: pkgconfig(CLI11)
+BuildRequires: glib2-devel
+BuildRequires: polkit-devel
+
+Obsoletes:     quickshell
+
+%description
+Flexible QtQuick based desktop shell toolkit.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%cmake  -GNinja \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DDISTRIBUTOR="Fedora Terra" \
+        -DDISTRIBUTOR_DEBUGINFO_AVAILABLE=YES \
+        -DGIT_REVISION=%{commit} \
+        -DINSTALL_QML_PREFIX=%{_lib}/qt6/qml
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%license LICENSE LICENSE-GPL
+%doc BUILD.md
+%doc CONTRIBUTING.md
+%doc README.md
+%doc changelog/next.md
+%{_bindir}/qs
+%{_bindir}/quickshell
+%{_appsdir}/dev.noctalia.noctalia-qs.desktop
+%{_scalableiconsdir}/dev.noctalia.noctalia-qs.svg
+%{_libdir}/qt6/qml/Quickshell
+
+%changelog
+* Fri Feb 27 2026 Willow C Reed <willow@willowidk.dev>
+- Initial commit based on quickshell spec

--- a/anda/desktops/noctalia-qs/update.rhai
+++ b/anda/desktops/noctalia-qs/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("noctalia-dev/noctalia-qs"));

--- a/anda/desktops/noctalia-shell/noctalia-shell.spec
+++ b/anda/desktops/noctalia-shell/noctalia-shell.spec
@@ -2,7 +2,7 @@
 
 Name:           noctalia-shell
 Version:		4.5.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
@@ -13,7 +13,7 @@ Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts
 Requires:    	gpu-screen-recorder
 Requires:	    qt6-qtmultimedia
-Requires:       quickshell
+Requires:       noctalia-qs
 Requires:       xdg-desktop-portal
 
 Recommends: 	cava
@@ -43,5 +43,8 @@ cp -r ./* %{buildroot}/etc/xdg/quickshell/noctalia-shell/
 %{_sysconfdir}/xdg/quickshell/noctalia-shell/
 
 %changelog
+* Fri Feb 27 2026 Willow C Reed <willow@willowidk.dev>
+- Change required quickshell to Noctalia's version
+
 * Fri Jan 02 2026 Willow Reed <willow@willowidk.dev>
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: noctalia-qs (#10131)](https://github.com/terrapkg/packages/pull/10131)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)