### PR TITLE
[f42] Update to the latest gamescope-session-ogui-steam (#10840)

### DIFF
--- a/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
+++ b/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
@@ -1,8 +1,8 @@
 %define debug_package %nil
 
-%global commit 26796534321ab87e6aad7cf52442297089f0d59d
+%global commit fbdc7682f39088b4fe480a9285808ca81b3f9d03
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260324
+%global commit_date 20260325
 
 Name:           gamescope-session-ogui-steam
 Version:        0~%{commit_date}git.%{shortcommit}
@@ -25,7 +25,7 @@ Gamescope Session for OpenGamepadUI in overlay mode with Steam
 %build
 
 %install
-install -Dpm0755 -t "%buildroot%_datadir/gamescope-session-plus/sessions.d/" ".%_datadir/gamescope-session-plus/sessions.d/steam-plus"
+install -Dpm0755 -t "%buildroot%_datadir/gamescope-session-plus/sessions.d/" ".%_datadir/gamescope-session-plus/sessions.d/ogui-steam"
 install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session-ogui-steam.desktop"
 install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session-steam-plus.desktop"
 install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamepadui-with-qam-session.desktop"
@@ -33,7 +33,7 @@ install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-
 %files
 %doc README.md
 %license LICENSE
-%{_datadir}/gamescope-session-plus/sessions.d/steam-plus
+%{_datadir}/gamescope-session-plus/sessions.d/ogui-steam
 %{_datadir}/wayland-sessions/gamescope-session-ogui-steam.desktop
 %{_datadir}/wayland-sessions/gamescope-session-steam-plus.desktop
 %{_datadir}/wayland-sessions/gamepadui-with-qam-session.desktop

--- a/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
+++ b/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
@@ -6,7 +6,7 @@
 
 Name:           gamescope-session-ogui-steam
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        gamescope-session-steam
 License:        GPL-3.0-only
 URL:            https://github.com/OpenGamingCollective/gamescope-session-ogui-steam


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Update to the latest gamescope-session-ogui-steam (#10840)](https://github.com/terrapkg/packages/pull/10840)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)