### PR TITLE
[f43] chore (neohtop): add screenshot to metainfo (#10203)

### DIFF
--- a/anda/apps/neohtop/com.github.neohtop.metainfo.xml
+++ b/anda/apps/neohtop/com.github.neohtop.metainfo.xml
@@ -8,6 +8,10 @@
   <name>NeoHtop</name>
   <summary>System monitoring on steroids</summary>
 
+  <screenshots>
+    <screenshot type="default"><image>https://github.com/Abdenasser/neohtop/blob/main/screenshot.png</image></screenshot>
+  </screenshots>
+
   <description>
     <p>
         A modern, cross-platform system monitor built on top of Svelte, Rust, and Tauri.

--- a/anda/apps/neohtop/neohtop.spec
+++ b/anda/apps/neohtop/neohtop.spec
@@ -3,7 +3,7 @@
 
 Name:           neohtop
 Version:        1.2.0
-Release:        4%?dist
+Release:        5%?dist
 Summary:        System monitoring on steroids
 SourceLicense:  MIT
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND (BSD-3-Clause AND MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND (BSD-3-Clause OR MIT) AND BSD-3-Clause AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND MPL-2.0 AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
@@ -63,7 +63,7 @@ install -Dpm644 src-tauri/icons/128x128.png      %{buildroot}%{_hicolordir}/128x
 
 %changelog
 * Wed Dec 24 2025 Owen Zimmerman <owen@fyralabs.com>
-- Clean up build, add %check 
+- Clean up build, add %check
 * Wed Nov 19 2025 Owen Zimmerman <owen@fyralabs.com>
 - Add metainfo
 * Sat Feb 15 2025 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (neohtop): add screenshot to metainfo (#10203)](https://github.com/terrapkg/packages/pull/10203)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)