### PR TITLE
[f43] add: shippinglabel (#10541)

### DIFF
--- a/anda/langs/python/shippinglabel/anda.hcl
+++ b/anda/langs/python/shippinglabel/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "shippinglabel.spec"
+  }
+}

--- a/anda/langs/python/shippinglabel/shippinglabel.spec
+++ b/anda/langs/python/shippinglabel/shippinglabel.spec
@@ -1,0 +1,45 @@
+%global pypi_name shippinglabel
+%global _desc Utilities for handling packages.
+
+Name:			python-%{pypi_name}
+Version:		2.3.0
+Release:		1%?dist
+Summary:		Utilities for handling packages
+License:		MIT
+URL:			https://shippinglabel.readthedocs.io/en/latest/
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-hatch-requirements-txt
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files shippinglabel
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+* Sat Mar 14 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/shippinglabel/update.rhai
+++ b/anda/langs/python/shippinglabel/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("shippinglabel"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: shippinglabel (#10541)](https://github.com/terrapkg/packages/pull/10541)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)