### PR TITLE
[el10] fix: noctalia-qs revision shows %{commit since %{commit} isn't defined (#10298)

### DIFF
--- a/anda/desktops/noctalia-qs/noctalia-qs.spec
+++ b/anda/desktops/noctalia-qs/noctalia-qs.spec
@@ -1,12 +1,14 @@
-Name:		noctalia-qs
-Version:	0.0.5
-Release:	1%?dist
-Summary:	Flexible QtQuick based desktop shell toolkit
-License:	LGPL-3.0-only AND GPL-3.0-only
-URL:		https://github.com/noctalia-dev/noctalia-qs
-Source0:	https://github.com/noctalia-dev/noctalia-qs/archive/refs/tags/v%{version}.tar.gz
+%global commit 1a02ba2ee11b1afa8ec9a94f8b6b652bf4f14e1d
 
-Packager:       Willow C Reed (willow@willowidk.dev)
+Name:	       noctalia-qs
+Version:       0.0.5
+Release:       2%?dist
+Summary:       Flexible QtQuick based desktop shell toolkit
+License:       LGPL-3.0-only AND GPL-3.0-only
+URL:	       https://github.com/noctalia-dev/noctalia-qs
+Source0:       https://github.com/noctalia-dev/noctalia-qs/archive/refs/tags/v%{version}.tar.gz
+
+Packager:      Willow C Reed (willow@willowidk.dev)
 
 BuildRequires: cmake
 BuildRequires: cmake(Qt6Core)
@@ -33,7 +35,8 @@ BuildRequires: pkgconfig(CLI11)
 BuildRequires: glib2-devel
 BuildRequires: polkit-devel
 
-Obsoletes:     quickshell
+Conflicts:    quickshell
+Provides:     quickshell
 
 %description
 Flexible QtQuick based desktop shell toolkit.
@@ -67,5 +70,9 @@ Flexible QtQuick based desktop shell toolkit.
 %{_libdir}/qt6/qml/Quickshell
 
 %changelog
+* Thu Mar 05 2026 Willow C Reed <willow@willowidk.dev>
+- Fix reision to actually be defined as a specific git commit since it never gets initialized rn
+- Also fix that noctalia-qs is replacing quickshell overall and not just for noctlaia users
+
 * Fri Feb 27 2026 Willow C Reed <willow@willowidk.dev>
 - Initial commit based on quickshell spec

--- a/anda/desktops/noctalia-qs/update.rhai
+++ b/anda/desktops/noctalia-qs/update.rhai
@@ -1,1 +1,7 @@
-rpm.version(gh("noctalia-dev/noctalia-qs"));
+let release = get(`https://api.github.com/repos/noctalia-dev/noctalia-qs/tags`).json_arr()[0];
+
+rpm.version(release.name);
+
+if rpm.changed() {
+  rpm.global("commit", release.commit.sha);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: noctalia-qs revision shows %{commit since %{commit} isn&#x27;t defined (#10298)](https://github.com/terrapkg/packages/pull/10298)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)