### PR TITLE
[f43] fix(goofcord): Remove patch (#10336)

### DIFF
--- a/anda/apps/goofcord/stable/goofcord.spec
+++ b/anda/apps/goofcord/stable/goofcord.spec
@@ -9,7 +9,6 @@ Summary:       A privacy-minded Legcord fork.
 Group:         Applications/Internet
 URL:           https://github.com/Milkshiift/%{git_name}
 Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
-Patch0:        %{url}/commit/5be00d22d09f118fa5a2ac40deb12c54f66f03b8.patch
 BuildRequires: anda-srpm-macros >= 0.3.0
 BuildRequires: bun-bin
 Packager:      Gilver E. <roachy@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(goofcord): Remove patch (#10336)](https://github.com/terrapkg/packages/pull/10336)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)