### PR TITLE
[f43] fix(goofcord): Rebuild for hotfix (#10275)

### DIFF
--- a/anda/apps/goofcord/stable/goofcord.spec
+++ b/anda/apps/goofcord/stable/goofcord.spec
@@ -3,7 +3,7 @@
 
 Name:          goofcord
 Version:       2.1.0
-Release:       1%?dist
+Release:       2%?dist
 License:       OSL-3.0
 Summary:       A privacy-minded Legcord fork.
 Group:         Applications/Internet


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(goofcord): Rebuild for hotfix (#10275)](https://github.com/terrapkg/packages/pull/10275)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)