### PR TITLE
[f43] noctalia-shell dep and source backport (#10401)

### DIFF
--- a/anda/desktops/noctalia-shell/noctalia-shell.spec
+++ b/anda/desktops/noctalia-shell/noctalia-shell.spec
@@ -1,17 +1,16 @@
 %global debug_package %{nil}
 
 Name:           noctalia-shell
-Version:		4.6.4
-Release:        1%{?dist}
+Version:		4.6.5
+Release:        3%{?dist}
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
 URL:            https://github.com/noctalia-dev/noctalia-shell
-Source0:        https://github.com/noctalia-dev/noctalia-shell/releases/latest/download/noctalia-latest.tar.gz
+Source0:        https://github.com/noctalia-dev/noctalia-shell/releases/download/v%{version}/noctalia-v%{version}.tar.gz
 
 Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts
-Requires:    	gpu-screen-recorder
 Requires:	    qt6-qtmultimedia
 Requires:       noctalia-qs
 Requires:       xdg-desktop-portal
@@ -22,6 +21,7 @@ Recommends:	    ddcutil
 Recommends:	    matugen
 Recommends:	    power-profiles-daemon
 Recommends:	    wlsunset
+Recommends:    	gpu-screen-recorder
 
 Packager:       Willow Reed <willow@willowidk.dev>
 
@@ -43,6 +43,9 @@ cp -r ./* %{buildroot}/etc/xdg/quickshell/noctalia-shell/
 %{_sysconfdir}/xdg/quickshell/noctalia-shell/
 
 %changelog
+* Mon Mar 09 2026 Willow C Reed <willow@willowidk.dev>
+- switch gpu-screen-recorder to be recommended as it's a plugin and not required anymore. also switched source to be based on version.
+
 * Fri Feb 27 2026 Willow C Reed <willow@willowidk.dev>
 - Change required quickshell to Noctalia's version
 

--- a/anda/desktops/noctalia-shell/noctalia-shell.spec
+++ b/anda/desktops/noctalia-shell/noctalia-shell.spec
@@ -2,7 +2,7 @@
 
 Name:           noctalia-shell
 Version:		4.6.5
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `f43`:
 - [noctalia-shell dep and source backport (#10401)](https://github.com/terrapkg/packages/pull/10401)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)