### PR TITLE
[f43] fix (stardust-XR-nightly): don’t dep on non existant package (#10303)

### DIFF
--- a/anda/stardust/telescope/nightly/stardust-telescope-nightly.spec
+++ b/anda/stardust/telescope/nightly/stardust-telescope-nightly.spec
@@ -4,7 +4,7 @@
 
 Name:           stardust-xr-telescope-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%?dist
 Summary:        See the stars! Easy stardust setups to run on your computer
 License:        MIT
 URL:            https://github.com/StardustXR/telescope
@@ -19,7 +19,7 @@ Requires:       stardust-xr-black-hole-nightly
 Requires:       stardust-xr-comet-nightly
 Requires:       stardust-xr-flatland-nightly
 Requires:       stardust-xr-gravity-nightly
-Requires:       stardust-xr-magnetar-nightly
+Requires:       stardust-xr-magnetar
 Requires:       stardust-xr-non-spatial-input-nightly
 Requires:       stardust-xr-protostar-nightly
 Requires:       stardust-xr-server-nightly


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (stardust-XR-nightly): don’t dep on non existant package (#10303)](https://github.com/terrapkg/packages/pull/10303)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)