### PR TITLE
[f44] fix (opensnitch): add update script (#10629)

### DIFF
--- a/anda/apps/opensnitch/update.rhai
+++ b/anda/apps/opensnitch/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("evilsocket/opensnitch"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (opensnitch): add update script (#10629)](https://github.com/terrapkg/packages/pull/10629)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)