### PR TITLE
[f43] fix: latex2mathml (#10459)

### DIFF
--- a/anda/langs/python/latex2mathml/latex2mathml.spec
+++ b/anda/langs/python/latex2mathml/latex2mathml.spec
@@ -17,6 +17,7 @@ BuildRequires:  python3-pip
 BuildRequires:  python3-poetry-core
 BuildRequires:  python3-installer
 BuildRequires:  python3-build
+BuildRequires:  python3-hatchling
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: latex2mathml (#10459)](https://github.com/terrapkg/packages/pull/10459)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)