### PR TITLE
add: wails and wails-v3

### DIFF
--- a/anda/lib/wails/v2/anda.hcl
+++ b/anda/lib/wails/v2/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "wails.spec"
+  }
+}

--- a/anda/lib/wails/v2/update.rhai
+++ b/anda/lib/wails/v2/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("wailsapp/wails"));

--- a/anda/lib/wails/v2/wails.spec
+++ b/anda/lib/wails/v2/wails.spec
@@ -16,8 +16,6 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 BuildRequires:  golang
 BuildRequires:  gcc
 BuildRequires:  go-rpm-macros
-BuildRequires:  webkit2gtk4.1-devel
-BuildRequires:  gtk3-devel
 Requires:       glibc
 Requires:       /usr/bin/npm
 Requires:       webkit2gtk4.1

--- a/anda/lib/wails/v2/wails.spec
+++ b/anda/lib/wails/v2/wails.spec
@@ -1,0 +1,58 @@
+%global goipath github.com/wailsapp/wails/v2
+Version:        2.11.0
+
+%gometa -f
+
+Name:           wails
+Release:        1%?dist
+Summary:        Create beautiful applications using Go
+
+License:        MIT
+URL:            https://wails.io/
+Source0:        https://github.com/wailsapp/wails/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+Requires:       glibc
+Requires:       /usr/bin/npm
+Requires:       webkit2gtk4.1
+Requires:       gtk3
+Provides:       wails3
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%goprep
+
+%build
+pushd v2/cmd/wails
+GO111MODULE=on go build
+popd
+
+%install
+install -Dm 0755 v2/cmd/wails/wails %{buildroot}%{_bindir}/wails
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md CONTRIBUTORS.md CHANGELOG.md SECURITY.md
+%lang(de) %doc README.de.md
+%lang(es) %doc README.es.md
+%lang(fr) %doc README.fr.md
+%lang(ja) %doc README.ja.md
+%lang(ko) %doc README.ko.md
+%lang(pt_BR) %doc README.pt-br.md
+%lang(ru) %doc README.ru.md
+%lang(tr) %doc README.tr.md
+%lang(uz) %doc README.uz.md
+%lang(zh_CN) %doc README.zh-Hans.md
+%{_bindir}/wails
+
+%changelog
+* Mon Mar 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/lib/wails/v2/wails.spec
+++ b/anda/lib/wails/v2/wails.spec
@@ -20,7 +20,6 @@ Requires:       glibc
 Requires:       /usr/bin/npm
 Requires:       webkit2gtk4.1
 Requires:       gtk3
-Provides:       wails3
 
 %description
 %{summary}.

--- a/anda/lib/wails/v2/wails.spec
+++ b/anda/lib/wails/v2/wails.spec
@@ -16,6 +16,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 BuildRequires:  golang
 BuildRequires:  gcc
 BuildRequires:  go-rpm-macros
+BuildRequires:  webkit2gtk4.1-devel
+BuildRequires:  gtk3-devel
 Requires:       glibc
 Requires:       /usr/bin/npm
 Requires:       webkit2gtk4.1
@@ -32,7 +34,7 @@ Provides:       wails3
 
 %build
 pushd v2/cmd/wails
-GO111MODULE=on go build
+GO111MODULE=on %gobuild
 popd
 
 %install

--- a/anda/lib/wails/v3/anda.hcl
+++ b/anda/lib/wails/v3/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "wails3.spec"
+  }
+}

--- a/anda/lib/wails/v3/update.rhai
+++ b/anda/lib/wails/v3/update.rhai
@@ -1,0 +1,1 @@
+rpm.global("ver", gh_tag("wailsapp/wails"));

--- a/anda/lib/wails/v3/wails3.spec
+++ b/anda/lib/wails/v3/wails3.spec
@@ -6,7 +6,7 @@ Version:        %{sanitized_ver}
 
 %gometa -f
 
-Name:           wails-v3
+Name:           wails3
 Release:        1%?dist
 Summary:        Create beautiful applications using Go
 
