### PR TITLE
[f42] backport: fix (opentrack): ver (#10663) (#10664)

### DIFF
--- a/anda/apps/opentrack/opentrack.spec
+++ b/anda/apps/opentrack/opentrack.spec
@@ -1,9 +1,11 @@
 %global debug_package %{nil}
 %global openvr_ver 2.12.14
 %global appid com.github.opentrack
+%global ver opentrack-2026.1.0
+%global sanitized_ver %(echo %{ver} | sed 's/opentrack\-//')
 
 Name:           opentrack
-Version:        2026.1.0
+Version:        %{sanitized_ver}
 Release:        1%{?dist}
 Summary:        Head tracking software for MS Windows, Linux, and Apple OSX
 

--- a/anda/apps/opentrack/opentrack.spec
+++ b/anda/apps/opentrack/opentrack.spec
@@ -6,7 +6,7 @@
 
 Name:           opentrack
 Version:        %{sanitized_ver}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Head tracking software for MS Windows, Linux, and Apple OSX
 
 License:        ISC AND BSD-3-Clause AND BSD-2-Clause AND LGPL-2.1-only AND GPL-3.0-only AND LGPL-2.1-or-later AND MIT AND LGPL-3.0-or-later

--- a/anda/apps/opentrack/update.rhai
+++ b/anda/apps/opentrack/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("opentrack/opentrack"));
+rpm.global("ver", gh("opentrack/opentrack"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `f42`:
 - [backport: fix (opentrack): ver (#10663) (#10664)](https://github.com/terrapkg/packages/pull/10664)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)