### PR TITLE
[el10] add: amdgpu_top (#10293)

### DIFF
--- a/anda/system/amdgpu_top/amdgpu_top.spec
+++ b/anda/system/amdgpu_top/amdgpu_top.spec
@@ -1,0 +1,56 @@
+%undefine __brp_add_determinism
+
+Name:           amdgpu_top
+Version:        0.11.2
+Release:        1%?dist
+Summary:        Tool to display AMDGPU usage
+License:        MIT
+Packager:       veuxit <erroor234@gmail.com>
+URL:            https://github.com/Umio-Yasuno/amdgpu_top
+
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires:  desktop-file-utils
+BuildRequires:  libdrm-devel
+BuildRequires:  cargo cargo-rpm-macros anda-srpm-macros
+
+%description
+%summary.
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+%{cargo_build} --locked
+
+%install
+
+install -Dm755 target/release/amdgpu_top %{buildroot}%{_bindir}/amdgpu_top
+
+install -Dm644 assets/amdgpu_top.desktop %{buildroot}%{_appsdir}/amdgpu_top.desktop
+
+install -Dm644 assets/amdgpu_top-tui.desktop %{buildroot}%{_appsdir}/amdgpu_top-tui.desktop
+
+install -Dpm644 assets/io.github.umio_yasuno.amdgpu_top.metainfo.xml %{buildroot}%{_metainfodir}/io.github.umio_yasuno.amdgpu_top.metainfo.xml
+
+install -Dm644 "docs/amdgpu_top.1" "%{buildroot}%{_mandir}/man1/amdgpu_top.1"
+
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/amdgpu_top.desktop
+%desktop_file_validate %{buildroot}%{_appsdir}/amdgpu_top-tui.desktop
+
+%files
+%doc README.md
+%doc CHANGELOG.md
+%doc AUTHORS
+%license LICENSE
+%{_bindir}/amdgpu_top
+%{_datadir}/applications/amdgpu_top.desktop
+%{_datadir}/applications/amdgpu_top-tui.desktop
+%{_metainfodir}/io.github.umio_yasuno.amdgpu_top.metainfo.xml
+%{_mandir}/man1/amdgpu_top.1.gz
+
+%changelog
+* Thu Mar 5 2026 veuxit <erroor234@gmail.com> - 0.11.2
+- Initial package release

--- a/anda/system/amdgpu_top/anda.hcl
+++ b/anda/system/amdgpu_top/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "amdgpu_top.spec"
+  }
+}

--- a/anda/system/amdgpu_top/update.rhai
+++ b/anda/system/amdgpu_top/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Umio-Yasuno/amdgpu_top"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: amdgpu_top (#10293)](https://github.com/terrapkg/packages/pull/10293)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)