### PR TITLE
[f43] fix(taidan): add dbus-daemon package as runtime dependency (#10636)

### DIFF
--- a/anda/system/taidan/taidan.spec
+++ b/anda/system/taidan/taidan.spec
@@ -1,12 +1,13 @@
 Name:           taidan
 Version:        0.1.39
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Out-Of-Box-Experience (OOBE) and Welcome App
 SourceLicense:  GPL-3.0-or-later AND GPL-2.0-or-later
 License:        (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND GPL-3.0-or-later AND GPL-2.0-or-later
 URL:            https://github.com/Ultramarine-Linux/taidan
 Packager:       Terra Packaging Team <terra@fyralabs.com>
 Conflicts:      initial-setup
+Requires:       dbus-daemon
 Requires:       (glib2 or (/usr/bin/plasma-apply-colorscheme and kf6-kconfig))
 Requires:       shadow-utils
 Requires:       systemd-udev
@@ -59,5 +60,8 @@ DESTDIR=%buildroot ./scripts/install.sh
 %_prefix/lib/taidan/labwc/*
 
 %changelog
+* Sun Mar 15 2026 Tulip Blossom <tulilirockz@outlook.com>
+- Add dbus-daemon as runtime dependency
+
 * Sun Mar 15 2026 Tulip Blossom <tulilirockz@outlook.com>
 - Port manifest from Ultramarine repos to Terra


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(taidan): add dbus-daemon package as runtime dependency (#10636)](https://github.com/terrapkg/packages/pull/10636)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)