### PR TITLE
[el10] fix: lua-language-server (#10138)

### DIFF
--- a/anda/langs/lua/lua-language-server/lua-language-server.spec
+++ b/anda/langs/lua/lua-language-server/lua-language-server.spec
@@ -2,13 +2,15 @@
 
 Name:           lua-language-server
 Version:        3.17.1
-Release:        1%?dist
+Release:        2%?dist
 License:        MIT
 URL:            https://luals.github.io/
 Source:         https://github.com/LuaLS/lua-language-server/archive/refs/tags/%version.tar.gz
 Summary:        A language server that offers Lua language support
 
 BuildRequires:  gcc-c++ make ninja-build glibc lua gcc cmake libstdc++-devel libstdc++-static libcxx libcxx-devel
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 A language server that offers Lua language support - programmed in Lua.
@@ -23,7 +25,7 @@ chmod +x make.sh
 
 %install
 mkdir -p %{buildroot}%{_bindir}
-mkdir -p %{buildroot}%{_libexecdir}/%{name}
+mkdir -p %{buildroot}%{_libexecdir}/%{name}/
 mkdir -p %{buildroot}%{_datadir}/%{name}/
 install -Dm755 bin/lua-language-server %{buildroot}%{_libexecdir}/%{name}/%{name}
 install -Dm644 bin/main.lua            %{buildroot}%{_libexecdir}/%{name}/main.lua
@@ -36,9 +38,12 @@ cp -av \
     meta \
     %{buildroot}%{_datadir}/%{name}/
 
+%{__ln_s} -f %{_libexecdir}/%{name}/main.lua %{buildroot}%{_libexecdir}/main.lua
+
 %files
 %license LICENSE
 %doc README.md
+%{_libexecdir}/main.lua
 %{_libexecdir}/%{name}/
 %{_datadir}/%{name}/
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: lua-language-server (#10138)](https://github.com/terrapkg/packages/pull/10138)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)