### PR TITLE
[f42] fix(stardust-xr-atmosphere): Binary name (#10507)

### DIFF
--- a/anda/stardust/atmosphere/nightly/stardust-atmosphere-nightly.spec
+++ b/anda/stardust/atmosphere/nightly/stardust-atmosphere-nightly.spec
@@ -32,7 +32,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{cargo_license_online} > LICENSE.dependencies
 
 %files
-%_bindir/stardust-xr-atmosphere
+%_bindir/atmosphere
 %license LICENSE
 %license LICENSE.dependencies
 %doc README.md

--- a/anda/stardust/atmosphere/stable/stardust-atmosphere.spec
+++ b/anda/stardust/atmosphere/stable/stardust-atmosphere.spec
@@ -29,7 +29,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{cargo_license_online} > LICENSE.dependencies
 
 %files
-%_bindir/%{name}
+%_bindir/atmosphere
 %license LICENSE
 %license LICENSE.dependencies
 %doc README.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(stardust-xr-atmosphere): Binary name (#10507)](https://github.com/terrapkg/packages/pull/10507)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)