### PR TITLE
[frawhide] fix: xpadneo (#10878)

### DIFF
--- a/anda/system/xpadneo/kmod-common/xpadneo.spec
+++ b/anda/system/xpadneo/kmod-common/xpadneo.spec
@@ -48,7 +48,7 @@ install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/metainfo/io.github.%{name}.met
 install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
 
 %files
-%license LICENSE
+%license LICENSE.md LICENSES
 %doc docs/*.md
 %{_modprobedir}/%{name}.conf
 %{_udevrulesdir}/60-%{name}.rules


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `frawhide`:
 - [fix: xpadneo (#10878)](https://github.com/terrapkg/packages/pull/10878)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)