### PR TITLE
[el10] backport: fix (arduino-app-lab-bin): update script (#10232)

### DIFF
--- a/anda/tools/arduino-app-lab-bin/arduino-app-lab-bin.spec
+++ b/anda/tools/arduino-app-lab-bin/arduino-app-lab-bin.spec
@@ -1,8 +1,8 @@
 %global appid cc.arduino.AppLab
 
 Name:           arduino-app-lab-bin
-Version:        0.3.2
-Release:        1%{?dist}
+Version:        0.5.0
+Release:        1%?dist
 Summary:        A powerful visual environment for managing the Arduino UNO Q
 
 Provides:       arduino-app-lab
@@ -20,7 +20,7 @@ Requires:       android-tools
 
 BuildRequires:  terra-appstream-helper desktop-file-utils
 
-Suggests:       arduino-flasher-cli arduino-app-cli  
+Suggests:       arduino-flasher-cli arduino-app-cli
 
 Packager:       Jaiden Riordan <jade@fyralabs.com>
 

--- a/anda/tools/arduino-app-lab-bin/update.rhai
+++ b/anda/tools/arduino-app-lab-bin/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh("arduino/arduino-app-lab"));
+let v = gh("arduino/arduino-app-lab");
+v.crop(3);
+print(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [backport: fix (arduino-app-lab-bin): update script (#10232)](https://github.com/terrapkg/packages/pull/10232)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)