### PR TITLE
[el10] fix: patch gamescope builds for f44 (#10472)

### DIFF
--- a/anda/games/terra-gamescope/0002-wlroots-libinput-switch-keypad-slide.patch
+++ b/anda/games/terra-gamescope/0002-wlroots-libinput-switch-keypad-slide.patch
@@ -1,0 +1,18 @@
+From: porkloin <porkloin@users.noreply.github.com>
+Subject: [PATCH] wlroots: handle LIBINPUT_SWITCH_KEYPAD_SLIDE enum in switch.c
+
+libinput added LIBINPUT_SWITCH_KEYPAD_SLIDE and GCC 16 on Fedora 44
+treats the unhandled enum value as -Werror=switch, breaking the build.
+
+diff --git a/subprojects/wlroots/backend/libinput/switch.c b/subprojects/wlroots/backend/libinput/switch.c
+--- a/subprojects/wlroots/backend/libinput/switch.c
++++ b/subprojects/wlroots/backend/libinput/switch.c
+@@ -34,6 +34,8 @@ void handle_switch_toggle(struct libinput_event *event,
+ 	case LIBINPUT_SWITCH_TABLET_MODE:
+ 		wlr_event.switch_type = WLR_SWITCH_TYPE_TABLET_MODE;
+ 		break;
++	case LIBINPUT_SWITCH_KEYPAD_SLIDE:
++		break;
+ 	}
+ 	switch (libinput_event_switch_get_switch_state(sevent)) {
+ 	case LIBINPUT_SWITCH_STATE_OFF:

--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -9,7 +9,7 @@
 Name:           terra-gamescope
 #Version:        100.%{gamescope_tag}
 Version:        134.%{short_commit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Micro-compositor for video games on Wayland
 
 License:        BSD
@@ -27,7 +27,10 @@ Patch0:         0001-cstdint.patch
 # https://github.com/ChimeraOS/gamescope
 Patch1:         handheld.patch
 
-#Patch2:         https://github.com/ValveSoftware/gamescope/pull/1867.patch
+# Fix build with libinput >= 1.27 / GCC 16 (-Werror=switch)
+Patch2:         0002-wlroots-libinput-switch-keypad-slide.patch
+
+#Patch3:         https://github.com/ValveSoftware/gamescope/pull/1867.patch
 
 BuildRequires:  meson >= 0.54.0
 BuildRequires:  ninja-build


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `el10`:
 - [fix: patch gamescope builds for f44 (#10472)](https://github.com/terrapkg/packages/pull/10472)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)