### PR TITLE
[f44] fix: deno (#10296)

### DIFF
--- a/anda/devs/deno/deno-fix-metadata-auto.diff
+++ b/anda/devs/deno/deno-fix-metadata-auto.diff
@@ -1,11 +1,11 @@
---- deno-2.6.9/Cargo.toml	1970-01-01T00:00:01+00:00
-+++ deno-2.6.9/Cargo.toml	2026-02-12T15:05:13.386522+00:00
-@@ -667,24 +667,3 @@
+--- deno-2.7.4/Cargo.toml	1970-01-01T00:00:01+00:00
++++ deno-2.7.4/Cargo.toml	2026-03-05T14:17:34.447378+00:00
+@@ -659,24 +659,3 @@
  [target."cfg(unix)".dependencies.shell-escape]
  version = "=0.1.5"
  
 -[target."cfg(windows)".dependencies.deno_subprocess_windows]
--version = "0.26.0"
+-version = "0.32.0"
 -
 -[target."cfg(windows)".dependencies.winapi]
 -version = "=0.3.9"


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: deno (#10296)](https://github.com/terrapkg/packages/pull/10296)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)