### PR TITLE
[f44] fix: Add SELinux rules for steamos-manager-powerstation (#10862)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -2,27 +2,34 @@
 %global shortcommit %{sub %{commit} 0 7}
 %global commitdate 20260325
 
-Name:           steamos-manager-powerstation
-Version:        0~%{commitdate}.git%{shortcommit}
-Release:        2%{?dist}
-Summary:        SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
-License:        MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND )Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
-URL:            https://github.com/OpenGamingCollective/steamos-manager
-Source0:        %{url}/archive/%{commit}.tar.gz
-BuildRequires:  anda-srpm-macros
-BuildRequires:  cargo-rpm-macros
-BuildRequires:  clang-devel
-BuildRequires:  rust
-BuildRequires:  mold
-BuildRequires:  glib2-devel
-BuildRequires:  speech-dispatcher-devel
-BuildRequires:  pkgconfig(libudev)
-Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+Name:             steamos-manager-powerstation
+Version:          0~%{commitdate}.git%{shortcommit}
+Release:          3%{?dist}
+Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
+License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
+URL:              https://github.com/OpenGamingCollective/steamos-manager
+Source0:          %{url}/archive/%{commit}.tar.gz
+Source1:          steamos_manager.te
+Source2:          steamos_manager.if
+Source3:          steamos_manager.fc
+BuildRequires:    anda-srpm-macros
+BuildRequires:    cargo-rpm-macros
+BuildRequires:    clang-devel
+BuildRequires:    rust
+BuildRequires:    mold
+BuildRequires:    glib2-devel
+BuildRequires:    speech-dispatcher-devel
+BuildRequires:    pkgconfig(libudev)
+BuildRequires:    selinux-policy-devel
+Packager:         Kyle Gospodnetich <me@kylegospodneti.ch>
 
-Provides:       steamos-manager
-Conflicts:      steamos-manager
-Requires:       powerstation
-Requires:       gamescope-session-ogui-steam
+Provides:         steamos-manager
+Conflicts:        steamos-manager
+Requires:         powerstation
+Requires:         gamescope-session-ogui-steam
+Requires:         selinux-policy
+Requires(post):   policycoreutils
+Requires(postun): policycoreutils
 
 %description
 SteamOS Manager is a system daemon that aims to abstract Steam's interactions
@@ -41,16 +48,19 @@ Requires:       %{name} = %{evr}
 
 %prep
 %autosetup -n steamos-manager-%{commit}
+install -Dp -m644 -t data/selinux %{SOURCE1} %{SOURCE2} %{SOURCE3}
 %cargo_prep_online
 
 %build
 %cargo_build
+make -f /usr/share/selinux/devel/Makefile -C data/selinux steamos_manager.pp
 
 %install
 %{cargo_license_online -a} > LICENSE.dependencies
 %make_install
 rm %{buildroot}%{_unitdir}/sddm.service.d/reset-oneshot-boot.conf # steamOS specific
 rm %{buildroot}%{_userunitdir}/orca.service # not used by anyone apparently, steamOS specific(?)
+install -D -m644 data/selinux/steamos_manager.pp %{buildroot}%{_datadir}/selinux/packages/steamos_manager.pp
 install -d %{buildroot}%{_userunitdir}/gamescope-session-plus.service.wants/steamos-manager.service
 ln -s %{_userunitdir}/steamos-manager.service %{buildroot}%{_userunitdir}/gamescope-session-plus.service.wants/steamos-manager.service
 
@@ -59,6 +69,8 @@ ln -s %{_userunitdir}/steamos-manager.service %{buildroot}%{_userunitdir}/gamesc
 %systemd_user_post steamos-manager.service
 %systemd_user_post steamos-manager-configure-cecd.service
 %systemd_user_post steamos-manager-session-cleanup.service
+semodule -i %{_datadir}/selinux/packages/steamos_manager.pp 2>/dev/null || :
+restorecon -R /usr/lib/steamos-manager /usr/bin/steamosctl /usr/share/steamos-manager /etc/steamos-manager 2>/dev/null || :
 
 %preun
 %systemd_preun steamos-manager.service
@@ -71,6 +83,9 @@ ln -s %{_userunitdir}/steamos-manager.service %{buildroot}%{_userunitdir}/gamesc
 %systemd_user_postun steamos-manager.service
 %systemd_user_postun steamos-manager-configure-cecd.service
 %systemd_user_postun steamos-manager-session-cleanup.service
