### PR TITLE
[f42] fix(materialyoucolor): BuildRequires (#10550)

### DIFF
--- a/anda/langs/python/materialyoucolor/python-materialyoucolor.spec
+++ b/anda/langs/python/materialyoucolor/python-materialyoucolor.spec
@@ -14,6 +14,7 @@ BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(pillow)
 BuildRequires:  python3dist(pip)
+BuildRequires:  python3dist(pybind11)
 BuildRequires:  python3dist(pytest)
 BuildRequires:  python3dist(rich)
 BuildRequires:  python3dist(setuptools)


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [fix(materialyoucolor): BuildRequires (#10550)](https://github.com/terrapkg/packages/pull/10550)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)