### PR TITLE
[el10] bump: rpcs3 (#9904)

### DIFF
--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -1,7 +1,7 @@
 # RPCS3 builds often break with GCC
 %global toolchain clang
 # Define which LLVM/Clang version RPCS3 needs
-%if 0%{?fedora} >= 45
+%if 0%{?fedora} >= 46
 %global llvm_major 21
 %global __cc clang-%{llvm_major}
 %global __cxx clang++-%{llvm_major}
@@ -14,7 +14,7 @@
 
 Name:           rpcs3
 Version:        %(echo %{ver} | sed 's/-/^/g')
-Release:        1%?dist
+Release:        2%?dist
 Summary:        PlayStation 3 emulator and debugger
 License:        GPL-2.0-only
 URL:            https://github.com/RPCS3/rpcs3


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [bump: rpcs3 (#9904)](https://github.com/terrapkg/packages/pull/9904)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)