### PR TITLE
[f42] feat: Update terra-gamescope to the latest OGC release (#10711)

### DIFF
--- a/anda/games/terra-gamescope/anda.hcl
+++ b/anda/games/terra-gamescope/anda.hcl
@@ -5,6 +5,7 @@ project pkg {
 	}
 	labels {
 		mock = 1
+        nightly = 1
 		subrepo = "extras"
 	}
 }

--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -2,7 +2,7 @@
 
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
-%global gamescope_commit b6a368af614ee93bf7b1d05a8d203f0c84a87c74
+%global gamescope_commit 402bfb81bc25943cac9061eb022fe229c5414f5e
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           terra-gamescope

--- a/anda/games/terra-gamescope/update.rhai
+++ b/anda/games/terra-gamescope/update.rhai
@@ -1,0 +1,6 @@
+if rpm.changed() {
+    rpm.release();
+    let v = gh_commit("OpenGamingCollective/gamescope"));
+    v.crop(1);
+    rpm.global("gamescope_commit", v);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat: Update terra-gamescope to the latest OGC release (#10711)](https://github.com/terrapkg/packages/pull/10711)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)