### PR TITLE
[f42] chore: let python macros do their thing (#10542)

### DIFF
--- a/anda/langs/python/fx2/fx2.spec
+++ b/anda/langs/python/fx2/fx2.spec
@@ -50,8 +50,6 @@ popd
 %doc README.md
 %license LICENSE-0BSD.txt
 %{_bindir}/fx2tool
-%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
-%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
 
 %changelog
 * Sun Sep 28 2025 Owen Zimmerman <owen@fyralabs.com>

--- a/anda/langs/python/gay/gay.spec
+++ b/anda/langs/python/gay/gay.spec
@@ -1,17 +1,13 @@
-%global commit af18bcf210659b8b5a40624ffab791d49e831017
-%global commit_date 20241015
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-
 %global pypi_name gay
 %global _desc Colour your text / terminal to be more gay.
 
 Name:			python-%{pypi_name}
-Version:		%commit_date.%shortcommit
+Version:		1.3.4
 Release:		2%?dist
 Summary:		Colour your text / terminal to be more gay
 License:		MIT
 URL:			https://github.com/ms-jpq/gay
-Source0:		%url/archive/%commit/gay-%commit.tar.gz
+Source0:		%{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
@@ -25,14 +21,13 @@ Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
 %package -n     python3-%{pypi_name}
 Summary:        %{summary}
-Provides:       gay
 %{?python_provide:%python_provide python3-%{pypi_name}}
 
 %description -n python3-%{pypi_name}
 %_desc
 
 %prep
-%autosetup -n gay-%{commit}
+%autosetup -n %{pypi_name}-%{version}
 
 %build
 %pyproject_wheel
@@ -44,7 +39,7 @@ Provides:       gay
 %doc README.md
 %license LICENSE
 %{_bindir}/gay
-%python3_sitelib/gay-1.3.4.dist-info/*
+%python3_sitelib/gay-%{version}.dist-info/*
 
 %changelog
 * Tue Sep 30 2025 Owen Zimmerman <owen@fyralabs.com>

--- a/anda/langs/python/gay/update.rhai
+++ b/anda/langs/python/gay/update.rhai
@@ -1,5 +1,1 @@
-rpm.global("commit", gh_commit("ms-jpq/gay"));
-if rpm.changed() {
-  rpm.release();
-  rpm.global("commit_date", date());
-}
+rpm.version(pypi("gay"));

--- a/anda/langs/python/magic-wormhole/magic-wormhole.spec
+++ b/anda/langs/python/magic-wormhole/magic-wormhole.spec
@@ -52,9 +52,6 @@ rm %{buildroot}%{_usr}/wormhole_complete.*
 %{_bindir}/magic-wormhole
 %{_bindir}/wormhole
 %{_mandir}/man1/wormhole.1.gz
-%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
-%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
-%python3_sitelib/magic_wormhole-%version.dist-info/*
 
 %changelog
 * Mon Nov 03 2025 Owen Zimmerman <owen@fyralabs.com>

--- a/anda/langs/python/mpv/python-mpv.spec
+++ b/anda/langs/python/mpv/python-mpv.spec
@@ -4,7 +4,7 @@
 
 Name:			python-%{pypi_name}
 Version:		1.0.8
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Python interface to the awesome mpv media player
 License:		GPL-2.0+ OR LGPL-2.1+
 URL:			https://github.com/jaseg/python-mpv
@@ -60,8 +60,6 @@ EOL
 %files -n python3-%{pypi_name} -f %{pyproject_files}
 %doc README.rst
 %license LICENSE.GPL LICENSE.LGPL
-%ghost %python3_sitelib/__pycache__/mpv.cpython-*.pyc
-%python3_sitelib/mpv.py
 %endif
 
 %changelog

--- a/anda/langs/python/spake2/spake2.spec
+++ b/anda/langs/python/spake2/spake2.spec
@@ -40,9 +40,6 @@ Summary:        %{summary}
 %files -n python3-%{pypi_name} -f %{pyproject_files}
 %doc README.md
 %license LICENSE
-%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
-%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
-%python3_sitelib/spake2-%version.dist-info/*
 
 %changelog
 * Mon Nov 03 2025 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: let python macros do their thing (#10542)](https://github.com/terrapkg/packages/pull/10542)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)