### PR TITLE
[f44] fix(nvidia): Patches and changes for kernel 6.19 (#10516)

### DIFF
--- a/anda/system/nvidia-580/compat-nvidia-repo/compat-nvidia-repo-580.spec
+++ b/anda/system/nvidia-580/compat-nvidia-repo/compat-nvidia-repo-580.spec
@@ -1,27 +1,29 @@
-Name:           compat-nvidia-repo-580
+Name:           compat-nvidia-repo-580xx
 Version:        580.142
 Epoch:          3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Compatibility package required by official CUDA packages
 License:        NVIDIA License
 URL:            https://developer.nvidia.com/cuda-toolkit
 
 BuildArch:      noarch
 
-Requires:       nvidia-driver-580 >= %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-driver-580-cuda >= %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-driver-580-cuda-libs >= %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-driver-580-libs >= %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-580-kmod >= %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-settings-580 >= %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-driver-580xx >= %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-driver-580xx-cuda >= %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-driver-580xx-cuda-libs >= %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-driver-580xx-libs >= %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-580xx-kmod >= %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-settings-580xx >= %{?epoch:%{epoch}:}%{version}
 
-Provides:       cuda-drivers-580 >= %{?epoch:%{epoch}:}%{version}
-Provides:       nvidia-open-580 >= %{?epoch:%{epoch}:}%{version}
+Provides:       cuda-drivers-580xx >= %{?epoch:%{epoch}:}%{version}
+Provides:       nvidia-open-580xx >= %{?epoch:%{epoch}:}%{version}
 # Add any versioned provides:
 Provides:       cuda-drivers-560 >= %{?epoch:%{epoch}:}%{version}
 Provides:       cuda-drivers-565 >= %{?epoch:%{epoch}:}%{version}
 Provides:       nvidia-open-560 >= %{?epoch:%{epoch}:}%{version}
 Provides:       nvidia-open-565 >= %{?epoch:%{epoch}:}%{version}
+
+Provides:       compat-nvidia-repo-580 = %{evr}
 
 %description
 Nvidia drivers metapackage required by official CUDA packages. It pulls in all

--- a/anda/system/nvidia-580/compat-nvidia-repo/compat-nvidia-repo-580.spec
+++ b/anda/system/nvidia-580/compat-nvidia-repo/compat-nvidia-repo-580.spec
@@ -1,7 +1,7 @@
 Name:           compat-nvidia-repo-580xx
 Version:        580.142
 Epoch:          3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Compatibility package required by official CUDA packages
 License:        NVIDIA License
 URL:            https://developer.nvidia.com/cuda-toolkit

--- a/anda/system/nvidia-580/dkms-nvidia/0001-Enable-atomic-kernel-modesetting-by-default.patch
+++ b/anda/system/nvidia-580/dkms-nvidia/0001-Enable-atomic-kernel-modesetting-by-default.patch
@@ -1,0 +1,42 @@
+From 60d1ddc17835226ec67ed1bc1c28524e3bb6e151 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Sun, 20 Apr 2025 18:13:22 +0200
+Subject: [PATCH 1/8] Enable atomic kernel modesetting by default
+
+This is required for proper functionality under Wayland. fbdev has been default enabled since 570 so that
+hunk can be removed from this patch.
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ nvidia-drm/nvidia-drm-linux.c        | 2 +-
+ nvidia-drm/nvidia-drm-os-interface.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git an/nvidia-drm/nvidia-drm-linux.c b/nvidia-drm/nvidia-drm-linux.c
+index 3cb1815d..209cb469 100644
+--- a/nvidia-drm/nvidia-drm-linux.c
++++ b/nvidia-drm/nvidia-drm-linux.c
+@@ -31,7 +31,7 @@
+ 
+ MODULE_PARM_DESC(
+     modeset,
+-    "Enable atomic kernel modesetting (1 = enable, 0 = disable (default))");
++    "Enable atomic kernel modesetting (1 = enable (default), 0 = disable)");
+ module_param_named(modeset, nv_drm_modeset_module_param, bool, 0400);
+ 
+ #if defined(NV_DRM_FBDEV_AVAILABLE)
+diff --git a/nvidia-drm/nvidia-drm-os-interface.c b/nvidia-drm/nvidia-drm-os-interface.c
+index 7617476d..f22afd77 100644
+--- a/nvidia-drm/nvidia-drm-os-interface.c
++++ b/nvidia-drm/nvidia-drm-os-interface.c
+@@ -41,7 +41,7 @@
+ #include <drm/drmP.h>
+ #endif
+ 
+-bool nv_drm_modeset_module_param = false;
++bool nv_drm_modeset_module_param = true;
+ bool nv_drm_fbdev_module_param = true;
+ 
+ void *nv_drm_calloc(size_t nmemb, size_t size)
+-- 
+2.49.0.391.g4bbb303af6

--- a/anda/system/nvidia-580/dkms-nvidia/dkms-nvidia-580.spec
+++ b/anda/system/nvidia-580/dkms-nvidia/dkms-nvidia-580.spec
@@ -3,22 +3,25 @@
 # RPM inexplicably thinks this package deps on a version of libcrypto it does not?
 %global __requires_exclude (libcrypto\\.so\\.1\\.1.*)$
 %global debug_package %{nil}
-%global modulename nvidia
+%global modulename nvidia-580xx
 
-Name:           dkms-%{modulename}-580
-Version:        580.119.02
-Release:        1%?dist
+Name:           dkms-%{modulename}
+Version:        580.142
+Release:        1%{?dist}
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License
 URL:            https://www.nvidia.com/object/unix.html
 Source0:        https://download.nvidia.com/XFree86/Linux-%{_arch}/%{version}/NVIDIA-Linux-%{_arch}-%{version}.run
-Source1:        dkms-%{modulename}.conf
+Source1:        dkms-nvidia.conf
+Patch0:         0001-Enable-atomic-kernel-modesetting-by-default.patch
 BuildRequires:  sed
-Provides:       %{modulename}-580-kmod = %{?epoch:%{epoch}:}%{version}
-Requires:       %{modulename}-580-kmod-common = %{?epoch:%{epoch}:}%{version}
+Provides:       %{modulename}-kmod = %{?epoch:%{epoch}:}%{version}
+Requires:       %{modulename}-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
 Conflicts:      akmod-nvidia
