### PR TITLE
[f42] add: dom_toml (#10538)

### DIFF
--- a/anda/langs/python/dom_toml/anda.hcl
+++ b/anda/langs/python/dom_toml/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "dom_toml.spec"
+  }
+}

--- a/anda/langs/python/dom_toml/dom_toml.spec
+++ b/anda/langs/python/dom_toml/dom_toml.spec
@@ -1,0 +1,46 @@
+%global pypi_name dom_toml
+%global _desc Dom's tools for Tom's Obvious, Minimal Language.
+
+Name:			python-%{pypi_name}
+Version:		2.3.0
+Release:		1%?dist
+Summary:		Dom's tools for Tom's Obvious, Minimal Language
+License:		MIT
+URL:			https://dom-toml.readthedocs.io/en/latest/
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-flit-core
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files dom_toml
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+* Sat Mar 14 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/dom_toml/update.rhai
+++ b/anda/langs/python/dom_toml/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("dom_toml"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: dom_toml (#10538)](https://github.com/terrapkg/packages/pull/10538)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)