### PR TITLE
[f43] add: pyproject-parser (#10539)

### DIFF
--- a/anda/langs/python/pyproject-parser/anda.hcl
+++ b/anda/langs/python/pyproject-parser/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+	spec = "pyproject-parser.spec"
+  }
+}

--- a/anda/langs/python/pyproject-parser/pyproject-parser.spec
+++ b/anda/langs/python/pyproject-parser/pyproject-parser.spec
@@ -1,0 +1,50 @@
+%global pypi_name pyproject-parser
+%global _desc Parser for 'pyproject.toml'
+
+Name:			python-%{pypi_name}
+Version:		0.14.0
+Release:		1%?dist
+Summary:		Parser for 'pyproject.toml'
+License:		MIT
+URL:			https://pyproject-parser.readthedocs.io/en/latest/
+Source0:		https://github.com/repo-helper/pyproject-parser/archive/refs/tags/v%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python3-pip
+BuildRequires:  python3-devel
+BuildRequires:  python3-hatch-requirements-txt
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+Provides:       pyvcd
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files pyproject_parser
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst
+%license LICENSE
+%{_bindir}/pyproject-fmt
+%{_bindir}/pyproject-info
+%{_bindir}/pyproject-parser
+%{_bindir}/check-pyproject
+
+%changelog
+* Sat Sep 27 2025 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/pyproject-parser/update.rhai
+++ b/anda/langs/python/pyproject-parser/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("pyproject-parser"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: pyproject-parser (#10539)](https://github.com/terrapkg/packages/pull/10539)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)