### PR TITLE
[el10] fix signal icons glitching in some menus (#10137)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -3,7 +3,7 @@
 Name:			signal-desktop
 %electronmeta -aD
 Version:		8.0.0
-Release:		2%?dist
+Release:		3%?dist
 Summary:		A private messenger for Windows, macOS, and Linux
 URL:			https://signal.org
 Source0:		https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz
@@ -59,10 +59,10 @@ Signal Desktop links with Signal on Android or iOS and lets you message from you
 
 %build
 export SIGNAL_ENV=production
-%{__pnpm} install
+%{__pnpm} install --frozen-lockfile
 %{__pnpm} run clean-transpile
 pushd sticker-creator
-%{__pnpm} install
+%{__pnpm} install --frozen-lockfile
 %{__pnpm} run build
 popd
 %pnpm_build -r generate,prepare-beta-build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix signal icons glitching in some menus (#10137)](https://github.com/terrapkg/packages/pull/10137)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)