### PR TITLE
[f44] fix (edit): metainfo (#10204)

### DIFF
--- a/anda/devs/edit/com.microsoft.edit.metainfo.xml
+++ b/anda/devs/edit/com.microsoft.edit.metainfo.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="console-application">
   <id>com.microsoft.edit</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
   <name>Microsoft Edit</name>
-  <summary>We all edit.</summary>
+  <summary>We all edit</summary>
   <screenshots>
-    <image type="source">https://github.com/microsoft/edit/blob/main/assets/edit_hero_image.png</image>
+    <screenshot type="default"><image>https://github.com/microsoft/edit/blob/main/assets/edit_hero_image.png</image></screenshot>
   </screenshots>
   <description>
     <p>A simple editor for simple needs.</p>
@@ -13,6 +15,7 @@
     The goal is to provide an accessible editor that even users largely unfamiliar with terminals can easily use.
     </p>
   </description>
+  <url type="homepage">https://github.com/microsoft/edit</url>
   <url type="vcs-browser">https://github.com/microsoft/edit</url>
   <developer id="com.microsoft">
     <name>Microsoft Corporation</name>

--- a/anda/devs/edit/edit.spec
+++ b/anda/devs/edit/edit.spec
@@ -8,7 +8,7 @@ An editor that pays homage to the classic MS-DOS Editor, but with a modern inter
 
 Name:          %{crate}
 Version:       1.2.1
-Release:       3%{?dist}
+Release:       4%{?dist}
 Summary:       A simple editor for simple needs.
 SourceLicense: MIT
 License:       MIT AND (MIT OR Apache-2.0)
@@ -58,4 +58,3 @@ install -Dm644 assets/%{appid}.desktop %{buildroot}%{_datadir}/applications/%{ap
 %changelog
 * Thu May 22 2025 Gilver E. <rockgrub@disroot.org> - 1.0.0-1
 - Initial package
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (edit): metainfo (#10204)](https://github.com/terrapkg/packages/pull/10204)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)