### PR TITLE
[f44] Update gamescope-session-ogui-steam to the latest version (#10808)

### DIFF
--- a/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
+++ b/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
@@ -1,12 +1,12 @@
 %define debug_package %nil
 
-%global commit 6835776876a2b9e5fc819bd8d98f06ae51fa6394
+%global commit 26796534321ab87e6aad7cf52442297089f0d59d
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20231030
+%global commit_date 20260324
 
 Name:           gamescope-session-ogui-steam
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        1%?dist
 Summary:        gamescope-session-steam
 License:        GPL-3.0-only
 URL:            https://github.com/OpenGamingCollective/gamescope-session-ogui-steam
@@ -26,6 +26,7 @@ Gamescope Session for OpenGamepadUI in overlay mode with Steam
 
 %install
 install -Dpm0755 -t "%buildroot%_datadir/gamescope-session-plus/sessions.d/" ".%_datadir/gamescope-session-plus/sessions.d/steam-plus"
+install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session-ogui-steam.desktop"
 install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session-steam-plus.desktop"
 install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamepadui-with-qam-session.desktop"
 
@@ -33,6 +34,7 @@ install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-
 %doc README.md
 %license LICENSE
 %{_datadir}/gamescope-session-plus/sessions.d/steam-plus
+%{_datadir}/wayland-sessions/gamescope-session-ogui-steam.desktop
 %{_datadir}/wayland-sessions/gamescope-session-steam-plus.desktop
 %{_datadir}/wayland-sessions/gamepadui-with-qam-session.desktop
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [Update gamescope-session-ogui-steam to the latest version (#10808)](https://github.com/terrapkg/packages/pull/10808)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)