### PR TITLE
[el10] fix: anki (#10443)

### DIFF
--- a/anda/apps/anki/anki.spec
+++ b/anda/apps/anki/anki.spec
@@ -4,9 +4,10 @@ Release:        1%?dist
 Summary:        Flashcard program for using space repetition learning
 License:        AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
 URL:            https://apps.ankiweb.net/
+Packager:       madonuko <mado@fyralabs.com>
 BuildRequires:  python3-devel python3-setuptools python3-waitress python3-protobuf python3-pysocks rpm_macro(fdupes)
 BuildRequires:  python3-distro python3-flask-cors python3-jsonschema python3-send2trash python3-certifi python3-simplejson
-BuildRequires:  python3-installer make mold cargo git rsync ninja-build libxcrypt-compat nodejs python3.9 python-unversioned-command gcc python3-pyqt6-webengine
+BuildRequires:  python3-installer make cargo git rsync ninja-build libxcrypt-compat nodejs python3.9 python-unversioned-command gcc python3-pyqt6-webengine
 Requires:       hicolor-icon-theme python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-send2trash
 Requires:       python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema sox libxcrypt-compat python3-pyqt6-webengine
 Recommends:     (mpv or mpv-nightly)
@@ -20,9 +21,7 @@ phrases in a foreign language) as easily, quickly and efficiently as possible.
 Anki is based on a theory called spaced repetition.
 
 %prep
-rm -rf *
-git clone https://github.com/ankitects/anki .
-git checkout %{version}
+%git_clone https://github.com/ankitects/anki
 %patch 0 -p1
 
 # See https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=anki
@@ -31,7 +30,7 @@ git checkout %{version}
 export RELEASE=1
 export PYTHONPATH=%_libdir/python3/dist-packages
 cargo update
-mold -run ./tools/build
+./tools/build
 
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: anki (#10443)](https://github.com/terrapkg/packages/pull/10443)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)