+Conflicts:      akmod-nvidia-580xx
+Provides:       dkms-nvidia-580 = %{evr}
 # Unlike most DKMS packages, this package is NOT noarch!
 ExclusiveArch:  x86_64 aarch64
 
@@ -28,7 +31,10 @@ This package provides the proprietary NVIDIA kernel driver modules.
 %prep
 sh %{SOURCE0} -x --target dkms-nvidia-%{version}-%{_arch}
 %setup -T -D -n dkms-nvidia-%{version}-%{_arch}
+
+pushd kernel-open
 %autopatch -p1
+popd
 
 cp -f %{SOURCE1} dkms.conf
 

--- a/anda/system/nvidia-580/nvidia-driver/nvidia-driver-580.spec
+++ b/anda/system/nvidia-580/nvidia-driver/nvidia-driver-580.spec
@@ -10,7 +10,7 @@
 %global _systemd_util_dir %{_prefix}/lib/systemd
 %endif
 
-Name:           %{real_name}-580
+Name:           %{real_name}-580xx
 Version:        580.142
 Release:        1%{?dist}
 Summary:        NVIDIA's proprietary display driver for NVIDIA graphic cards
@@ -55,6 +55,8 @@ Conflicts:      nvidia-x11-drv-470xx
 Conflicts:      xorg-x11-drv-nvidia
 Conflicts:      xorg-x11-drv-nvidia-470xx
 
+Provides:       %{real_name}-580 = %{evr}
+
 %description
 This package provides the most recent NVIDIA display driver which allows for
 hardware accelerated rendering with recent NVIDIA chipsets.
@@ -74,7 +76,7 @@ Requires:       libglvnd-egl%{?_isa} >= 1.0
 Requires:       libglvnd-gles%{?_isa} >= 1.0
 Requires:       libglvnd-glx%{?_isa} >= 1.0
 Requires:       libglvnd-opengl%{?_isa} >= 1.0
-Requires:       libnvidia-ml-580%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libnvidia-ml-580xx%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:       vulkan-loader
 %if 0%{?fedora}
 %ifarch x86_64
