### PR TITLE
[f42] fix(xonedo): Update scripts and versioning (#10623)

### DIFF
--- a/anda/system/xonedo/nightly/kmod-common/update.rhai
+++ b/anda/system/xonedo/nightly/kmod-common/update.rhai
@@ -2,7 +2,7 @@ rpm.global("commit", gh_commit("OpenGamingCollective/xonedo"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commitdate", date());
-    let v = gh("OpenGamingCollective/xonedo");
+    let v = gh_tag("OpenGamingCollective/xonedo");
     v.crop(1);
-    rpm.global("ver", v);
+    rpm.global("relver", v);
 }

--- a/anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec
+++ b/anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec
@@ -1,7 +1,8 @@
 %global commit 982cbcb019ae4d2bee5ae69385223409ee555c88
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commitdate 20260314
-%global ver 0.5.7
+%global relver 0.5.7-ogc1
+%global ver %(echo %{relver} | sed 's/-/^/g')
 %global modulename xonedo
 %global _dracutconfdir %{_prefix}/lib/dracut/dracut.conf.d
 %global firmware_hash0 080ce4091e53a4ef3e5fe29939f51fd91f46d6a88be6d67eb6e99a5723b3a223

--- a/anda/system/xonedo/stable/kmod-common/update.rhai
+++ b/anda/system/xonedo/stable/kmod-common/update.rhai
@@ -1,1 +1,7 @@
-rpm.version(gh("OpenGamingCollective/xonedo"));
+let v = gh_tag("OpenGamingCollective/xonedo")
+v.crop(1);
+rpm.global("ver", v);
+
+if rpm.changed() {
+  rpm.release();
+}

--- a/anda/system/xonedo/stable/kmod-common/xonedo.spec
+++ b/anda/system/xonedo/stable/kmod-common/xonedo.spec
@@ -3,10 +3,10 @@
 %global firmware_hash1 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
 %global firmware_hash2 0023a7bae02974834500c665a281e25b1ba52c9226c84989f9084fa5ce591d9b
 %global firmware_hash3 e2710daf81e7b36d35985348f68a81d18bc537a2b0c508ffdfde6ac3eae1bad7
-%global ogcversion 1
+%global ver 0.5.7-ogc1
 
 Name:           xonedo
-Version:        0.5.7
+Version:        %(echo %{ver} | sed 's/-/^/g')
 Release:        1%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(xonedo): Update scripts and versioning (#10623)](https://github.com/terrapkg/packages/pull/10623)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)