### PR TITLE
[el10] security: Add dependabot config for github action updating (#10792)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Maintain GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [security: Add dependabot config for github action updating (#10792)](https://github.com/terrapkg/packages/pull/10792)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)