### PR TITLE
[f44] fix (libayatana-appindicator-glib): license identifier (#10413)

### DIFF
--- a/anda/lib/libayatana-appindicator-glib/libayatana-appindicator-glib.spec
+++ b/anda/lib/libayatana-appindicator-glib/libayatana-appindicator-glib.spec
@@ -3,8 +3,8 @@
 Name:       libayatana-appindicator-glib
 Summary:    Ayatana Application Indicators Shared Library
 Version:    2.0.1
-Release:    1%?dist
-License:    GPL-3.0
+Release:    2%?dist
+License:    GPL-3.0-or-later
 Packager:   veuxit <erroor234@gmail.com>
 URL:        https://github.com/AyatanaIndicators/libayatana-appindicator-glib
 Source0:    %{url}/archive/refs/tags/%{version}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (libayatana-appindicator-glib): license identifier (#10413)](https://github.com/terrapkg/packages/pull/10413)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)