@@ -24,7 +24,7 @@ Requires:       glibc
 Requires:       /usr/bin/npm
 Requires:       webkit2gtk4.1
 Requires:       gtk3
-Provides:       wails3
+Provides:       wails-v3
 
 %description
 %{summary}.

--- a/anda/lib/wails/v3/wails3.spec
+++ b/anda/lib/wails/v3/wails3.spec
@@ -1,0 +1,61 @@
+%global ver 3.0.0-alpha.74
+%global sanitized_ver %(echo %{ver} | sed 's/-/./g')
+
+%global goipath github.com/wailsapp/wails/v3
+Version:        %{sanitized_ver}
+
+%gometa -f
+
+Name:           wails-v3
+Release:        1%?dist
+Summary:        Create beautiful applications using Go
+
+License:        MIT
+URL:            https://wails.io/
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+Requires:       glibc
+Requires:       /usr/bin/npm
+Requires:       webkit2gtk4.1
+Requires:       gtk3
+Provides:       wails3
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%git_clone https://github.com/wailsapp/wails v3-alpha
+
+%build
+pushd v3/cmd/wails3
+GO111MODULE=on go build
+%dnl %define gomodulesmode GO111MODULE=on
+%dnl %gobuild -o %{gobuilddir}/v3/cmd/wails3/ %{goipath}/cmd/wails
+
+%install
+install -Dm 0755 v3/cmd/wails3/wails3 %{buildroot}%{_bindir}/wails3
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md CONTRIBUTORS.md CHANGELOG.md SECURITY.md
+%lang(de) %doc README.de.md
+%lang(es) %doc README.es.md
+%lang(fr) %doc README.fr.md
+%lang(ja) %doc README.ja.md
+%lang(ko) %doc README.ko.md
+%lang(pt_BR) %doc README.pt-br.md
+%lang(ru) %doc README.ru.md
+%lang(tr) %doc README.tr.md
+%lang(uz) %doc README.uz.md
+%lang(zh_CN) %doc README.zh-Hans.md
+%{_bindir}/wails3
+
+%changelog
+* Mon Mar 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/lib/wails/v3/wails3.spec
+++ b/anda/lib/wails/v3/wails3.spec
@@ -18,6 +18,8 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 BuildRequires:  golang
 BuildRequires:  gcc
 BuildRequires:  go-rpm-macros
+BuildRequires:  webkit2gtk4.1-devel
+BuildRequires:  gtk3-devel
 Requires:       glibc
 Requires:       /usr/bin/npm
 Requires:       webkit2gtk4.1
@@ -34,7 +36,7 @@ Provides:       wails3
 
 %build
 pushd v3/cmd/wails3
-GO111MODULE=on go build
+GO111MODULE=on %gobuild
 popd
 
 %install

--- a/anda/lib/wails/v3/wails3.spec
+++ b/anda/lib/wails/v3/wails3.spec
@@ -1,5 +1,5 @@
 %global ver 3.0.0-alpha.74
-%global sanitized_ver %(echo %{ver} | sed 's/-/./g')
+%global sanitized_ver %(echo %{ver} | sed 's/-/~/g')
 
 %global goipath github.com/wailsapp/wails/v3
 Version:        %{sanitized_ver}

--- a/anda/lib/wails/v3/wails3.spec
+++ b/anda/lib/wails/v3/wails3.spec
@@ -35,8 +35,7 @@ Provides:       wails3
 %build
 pushd v3/cmd/wails3
 GO111MODULE=on go build
-%dnl %define gomodulesmode GO111MODULE=on
-%dnl %gobuild -o %{gobuilddir}/v3/cmd/wails3/ %{goipath}/cmd/wails
+popd
 
 %install
 install -Dm 0755 v3/cmd/wails3/wails3 %{buildroot}%{_bindir}/wails3


### PR DESCRIPTION
Yes I am not using the go directory macros when building. Yes I am using `%git_clone` for v3. Blame upstream.
The update scripts will actually properly track the v3 alpha tags and the normal v2 updates, so that's cool, W upstream.