### PR TITLE
[f43] add: handy-archives (#10537)

### DIFF
--- a/anda/langs/python/handy-archives/anda.hcl
+++ b/anda/langs/python/handy-archives/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "handy-archives.spec"
+  }
+}

--- a/anda/langs/python/handy-archives/handy-archives.spec
+++ b/anda/langs/python/handy-archives/handy-archives.spec
@@ -1,0 +1,46 @@
+%global pypi_name handy_archives
+%global _desc Some handy archive helpers for Python.
+
+Name:			python-%{pypi_name}
+Version:		0.2.0
+Release:		1%?dist
+Summary:		Some handy archive helpers for Python
+License:		MIT
+URL:			https://handy-archives.readthedocs.io/en/latest/
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+BuildRequires:  python3-flit-core
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files handy_archives
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+
+%changelog
+* Sat Mar 14 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/handy-archives/update.rhai
+++ b/anda/langs/python/handy-archives/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("handy-archives"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: handy-archives (#10537)](https://github.com/terrapkg/packages/pull/10537)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)