### PR TITLE
[f42] Add package xdg-terminal-exec-nautilus (#10457)

### DIFF
--- a/anda/misc/xdg-terminal-exec-nautilus/anda.hcl
+++ b/anda/misc/xdg-terminal-exec-nautilus/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "xdg-terminal-exec-nautilus.spec"
+  }
+}

--- a/anda/misc/xdg-terminal-exec-nautilus/update.rhai
+++ b/anda/misc/xdg-terminal-exec-nautilus/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("zirconium-dev/xdg-terminal-exec-nautilus"));

--- a/anda/misc/xdg-terminal-exec-nautilus/xdg-terminal-exec-nautilus.spec
+++ b/anda/misc/xdg-terminal-exec-nautilus/xdg-terminal-exec-nautilus.spec
@@ -1,0 +1,32 @@
+Name:               xdg-terminal-exec-nautilus
+Version:            0.1.0
+Release:            1%?dist
+Summary:            xdg-terminal-exec extension for nautilus-python
+License:            Apache-2.0
+Group:              System
+URL:                https://github.com/zirconium-dev/xdg-terminal-exec-nautilus
+Source0:            %{url}/archive/refs/tags/%{version}.tar.gz
+
+BuildArch:          noarch
+Requires:           nautilus-python
+Packager:           Tulip Blossom (tulilirockz@outlook.com)
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n xdg-terminal-exec-nautilus-%{version}
+
+%build
+
+%install
+install -Dpm0644 -t %{buildroot}%{_datadir}/nautilus-python/extensions/ ./xdg-terminal-exec-nautilus.py
+
+%files
+%license LICENSE
+%doc README.md
+%{_datadir}/nautilus-python/extensions/xdg-terminal-exec-nautilus.py
+
+%changelog
+* Fri Mar 13 2026 Tulip Blossom <tulilirockz@outlook.com>
+- Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Add package xdg-terminal-exec-nautilus (#10457)](https://github.com/terrapkg/packages/pull/10457)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)