### PR TITLE
[el10] fix(gamescope): If condition for patch (#10496)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -23,8 +23,10 @@ Patch0:         Use-system-stb-glm.patch
 
 Patch1:         0001-cstdint.patch
 
+%if 0%{?fedora} >= 44
 # Fix build with libinput >= 1.27 / GCC 16 (-Werror=switch)
 Patch2:         0002-wlroots-libinput-switch-keypad-slide.patch
+%endif
 
 BuildRequires:  cmake
 BuildRequires:  gcc
@@ -139,6 +141,7 @@ export PKG_CONFIG_PATH=pkgconfig
 %{_bindir}/gamescopectl
 %{_bindir}/gamescopestream
 %{_bindir}/gamescopereaper
+%{_bindir}/gamescope-type
 %{_datadir}/gamescope/*
 
 %files libs


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [fix(gamescope): If condition for patch (#10496)](https://github.com/terrapkg/packages/pull/10496)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)