### PR TITLE
[el10] Fix hollywood to only build on x86 (#10764)

### DIFF
--- a/anda/misc/hollywood/anda.hcl
+++ b/anda/misc/hollywood/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+    arches = ["x86_64"]
   rpm {
     spec = "hollywood.spec"
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Fix hollywood to only build on x86 (#10764)](https://github.com/terrapkg/packages/pull/10764)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)