### PR TITLE
[f44] chore(ci): Update atrifact actions (#10287)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -51,7 +51,7 @@ jobs:
       image: ghcr.io/terrapkg/appstream-generator:main
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: ./artifacts

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -99,7 +99,7 @@ jobs:
           x=${NAME//\//@}
           echo "name=$x" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.art.outputs.name }}
           compression-level: 0 # The RPMs are already compressed :p


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(ci): Update atrifact actions (#10287)](https://github.com/terrapkg/packages/pull/10287)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)