### PR TITLE
[f44] chore (dwarfs): remove unnecessary deps (#10746)

### DIFF
--- a/anda/lib/dwarfs/dwarfs.spec
+++ b/anda/lib/dwarfs/dwarfs.spec
@@ -6,7 +6,7 @@ A fast high compression read-only file system for Linux and Windows.}
 
 Name:          dwarfs
 Version:       0.15.1
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       A fast high compression read-only file system for Linux, Windows and macOS
 License:       GPL-3.0-or-later
 URL:           https://github.com/mhx/%{name}

--- a/anda/lib/dwarfs/dwarfs.spec
+++ b/anda/lib/dwarfs/dwarfs.spec
@@ -10,7 +10,7 @@ Release:       1%{?dist}
 Summary:       A fast high compression read-only file system for Linux, Windows and macOS
 License:       GPL-3.0-or-later
 URL:           https://github.com/mhx/%{name}
-Source0:       https://github.com/mhx/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.xz
+Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires: binutils-devel
 BuildRequires: boost-devel
 %if 0%{?fedora} >= 44
@@ -23,7 +23,6 @@ BuildRequires: bubblewrap
 BuildRequires: ccache
 BuildRequires: clang
 BuildRequires: cmake
-BuildRequires: double-conversion-devel
 BuildRequires: flac-devel
 BuildRequires: fmt-devel
 BuildRequires: fuse
@@ -33,21 +32,16 @@ BuildRequires: fuse-devel
 BuildRequires: g++
 BuildRequires: gcc
 BuildRequires: git
-BuildRequires: glog-devel
 BuildRequires: google-benchmark
 BuildRequires: jemalloc-devel
 BuildRequires: json-devel
 BuildRequires: libarchive-devel
-BuildRequires: libdwarf-devel
-BuildRequires: libevent-devel
-BuildRequires: libunwind-devel
 BuildRequires: libzstd-devel
 BuildRequires: lz4-devel
 BuildRequires: make
 BuildRequires: man
 BuildRequires: ninja-build
 BuildRequires: openssl-devel
-BuildRequires: pip
 BuildRequires: pkg-config
 BuildRequires: range-v3-devel
 BuildRequires: rubygem-ronn-ng
@@ -55,8 +49,6 @@ BuildRequires: utf8cpp-devel
 BuildRequires: xxhash-devel
 BuildRequires: xz-devel
 BuildRequires: zstd
-Requires:      bzip2-libs
-Requires:      gflags
 Requires:      libattr
 Requires:      libxml2
 Requires:      libzstd


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (dwarfs): remove unnecessary deps (#10746)](https://github.com/terrapkg/packages/pull/10746)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)