### PR TITLE
[f44] chore (minecraft-java): add metainfo icon (#10206)

### DIFF
--- a/anda/games/minecraft-java/com.mojang.Minecraft.metainfo.xml
+++ b/anda/games/minecraft-java/com.mojang.Minecraft.metainfo.xml
@@ -2,6 +2,7 @@
 <component type="desktop-application">
   <id>com.mojang.Minecraft</id>
   <name>Minecraft</name>
+  <icon type="remote">https://minecraft.wiki/images/Minecraft_social_icon.png?fcb53</icon>
   <name xml:lang="ar">ماين كرافت</name>
   <name xml:lang="bn">মাইনক্রাফ্ট</name>
   <name xml:lang="es">Minecraft</name>

--- a/anda/games/minecraft-java/minecraft-java.spec
+++ b/anda/games/minecraft-java/minecraft-java.spec
@@ -6,7 +6,7 @@
 
 Name:		minecraft-launcher
 Version:	2.3.2
-Release:	3%{?dist}
+Release:	4%{?dist}
 Summary:	Official launcher for Minecraft
 
 License:	https://www.minecraft.net/en-us/eula


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (minecraft-java): add metainfo icon (#10206)](https://github.com/terrapkg/packages/pull/10206)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)