### PR TITLE
[f44] fix(depthcharge-tools): Use pyproject macros (#10327)

### DIFF
--- a/anda/system/depthcharge-tools/anda.hcl
+++ b/anda/system/depthcharge-tools/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+        arches = ["x86_64"]
 	rpm {
 		spec = "depthcharge-tools.spec"
 	}

--- a/anda/system/depthcharge-tools/depthcharge-tools.spec
+++ b/anda/system/depthcharge-tools/depthcharge-tools.spec
@@ -6,7 +6,7 @@ License:		GPL-2.0-or-later
 URL:			https://gitlab.postmarketos.org/postmarketOS/depthcharge-tools
 Source0:		%url/-/archive/v%version/%name-v%version.tar.gz
 Requires:		vboot-utils dtc gzip lz4 python3-setuptools uboot-tools vboot-utils xz
-BuildRequires:	python3-setuptools python3-rpm-macros systemd-rpm-macros redhat-rpm-config python3-docutils python3-importlib-resources
+BuildRequires:	python3-setuptools python3-rpm-macros pyproject-rpm-macros python3dist(pip) systemd-rpm-macros redhat-rpm-config python3-docutils python3-importlib-resources
 BuildArch:		noarch
 
 %description
@@ -19,10 +19,11 @@ with depthcharge, the Chrome OS bootloader.
 %autosetup -n %name-v%version
 
 %build
-python3 setup.py build
+%pyproject_wheel
 
 %install
-python3 setup.py install --skip-build --root=%buildroot
+%pyproject_install
+%pyproject_save_files depthcharge_tools
 mkdir -p %buildroot/usr/lib/kernel/install.d %buildroot{%_unitdir,%bash_completions_dir,%zsh_completions_dir,%_mandir/man1}
 install -Dm644 systemd/*.install %buildroot/usr/lib/kernel/install.d/
 install -Dm644 systemd/*.service %buildroot%_unitdir/
@@ -34,15 +35,13 @@ rst2man mkdepthcharge.rst | gzip > mkdepthcharge.1.gz
 rst2man depthchargectl.rst | gzip > depthchargectl.1.gz
 install -Dm644 *.1.gz %buildroot%_mandir/man1/
 
-%files
+%files -f %{pyproject_files}
 %doc README.rst
 %license LICENSE
 %_bindir/{mkdepthcharge,depthchargectl}
 %_mandir/man1/{mkdepthcharge,depthchargectl}.1.gz
 /usr/lib/kernel/install.d/90-depthcharge-tools.install
 %_unitdir/depthchargectl-bless.service
-%_prefix/lib/python%python3_version/site-packages/depthcharge_tools-%version-py%python3_version.egg-info/
-%_prefix/lib/python%python3_version/site-packages/depthcharge_tools/
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(depthcharge-tools): Use pyproject macros (#10327)](https://github.com/terrapkg/packages/pull/10327)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)