### PR TITLE
[f43] feat: Add new steamos-manager-powerstation package (#10703)

### DIFF
--- a/anda/games/steamos-manager-powerstation/anda.hcl
+++ b/anda/games/steamos-manager-powerstation/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "steamos-manager-powerstation.spec"
+    }
+}

--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,0 +1,96 @@
+%global commit 81e1d500211483e01edde6c2b985c45499aec500
+%global shortcommit %{sub %{commit} 0 7}
+%global commitdate 20260312
+
+Name:           steamos-manager-powerstation
+Version:        0~%{commitdate}.git%{shortcommit}
+Release:        1%{?dist}
+Summary:        SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
+License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND )Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
+URL:            https://github.com/honjow/steamos-manager
+Source0:        %{url}/archive/%{commit}.tar.gz
+BuildRequires:  anda-srpm-macros
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  clang-devel
+BuildRequires:  rust
+BuildRequires:  mold
+BuildRequires:  glib2-devel
+BuildRequires:  speech-dispatcher-devel
+BuildRequires:  pkgconfig(libudev)
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+Provides:       steamos-manager
+Conflicts:      steamos-manager
+Requires:       powerstation
+
+%description
+SteamOS Manager is a system daemon that aims to abstract Steam's interactions
+with the operating system. The goal is to have a standardized interface so that
+SteamOS specific features in the Steam client, e.g. TDP management, can be
+exposed in any Linux distro that provides an implementation of this DBus API.
+This version has been patched with additional compatibility with powerstation.
+
+%package gamescope-session-plus
+Summary:        Compatibility symlink service for starting steamos-manager on gamescope-session-plus
+Requires:       %{name} = %{evr}
+
+%description gamescope-session-plus
+%summary.
+
+%prep
+%autosetup -n steamos-manager-%{commit}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+%{cargo_license_online -a} > LICENSE.dependencies
+%make_install
+rm %{buildroot}%{_unitdir}/sddm.service.d/reset-oneshot-boot.conf # steamOS specific
+rm %{buildroot}%{_userunitdir}/orca.service # not used by anyone apparently, steamOS specific(?)
+install -d %{buildroot}%{_userunitdir}/gamescope-session-plus.service.wants/steamos-manager.service
+ln -s %{_userunitdir}/steamos-manager.service %{buildroot}%{_userunitdir}/gamescope-session-plus.service.wants/steamos-manager.service
+
+%post
+%systemd_post steamos-manager.service
+%systemd_user_post steamos-manager.service
+%systemd_user_post steamos-manager-configure-cecd.service
+%systemd_user_post steamos-manager-session-cleanup.service
+
+%preun
+%systemd_preun steamos-manager.service
+%systemd_user_preun steamos-manager.service
+%systemd_user_preun steamos-manager-configure-cecd.service
+%systemd_user_preun steamos-manager-session-cleanup.service
+
+%postun
+%systemd_postun_with_restart steamos-manager.service
+%systemd_user_postun steamos-manager.service
+%systemd_user_postun steamos-manager-configure-cecd.service
+%systemd_user_postun steamos-manager-session-cleanup.service
+
+%files
+%license %{_datadir}/licenses/steamos-manager/LICENSE
+%license LICENSE.dependencies
+%doc README.md
+%{_bindir}/steamosctl
+#{_datadir}/dbus-1/interfaces/com.steampowered.SteamOSManager1.Manager.xml
+%{_datadir}/dbus-1/interfaces/com.steampowered.SteamOSManager1.xml
+%{_datadir}/dbus-1/services/com.steampowered.SteamOSManager1.service
+%{_datadir}/dbus-1/system.d/com.steampowered.SteamOSManager1.conf
+%{_datadir}/dbus-1/system-services/com.steampowered.SteamOSManager1.service
+%{_datadir}/steamos-manager/devices/*.toml
+%{_datadir}/steamos-manager/platform.toml
+%{_prefix}/lib/steamos-manager
+%{_unitdir}/steamos-manager.service
+%{_userunitdir}/steamos-manager.service
+%{_userunitdir}/steamos-manager-configure-cecd.service
+%{_userunitdir}/steamos-manager-session-cleanup.service
+
+%files gamescope-session-plus
+%{_userunitdir}/gamescope-session-plus.service.wants/steamos-manager.service
+
+%changelog
+* Wed Mar 18 2026 Kyle Gospodnetich <me@kylegospodneti.ch> - 26.0.1-1
+- Intial Commit

--- a/anda/games/steamos-manager-powerstation/update.rhai
+++ b/anda/games/steamos-manager-powerstation/update.rhai
@@ -1,0 +1,6 @@
+rpm.global("commit", get("https://api.github.com/repos/honjow/steamos-manager/commits/dev").json().sha);
+if rpm.changed() {
+        rpm.global("ver", gh("honjow/steamos-manager"));
+        rpm.global("commit_date", date());
+        rpm.release();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Add new steamos-manager-powerstation package (#10703)](https://github.com/terrapkg/packages/pull/10703)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)