### PR TITLE
[f43] chore (moonshot): use %set_javascript_build_flags (#10258)

### DIFF
--- a/anda/apps/moonshot/moonshot.spec
+++ b/anda/apps/moonshot/moonshot.spec
@@ -33,6 +33,7 @@ Why?
 %autosetup
 
 %build
+%set_javascript_build_flags
 EXTRA_TAGS=gtk4 wails3 build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (moonshot): use %set_javascript_build_flags (#10258)](https://github.com/terrapkg/packages/pull/10258)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)