### PR TITLE
[f43] backport: chore (mock-configs): add riscv64 configs (#10378) (#10666)

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -34,9 +34,13 @@ install -Dpm644 *.cfg -t %{buildroot}%{_sysconfdir}/mock/
 %config %{_sysconfdir}/mock/templates/terra-rawhide.tpl
 %config %{_sysconfdir}/mock/terra-*-x86_64.cfg
 %config %{_sysconfdir}/mock/terra-*-aarch64.cfg
+%config %{_sysconfdir}/mock/terra-*-riscv64.cfg
 %config %{_sysconfdir}/mock/terra-*-i386.cfg
 
 %changelog
+* Sat Mar 07 2026 Owen Zimmerman <owen@fyralabs.com> - 2.2.5-1
+- Add riscv64 configs
+
 * Fri Jul 26 2024 madonuko <mado@fyralabs.com> - 1:1.1.0-1
 - Include mock files for Terra 41
 

--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,6 +1,6 @@
 Name:           terra-mock-configs
 Version:        2.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Epoch:          1
 Summary:        Mock configs for Terra repos
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `f43`:
 - [backport: chore (mock-configs): add riscv64 configs (#10378) (#10666)](https://github.com/terrapkg/packages/pull/10666)

<!--- Backport version: 10.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)