+if [ $1 -eq 0 ]; then
+    semodule -r steamos_manager 2>/dev/null || :
+fi
 
 %files
 %license %{_datadir}/licenses/steamos-manager/LICENSE
@@ -89,6 +104,7 @@ ln -s %{_userunitdir}/steamos-manager.service %{buildroot}%{_userunitdir}/gamesc
 %{_userunitdir}/steamos-manager.service
 %{_userunitdir}/steamos-manager-configure-cecd.service
 %{_userunitdir}/steamos-manager-session-cleanup.service
+%{_datadir}/selinux/packages/steamos_manager.pp
 
 %files gamescope-session-plus
 %{_userunitdir}/gamescope-session-plus.service.wants/steamos-manager.service

--- a/anda/games/steamos-manager-powerstation/steamos_manager.fc
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.fc
@@ -1,0 +1,13 @@
+# steamos-manager SELinux file contexts
+
+# Daemon binary
+/usr/lib/steamos-manager		--	gen_context(system_u:object_r:steamos_manager_exec_t,s0)
+
+# CLI tool
+/usr/bin/steamosctl			--	gen_context(system_u:object_r:steamos_manager_exec_t,s0)
+
+# Data directory
+/usr/share/steamos-manager(/.*)?		gen_context(system_u:object_r:steamos_manager_data_t,s0)
+
+# Configuration directory
+/etc/steamos-manager(/.*)?			gen_context(system_u:object_r:steamos_manager_conf_t,s0)

