### PR TITLE
[f43] fix(kde-material-you-colors): Update script (#10415)

### DIFF
--- a/anda/themes/kde-material-you-colors/update.rhai
+++ b/anda/themes/kde-material-you-colors/update.rhai
@@ -1,7 +1,7 @@
 import "andax/bump_extras.rhai" as bump;
 import "andax/spec.rhai" as spec;
 
-rpm.version(pypi("kde-material-you-colors"));
+rpm.version(find(`version = \"([\d.]+)\"`, gh_rawfile("luisbocanegra/kde-material-you-colors", "main", "pyproject.toml"), 1));
 
 open_file("anda/themes/kde-material-you-colors/VERSION_qt6-qtbase.txt", "w").write(bump::bodhi("qt6-qtbase", bump::as_bodhi_ver(labels.branch)));
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(kde-material-you-colors): Update script (#10415)](https://github.com/terrapkg/packages/pull/10415)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)