### PR TITLE
[f42] fix (powershell): metainfo (#10205)

### DIFF
--- a/anda/devs/powershell/com.microsoft.PowerShell.metainfo.xml
+++ b/anda/devs/powershell/com.microsoft.PowerShell.metainfo.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="console-application">
   <id>com.microsoft.PowerShell</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
   <name>Microsoft PowerShell</name>
   <summary>PowerShell for every system!</summary>
   <screenshots>
-    <image type="source">https://github.com/PowerShell/PowerShell/blob/master/assets/Powershell_256.png</image>
+    <screenshot type="default"><image>https://github.com/PowerShell/PowerShell/blob/master/assets/Powershell_256.png</image></screenshot>
   </screenshots>
   <description>
     <p>
@@ -16,4 +18,5 @@
     <name>Microsoft Corporation</name>
   </developer>
   <icon type="stock">com.microsoft.PowerShell</icon>
+  <url type="homepage">https://microsoft.com/PowerShell</url>
 </component>

--- a/anda/devs/powershell/powershell.spec
+++ b/anda/devs/powershell/powershell.spec
@@ -19,7 +19,7 @@
 
 Name:          powershell
 Version:       7.5.4
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       A cross-platform automation and configuration tool/framework
 SourceLicense: MIT
 License:       Apache-2.0 AND BSD-2-Clause AND MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (powershell): metainfo (#10205)](https://github.com/terrapkg/packages/pull/10205)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)