### PR TITLE
[f43] add: wails and wails-v3 (#10192)

### DIFF
--- a/anda/lib/wails/v2/anda.hcl
+++ b/anda/lib/wails/v2/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "wails.spec"
+  }
+}

--- a/anda/lib/wails/v2/update.rhai
+++ b/anda/lib/wails/v2/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("wailsapp/wails"));

--- a/anda/lib/wails/v2/wails.spec
+++ b/anda/lib/wails/v2/wails.spec
@@ -1,0 +1,57 @@
+%global goipath github.com/wailsapp/wails/v2
+Version:        2.11.0
+
+%gometa -f
+
+Name:           wails
+Release:        1%?dist
+Summary:        Create beautiful applications using Go
+
+License:        MIT
+URL:            https://wails.io/
+Source0:        https://github.com/wailsapp/wails/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+Requires:       glibc
+Requires:       /usr/bin/npm
+Requires:       webkit2gtk4.1
+Requires:       gtk3
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%goprep
+
+%build
+pushd v2/cmd/wails
+GO111MODULE=on %gobuild
+popd
+
+%install
+install -Dm 0755 v2/cmd/wails/wails %{buildroot}%{_bindir}/wails
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md CONTRIBUTORS.md CHANGELOG.md SECURITY.md
+%lang(de) %doc README.de.md
+%lang(es) %doc README.es.md
+%lang(fr) %doc README.fr.md
+%lang(ja) %doc README.ja.md
+%lang(ko) %doc README.ko.md
+%lang(pt_BR) %doc README.pt-br.md
+%lang(ru) %doc README.ru.md
+%lang(tr) %doc README.tr.md
+%lang(uz) %doc README.uz.md
+%lang(zh_CN) %doc README.zh-Hans.md
+%{_bindir}/wails
+
+%changelog
+* Mon Mar 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/lib/wails/v3/anda.hcl
+++ b/anda/lib/wails/v3/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "wails3.spec"
+  }
+}

--- a/anda/lib/wails/v3/update.rhai
+++ b/anda/lib/wails/v3/update.rhai
@@ -1,0 +1,1 @@
+rpm.global("ver", gh_tag("wailsapp/wails"));

--- a/anda/lib/wails/v3/wails3.spec
+++ b/anda/lib/wails/v3/wails3.spec
@@ -1,0 +1,62 @@
+%global ver 3.0.0-alpha.74
+%global sanitized_ver %(echo %{ver} | sed 's/-/~/g')
+
+%global goipath github.com/wailsapp/wails/v3
+Version:        %{sanitized_ver}
+
+%gometa -f
+
+Name:           wails3
+Release:        1%?dist
+Summary:        Create beautiful applications using Go
+
+License:        MIT
+URL:            https://wails.io/
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+BuildRequires:  webkit2gtk4.1-devel
+BuildRequires:  gtk3-devel
+Requires:       glibc
+Requires:       /usr/bin/npm
+Requires:       webkit2gtk4.1
+Requires:       gtk3
+Provides:       wails-v3
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%git_clone https://github.com/wailsapp/wails v3-alpha
+
+%build
+pushd v3/cmd/wails3
+GO111MODULE=on %gobuild
+popd
+
+%install
+install -Dm 0755 v3/cmd/wails3/wails3 %{buildroot}%{_bindir}/wails3
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md CONTRIBUTORS.md CHANGELOG.md SECURITY.md
+%lang(de) %doc README.de.md
+%lang(es) %doc README.es.md
+%lang(fr) %doc README.fr.md
+%lang(ja) %doc README.ja.md
+%lang(ko) %doc README.ko.md
+%lang(pt_BR) %doc README.pt-br.md
+%lang(ru) %doc README.ru.md
+%lang(tr) %doc README.tr.md
+%lang(uz) %doc README.uz.md
+%lang(zh_CN) %doc README.zh-Hans.md
+%{_bindir}/wails3
+
+%changelog
+* Mon Mar 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: wails and wails-v3 (#10192)](https://github.com/terrapkg/packages/pull/10192)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)