### PR TITLE
[f43] fix (depthcharge-tools): patch __init__.py (#10344)

### DIFF
--- a/anda/system/depthcharge-tools/depthcharge-tools.spec
+++ b/anda/system/depthcharge-tools/depthcharge-tools.spec
@@ -1,12 +1,13 @@
 Name:			depthcharge-tools
 Version:		0.6.3
-Release:		3%?dist
+Release:		4%?dist
 Summary:		Tools to manage the Chrome OS bootloader
 License:		GPL-2.0-or-later
 URL:			https://gitlab.postmarketos.org/postmarketOS/depthcharge-tools
 Source0:		%url/-/archive/v%version/%name-v%version.tar.gz
 Requires:		vboot-utils dtc gzip lz4 python3-setuptools uboot-tools vboot-utils xz python3-importlib-resources
 BuildRequires:	python3-setuptools python3-rpm-macros pyproject-rpm-macros python3dist(pip) systemd-rpm-macros redhat-rpm-config python3-docutils python3-importlib-resources
+Patch0:         fix-importlib.patch
 BuildArch:		noarch
 
 %description
@@ -16,7 +17,7 @@ with depthcharge, the Chrome OS bootloader.
 %pkg_completion -Bz mkdepthcharge depthchargectl
 
 %prep
-%autosetup -n %name-v%version
+%autosetup -n %name-v%version -p1
 
 %build
 %pyproject_wheel

--- a/anda/system/depthcharge-tools/fix-importlib.patch
+++ b/anda/system/depthcharge-tools/fix-importlib.patch
@@ -1,0 +1,12 @@
+diff --git a/depthcharge_tools/__init__.py b/depthcharge_tools/__init__.py
+index fabb79d..2b7d7d5 100644
+--- a/depthcharge_tools/__init__.py
++++ b/depthcharge_tools/__init__.py
+@@ -9,6 +9,7 @@ import glob
+ import logging
+ import pathlib
+ import importlib
++import importlib.resources
+ import importlib_metadata
+ from packaging.version import parse as parse_version
+ import re


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (depthcharge-tools): patch __init__.py (#10344)](https://github.com/terrapkg/packages/pull/10344)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)