### PR TITLE
[el10] fix(kde-material-you-colors): Drop patch (#10781)

### DIFF
--- a/anda/themes/kde-material-you-colors/kde-material-you-colors.spec
+++ b/anda/themes/kde-material-you-colors/kde-material-you-colors.spec
@@ -52,7 +52,7 @@ BuildArch:      noarch
 Python files for KDE Material You Colors.
 
 %prep
-%autosetup -p1 -n %{name}-%{version}
+%autosetup -n %{name}-%{version}
 sed -iE 's:\"python-magic.*\":\"file-magic\":' pyproject.toml
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(kde-material-you-colors): Drop patch (#10781)](https://github.com/terrapkg/packages/pull/10781)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)