### PR TITLE
[f44] add: vapor-mod-overlay (#10244)

### DIFF
--- a/anda/games/vapor-mod-overlay/anda.hcl
+++ b/anda/games/vapor-mod-overlay/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "vapor-mod-overlay.spec"
+	}
+}

--- a/anda/games/vapor-mod-overlay/update.rhai
+++ b/anda/games/vapor-mod-overlay/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("ChristianSilvermoon/vapor-mod-overlay"));

--- a/anda/games/vapor-mod-overlay/vapor-mod-overlay.spec
+++ b/anda/games/vapor-mod-overlay/vapor-mod-overlay.spec
@@ -1,0 +1,33 @@
+Name:      vapor-mod-overlay
+Version:   0.0.1
+Release:   1%{?dist}
+Summary:   A fairly basic OverlayFS powered mod loader for Steam
+License:   MIT
+URL:       https://github.com/ChristianSilvermoon/vapor-mod-overlay
+Source0:   %{url}/archive/refs/tags/v%{version}.tar.gz
+Requires:  bash
+Requires:  fuse-overlayfs
+BuildArch: noarch
+Packager:  Gilver E. <roachy@fyralabs.com>
+
+%description
+This is an attempt at a very basic sort of Mod Loader for Valve's Steam Client on GNU/Linux systems that uses OverlayFS.
+This was inspired by a bug in Portal 2 VR that required the mod to be disabled temporarily to bypass a crash.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+# The voices are getting louder.
+
+%install
+install -Dpm755 %{name}.sh %{buildroot}%{_bindir}/%{name}
+
+%files
+%doc README.md
+%license LICENSE.md
+%{_bindir}/%{name}
+
+%changelog
+* Mon Mar 2 2026 Gilver E. <roachy@fyralabs.com>
+- Initial package

--- a/anda/games/vapor-mod-overlay/vapor-mod-overlay.spec
+++ b/anda/games/vapor-mod-overlay/vapor-mod-overlay.spec
@@ -1,6 +1,6 @@
 Name:      vapor-mod-overlay
 Version:   0.0.1
-Release:   1%{?dist}
+Release:   2%{?dist}
 Summary:   A fairly basic OverlayFS powered mod loader for Steam
 License:   MIT
 URL:       https://github.com/ChristianSilvermoon/vapor-mod-overlay


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: vapor-mod-overlay (#10244)](https://github.com/terrapkg/packages/pull/10244)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)