### PR TITLE
[el10] add: pion (#10689)

### DIFF
--- a/anda/system/pion/anda.hcl
+++ b/anda/system/pion/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "pion.spec"
+  }
+}

--- a/anda/system/pion/pion.spec
+++ b/anda/system/pion/pion.spec
@@ -1,0 +1,47 @@
+Name:           pion
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        Binder IPC Linux userspace root service
+License:        MIT AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (Unlicense OR MIT)
+URL:            https://github.com/technobaboo/pion
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  systemd-rpm-macros
+
+%description
+Binder IPC Linux userspace root service... Binder objects bound to files (like UNIX domain sockets!).
+
+%prep
+%autosetup
+%cargo_prep_online
+
+%build
+%cargo_build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+install -Dm755 target/rpm/pion-binder   %{buildroot}%{_bindir}/pion-binder
+install -Dm644 dist/pion-binder.service %{buildroot}%{_unitdir}/pion-binder.service
+install -Dm644 dist/dev-binderfs.mount  %{buildroot}%{_unitdir}/dev-binderfs.mount
+
+%post
+%systemd_post pion-binder.service
+
+%preun
+%systemd_preun pion-binder.service
+
+%postun
+%systemd_postun_with_restart pion-binder.service
+
+%files
+%doc README.md
+%license LICENSE LICENSE.dependencies
+%{_bindir}/pion-binder
+%{_unitdir}/pion-binder.service
+%{_unitdir}/dev-binderfs.mount
+
+%changelog
+* Tue Mar 17 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/system/pion/update.rhai
+++ b/anda/system/pion/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("technobaboo/pion"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: pion (#10689)](https://github.com/terrapkg/packages/pull/10689)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)