### PR TITLE
[f42] feat: Add xonedo driver (#10614)

### DIFF
--- a/anda/system/xonedo/nightly/akmod/anda.hcl
+++ b/anda/system/xonedo/nightly/akmod/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+	rpm {
+		spec = "xonedo-nightly-kmod.spec"
+	}
+	labels {
+		mock = 1
+		updbranch = 1
+	}
+}

--- a/anda/system/xonedo/nightly/akmod/update.rhai
+++ b/anda/system/xonedo/nightly/akmod/update.rhai
@@ -1,0 +1,13 @@
+let c = sh("cat anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec | grep '%global commit ' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commitdate", d);
+    let v = sh("cat anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}
+

--- a/anda/system/xonedo/nightly/akmod/xonedo-nightly-kmod.spec
+++ b/anda/system/xonedo/nightly/akmod/xonedo-nightly-kmod.spec
@@ -1,0 +1,68 @@
+%global commit 982cbcb019ae4d2bee5ae69385223409ee555c88
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260315
+%global ver 0.5.7
+%define buildforkernels akmod
+%global debug_package %{nil}
+%global modulename xonedo
+
+Name:           %{modulename}-nightly-kmod
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          1
+%endif
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
+License:        GPL-2.0-or-later
+URL:            https://github.com/OpenGamingCollective/xonedo
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
+BuildRequires:  kmodtool
+BuildRequires:  systemd-rpm-macros
+Requires:       %{modulename}-nightly = %{?epoch:%{epoch}:}%{version}
+Requires:       %{modulename}-nightly-akmod-modules = %{?epoch:%{epoch}:}%{version}
+Requires:       akmods
+Conflicts:      dkms-%{modulename}-nightly
+Conflicts:      %{modulename}-kmod
+Conflicts:      dkms-xone-nightly
+Conflicts:      xone-kmod
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
+%endif
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories. Compatible with the xpad kernel module.
+
+%prep
+%{?kmodtool_check}
+kmodtool  --target %{_target_cpu}  --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%autosetup -p1 -n %{modulename}-%{commit}
+
+find . -type f -name '*.c' -exec sed -i "s/#VERSION#/%{version}/" {} \;
+
+for kernel_version in %{?kernel_versions}; do
+    mkdir _kmod_build_${kernel_version%%___*}
+    cp -fr auth bus driver transport Kbuild _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version in %{?kernel_versions}; do
+    pushd _kmod_build_${kernel_version%%___*}/
+        %make_build -C "${kernel_version##*___}" M=$(pwd) VERSION="v%{version}" modules
+    popd
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+    mkdir -p %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+    install -p -m 0755 _kmod_build_${kernel_version%%___*}/*.ko \
+        %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+done
+%{?akmod_install}
+
+%changelog
+* Sun Mar 15 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package

--- a/anda/system/xonedo/nightly/dkms/anda.hcl
+++ b/anda/system/xonedo/nightly/dkms/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+               arches=["x86_64"]
+	rpm {
+		spec = "dkms-xonedo-nightly.spec"
+	}
+	labels {
+		mock = 1
+		updbranch = 1
+	}
+}

--- a/anda/system/xonedo/nightly/dkms/dkms-xonedo-nightly.spec
+++ b/anda/system/xonedo/nightly/dkms/dkms-xonedo-nightly.spec
@@ -1,0 +1,75 @@
+%global commit 982cbcb019ae4d2bee5ae69385223409ee555c88
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260314
+%global ver 0.5.7
+%global debug_package %{nil}
+%global modulename xonedo
+
+Name:           dkms-%{modulename}-nightly
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          1
+%endif
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
+License:        GPL-2.0-or-later
+URL:            https://github.com/OpenGamingCollective/xonedo
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
+Source1:        no-weak-modules.conf
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       %{modulename}-nightly = %{?epoch:%{epoch}:}%{version}
+Requires:       dkms
+Conflicts:      akmod-%{modulename}-nightly
+Conflicts:      %{modulename}-kmod
+Conflicts:      dkms-xone-nightly
+Conflicts:      dkms-xone
+Provides:       %{modulename}-nightly-kmod = %{?epoch:%{epoch}:}%{version}
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Obsoletes:      dkms-%{modulename} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
+%endif
+BuildArch:      noarch
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories. Compatible with the xpad kernel module.
+
+%prep
+%autosetup -p1 -n %{modulename}-%{commit}
+
+sed -i \
+    -e 's|#VERSION#|%{version}|g' \
+    -e 's|kernel/drivers/input/joystick|extra|g' \
+    dkms.conf
+
+find . -type f -name '*.c' -exec sed -i "s/#VERSION#/%{version}/" {} \;
+
+%install
+# Create empty tree:
+mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+cp -fr auth bus driver transport Kbuild dkms.conf %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+
+%if 0%{?fedora}
+# Do not enable weak modules support in Fedora (no kABI):
+install -Dpm644 %{SOURCE1} %{buildroot}%{_sysconfdir}/dkms/%{modulename}.conf
+%endif
+
+%post
+dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{modulename} -v %{version} -q || :
+dkms install -m %{modulename} -v %{version} -q --force || :
+
+%preun
+# Remove all versions from DKMS registry:
+dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
+
+%files
+%{_usrsrc}/%{modulename}-%{version}
+%if 0%{?fedora}
+%{_sysconfdir}/dkms/%{modulename}.conf
+%endif
+
+%changelog
+* Sun Mar 15 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package

--- a/anda/system/xonedo/nightly/dkms/no-weak-modules.conf
+++ b/anda/system/xonedo/nightly/dkms/no-weak-modules.conf
@@ -1,0 +1,1 @@
+NO_WEAK_MODULES="yes"

--- a/anda/system/xonedo/nightly/dkms/update.rhai
+++ b/anda/system/xonedo/nightly/dkms/update.rhai
@@ -1,0 +1,13 @@
+let c = sh("cat anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec | grep '%global commit ' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commitdate", d);
+    let v = sh("cat anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
+    v.pop();
+    rpm.global("ver", v);
+}
+

--- a/anda/system/xonedo/nightly/kmod-common/anda.hcl
+++ b/anda/system/xonedo/nightly/kmod-common/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+               arches = ["x86_64"]
+	rpm {
+		spec = "xonedo-nightly.spec"
+	}
+	labels {
+                nightly = 1
+	}
+}

--- a/anda/system/xonedo/nightly/kmod-common/modules.conf
+++ b/anda/system/xonedo/nightly/kmod-common/modules.conf
@@ -1,0 +1,1 @@
+add_drivers+=" snd-pcm snd-seq "

--- a/anda/system/xonedo/nightly/kmod-common/update.rhai
+++ b/anda/system/xonedo/nightly/kmod-common/update.rhai
@@ -1,0 +1,8 @@
+rpm.global("commit", gh_commit("OpenGamingCollective/xonedo"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+    let v = gh("OpenGamingCollective/xonedo");
+    v.crop(1);
+    rpm.global("ver", v);
+}

--- a/anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec
+++ b/anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec
@@ -1,0 +1,138 @@
+%global commit 982cbcb019ae4d2bee5ae69385223409ee555c88
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260314
+%global ver 0.5.7
+%global modulename xonedo
+%global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
+%global firmware_hash0 080ce4091e53a4ef3e5fe29939f51fd91f46d6a88be6d67eb6e99a5723b3a223
+%global firmware_hash1 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
+%global firmware_hash2 0023a7bae02974834500c665a281e25b1ba52c9226c84989f9084fa5ce591d9b
+%global firmware_hash3 e2710daf81e7b36d35985348f68a81d18bc537a2b0c508ffdfde6ac3eae1bad7
+
+Name:           xonedo-nightly
+Version:        %{ver}^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          1
+%endif
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories common files
+License:        GPL-2.0-or-later
+URL:            https://github.com/OpenGamingCollective/xonedo
+Source0:        %{url}/archive/%{commit}.tar.gz#/xone-%{shortcommit}.tar.gz
+Source1:        modules.conf
+Source2:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2017/03/2ea9591b-f751-442c-80ce-8f4692cdc67b_6b555a3a288153cf04aec6e03cba360afe2fce34.cab
+Source3:        https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
+Source4:        https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/06/1dbd7cb4-53bc-4857-a5b0-5955c8acaf71_9081931e7d664429a93ffda0db41b7545b7ac257.cab
+Source5:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2017/08/aeff215c-3bc4-4d36-a3ea-e14bfa8fa9d2_e58550c4f74a27e51e5cb6868b10ff633fa77164.cab
+### Microsoft TOU copy:
+Source6:        https://www.microsoft.com/en-us/legal/terms-of-use
+BuildRequires:  cabextract
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       wireless-regdb
+Requires:       %{name}-firmware = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
+Requires(post): dracut
+Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Conflicts:      xone
+Conflicts:      %{modulename}
+Conflicts:      xow <= 0.5
+Obsoletes:      xow <= 0.5
+BuildArch:      noarch
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories common files. Compatible with the xpad kernel module.
+
+%package        akmod-modules
+Summary:        Modules for Akmods
+Requires:       akmod-%{name}
+BuildArch:      noarch
+
+%description    akmod-modules
+Akmods modules for the akmod-%{name} package.
+
+%package         firmware
+Summary:         Firmware for the XBox One controller dongle
+License:         Proprietary
+Requires:        wireless-regdb
+Conflicts:       xone-firmware
+BuildArch:       noarch
+
+%description     firmware
+Proprietary firmware for XBox controller dongles.
+ 
+%prep
+%autosetup -p1 -n %{modulename}-%{commit}
+/usr/bin/sed -nE '/^BUILT_MODULE_NAME/{s@^.+"(.+)"@\1@; s|-|_|g; p}' dkms.conf > %{modulename}.conf
+
+### Firmware:
+# Some of the .bin files have the same name so put them in subdirs
+mkdir firm{0..4}
+
+pushd firm0
+cabextract -F FW_ACC_00U.bin %{SOURCE2}
+echo %{firmware_hash0} FW_ACC_00U.bin | sha256sum -c
+popd
+
+pushd firm1
+cabextract -F FW_ACC_00U.bin %{SOURCE3}
+echo %{firmware_hash1} FW_ACC_00U.bin | sha256sum -c
+popd
+
+pushd firm2
+cabextract -F FW_ACC_CL.bin %{SOURCE4}
+echo %{firmware_hash2} FW_ACC_CL.bin | sha256sum -c
+popd
+
+pushd firm3
+cabextract -F FW_ACC_BR.bin %{SOURCE5}
+echo %{firmware_hash3} FW_ACC_BR.bin | sha256sum -c
+popd
+
+%install
+# xone-gip-headset module should have the snd-pcm and snd-seq modules be preloaded or it will give errors on boot due to injecting late.
+# It still loads afterwards, but this error is easily fixable by just loading the modules in the initramfs.
+install -Dpm644 %{SOURCE1} %{buildroot}%{_dracutconfdir}/60-%{modulename}-snd.conf
+
+# Blacklist:
+install -Dpm644 install/modprobe.conf %{buildroot}%{_modprobedir}/60-%{modulename}.conf
+
+# Firmware:
+install -Dpm644 firm0/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02e6.bin
+install -Dpm644 firm1/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02fe.bin
+install -Dpm644 firm2/FW_ACC_CL.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02f9.bin
+install -Dpm644 firm3/FW_ACC_BR.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_091e.bin
+
+# Akmods modules
+install -Dm644 %{modulename}.conf -t %{buildroot}%{_modulesloaddir}
+
+# TOU file
+/usr/bin/cp %{SOURCE6} .
+
+%files
+%license LICENSE
+%doc README.md
+%{_modprobedir}/60-%{modulename}.conf
+%{_dracutconfdir}/60-%{modulename}-snd.conf
+
+%files akmod-modules
+%{_modulesloaddir}/%{modulename}.conf
+
+%files firmware
+%license terms-of-use
+%{_prefix}/lib/firmware/xone_dongle_02e6.bin
+%{_prefix}/lib/firmware/xone_dongle_02fe.bin
+%{_prefix}/lib/firmware/xone_dongle_02f9.bin
+%{_prefix}/lib/firmware/xone_dongle_091e.bin
+
+%postun
+/usr/bin/dracut -f || :
+
+%post firmware
+echo "The firmware for the wireless dongle is subject to Microsoft's Terms of Use:"
+echo 'https://www.microsoft.com/en-us/legal/terms-of-use'
+
+%changelog
+* Sun Mar 15 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package

--- a/anda/system/xonedo/stable/akmod/anda.hcl
+++ b/anda/system/xonedo/stable/akmod/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+	rpm {
+		spec = "xonedo-kmod.spec"
+	}
+	labels {
+		mock = 1
+		updbranch = 1
+	}
+}

--- a/anda/system/xonedo/stable/akmod/update.rhai
+++ b/anda/system/xonedo/stable/akmod/update.rhai
@@ -1,0 +1,4 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::madoguchi("xonedo", labels.branch));
+

--- a/anda/system/xonedo/stable/akmod/xonedo-kmod.spec
+++ b/anda/system/xonedo/stable/akmod/xonedo-kmod.spec
@@ -1,0 +1,65 @@
+%define buildforkernels akmod
+%global debug_package %{nil}
+%global modulename xonedo
+%global ogcversion 1
+
+Name:           %{modulename}-kmod
+Version:        0.5.7
+Release:        1%?dist
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          2
+%endif
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
+License:        GPL-2.0-or-later
+URL:            https://github.com/OpenGamingCollective/xonedo
+Source0:        %{url}/archive/refs/tags/v%{version}-ogc%{ogcversion}.tar.gz
+BuildRequires:  kmodtool
+BuildRequires:  systemd-rpm-macros
+Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
+Requires:       %{modulename}-akmod-modules = %{?epoch:%{epoch}:}%{version}
+Requires:       akmods
+Conflicts:      dkms-%{modulename}
+Conflicts:      %{modulename}-nightly-kmod
+Conflicts:      dkms-xone
+Conflicts:      xone-nightly-kmod
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}0.3.4
+%endif
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories. Compatible with the xpad kernel module.
+
+%prep
+%{?kmodtool_check}
+kmodtool  --target %{_target_cpu}  --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%autosetup -p1 -n %{modulename}-%{version}-ogc%{ogcversion}
+
+find . -type f -name '*.c' -exec sed -i "s/#VERSION#/%{version}/" {} \;
+
+for kernel_version in %{?kernel_versions}; do
+    mkdir _kmod_build_${kernel_version%%___*}
+    cp -fr auth bus driver transport Kbuild _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version in %{?kernel_versions}; do
+    pushd _kmod_build_${kernel_version%%___*}/
+        %make_build -C "${kernel_version##*___}" M=$(pwd) VERSION="v%{version}" modules
+    popd
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+    mkdir -p %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+    install -p -m 0755 _kmod_build_${kernel_version%%___*}/*.ko \
+        %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+done
+%{?akmod_install}
+
+%changelog
+* Sun Mar 15 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package

--- a/anda/system/xonedo/stable/dkms/anda.hcl
+++ b/anda/system/xonedo/stable/dkms/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+               arches=["x86_64"]
+	rpm {
+		spec = "dkms-xonedo.spec"
+	}
+	labels {
+		mock = 1
+		updbranch = 1
+	}
+}

--- a/anda/system/xonedo/stable/dkms/dkms-xonedo.spec
+++ b/anda/system/xonedo/stable/dkms/dkms-xonedo.spec
@@ -1,0 +1,72 @@
+%global debug_package %{nil}
+%global modulename xonedo
+%global ogcversion 1
+
+Name:           dkms-%{modulename}
+Version:        0.5.7
+Release:        1%?dist
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          2
+%endif
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
+License:        GPL-2.0-or-later
+URL:            https://github.com/OpenGamingCollective/xonedo
+Source0:        %{url}/archive/refs/tags/v%{version}-ogc%{ogcversion}.tar.gz
+Source1:        no-weak-modules.conf
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
+Requires:       dkms
+Conflicts:      akmod-%{modulename}
+Conflicts:      %{modulename}-nightly-kmod
+Conflicts:      akmod-xone
+Conflicts:      xone-nightly-kmod
+Provides:       %{modulename}-kmod
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}0.3.4
+%endif
+BuildArch:      noarch
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories. Compatible with the xpad kernel module.
+
+%prep
+%autosetup -p1 -n %{modulename}-%{version}-ogc%{ogcversion}
+
+sed -i \
+    -e 's|#VERSION#|%{version}|g' \
+    -e 's|kernel/drivers/input/joystick|extra|g' \
+    dkms.conf
+
+find . -type f -name '*.c' -exec sed -i "s/#VERSION#/%{version}/" {} \;
+
+%install
+# Create empty tree:
+mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+cp -fr auth bus driver transport Kbuild dkms.conf %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+
+%if 0%{?fedora}
+# Do not enable weak modules support in Fedora (no kABI):
+install -Dpm644 %{SOURCE1} %{buildroot}%{_sysconfdir}/dkms/%{modulename}.conf
+%endif
+
+%post
+dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{modulename} -v %{version} -q || :
+dkms install -m %{modulename} -v %{version} -q --force || :
+
+%preun
+# Remove all versions from DKMS registry:
+dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
+
+%files
+%{_usrsrc}/%{modulename}-%{version}
+%if 0%{?fedora}
+%{_sysconfdir}/dkms/%{modulename}.conf
+%endif
+
+%changelog
+* Sun Mar 15 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package

--- a/anda/system/xonedo/stable/dkms/no-weak-modules.conf
+++ b/anda/system/xonedo/stable/dkms/no-weak-modules.conf
@@ -1,0 +1,1 @@
+NO_WEAK_MODULES="yes"

--- a/anda/system/xonedo/stable/dkms/update.rhai
+++ b/anda/system/xonedo/stable/dkms/update.rhai
@@ -1,0 +1,4 @@
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::madoguchi("xonedo", labels.branch));
+

--- a/anda/system/xonedo/stable/kmod-common/anda.hcl
+++ b/anda/system/xonedo/stable/kmod-common/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+               arches = ["x86_64"]
+	rpm {
+		spec = "xonedo.spec"
+	}
+}

--- a/anda/system/xonedo/stable/kmod-common/modules.conf
+++ b/anda/system/xonedo/stable/kmod-common/modules.conf
@@ -1,0 +1,1 @@
+add_drivers+=" snd-pcm snd-seq "

--- a/anda/system/xonedo/stable/kmod-common/update.rhai
+++ b/anda/system/xonedo/stable/kmod-common/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("OpenGamingCollective/xonedo"));

--- a/anda/system/xonedo/stable/kmod-common/xonedo.spec
+++ b/anda/system/xonedo/stable/kmod-common/xonedo.spec
@@ -1,0 +1,138 @@
+%global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
+%global firmware_hash0 080ce4091e53a4ef3e5fe29939f51fd91f46d6a88be6d67eb6e99a5723b3a223
+%global firmware_hash1 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
+%global firmware_hash2 0023a7bae02974834500c665a281e25b1ba52c9226c84989f9084fa5ce591d9b
+%global firmware_hash3 e2710daf81e7b36d35985348f68a81d18bc537a2b0c508ffdfde6ac3eae1bad7
+%global ogcversion 1
+
+Name:           xonedo
+Version:        0.5.7
+Release:        1%?dist
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Epoch:          2
+%endif
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories common files
+License:        GPL-2.0-or-later
+URL:            https://github.com/OpenGamingCollective/xonedo
+Source0:        %{url}/archive/refs/tags/v%{version}-ogc%{ogcversion}.tar.gz
+Source1:        modules.conf
+### Windows drivers and firmware files:
+Source2:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2017/03/2ea9591b-f751-442c-80ce-8f4692cdc67b_6b555a3a288153cf04aec6e03cba360afe2fce34.cab
+Source3:        https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
+Source4:        https://catalog.s.download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/06/1dbd7cb4-53bc-4857-a5b0-5955c8acaf71_9081931e7d664429a93ffda0db41b7545b7ac257.cab
+Source5:        https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2017/08/aeff215c-3bc4-4d36-a3ea-e14bfa8fa9d2_e58550c4f74a27e51e5cb6868b10ff633fa77164.cab
+### Microsoft TOU copy:
+Source6:        https://www.microsoft.com/en-us/legal/terms-of-use
+BuildRequires:  cabextract
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       wireless-regdb
+Requires:       %{name}-firmware = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
+Requires(post): dracut
+Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Conflicts:      %{name}-nightly
+Conflicts:      xone-nightly
+Conflicts:      xone
+Conflicts:      xow <= 0.5
+Obsoletes:      xow <= 0.5
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Obsoletes:      %{name} < %{?epoch:%{epoch}:}0.3.4
+%endif
+BuildArch:      noarch
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.
+
+%package        akmod-modules
+Summary:        Modules for Akmods
+Requires:       akmod-%{name}
+BuildArch:      noarch
+
+%description    akmod-modules
+Akmods modules for the akmod-%{name} package.
+
+%package         firmware
+Summary:         Firmware for the XBox One controller dongle
+License:         Proprietary
+Requires:        wireless-regdb
+%if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
+Obsoletes:      %{name}-firmware < %{?epoch:%{epoch}:}0.3^20250419git.c682b0c
+%endif
+Conflicts:       xone-firmware
+BuildArch:       noarch
+
+%description     firmware
+Proprietary firmware for XBox controller dongles.
+ 
+%prep
+%autosetup -p1 -n %{name}-%{version}-ogc%{ogcversion}
+/usr/bin/sed -nE '/^BUILT_MODULE_NAME/{s@^.+"(.+)"@\1@; s|-|_|g; p}' dkms.conf > %{name}.conf
+
+### Firmware:
+# Some of the .bin files have the same name so put them in subdirs
+mkdir firm{0..4}
+
+pushd firm0
+cabextract -F FW_ACC_00U.bin %{SOURCE2}
+echo %{firmware_hash0} FW_ACC_00U.bin | sha256sum -c
+popd
+
+pushd firm1
+cabextract -F FW_ACC_00U.bin %{SOURCE3}
+echo %{firmware_hash1} FW_ACC_00U.bin | sha256sum -c
+popd
+
+pushd firm2
+cabextract -F FW_ACC_CL.bin %{SOURCE4}
+echo %{firmware_hash2} FW_ACC_CL.bin | sha256sum -c
+popd
+
+pushd firm3
+cabextract -F FW_ACC_BR.bin %{SOURCE5}
+echo %{firmware_hash3} FW_ACC_BR.bin | sha256sum -c
+popd
+
+%install
+# xone-gip-headset module should have the snd-pcm and snd-seq modules be preloaded or it will give errors on boot due to injecting late.
+# It still loads afterwards, but this error is easily fixable by just loading the modules in the initramfs.
+install -Dpm644 %{SOURCE1} %{buildroot}%{_dracutconfdir}/60-%{name}-snd.conf
+
+# Blacklist:
+install -Dpm644 install/modprobe.conf %{buildroot}%{_modprobedir}/60-%{name}.conf
+
+# Firmware:
+install -Dpm644 firm0/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02e6.bin
+install -Dpm644 firm1/FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02fe.bin
+install -Dpm644 firm2/FW_ACC_CL.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_02f9.bin
+install -Dpm644 firm3/FW_ACC_BR.bin %{buildroot}%{_prefix}/lib/firmware/xone_dongle_091e.bin
+
+# Akmods modules
+install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
+
+# TOU file
+/usr/bin/cp %{SOURCE6} .
+
+%files
+%license LICENSE
+%doc README.md
+%{_modprobedir}/60-%{name}.conf
+%{_dracutconfdir}/60-%{name}-snd.conf
+
+%files akmod-modules
+%{_modulesloaddir}/%{name}.conf
+
+%files firmware
+%license terms-of-use
+%{_prefix}/lib/firmware/xone_dongle_02e6.bin
+%{_prefix}/lib/firmware/xone_dongle_02fe.bin
+%{_prefix}/lib/firmware/xone_dongle_02f9.bin
+%{_prefix}/lib/firmware/xone_dongle_091e.bin
+
+%postun
+/usr/bin/dracut -f || :
+
+%changelog
+* Sun Mar 15 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat: Add xonedo driver (#10614)](https://github.com/terrapkg/packages/pull/10614)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)