### PR TITLE
[f43] add: driftwm (#10695)

### DIFF
--- a/anda/desktops/driftwm/anda.hcl
+++ b/anda/desktops/driftwm/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "driftwm.spec"
+	}
+}

--- a/anda/desktops/driftwm/driftwm.spec
+++ b/anda/desktops/driftwm/driftwm.spec
@@ -1,0 +1,46 @@
+Name:           driftwm
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        A trackpad-first infinite canvas Wayland compositor
+License:        GPL-3.0-or-later
+URL:            https://github.com/malbiruk/driftwm
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  pkgconfig(libudev)
+BuildRequires:  pkgconfig(libseat)
+BuildRequires:  pkgconfig(libdisplay-info)
+BuildRequires:  libinput-devel
+BuildRequires:  libxkbcommon-devel
+BuildRequires:  mesa-libgbm-devel
+
+%description
+%{summary}.
+
+%prep
+%autosetup
+%cargo_prep_online
+
+%build
+%cargo_build
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+export PREFIX=/usr
+%make_install
+
+%files
+%doc README.md
+%license LICENSE LICENSE.dependencies
+%{_bindir}/driftwm
+%{_bindir}/driftwm-session
+%{_datadir}/wayland-sessions/driftwm.desktop
+%{_datadir}/xdg-desktop-portal/driftwm-portals.conf
+%{_sysconfdir}/driftwm/config.toml
+%{_datadir}/driftwm/wallpapers/*.glsl
+
+%changelog
+* Tue Mar 17 2026 Owen Zimmerman <owen@fyralabs.com> - 0.1.0-1
+- Initial commit

--- a/anda/desktops/driftwm/update.rhai
+++ b/anda/desktops/driftwm/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("malbiruk/driftwm"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: driftwm (#10695)](https://github.com/terrapkg/packages/pull/10695)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)