--- a/anda/games/steamos-manager-powerstation/steamos_manager.if
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.if
@@ -1,0 +1,20 @@
+## <summary>policy for steamos_manager</summary>
+
+########################################
+## <summary>
+##	Execute steamos_manager in the steamos_manager domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`steamos_manager_domtrans',`
+	gen_require(`
+		type steamos_manager_t, steamos_manager_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, steamos_manager_exec_t, steamos_manager_t)
+')

--- a/anda/games/steamos-manager-powerstation/steamos_manager.te
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.te
@@ -1,0 +1,194 @@
+policy_module(steamos_manager, 1.0.0)
+
+########################################
+# Init
+########################################
+
+type steamos_manager_t;
+type steamos_manager_exec_t;
+type steamos_manager_data_t;
+type steamos_manager_conf_t;
+
+# Mark as a domain and entry point
+init_daemon_domain(steamos_manager_t, steamos_manager_exec_t)
+
+# Mark data and config as file types
+files_type(steamos_manager_data_t)
+files_config_file(steamos_manager_conf_t)
+
+# Allow systemd to manage the service (start/stop/status)
+init_dbus_chat(steamos_manager_t)
+
+########################################
+# Process permissions
+########################################
+
+# Standard process operations
+allow steamos_manager_t self:process { signal signull getsched setsched };
+
+# Forking for script execution
+allow steamos_manager_t self:fifo_file { read write getattr };
+
+# Notify socket for Type=notify-reload (sd_notify)
+init_dgram_send(steamos_manager_t)
+
+########################################
+# DBus access
+########################################
+
+dbus_system_bus_client(steamos_manager_t)
+dbus_session_bus_client(steamos_manager_t)
+dbus_connect_system_bus(steamos_manager_t)
+dbus_connect_session_bus(steamos_manager_t)
+
+# Own the service name
+allow steamos_manager_t self:dbus { send_msg acquire_svc };
+
+# Talk to systemd
+optional_policy(`
+	systemd_dbus_chat_logind(steamos_manager_t)
+')
+
+########################################
+# Sysfs access (hardware management)
+########################################
+
+# Read/write sysfs for TDP, GPU, backlight, power_supply, CPU scaling,
+# hwmon, firmware-attributes, platform-profile, hidraw, drm, DMI
+dev_read_sysfs(steamos_manager_t)
+dev_rw_sysfs(steamos_manager_t)
+
+########################################
+# Procfs access
+########################################
+
+# Read /proc/cpuinfo
+kernel_read_system_state(steamos_manager_t)
+
+# Read /proc/{pid}/comm, environ, stat, fd/ for display sleep inhibition
+domain_read_all_domains_state(steamos_manager_t)
+
+########################################
+# Tracefs and debugfs
+########################################
+
+# ftrace access: /sys/kernel/tracing/instances/steamos-manager/
+# debugfs access: /sys/kernel/debug/ath11k/
+kernel_read_debugfs(steamos_manager_t)
+kernel_manage_debugfs(steamos_manager_t)
+
+########################################
+# Device access
+########################################
+
+# /dev/uinput — virtual input devices
+optional_policy(`
+	gen_require(`
+		type uinput_device_t;
+	')
+	allow steamos_manager_t uinput_device_t:chr_file { open read write ioctl getattr };
+')
+
+# /dev/hidraw* — DualSense controller inhibitor
+optional_policy(`
+	gen_require(`
+		type hidraw_device_t;
+	')
+	allow steamos_manager_t hidraw_device_t:chr_file { open read write getattr ioctl };
+')
+
+# /dev/input/event* — inputplumber
+dev_rw_input_dev(steamos_manager_t)
+
+# Udev events via netlink socket
+allow steamos_manager_t self:netlink_kobject_uevent_socket { create bind getattr read setopt };
+
+# Watch /dev/ directory via inotify for device creation
+dev_list_all_dev_nodes(steamos_manager_t)
+allow steamos_manager_t device_t:dir { watch };
+
+########################################
+# Configuration & Data Files
+########################################
+
+# Data Files
+allow steamos_manager_t steamos_manager_data_t:dir list_dir_perms;
+allow steamos_manager_t steamos_manager_data_t:file read_file_perms;
+
+# Config files
+allow steamos_manager_t steamos_manager_conf_t:dir list_dir_perms;
+allow steamos_manager_t steamos_manager_conf_t:file read_file_perms;
+
+########################################
+# System configuration writes
+########################################
+
+# /etc/sddm.conf.d/, /etc/NetworkManager/conf.d/
+allow steamos_manager_t etc_t:dir { add_name remove_name write search create };
+allow steamos_manager_t etc_t:file { create write unlink open getattr rename };
+
+# /etc/systemd/system/iwd.service.d/
+optional_policy(`
+	systemd_manage_all_unit_files(steamos_manager_t)
+')
+
+########################################
+# User state and runtime files
+########################################
+
+# XDG_STATE_HOME
+userdom_manage_user_home_content_files(steamos_manager_t)
+userdom_manage_user_home_content_dirs(steamos_manager_t)
+
+# XDG_RUNTIME_DIR
+# XDG_CONFIG_HOME
+userdom_manage_user_tmp_dirs(steamos_manager_t)
+userdom_manage_user_tmp_files(steamos_manager_t)
+
+# /usr/share/wayland-sessions/ and /usr/share/xsessions/
+files_read_usr_files(steamos_manager_t)
+
+# /tmp/
+files_manage_generic_tmp_files(steamos_manager_t)
+files_tmp_filetrans(steamos_manager_t, tmp_t, file)
+
+# /var/lib/steamos-log-submitter/data/
+files_search_var_lib(steamos_manager_t)
+files_manage_var_lib_files(steamos_manager_t)
+files_manage_var_lib_dirs(steamos_manager_t)
+
+########################################
+# External command execution
+########################################
+
+# Execute system binaries
+corecmd_exec_bin(steamos_manager_t)
+corecmd_exec_shell(steamos_manager_t)
+
+# Execute libraries/scripts under /usr/lib/ paths
+libs_exec_lib_files(steamos_manager_t)
+
+########################################
+# Network and IPC
+########################################
+
+# Unix domain sockets for DBus
+allow steamos_manager_t self:unix_stream_socket { create connect read write getattr shutdown };
+allow steamos_manager_t self:unix_dgram_socket { create connect read write getattr sendto };
+
+# Speech-dispatcher and dconf-service connections
+corenet_tcp_connect_all_ports(steamos_manager_t)
+
+########################################
+# Logging
+########################################
+
+logging_send_syslog_msg(steamos_manager_t)
+
+########################################
+# Miscellaneous
+########################################
+
+# Read locale and system state
+miscfiles_read_localization(steamos_manager_t)
+kernel_read_kernel_sysctls(steamos_manager_t)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: Add SELinux rules for steamos-manager-powerstation (#10862)](https://github.com/terrapkg/packages/pull/10862)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)