### PR TITLE
[el10] sync(steamos-manager-powerstation): frawhide -> f44 (#10846)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,13 +1,13 @@
-%global commit 81e1d500211483e01edde6c2b985c45499aec500
+%global commit 7b4d0f49351a60d1f93d48f081b4c0e35e10fa6d
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260312
+%global commitdate 20260325
 
 Name:           steamos-manager-powerstation
 Version:        0~%{commitdate}.git%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND )Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
-URL:            https://github.com/honjow/steamos-manager
+URL:            https://github.com/OpenGamingCollective/steamos-manager
 Source0:        %{url}/archive/%{commit}.tar.gz
 BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros
@@ -22,13 +22,15 @@ Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
 Provides:       steamos-manager
 Conflicts:      steamos-manager
 Requires:       powerstation
+Requires:       gamescope-session-ogui-steam
 
 %description
 SteamOS Manager is a system daemon that aims to abstract Steam's interactions
 with the operating system. The goal is to have a standardized interface so that
 SteamOS specific features in the Steam client, e.g. TDP management, can be
 exposed in any Linux distro that provides an implementation of this DBus API.
-This version has been patched with additional compatibility with powerstation.
+This version has been patched with additional compatibility with powerstation
+and OGC gamescope-sessions.
 
 %package gamescope-session-plus
 Summary:        Compatibility symlink service for starting steamos-manager on gamescope-session-plus

--- a/anda/games/steamos-manager-powerstation/update.rhai
+++ b/anda/games/steamos-manager-powerstation/update.rhai
@@ -1,6 +1,6 @@
-rpm.global("commit", get("https://api.github.com/repos/honjow/steamos-manager/commits/dev").json().sha);
+rpm.global("commit", get("https://api.github.com/repos/OpenGamingCollective/steamos-manager/commits/dev").json().sha);
 if rpm.changed() {
-        rpm.global("ver", gh("honjow/steamos-manager"));
+        rpm.global("ver", gh("OpenGamingCollective/steamos-manager"));
         rpm.global("commit_date", date());
         rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `el10`:
 - [sync(steamos-manager-powerstation): frawhide -> f44 (#10846)](https://github.com/terrapkg/packages/pull/10846)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)