### PR TITLE
[el10] add: bpftune bpftune-nightly (#10320)

### DIFF
--- a/anda/system/bpftune/nightly/anda.hcl
+++ b/anda/system/bpftune/nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "bpftune-nightly.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/system/bpftune/nightly/bpftune-nightly.spec
+++ b/anda/system/bpftune/nightly/bpftune-nightly.spec
@@ -1,0 +1,104 @@
+# BPF-based auto-tuning SPEC file
+
+%define pcpdir	    /var/lib/pcp/pmdas
+
+%global ver 0.4-2
+%global releaseS %(echo '%ver' | sed -E 's/^[^-]+-//')
+%define nameR    bpftune
+
+%bcond_with openrc
+
+%global commit  4712347f2da0b7d4a5fbdb0d81d071c1704b3f20
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commit_date 20260227
+
+Name:           bpftune-nightly
+Version:        %(echo '%ver' | sed 's/-/~/g')^%{commit_date}git.%{shortcommit}
+Release:        1%?dist
+Summary:        BPF/tracing tools for auto-tuning Linux
+License:        GPL-2.0-only WITH Linux-syscall-note
+Packager:       veuxit <erroor234@gmail.com>
+URL:            https://github.com/oracle/bpftune
+Conflicts:      bpftune
+
+Source0:        %{url}/archive/%{commit}/bpftune-%{commit}.tar.gz
+
+Group:          Development/Tools
+Requires:       libbpf >= 0.6
+Requires:       libnl3
+Requires:       libcap
+BuildRequires:  libbpf-devel >= 0.6
+BuildRequires:  libcap-devel
+BuildRequires:	bpftool >= 4.18
+BuildRequires:  libnl3-devel
+BuildRequires:  clang >= 11
+BuildRequires:  clang-libs >= 11
+BuildRequires:  llvm >= 11
+BuildRequires:  llvm-libs >= 11
+BuildRequires:	python3-docutils
+
+%description
+Service consisting of daemon (bpftune) and plugins which
+support auto-tuning of Linux via BPF observability.
+
+%package devel
+Requires:   %{name} = %{evr}
+Requires:   libbpf-devel >= 0.6
+Requires:   libcap-devel
+Requires:   bpftool
+Requires:   libnl3-devel
+
+%pkg_devel_files
+
+%package pcp-pmda
+Summary:	Performance Co-Pilot PMDA for bpftune
+Requires:   %{name} = %{evr}
+Requires:	pcp
+Requires:   python3-pcp 
+
+%description pcp-pmda
+The %{name}-pcp-pmda exports tunables and metrics from bpftune
+to Performance Co-Pilot (PCP)
+
+%prep
+%autosetup -n bpftune-%{commit}
+
+%build
+%make_build
+
+%install
+%make_install
+
+%post
+%systemd_post bpftune.service
+
+%preun
+%systemd_preun bpftune.service
+
+%postun
+%systemd_postun_with_restart bpftune.service
+
+%files
+%doc README.md TROUBLESHOOTING.md SECURITY.md
+%license LICENSE.txt
+%defattr(-,root,root)
+%{_sysconfdir}/ld.so.conf.d/libbpftune.conf
+%{_bindir}/bpftune
+%{_unitdir}/bpftune.service
+%{_libdir}/libbpftune.so.%(echo '%ver' | sed 's/-/./g')
+%{_libdir}/bpftune/*
+%{_mandir}/*/*
+%if %{with openrc}
+%{_sysconfdir}/conf.d/bpftune
+%{_sysconfdir}/init.d/bpftune
+%else
+%exclude %{_sysconfdir}/conf.d/bpftune
+%exclude %{_sysconfdir}/init.d/bpftune
+%endif
+
+%files pcp-pmda
+%{pcpdir}/%{nameR}/*
+
+%changelog
+* Fri Mar 6 2026 veuxit <erroor234@gmail.com> - 0.4-2
+- Initial package release

--- a/anda/system/bpftune/nightly/update.rhai
+++ b/anda/system/bpftune/nightly/update.rhai
@@ -1,0 +1,7 @@
+rpm.global("commit", gh_commit("oracle/bpftune"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+    let v = gh("oracle/bpftune");
+    rpm.global("ver", v);
+}

--- a/anda/system/bpftune/stable/anda.hcl
+++ b/anda/system/bpftune/stable/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "bpftune.spec"
+  }
+}

--- a/anda/system/bpftune/stable/bpftune.spec
+++ b/anda/system/bpftune/stable/bpftune.spec
@@ -1,0 +1,102 @@
+# BPF-based auto-tuning SPEC file
+
+%global ver 0.4-2
+%global releaseS %(echo '%ver' | sed -E 's/^[^-]+-//')
+
+%define pcpdir	    /var/lib/pcp/pmdas
+%define _sbindir    /usr/sbin
+
+%undefine __brp_add_determinism
+
+%bcond_with openrc
+
+Name:           bpftune
+Version:        %(echo '%ver' | sed 's/-/~/g')
+Release:        1%?dist
+Summary:        BPF/tracing tools for auto-tuning Linux
+License:        GPL-2.0-only WITH Linux-syscall-note
+Packager:       veuxit <erroor234@gmail.com>
+URL:            https://github.com/oracle/bpftune
+Conflicts:      bpftune-nightly
+
+Source0:        %{url}/archive/refs/tags/%{ver}.tar.gz
+
+Group:          Development/Tools
+Requires:       libbpf >= 0.6
+Requires:       libnl3
+Requires:       libcap
+BuildRequires:  libbpf-devel >= 0.6
+BuildRequires:  libcap-devel
+BuildRequires:	bpftool >= 4.18
+BuildRequires:  libnl3-devel
+BuildRequires:  clang >= 11
+BuildRequires:  clang-libs >= 11
+BuildRequires:  llvm >= 11
+BuildRequires:  llvm-libs >= 11
+BuildRequires:	python3-docutils
+
+%description
+Service consisting of daemon (bpftune) and plugins which
+support auto-tuning of Linux via BPF observability.
+
+%package devel
+Requires:   %{name} = %{evr}
+Requires:   libbpf-devel >= 0.6
+Requires:   libcap-devel
+Requires:   bpftool
+Requires:   libnl3-devel
+
+%pkg_devel_files
+
+%package pcp-pmda
+Summary:	Performance Co-Pilot PMDA for bpftune
+Requires:   %{name} = %{evr}
+Requires:	pcp
+Requires:   python3-pcp 
+
+%description pcp-pmda
+The %{name}-pcp-pmda exports tunables and metrics from bpftune
+to Performance Co-Pilot (PCP)
+
+%prep
+%autosetup -n %{name}-%{ver}
+
+%build
+%make_build
+
+%install
+%make_install
+
+%post
+%systemd_post bpftune.service
+
+%preun
+%systemd_preun bpftune.service
+
+%postun
+%systemd_postun_with_restart bpftune.service
+
+%files
+%doc README.md TROUBLESHOOTING.md SECURITY.md
+%license LICENSE.txt
+%defattr(-,root,root)
+%{_sysconfdir}/ld.so.conf.d/libbpftune.conf
+%{_sbindir}/bpftune
+%{_unitdir}/bpftune.service
+%{_libdir}/libbpftune.so.%(echo '%ver' | sed 's/-/./g')
+%{_libdir}/bpftune/*
+%{_mandir}/*/*
+%if %{with openrc}
+%{_sysconfdir}/conf.d/bpftune
+%{_sysconfdir}/init.d/bpftune
+%else
+%exclude %{_sysconfdir}/conf.d/bpftune
+%exclude %{_sysconfdir}/init.d/bpftune
+%endif
+
+%files pcp-pmda
+%{pcpdir}/%{name}/*
+
+%changelog
+* Fri Mar 6 2026 veuxit <erroor234@gmail.com> - 0.4-2
+- Initial package release

--- a/anda/system/bpftune/stable/update.rhai
+++ b/anda/system/bpftune/stable/update.rhai
@@ -1,0 +1,1 @@
+rpm.global("ver", gh("oracle/bpftune"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: bpftune bpftune-nightly (#10320)](https://github.com/terrapkg/packages/pull/10320)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)