### PR TITLE
[f43] add: moonshot (#10202)

### DIFF
--- a/anda/apps/moonshot/anda.hcl
+++ b/anda/apps/moonshot/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+      spec = "moonshot.spec"
+    }
+}

--- a/anda/apps/moonshot/com.fyralabs.moonshot.metainfo.xml
+++ b/anda/apps/moonshot/com.fyralabs.moonshot.metainfo.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>com.fyralabs.moonshot</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <icon type="local">/usr/share/icons/hicolor/512x512/apps/moonshot.png</icon>
+
+  <name>Moonshot</name>
+  <summary>A beautiful cross-platform flashing tool</summary>
+
+  <screenshots>
+    <screenshot type="default"><image
+            >https://github.com/FyraLabs/moonshot/blob/main/build/screenshot.png</image></screenshot>
+  </screenshots>
+
+  <description>
+    <p>
+    A beautiful cross-platform flashing tool.
+    Why?
+
+        - Community frustration with existing flashing tools.
+        - We have unique ideas that we want to implement in the future, ex: selecting distro images from within the app.
+        - For fun.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">moonshot.desktop</launchable>
+
+  <url type="homepage">https://github.com/FyraLabs/moonshot</url>
+  <url type="bugtracker">https://github.com/FyraLabs/moonshot/issues</url>
+  <url type="donation">https://github.com/sponsors/FyraLabs</url>
+  <url type="contact">https://fyralabs.com/contact/</url>
+  <provides>
+    <binary>moonshot</binary>
+  </provides>
+
+  <keywords>
+    <keyword>disk flashing</keyword>
+    <keyword>imaging</keyword>
+    <keyword>flashing tool</keyword>
+    <keyword>flasher</keyword>
+    <keyword>etcher</keyword>
+    <keyword>usb</keyword>
+    <keyword>sd card</keyword>
+  </keywords>
+
+  <developer id="com.fyralabs.moonshot">
+    <name>Fyra Labs</name>
+  </developer>
+</component>

--- a/anda/apps/moonshot/moonshot.spec
+++ b/anda/apps/moonshot/moonshot.spec
@@ -1,0 +1,55 @@
+%define debug_package %{nil}
+%define appid com.fyralabs.moonshot
+
+Name:           moonshot
+Version:        1.0.1
+Release:        1%?dist
+Summary:        A beautiful cross-platform flashing tool
+License:        GPL-3.0-or-later
+URL:            https://github.com/FyraLabs/moonshot
+Source0:        %url/archive/refs/tags/v%version.tar.gz
+Source1:        com.fyralabs.moonshot.metainfo.xml
+
+BuildRequires:  wails3
+BuildRequires:  golang
+BuildRequires:  bun-bin
+BuildRequires:  pkgconfig(webkit2gtk-4.1)
+BuildRequires:  pkgconfig(gtk4)
+BuildRequires:  pkgconfig(webkitgtk-6.0)
+BuildRequires:  pkgconfig(gio-unix-2.0)
+BuildRequires:  pkgconfig(libsoup-3.0)
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+Why?
+
+    - Community frustration with existing flashing tools.
+    - We have unique ideas that we want to implement in the future, ex: selecting distro images from within the app.
+    - For fun.
+
+%prep
+%autosetup
+
+%build
+EXTRA_TAGS=gtk4 wails3 build
+
+%install
+install -Dm755 bin/moonshot                 %{buildroot}%{_bindir}/moonshot
+install -Dm644 build/linux/moonshot.desktop %{buildroot}%{_appsdir}/%{appid}.desktop
+install -Dm644 build/appicon.png            %{buildroot}%{_hicolordir}/512x512/apps/moonshot.png
+
+%terra_appstream -o %{SOURCE1}
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/moonshot
+%{_appsdir}/%{appid}.desktop
+%{_hicolordir}/512x512/apps/moonshot.png
+%{_metainfodir}/com.fyralabs.moonshot.metainfo.xml
+
+%changelog
+* Mon Mar 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/apps/moonshot/update.rhai
+++ b/anda/apps/moonshot/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("FyraLabs/moonshot"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: moonshot (#10202)](https://github.com/terrapkg/packages/pull/10202)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)