### PR TITLE
[f43] fix(mesa): split out cargo dependencies into architecture-specific files to prevent conflicts with i386 and amd64 package installs (#10641)

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -87,7 +87,7 @@ Summary:        Mesa graphics libraries
 %global ver 26.0.2
 Epoch:          1
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        2
+Release:        3
 Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            https://mesa3d.org
@@ -480,7 +480,7 @@ rewrite_wrap_file rustc-hash
 
 %if 0%{?with_nvk}
 %cargo_license_summary
-%{cargo_license} > LICENSE.dependencies
+%{cargo_license} > LICENSE.dependencies.%{_arch}
 %if 0%{?vendor_nvk_crates}
 %cargo_vendor_manifest
 %endif
@@ -677,7 +677,7 @@ ln -s %{_libdir}/libGLX_mesa.so.0 %{buildroot}%{_libdir}/libGLX_system.so.0
 
 %files vulkan-drivers
 %if 0%{?with_nvk}
-%license LICENSE.dependencies
+%license LICENSE.dependencies.%{_arch}
 %if 0%{?vendor_nvk_crates}
 %license cargo-vendor.txt
 %endif
@@ -727,4 +727,5 @@ ln -s %{_libdir}/libGLX_mesa.so.0 %{buildroot}%{_libdir}/libGLX_system.so.0
 %endif
 
 %changelog
-%autochangelog
+* Sun Mar 15 2026 Tulip Blossom <tulilirockz@outlook.com>
+- Split out cargo dependencies into architecture-specific files to prevent conflicts with i386 and amd64 package installs


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(mesa): split out cargo dependencies into architecture-specific files to prevent conflicts with i386 and amd64 package installs (#10641)](https://github.com/terrapkg/packages/pull/10641)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)