### PR TITLE
[f42] backport: fix (proton-vpn): .desktop file (#10836)

### DIFF
--- a/anda/apps/proton-vpn/proton-vpn.spec
+++ b/anda/apps/proton-vpn/proton-vpn.spec
@@ -1,11 +1,14 @@
+%global metainfo_commit eddfed5f7e2cd6f097cd11ad1bc8773c22a418a1
+
 Name:			proton-vpn-gtk-app
-Version:		4.15.0
-Release:		1%{?dist}
+Version:		4.15.1
+Release:		3%{?dist}
 Summary:		Official ProtonVPN Linux app
 License:		GPL-3.0-only
 URL:			https://protonvpn.com/download-linux
 Source0:		https://github.com/ProtonVPN/proton-vpn-gtk-app/archive/refs/tags/v%version.tar.gz
-Source1:        https://github.com/flathub/com.protonvpn.www/blob/master/com.protonvpn.www.metainfo.xml
+# So cursed but makes our lives easier
+Source1:        https://github.com/flathub/com.protonvpn.www/archive/%{metainfo_commit}/com.protonvpn.www-%{metainfo_commit}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
@@ -42,6 +45,7 @@ with the user signup process handled on the website.
 
 %prep
 %autosetup -n %{name}-%{version}
+tar -xvf %{SOURCE1}
 
 %build
 %pyproject_wheel
@@ -50,18 +54,25 @@ with the user signup process handled on the website.
 %pyproject_install
 %pyproject_save_files proton
 install -Dm644 rpmbuild/SOURCES/proton-vpn-logo.svg %{buildroot}%{_scalableiconsdir}/proton-vpn-logo.svg
-install -Dm644 %{SOURCE1} %{buildroot}%{_metainfodir}/com.protonvpn.www.metainfo.xml
-# Match metainfo
-install -Dm644 rpmbuild/SOURCES/proton.vpn.app.gtk.desktop %{buildroot}%{_appsdir}/com.protonvpn.www.desktop
+install -Dm644 com.protonvpn.www-%{metainfo_commit}/com.protonvpn.www.metainfo.xml %{buildroot}%{_metainfodir}/com.protonvpn.www.metainfo.xml
+install -Dm644 rpmbuild/SOURCES/proton.vpn.app.gtk.desktop %{buildroot}%{_appsdir}/proton.vpn.app.gtk.desktop
+
+# We pull in a metainfo file that often changes upstream, that calls the .desktop file what we are symlinking it to.
+# If we install the .desktop file with the new name, the icon does not show properly on KDE Plasma.
+%{__ln_s} -f %{_appsdir}/proton.vpn.app.gtk.desktop %{buildroot}%{_appsdir}/com.protonvpn.www.desktop
 
 %files -f %{pyproject_files}
 %doc README.md CONTRIBUTING.md CODEOWNERS
 %license LICENSE COPYING.md
 %{_bindir}/protonvpn-app
+%{_appsdir}/proton.vpn.app.gtk.desktop
 %{_appsdir}/com.protonvpn.www.desktop
 %{_scalableiconsdir}/proton-vpn-logo.svg
 %{_metainfodir}/com.protonvpn.www.metainfo.xml
 
 %changelog
+* Wed Mar 25 2026 Owen Zimmerman <owen@fyralabs.com>
+- Fix metainfo and .desktop file
+
 * Sat Jan 17 2026 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit

--- a/anda/apps/proton-vpn/update.rhai
+++ b/anda/apps/proton-vpn/update.rhai
@@ -1,1 +1,3 @@
 rpm.version(gh_tag("ProtonVPN/proton-vpn-gtk-app"));
+
+rpm.global("metainfo_commit", gh_commit("flathub/com.protonvpn.www"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `f42`:
 - [backport: fix (proton-vpn): .desktop file (#10836)](https://github.com/terrapkg/packages/pull/10836)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)