### PR TITLE
[el10] fix: Update commit for the latest OGC gamescope (#10486)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -2,12 +2,11 @@
 
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
-%global gamescope_commit 0fd7f48010fd0cf9cb577d7e282facb8e611a288
+%global gamescope_commit b6a368af614ee93bf7b1d05a8d203f0c84a87c74
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           terra-gamescope
-#Version:        100.%{gamescope_tag}
-Version:        135.%{short_commit}
+Version:        136.%{short_commit}
 Release:        1%?dist
 Summary:        Micro-compositor for video games on Wayland
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: Update commit for the latest OGC gamescope (#10486)](https://github.com/terrapkg/packages/pull/10486)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)