### PR TITLE
[f43] chore: update lomiri frame (#10380)

### DIFF
--- a/anda/desktops/lomiri-unity/frame/frame.spec
+++ b/anda/desktops/lomiri-unity/frame/frame.spec
@@ -1,9 +1,9 @@
 Name:           frame
 Version:        2.5.0
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Touch Frame Library
 
-License:        GPL-3.0 AND LGPL-3.0
+License:        GPL-3.0-or-later AND LGPL-3.0-or-later
 URL:            https://launchpad.net/frame
 Source0:        http://archive.ubuntu.com/ubuntu/pool/universe/f/frame/frame_%{version}daily13.06.05+16.10.20160809.orig.tar.gz
 Patch0:         http://archive.ubuntu.com/ubuntu/pool/universe/f/frame/frame_%{version}daily13.06.05+16.10.20160809-0ubuntu3.diff.gz
@@ -24,7 +24,7 @@ Frame handles the buildup and synchronization of a set of simultaneous touches.
 
 %package devel
 Summary:  Development files for %{name}
-Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: %{name}%{?_isa} = %{evr}
 
 %description devel
 The %{name}-devel package contains libraries and header files for


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: update lomiri frame (#10380)](https://github.com/terrapkg/packages/pull/10380)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)