### PR TITLE
fix: noctalia-shell: switch gpu-screen-recorder to recommended and fix source tar path

### DIFF
--- a/anda/desktops/noctalia-shell/noctalia-shell.spec
+++ b/anda/desktops/noctalia-shell/noctalia-shell.spec
@@ -7,11 +7,10 @@ Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
 URL:            https://github.com/noctalia-dev/noctalia-shell
-Source0:        https://github.com/noctalia-dev/noctalia-shell/releases/latest/download/noctalia-latest.tar.gz
+Source0:        https://github.com/noctalia-dev/noctalia-shell/releases/download/%{version}/noctalia-%{version}.tar.gz
 
 Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts
-Requires:    	gpu-screen-recorder
 Requires:	    qt6-qtmultimedia
 Requires:       noctalia-qs
 Requires:       xdg-desktop-portal
@@ -22,6 +21,7 @@ Recommends:	    ddcutil
 Recommends:	    matugen
 Recommends:	    power-profiles-daemon
 Recommends:	    wlsunset
+Recommends:    	gpu-screen-recorder
 
 Packager:       Willow Reed <willow@willowidk.dev>
 
@@ -43,6 +43,9 @@ cp -r ./* %{buildroot}/etc/xdg/quickshell/noctalia-shell/
 %{_sysconfdir}/xdg/quickshell/noctalia-shell/
 
 %changelog
+* Mon Mar 09 2026 Willow C Reed <willow@willowidk.dev>
+- switch gpu-screen-recorder to be recommended as it's a plugin and not required anymore. also switched source to be based on version.
+
 * Fri Feb 27 2026 Willow C Reed <willow@willowidk.dev>
 - Change required quickshell to Noctalia's version
 

--- a/anda/desktops/noctalia-shell/noctalia-shell.spec
+++ b/anda/desktops/noctalia-shell/noctalia-shell.spec
@@ -2,7 +2,7 @@
 
 Name:           noctalia-shell
 Version:		4.6.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT

--- a/anda/desktops/noctalia-shell/noctalia-shell.spec
+++ b/anda/desktops/noctalia-shell/noctalia-shell.spec
@@ -7,7 +7,7 @@ Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
 URL:            https://github.com/noctalia-dev/noctalia-shell
-Source0:        https://github.com/noctalia-dev/noctalia-shell/releases/download/%{version}/noctalia-%{version}.tar.gz
+Source0:        https://github.com/noctalia-dev/noctalia-shell/releases/download/v%{version}/noctalia-v%{version}.tar.gz
 
 Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts


### PR DESCRIPTION
gpu-screen-recorder is part of a plugin instead of being required for noctalia now. also, the source tarball was just based on being "latest" instead of being based on a version, which could cause issues if we choose to pin a version or something.