### PR TITLE
[f42] backport: remove nightly tag from android studio canary (#10250)

### DIFF
--- a/anda/devs/android-studio/canary/anda.hcl
+++ b/anda/devs/android-studio/canary/anda.hcl
@@ -3,7 +3,4 @@ project pkg {
   rpm {
     spec = "android-studio-canary.spec"
   }
-  labels { 
-    nightly = "1" 
-  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `f42`:
 - [backport: remove nightly tag from android studio canary (#10250)](https://github.com/terrapkg/packages/pull/10250)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)