### PR TITLE
[el10] fix (mesa): add epoch to dri-drivers obsoletes (#10193)

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -87,7 +87,7 @@ Summary:        Mesa graphics libraries
 %global ver 26.0.1
 Epoch:          1
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        1
+Release:        2
 Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            https://mesa3d.org
@@ -271,8 +271,8 @@ Requires:       %{name}-filesystem%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{rel
 Obsoletes:      %{name}-libglapi < %{?epoch:%{epoch}:}25.0.0~rc2-1
 Provides:       %{name}-libglapi >= %{?epoch:%{epoch}:}25.0.0~rc2-1
 
-Obsoletes:      %{name}-va-drivers < 26.0.0-5
-Provides:       %{name}-va-drivers >= 26.0.0-5
+Obsoletes:      %{name}-va-drivers < %{?epoch:%{epoch}:}26.0.0-5
+Provides:       %{name}-va-drivers >= %{?epoch:%{epoch}:}26.0.0-5
 Obsoletes:      %{name}-vaapi-drivers < %{?epoch:%{epoch}:}22.2.0-5
 
 %description dri-drivers


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (mesa): add epoch to dri-drivers obsoletes (#10193)](https://github.com/terrapkg/packages/pull/10193)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)