### PR TITLE
[f42] chore: Bump some releases (#10735)

### DIFF
--- a/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
+++ b/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
@@ -6,7 +6,7 @@
 
 Name:           gamescope-session-ogui-steam
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        gamescope-session-steam
 License:        GPL-3.0-only
 URL:            https://github.com/OpenGamingCollective/gamescope-session-ogui-steam


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: Bump some releases (#10735)](https://github.com/terrapkg/packages/pull/10735)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)