### PR TITLE
android-studio-canary: remove nightly

### DIFF
--- a/anda/devs/android-studio/canary/anda.hcl
+++ b/anda/devs/android-studio/canary/anda.hcl
@@ -3,7 +3,4 @@ project pkg {
   rpm {
     spec = "android-studio-canary.spec"
   }
-  labels { 
-    nightly = "1" 
-  }
 }


### PR DESCRIPTION
This will allow android studio canary to get updates as soon as they are released and not wait 24 hours to update 