@@ -82,14 +84,16 @@ Requires:       (%{name}-libs(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release}
 %endif
 %endif
 # dlopened
-Requires:       libnvidia-gpucomp-580%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Requires:       libnvidia-ml-580%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libnvidia-gpucomp-580xx%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libnvidia-ml-580xx%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:       %{name}-cuda-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 
 Conflicts:      nvidia-x11-drv-libs
 Conflicts:      nvidia-x11-drv-470xx-libs
 Conflicts:      xorg-x11-drv-nvidia-libs
 Conflicts:      xorg-x11-drv-nvidia-470xx-libs
+
+Provides:       %{real_name}-580-libs = %{evr}
 
 %description libs
 This package provides the shared libraries for %{name}.
@@ -98,20 +102,21 @@ This package provides the shared libraries for %{name}.
 Summary:        Libraries for %{name}-cuda
 Provides:       %{name}-devel = %{?epoch:%{epoch}:}%{version}-%{release}
 Obsoletes:      %{name}-devel < %{?epoch:%{epoch}:}%{version}-%{release}
-Requires:       libnvidia-ml-580 = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       %{real_name}-580-cuda-libs = %{evr}
+Requires:       libnvidia-ml-580xx = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:       %{name}-cuda-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 
 %ifarch x86_64 aarch64
-Requires:       libnvidia-cfg-580 = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libnvidia-cfg-580xx = %{?epoch:%{epoch}:}%{version}-%{release}
 %endif
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       (%{name}-cuda-libs-580(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
+Requires:       (%{name}-cuda-libs-580xx(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
 # dlopened:
-Requires:       libnvidia-gpucomp-580%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Requires:       libnvidia-ml-580 = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libnvidia-gpucomp-580xx%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       libnvidia-ml-580xx = %{?epoch:%{epoch}:}%{version}-%{release}
 
 Conflicts:      xorg-x11-drv-nvidia-cuda-libs
 Conflicts:      xorg-x11-drv-nvidia-470xx-cuda-libs
@@ -119,48 +124,51 @@ Conflicts:      xorg-x11-drv-nvidia-470xx-cuda-libs
 %description cuda-libs
 This package provides the CUDA libraries for %{name}-cuda.
 
-%package -n libnvidia-fbc-580
+%package -n libnvidia-fbc-580xx
 Summary:        NVIDIA OpenGL-based Framebuffer Capture libraries
-Provides:       %{real_name}-NvFBCOpenGL-580 = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       %{real_name}-NvFBCOpenGL-580xx = %{?epoch:%{epoch}:}%{version}-%{release}
 Obsoletes:      %{real_name}-NvFBCOpenGL < %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       libnvidia-fbc-580 = %{evr}
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       (libnvidia-fbc-580(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
+Requires:       (libnvidia-fbc-580xx(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
 # dlopened:
-Requires:       %{name}-cuda-libs-580%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires:       %{name}-cuda-libs-580xx%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 
-%description -n libnvidia-fbc-580
+%description -n libnvidia-fbc-580xx
 This library provides a high performance, low latency interface to capture and
 optionally encode the composited framebuffer of an X screen. NvFBC are private
 APIs that are only available to NVIDIA approved partners for use in remote
 graphics scenarios.
 
-%package -n libnvidia-gpucomp-580
+%package -n libnvidia-gpucomp-580xx
 Summary:        NVIDIA library for shader compilation (nvgpucomp)
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       (libnvidia-gpucomp-580(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
+Requires:       (libnvidia-gpucomp-580xx(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
+Provides:       libnvidia-gpucomp-580 = %{evr}
 
-%description -n libnvidia-gpucomp-580
+%description -n libnvidia-gpucomp-580xx
 This package contains the private libnvidia-gpucomp runtime library which is used by
 other driver components.
 
-%package -n libnvidia-ml-580
+%package -n libnvidia-ml-580xx
 Summary:        NVIDIA Management Library (NVML)
-Provides:       cuda-nvml-580%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Provides:       %{real_name}-NVML-580 = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       cuda-nvml-580xx%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       %{real_name}-NVML-580xx = %{?epoch:%{epoch}:}%{version}-%{release}
+Provides:       libnvidia-ml-580 = %{evr}
 %if 0%{?fedora}
 %ifarch x86_64
-Requires:       (libnvidia-ml-580(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
+Requires:       (libnvidia-ml-580xx(x86-32) = %{?epoch:%{epoch}:}%{version}-%{release} if steam(x86-32))
 %endif
 %endif
 Obsoletes:      %{real_name}-NVML < %{?epoch:%{epoch}:}%{version}-%{release}
 
-%description -n libnvidia-ml-580
+%description -n libnvidia-ml-580xx
 A C-based API for monitoring and managing various states of the NVIDIA GPU
 devices. It provides a direct access to the queries and commands exposed via
 nvidia-smi. The run-time version of NVML ships with the NVIDIA display driver,
@@ -170,38 +178,43 @@ to be a platform for building 3rd party applications.
 
 %ifarch x86_64 aarch64
 
-%package -n libnvidia-cfg-580
+%package -n libnvidia-cfg-580xx
 Summary:        NVIDIA Config public interface (nvcfg)
+Provides:       libnvidia-cfg-580 = %{evr}
 
-%description -n libnvidia-cfg-580
+%description -n libnvidia-cfg-580xx
 This package contains the private libnvidia-cfg runtime library which is used by
 other driver components.
 
 %package cuda
 Summary:        CUDA integration for %{name}
-Requires:       %{name}-cuda-libs-580%{?_isa} = %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-580-kmod-common = %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-persistenced-580 = %{?epoch:%{epoch}:}%{version}
+Requires:       %{name}-cuda-libs-580xx%{?_isa} = %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-580xx-kmod-common = %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-persistenced-580xx = %{?epoch:%{epoch}:}%{version}
 Requires:       opencl-filesystem
 Requires:       ocl-icd
 
 Conflicts:      xorg-x11-drv-nvidia-cuda
 Conflicts:      xorg-x11-drv-nvidia-470xx-cuda
 
+Provides:       %{real_name}-580-cuda = %{evr}
+
 %description cuda
 This package provides the CUDA integration components for %{name}.
 
 %if 0%{?fedora} || 0%{?rhel} < 10
-%package -n xorg-x11-nvidia-580
+%package -n xorg-x11-nvidia-580xx
 Summary:        X.org X11 NVIDIA driver and extensions
 Requires:       %{name}%{?_isa} = %{?epoch:%{epoch}:}%{version}
 Requires:       xorg-x11-server-Xorg%{?_isa}
-Supplements:    (%{real_name}-580 and xorg-x11-server-Xorg)
+Supplements:    (%{real_name}-580xx and xorg-x11-server-Xorg)
 
 Conflicts:      xorg-x11-drv-nvidia
 Conflicts:      xorg-x11-drv-nvidia-470xx
 
-%description -n xorg-x11-nvidia-580
+Provides:       xorg-x11-nvidia-580 = %{evr}
+
+%description -n xorg-x11-nvidia-580xx
 The NVIDIA X.org X11 driver and associated components.
 %endif
 
@@ -414,13 +427,13 @@ appstream-util validate --nonet %{buildroot}%{_metainfodir}/com.nvidia.driver.me
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} < 10
-%files -n xorg-x11-nvidia-580
+%files -n xorg-x11-nvidia-580xx
 %config(noreplace) %{_sysconfdir}/X11/xorg.conf.d/10-nvidia.conf
 %{_libdir}/xorg/modules/extensions/libglxserver_nvidia.so
 %{_libdir}/xorg/modules/drivers/nvidia_drv.so
 %endif
 
-%files -n libnvidia-cfg-580
+%files -n libnvidia-cfg-580xx
 %{_libdir}/libnvidia-cfg.so.1
 %{_libdir}/libnvidia-cfg.so.%{version}
 
@@ -523,14 +536,14 @@ appstream-util validate --nonet %{buildroot}%{_metainfodir}/com.nvidia.driver.me
 %endif
 %endif
 
-%files -n libnvidia-fbc-580
+%files -n libnvidia-fbc-580xx
 %{_libdir}/libnvidia-fbc.so.1
 %{_libdir}/libnvidia-fbc.so.%{version}
 
-%files -n libnvidia-gpucomp-580
+%files -n libnvidia-gpucomp-580xx
 %{_libdir}/libnvidia-gpucomp.so.%{version}
 
-%files -n libnvidia-ml-580
+%files -n libnvidia-ml-580xx
 %{_libdir}/libnvidia-ml.so.1
 %{_libdir}/libnvidia-ml.so.%{version}
 

--- a/anda/system/nvidia-580/nvidia-driver/nvidia-driver-580.spec
+++ b/anda/system/nvidia-580/nvidia-driver/nvidia-driver-580.spec
@@ -12,7 +12,7 @@
 
 Name:           %{real_name}-580xx
 Version:        580.142
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        NVIDIA's proprietary display driver for NVIDIA graphic cards
 Epoch:          3
 License:        NVIDIA License

--- a/anda/system/nvidia-580/nvidia-kmod-common/nvidia-580-kmod-common.spec
+++ b/anda/system/nvidia-580/nvidia-kmod-common/nvidia-580-kmod-common.spec
@@ -3,10 +3,11 @@
 # gsp_*.bin: ELF 64-bit LSB executable, UCB RISC-V
 %global _binaries_in_noarch_packages_terminate_build 0
 %global __brp_strip %{nil}
+%global modulename nvidia-580xx
 
-Name:           nvidia-580-kmod-common
+Name:           %{modulename}-kmod-common
 Version:        580.142
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Common file for NVIDIA's proprietary driver kernel modules
 Epoch:          3
 License:        NVIDIA License
@@ -25,11 +26,12 @@ Source21:       99-nvidia.conf
 BuildRequires:  systemd-rpm-macros
 
 Requires:       dracut
-Requires:       nvidia-modprobe-580
-Requires:       nvidia-driver-580 = %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-driver-580-libs = %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-580-kmod = %{?epoch:%{epoch}:}%{version}
-Provides:       nvidia-580-kmod-common = %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-modprobe-580xx
+Requires:       nvidia-driver-580xx = %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-driver-580xx-libs = %{?epoch:%{epoch}:}%{version}
+Requires:       %{modulename}-kmod = %{?epoch:%{epoch}:}%{version}
+Provides:       %{modulename}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Provides:       nvidia-580-kmod-common = %{evr}
 Obsoletes:      cuda-nvidia-kmod-common < %{?epoch:%{epoch}:}%{version}
 
 %description

--- a/anda/system/nvidia-580/nvidia-kmod-common/nvidia-580-kmod-common.spec
+++ b/anda/system/nvidia-580/nvidia-kmod-common/nvidia-580-kmod-common.spec
@@ -7,7 +7,7 @@
 
 Name:           %{modulename}-kmod-common
 Version:        580.142
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Common file for NVIDIA's proprietary driver kernel modules
 Epoch:          3
 License:        NVIDIA License

--- a/anda/system/nvidia-580/nvidia-kmod/0001-Enable-atomic-kernel-modesetting-by-default.patch
+++ b/anda/system/nvidia-580/nvidia-kmod/0001-Enable-atomic-kernel-modesetting-by-default.patch
@@ -1,0 +1,42 @@
+From 60d1ddc17835226ec67ed1bc1c28524e3bb6e151 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Sun, 20 Apr 2025 18:13:22 +0200
+Subject: [PATCH 1/8] Enable atomic kernel modesetting by default
+
+This is required for proper functionality under Wayland. fbdev has been default enabled since 570 so that
+hunk can be removed from this patch.
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ nvidia-drm/nvidia-drm-linux.c        | 2 +-
+ nvidia-drm/nvidia-drm-os-interface.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git an/nvidia-drm/nvidia-drm-linux.c b/nvidia-drm/nvidia-drm-linux.c
+index 3cb1815d..209cb469 100644
+--- a/nvidia-drm/nvidia-drm-linux.c
++++ b/nvidia-drm/nvidia-drm-linux.c
+@@ -31,7 +31,7 @@
+ 
+ MODULE_PARM_DESC(
+     modeset,
+-    "Enable atomic kernel modesetting (1 = enable, 0 = disable (default))");
++    "Enable atomic kernel modesetting (1 = enable (default), 0 = disable)");
+ module_param_named(modeset, nv_drm_modeset_module_param, bool, 0400);
+ 
+ #if defined(NV_DRM_FBDEV_AVAILABLE)
+diff --git a/nvidia-drm/nvidia-drm-os-interface.c b/nvidia-drm/nvidia-drm-os-interface.c
+index 7617476d..f22afd77 100644
+--- a/nvidia-drm/nvidia-drm-os-interface.c
++++ b/nvidia-drm/nvidia-drm-os-interface.c
+@@ -41,7 +41,7 @@
+ #include <drm/drmP.h>
+ #endif
+ 
+-bool nv_drm_modeset_module_param = false;
++bool nv_drm_modeset_module_param = true;
+ bool nv_drm_fbdev_module_param = true;
+ 
+ void *nv_drm_calloc(size_t nmemb, size_t size)
+-- 
+2.49.0.391.g4bbb303af6

--- a/anda/system/nvidia-580/nvidia-kmod/anda.hcl
+++ b/anda/system/nvidia-580/nvidia-kmod/anda.hcl
@@ -1,6 +1,6 @@
 project "pkg" {
     rpm {
-        spec = "nvidia-580-kmod.spec"
+        spec = "nvidia-580xx-kmod.spec"
     }
     labels {
         mock = 1

--- a/anda/system/nvidia-580/nvidia-kmod/nvidia-580xx-kmod.spec
+++ b/anda/system/nvidia-580/nvidia-kmod/nvidia-580xx-kmod.spec
@@ -1,12 +1,12 @@
 # Build only the akmod package and no kernel module packages:
 %define buildforkernels akmod
-%global modulename nvidia-580
+%global modulename nvidia-580xx
 
 %global debug_package %{nil}
 
 Name:           %{modulename}-kmod
-Version:        580.119.02
-Release:        1%?dist
+Version:        580.142
+Release:        1%{?dist}
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License
@@ -14,15 +14,17 @@ URL:            http://www.nvidia.com/object/unix.html
 ExclusiveArch:  x86_64 aarch64
 
 Source0:        http://download.nvidia.com/XFree86/Linux-%{_arch}/%{version}/NVIDIA-Linux-%{_arch}-%{version}.run
-Requires:       nvidia-580-kmod-common = %{?epoch:%{epoch}:}%{version}
+Patch0:         0001-Enable-atomic-kernel-modesetting-by-default.patch
+Requires:       nvidia-580xx-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       akmods
+Provides:       akmod-nvidia-580 = %{evr}
 
 
 # Get the needed BuildRequires (in parts depending on what we build for):
 BuildRequires:  kmodtool
 
 # kmodtool does its magic here:
-%{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
 
 %description
 The NVidia %{version} display driver kernel module for kernel %{kversion}.
@@ -35,7 +37,10 @@ kmodtool  --target %{_target_cpu}  --repo terra.fyralabs.com --kmodname %{module
 
 sh %{SOURCE0} -x --target %{real_name}-%{version}-%{_arch}
 %setup -T -D -n %{real_name}-%{version}-%{_arch}
+
+pushd kernel-open
 %autopatch -p1
+popd
 
 rm -f */dkms.conf
 

--- a/anda/system/nvidia-580/nvidia-modprobe/nvidia-modprobe-580.spec
+++ b/anda/system/nvidia-580/nvidia-modprobe/nvidia-modprobe-580.spec
@@ -1,8 +1,8 @@
 %global real_name nvidia-modprobe
 
-Name:           %{real_name}-580
+Name:           %{real_name}-580xx
 Version:        580.142
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        NVIDIA kernel module loader
 Epoch:          3
 License:        GPLv2+
@@ -14,6 +14,8 @@ Patch0:         %{real_name}-man-page-permissions.patch
 
 BuildRequires:  gcc
 BuildRequires:  m4
+
+Provides:      %{real_name}-580 = %{evr}
 
 %description
 This utility is used by user-space NVIDIA driver components to make sure the

--- a/anda/system/nvidia-580/nvidia-modprobe/nvidia-modprobe-580.spec
+++ b/anda/system/nvidia-580/nvidia-modprobe/nvidia-modprobe-580.spec
@@ -2,7 +2,7 @@
 
 Name:           %{real_name}-580xx
 Version:        580.142
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        NVIDIA kernel module loader
 Epoch:          3
 License:        GPLv2+

--- a/anda/system/nvidia-580/nvidia-persistenced/nvidia-persistenced-580.spec
+++ b/anda/system/nvidia-580/nvidia-persistenced/nvidia-persistenced-580.spec
@@ -1,8 +1,8 @@
 %global real_name nvidia-persistenced
 
-Name:           %{real_name}-580
+Name:           %{real_name}-580xx
 Version:        580.142
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A daemon to maintain persistent software state in the NVIDIA driver
 Epoch:          3
 License:        GPLv2+
@@ -21,7 +21,9 @@ BuildRequires:      systemd-devel
 Requires(post):     systemd
 Requires(preun):    systemd
 Requires(postun):   systemd
-Requires:           libnvidia-cfg-580%{?_isa} >= %{?epoch:%{epoch}:}%{version}
+Requires:           libnvidia-cfg-580xx%{?_isa} >= %{?epoch:%{epoch}:}%{version}
+
+Provides:           %{real_name}-580 = %{evr}
 
 %description
 The %{real_name} utility is used to enable persistent software state in the NVIDIA

--- a/anda/system/nvidia-580/nvidia-persistenced/nvidia-persistenced-580.spec
+++ b/anda/system/nvidia-580/nvidia-persistenced/nvidia-persistenced-580.spec
@@ -2,7 +2,7 @@
 
 Name:           %{real_name}-580xx
 Version:        580.142
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A daemon to maintain persistent software state in the NVIDIA driver
 Epoch:          3
 License:        GPLv2+

--- a/anda/system/nvidia-580/nvidia-settings/nvidia-settings-580.spec
+++ b/anda/system/nvidia-580/nvidia-settings/nvidia-settings-580.spec
@@ -1,8 +1,8 @@
 %global real_name nvidia-settings
 
-Name:           %{real_name}-580
+Name:           %{real_name}-580xx
 Version:        580.142
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Configure the NVIDIA graphics driver
 Epoch:          3
 License:        GPLv2+
@@ -35,10 +35,12 @@ BuildRequires:  pkgconfig(gtk+-3.0)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  vulkan-headers
 
-Requires:       nvidia-libXNVCtrl-580%{?_isa} = %{?epoch}:%{version}-%{release}
-Requires:       nvidia-driver-580%{?_isa} = %{?epoch}:%{version}
+Requires:       nvidia-libXNVCtrl-580xx%{?_isa} = %{?epoch}:%{version}-%{release}
+Requires:       nvidia-driver-580xx%{?_isa} = %{?epoch}:%{version}
 # Loaded at runtime
 Requires:       libvdpau%{?_isa} >= 0.9
+
+Provides:       %{real_name}-580 = %{evr}
 
 %description
 The %{real_name} utility is a tool for configuring the NVIDIA graphics
@@ -47,21 +49,24 @@ updating state as appropriate.
 
 This communication is done with the NV-CONTROL X extension.
 
-%package -n nvidia-libXNVCtrl-580
+%package -n nvidia-libXNVCtrl-580xx
 Summary:        Library providing the NV-CONTROL API
 Obsoletes:      libXNVCtrl < %{?epoch}:%{version}-%{release}
+Provides:       libXNVCtrl-580xx = %{?epoch}:%{version}-%{release}
+Provides:       nvidia-libXNVCtrl-580 = %{?epoch}:%{version}-%{release}
 Provides:       libXNVCtrl-580 = %{?epoch}:%{version}-%{release}
 
-%description -n nvidia-libXNVCtrl-580
+%description -n nvidia-libXNVCtrl-580xx
 This library provides the NV-CONTROL API for communicating with the proprietary
 NVidia xorg driver. It is required for proper operation of the %{real_name} utility.
 
-%package -n nvidia-libXNVCtrl-580-devel
+%package -n nvidia-libXNVCtrl-580xx-devel
 Summary:        Development files for libXNVCtrl
-Requires:       nvidia-libXNVCtrl-580 = %{?epoch}:%{version}-%{release}
+Requires:       nvidia-libXNVCtrl-580xx = %{?epoch}:%{version}-%{release}
 Requires:       libX11-devel
+Provides:       nvidia-libXNVCtrl-580-devel = %{evr}
 
-%description -n nvidia-libXNVCtrl-580-devel
+%description -n nvidia-libXNVCtrl-580xx-devel
 This devel package contains libraries and header files for
 developing applications that use the NV-CONTROL API.
 
@@ -126,11 +131,11 @@ appstream-util validate-relax --nonet %{buildroot}/%{_metainfodir}/%{real_name}.
 %{_mandir}/man1/%{real_name}.*
 %{_sysconfdir}/xdg/autostart/%{real_name}-load.desktop
 
-%files -n nvidia-libXNVCtrl-580
+%files -n nvidia-libXNVCtrl-580xx
 %license COPYING
 %{_libdir}/libXNVCtrl.so.*
 
-%files -n nvidia-libXNVCtrl-580-devel
+%files -n nvidia-libXNVCtrl-580xx-devel
 %doc doc/NV-CONTROL-API.txt doc/FRAMELOCK.txt
 %{_includedir}/NVCtrl
 %{_libdir}/libXNVCtrl.so

--- a/anda/system/nvidia-580/nvidia-settings/nvidia-settings-580.spec
+++ b/anda/system/nvidia-580/nvidia-settings/nvidia-settings-580.spec
@@ -2,7 +2,7 @@
 
 Name:           %{real_name}-580xx
 Version:        580.142
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Configure the NVIDIA graphics driver
 Epoch:          3
 License:        GPLv2+

--- a/anda/system/nvidia-580/nvidia-xconfig/nvidia-xconfig-580.spec
+++ b/anda/system/nvidia-580/nvidia-xconfig/nvidia-xconfig-580.spec
@@ -1,8 +1,8 @@
 %global real_name nvidia-xconfig
 
-Name:           %{real_name}-580
+Name:           %{real_name}-580xx
 Version:        580.142
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        NVIDIA X configuration file editor
 Epoch:          3
 License:        GPLv2+
@@ -15,8 +15,10 @@ BuildRequires:  gcc
 BuildRequires:  libpciaccess-devel
 BuildRequires:  m4
 
-Requires:       libnvidia-cfg-580%{?_isa} >= %{?epoch:%{epoch}:}%{version}
-Requires:       xorg-x11-nvidia-580%{?_isa} >= %{?epoch:%{epoch}:}%{version}
+Requires:       libnvidia-cfg-580xx%{?_isa} >= %{?epoch:%{epoch}:}%{version}
+Requires:       xorg-x11-nvidia-580xx%{?_isa} >= %{?epoch:%{epoch}:}%{version}
+
+Provides:       %{real_name}-580 = %{evr}
 
 %description
 %{real_name} is a command line tool intended to provide basic control over

--- a/anda/system/nvidia-580/nvidia-xconfig/nvidia-xconfig-580.spec
+++ b/anda/system/nvidia-580/nvidia-xconfig/nvidia-xconfig-580.spec
@@ -2,7 +2,7 @@
 
 Name:           %{real_name}-580xx
 Version:        580.142
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        NVIDIA X configuration file editor
 Epoch:          3
 License:        GPLv2+

--- a/anda/system/nvidia/dkms-nvidia/0001-Enable-atomic-kernel-modesetting-by-default.patch
+++ b/anda/system/nvidia/dkms-nvidia/0001-Enable-atomic-kernel-modesetting-by-default.patch
@@ -1,0 +1,44 @@
+From 60d1ddc17835226ec67ed1bc1c28524e3bb6e151 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Sun, 20 Apr 2025 18:13:22 +0200
+Subject: [PATCH 1/8] Enable atomic kernel modesetting by default
+
+This is required for proper functionality under Wayland. fbdev has been default enabled since 570 so that
+hunk can be removed from this patch.
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ kernel-open/nvidia-drm/nvidia-drm-linux.c        | 2 +-
+ kernel-open/nvidia-drm/nvidia-drm-os-interface.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git an/kernel-open/nvidia-drm/nvidia-drm-linux.c b/kernel-open/nvidia-drm/nvidia-drm-linux.c
+index 3cb1815d..209cb469 100644
+--- a/kernel-open/nvidia-drm/nvidia-drm-linux.c
++++ b/kernel-open/nvidia-drm/nvidia-drm-linux.c
+@@ -31,7 +31,7 @@
+ 
+ MODULE_PARM_DESC(
+     modeset,
+-    "Enable atomic kernel modesetting (1 = enable, 0 = disable (default))");
++    "Enable atomic kernel modesetting (1 = enable (default), 0 = disable)");
+ module_param_named(modeset, nv_drm_modeset_module_param, bool, 0400);
+ 
+ #if defined(NV_DRM_FBDEV_AVAILABLE)
+diff --git a/kernel-open/nvidia-drm/nvidia-drm-os-interface.c b/kernel-open/nvidia-drm/nvidia-drm-os-interface.c
+index 7617476d..f22afd77 100644
+--- a/kernel-open/nvidia-drm/nvidia-drm-os-interface.c
++++ b/kernel-open/nvidia-drm/nvidia-drm-os-interface.c
+@@ -41,7 +41,7 @@
+ #include <drm/drmP.h>
+ #endif
+ 
+-bool nv_drm_modeset_module_param = false;
++bool nv_drm_modeset_module_param = true;
+ bool nv_drm_fbdev_module_param = true;
+ 
+ void *nv_drm_calloc(size_t nmemb, size_t size)
+-- 
+2.49.0.391.g4bbb303af6
+
+

--- a/anda/system/nvidia/dkms-nvidia/6.19-590.patch
+++ b/anda/system/nvidia/dkms-nvidia/6.19-590.patch
@@ -1,0 +1,130 @@
+From c9457ce40a6af2ce74c520564e2d8775f49e3d27 Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@cachyos.org>
+Date: Thu, 18 Dec 2025 12:36:06 +0800
+Subject: [PATCH 3/3] Fix compile for 6.19
+
+Contains:
+- Rename page_free callback -> folio_free callback for 6.19+
+- Adjust zone_device_page_init() call for 6.19; it has one extra argument now
+- 6.19-rc8 introduced yet another argument for zone_device_page_init()
+
+Link: https://github.com/torvalds/linux/commit/12b2285bf3d14372238d36215b73af02ac3bdfc1
+Signed-off-by: Eric Naim <dnaim@cachyos.org>
+---
+ kernel-open/nvidia-uvm/uvm_hmm.c     |  4 ++++
+ kernel-open/nvidia-uvm/uvm_pmm_gpu.c | 34 ++++++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+)
+
+diff --git a/kernel-open/nvidia-uvm/uvm_hmm.c b/kernel-open/nvidia-uvm/uvm_hmm.c
+index 9b676f971385..22db001384a4 100644
+--- a/kernel-open/nvidia-uvm/uvm_hmm.c
++++ b/kernel-open/nvidia-uvm/uvm_hmm.c
+@@ -2140,7 +2140,11 @@ static void fill_dst_pfn(uvm_va_block_t *va_block,
+ 
+         UVM_ASSERT(!page_count(dpage));
+         UVM_ASSERT(!dpage->zone_device_data);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++        zone_device_page_init(dpage, page_pgmap(dpage), 0);
++#else
+         zone_device_page_init(dpage);
++#endif
+         dpage->zone_device_data = gpu_chunk;
+         atomic64_inc(&va_block->hmm.va_space->hmm.allocated_page_count);
+     }
+diff --git a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
+index 97ff13dcdd04..98423002776b 100644
+--- a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
++++ b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
+@@ -177,6 +177,8 @@
+ #include "uvm_test.h"
+ #include "uvm_linux.h"
+ 
++#include <linux/version.h>
++
+ #if defined(CONFIG_PCI_P2PDMA) && defined(NV_STRUCT_PAGE_HAS_ZONE_DEVICE_DATA)
+ #include <linux/pci-p2pdma.h>
+ #endif
+@@ -2999,8 +3001,14 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
+     return ret;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void devmem_folio_free(struct folio *folio)
++{
++    struct page *page = &folio->page;
++#else
+ static void devmem_page_free(struct page *page)
+ {
++#endif
+     uvm_gpu_chunk_t *chunk = uvm_pmm_devmem_page_to_chunk(page);
+     uvm_gpu_t *gpu = uvm_gpu_chunk_get_gpu(chunk);
+ 
+@@ -3060,7 +3068,11 @@ static vm_fault_t devmem_fault_entry(struct vm_fault *vmf)
+ 
+ static const struct dev_pagemap_ops uvm_pmm_devmem_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = devmem_folio_free,
++#else
+     .page_free = devmem_page_free,
++#endif
+     .migrate_to_ram = devmem_fault_entry,
+ };
+ 
+@@ -3148,8 +3160,14 @@ static void device_p2p_page_free_wake(struct nv_kref *ref)
+     wake_up(&p2p_mem->waitq);
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void device_p2p_folio_free(struct folio *folio)
++{
++    struct page *page = &folio->page;
++#else
+ static void device_p2p_page_free(struct page *page)
+ {
++#endif
+     uvm_device_p2p_mem_t *p2p_mem = page->zone_device_data;
+ 
+     page->zone_device_data = NULL;
+@@ -3158,14 +3176,26 @@ static void device_p2p_page_free(struct page *page)
+ #endif
+ 
+ #if UVM_CDMM_PAGES_SUPPORTED()
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void device_coherent_folio_free(struct folio *folio)
++{
++    device_p2p_folio_free(folio);
++}
++#else
+ static void device_coherent_page_free(struct page *page)
+ {
+     device_p2p_page_free(page);
+ }
++#endif
+ 
+ static const struct dev_pagemap_ops uvm_device_coherent_pgmap_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = device_coherent_folio_free,
++#else
+     .page_free = device_coherent_page_free,
++#endif
+ };
+ 
+ static NV_STATUS uvm_pmm_cdmm_init(uvm_parent_gpu_t *parent_gpu)
+@@ -3302,7 +3332,11 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
+ 
+ static const struct dev_pagemap_ops uvm_device_p2p_pgmap_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = device_p2p_folio_free,
++#else
+     .page_free = device_p2p_page_free,
++#endif
+ };
+ 
+ void uvm_pmm_gpu_device_p2p_init(uvm_parent_gpu_t *parent_gpu)
+-- 
+2.52.0
+

--- a/anda/system/nvidia/dkms-nvidia/dkms-nvidia.spec
+++ b/anda/system/nvidia/dkms-nvidia/dkms-nvidia.spec
@@ -12,6 +12,8 @@ License:        NVIDIA License
 URL:            https://www.nvidia.com/object/unix.html
 Source0:        https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{version}/open-gpu-kernel-modules-%{version}.tar.gz
 Source1:        %{name}.conf
+Patch0:         0001-Enable-atomic-kernel-modesetting-by-default.patch
+Patch1:         6.19-590.patch
 BuildRequires:  sed
 Provides:       %{modulename}-kmod = %{?epoch:%{epoch}:}%{version}
 Requires:       %{modulename}-kmod-common = %{?epoch:%{epoch}:}%{version}

--- a/anda/system/nvidia/dkms-nvidia/dkms-nvidia.spec
+++ b/anda/system/nvidia/dkms-nvidia/dkms-nvidia.spec
@@ -5,7 +5,7 @@
 
 Name:           dkms-%{modulename}
 Version:        590.48.01
-Release:        2%?dist
+Release:        3%?dist
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License

--- a/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
+++ b/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
@@ -6,7 +6,7 @@
 
 Name:           nvidia-kmod-common
 Version:        590.48.01
-Release:        1%?dist
+Release:        2%{?dist}
 Summary:        Common file for NVIDIA's proprietary driver kernel modules
 Epoch:          3
 License:        NVIDIA License
@@ -29,6 +29,7 @@ Requires:       nvidia-modprobe
 Requires:       nvidia-driver = %{?epoch:%{epoch}:}%{version}
 Requires:       nvidia-driver-libs = %{?epoch:%{epoch}:}%{version}
 Requires:       nvidia-kmod = %{?epoch:%{epoch}:}%{version}
+Requires:       gcc-c++
 Provides:       nvidia-kmod-common = %{?epoch:%{epoch}:}%{version}
 Obsoletes:      nvidia-open-kmod-common < %{?epoch:%{epoch}:}%{version}
 Obsoletes:      cuda-nvidia-kmod-common < %{?epoch:%{epoch}:}%{version}

--- a/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
+++ b/anda/system/nvidia/nvidia-kmod-common/nvidia-kmod-common.spec
@@ -6,7 +6,7 @@
 
 Name:           nvidia-kmod-common
 Version:        590.48.01
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Common file for NVIDIA's proprietary driver kernel modules
 Epoch:          3
 License:        NVIDIA License

--- a/anda/system/nvidia/nvidia-kmod/0001-Enable-atomic-kernel-modesetting-by-default.patch
+++ b/anda/system/nvidia/nvidia-kmod/0001-Enable-atomic-kernel-modesetting-by-default.patch
@@ -1,0 +1,44 @@
+From 60d1ddc17835226ec67ed1bc1c28524e3bb6e151 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Sun, 20 Apr 2025 18:13:22 +0200
+Subject: [PATCH 1/8] Enable atomic kernel modesetting by default
+
+This is required for proper functionality under Wayland. fbdev has been default enabled since 570 so that
+hunk can be removed from this patch.
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ kernel-open/nvidia-drm/nvidia-drm-linux.c        | 2 +-
+ kernel-open/nvidia-drm/nvidia-drm-os-interface.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git an/kernel-open/nvidia-drm/nvidia-drm-linux.c b/kernel-open/nvidia-drm/nvidia-drm-linux.c
+index 3cb1815d..209cb469 100644
+--- a/kernel-open/nvidia-drm/nvidia-drm-linux.c
++++ b/kernel-open/nvidia-drm/nvidia-drm-linux.c
+@@ -31,7 +31,7 @@
+ 
+ MODULE_PARM_DESC(
+     modeset,
+-    "Enable atomic kernel modesetting (1 = enable, 0 = disable (default))");
++    "Enable atomic kernel modesetting (1 = enable (default), 0 = disable)");
+ module_param_named(modeset, nv_drm_modeset_module_param, bool, 0400);
+ 
+ #if defined(NV_DRM_FBDEV_AVAILABLE)
+diff --git a/kernel-open/nvidia-drm/nvidia-drm-os-interface.c b/kernel-open/nvidia-drm/nvidia-drm-os-interface.c
+index 7617476d..f22afd77 100644
+--- a/kernel-open/nvidia-drm/nvidia-drm-os-interface.c
++++ b/kernel-open/nvidia-drm/nvidia-drm-os-interface.c
+@@ -41,7 +41,7 @@
+ #include <drm/drmP.h>
+ #endif
+ 
+-bool nv_drm_modeset_module_param = false;
++bool nv_drm_modeset_module_param = true;
+ bool nv_drm_fbdev_module_param = true;
+ 
+ void *nv_drm_calloc(size_t nmemb, size_t size)
+-- 
+2.49.0.391.g4bbb303af6
+
+

--- a/anda/system/nvidia/nvidia-kmod/6.19-590.patch
+++ b/anda/system/nvidia/nvidia-kmod/6.19-590.patch
@@ -1,0 +1,130 @@
+From c9457ce40a6af2ce74c520564e2d8775f49e3d27 Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@cachyos.org>
+Date: Thu, 18 Dec 2025 12:36:06 +0800
+Subject: [PATCH 3/3] Fix compile for 6.19
+
+Contains:
+- Rename page_free callback -> folio_free callback for 6.19+
+- Adjust zone_device_page_init() call for 6.19; it has one extra argument now
+- 6.19-rc8 introduced yet another argument for zone_device_page_init()
+
+Link: https://github.com/torvalds/linux/commit/12b2285bf3d14372238d36215b73af02ac3bdfc1
+Signed-off-by: Eric Naim <dnaim@cachyos.org>
+---
+ kernel-open/nvidia-uvm/uvm_hmm.c     |  4 ++++
+ kernel-open/nvidia-uvm/uvm_pmm_gpu.c | 34 ++++++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+)
+
+diff --git a/kernel-open/nvidia-uvm/uvm_hmm.c b/kernel-open/nvidia-uvm/uvm_hmm.c
+index 9b676f971385..22db001384a4 100644
+--- a/kernel-open/nvidia-uvm/uvm_hmm.c
++++ b/kernel-open/nvidia-uvm/uvm_hmm.c
+@@ -2140,7 +2140,11 @@ static void fill_dst_pfn(uvm_va_block_t *va_block,
+ 
+         UVM_ASSERT(!page_count(dpage));
+         UVM_ASSERT(!dpage->zone_device_data);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++        zone_device_page_init(dpage, page_pgmap(dpage), 0);
++#else
+         zone_device_page_init(dpage);
++#endif
+         dpage->zone_device_data = gpu_chunk;
+         atomic64_inc(&va_block->hmm.va_space->hmm.allocated_page_count);
+     }
+diff --git a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
+index 97ff13dcdd04..98423002776b 100644
+--- a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
++++ b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
+@@ -177,6 +177,8 @@
+ #include "uvm_test.h"
+ #include "uvm_linux.h"
+ 
++#include <linux/version.h>
++
+ #if defined(CONFIG_PCI_P2PDMA) && defined(NV_STRUCT_PAGE_HAS_ZONE_DEVICE_DATA)
+ #include <linux/pci-p2pdma.h>
+ #endif
+@@ -2999,8 +3001,14 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
+     return ret;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void devmem_folio_free(struct folio *folio)
++{
++    struct page *page = &folio->page;
++#else
+ static void devmem_page_free(struct page *page)
+ {
++#endif
+     uvm_gpu_chunk_t *chunk = uvm_pmm_devmem_page_to_chunk(page);
+     uvm_gpu_t *gpu = uvm_gpu_chunk_get_gpu(chunk);
+ 
+@@ -3060,7 +3068,11 @@ static vm_fault_t devmem_fault_entry(struct vm_fault *vmf)
+ 
+ static const struct dev_pagemap_ops uvm_pmm_devmem_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = devmem_folio_free,
++#else
+     .page_free = devmem_page_free,
++#endif
+     .migrate_to_ram = devmem_fault_entry,
+ };
+ 
+@@ -3148,8 +3160,14 @@ static void device_p2p_page_free_wake(struct nv_kref *ref)
+     wake_up(&p2p_mem->waitq);
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void device_p2p_folio_free(struct folio *folio)
++{
++    struct page *page = &folio->page;
++#else
+ static void device_p2p_page_free(struct page *page)
+ {
++#endif
+     uvm_device_p2p_mem_t *p2p_mem = page->zone_device_data;
+ 
+     page->zone_device_data = NULL;
+@@ -3158,14 +3176,26 @@ static void device_p2p_page_free(struct page *page)
+ #endif
+ 
+ #if UVM_CDMM_PAGES_SUPPORTED()
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void device_coherent_folio_free(struct folio *folio)
++{
++    device_p2p_folio_free(folio);
++}
++#else
+ static void device_coherent_page_free(struct page *page)
+ {
+     device_p2p_page_free(page);
+ }
++#endif
+ 
+ static const struct dev_pagemap_ops uvm_device_coherent_pgmap_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = device_coherent_folio_free,
++#else
+     .page_free = device_coherent_page_free,
++#endif
+ };
+ 
+ static NV_STATUS uvm_pmm_cdmm_init(uvm_parent_gpu_t *parent_gpu)
+@@ -3302,7 +3332,11 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
+ 
+ static const struct dev_pagemap_ops uvm_device_p2p_pgmap_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = device_p2p_folio_free,
++#else
+     .page_free = device_p2p_page_free,
++#endif
+ };
+ 
+ void uvm_pmm_gpu_device_p2p_init(uvm_parent_gpu_t *parent_gpu)
+-- 
+2.52.0
+

--- a/anda/system/nvidia/nvidia-kmod/nvidia-kmod.spec
+++ b/anda/system/nvidia/nvidia-kmod/nvidia-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           nvidia-kmod
 Version:        590.48.01
-Release:        4%?dist
+Release:        5%{?dist}
 Summary:        NVIDIA display driver kernel module
 Epoch:          3
 License:        NVIDIA License
@@ -16,9 +16,10 @@ URL:            http://www.nvidia.com/object/unix.html
 ExclusiveArch:  x86_64 aarch64
 
 Source0:        https://github.com/NVIDIA/open-gpu-kernel-modules/archive/%{version}/open-gpu-kernel-modules-%{version}.tar.gz
+Patch0:         0001-Enable-atomic-kernel-modesetting-by-default.patch
+Patch1:         6.19-590.patch
 Requires:       nvidia-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       akmods
-Requires:       gcc-c++
 Provides:       akmod-nvidia-open = %{?epoch:%{epoch}:}%{version}
 Obsoletes:      akmod-nvidia-open < %{?epoch:%{epoch}:}%{version}
 
@@ -38,7 +39,11 @@ The NVidia %{version} display driver kernel module for kernel %{kversion}.
 # Print kmodtool output for debugging purposes:
 kmodtool  --target %{_target_cpu}  --repo terra.fyralabs.com --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
 
-%autosetup -p1 -c
+%setup -c
+
+pushd open-gpu-kernel-modules-%{version}
+%autopatch -p1
+popd
 
 rm -f open-gpu-kernel-modules-%{version}/dkms.conf
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(nvidia): Patches and changes for kernel 6.19 (#10516)](https://github.com/terrapkg/packages/pull/10516)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)