### PR TITLE
fix: bump gamescope-session(and -opengamepadui) for f44

### DIFF
--- a/anda/games/gamescope-session-opengamepadui/gamescope-session-opengamepadui.spec
+++ b/anda/games/gamescope-session-opengamepadui/gamescope-session-opengamepadui.spec
@@ -1,6 +1,6 @@
-%global commit 1a3fdb7fa15a4bba7204bef69702b7a10a297828
+%global commit 88087a086ab732211c466b41f5d64229ce51c050
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260205
+%global commit_date 20260204
 
 Name:           gamescope-session-opengamepadui
 Version:        0~%{commit_date}git.%{shortcommit}

--- a/anda/games/gamescope-session-opengamepadui/gamescope-session-opengamepadui.spec
+++ b/anda/games/gamescope-session-opengamepadui/gamescope-session-opengamepadui.spec
@@ -4,7 +4,7 @@
 
 Name:           gamescope-session-opengamepadui
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Gamescope session for OpenGamepadUI
 License:        GPL-3.0-only
 URL:            https://github.com/OpenGamingCollective/gamescope-session-opengamepadui

--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -6,7 +6,7 @@
 
 Name:           gamescope-session
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Gamescope session based on Valve's gamescope
 License:        MIT
 URL:            https://github.com/OpenGamingCollective/gamescope-session


### PR DESCRIPTION
Last two F44 packages we need that are busted on [zirconium-jackrabbit](https://github.com/zirconium-dev/zirconium-jackrabbit)