### PR TITLE
[el10] add: deprecation-alias (#10527)

### DIFF
--- a/anda/langs/python/deprecation-alias/anda.hcl
+++ b/anda/langs/python/deprecation-alias/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "deprecation-alias.spec"
+    }
+}

--- a/anda/langs/python/deprecation-alias/deprecation-alias.spec
+++ b/anda/langs/python/deprecation-alias/deprecation-alias.spec
@@ -1,0 +1,48 @@
+%global pypi_name deprecation-alias
+%global _desc A wrapper around 'deprecation' providing support for deprecated aliases.
+
+Name:			python-%{pypi_name}
+Version:		0.4.0
+Release:		1%?dist
+Summary:		A wrapper around 'deprecation' providing support for deprecated aliases
+License:		Apache-2.0
+URL:			https://github.com/domdfcoding/deprecation-alias
+Source0:		%{url}/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-hatchling
+BuildRequires:  python3-importlib-metadata
+BuildRequires:  python3-hatch-requirements-txt
+BuildArch:      noarch
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files deprecation_alias
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+* Sat Mar 14 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/deprecation-alias/update.rhai
+++ b/anda/langs/python/deprecation-alias/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("deprecation-alias"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: deprecation-alias (#10527)](https://github.com/terrapkg/packages/pull/10527)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)