### PR TITLE
[f43] fix(noctalia-qs): notification-daemon and polkit provides (#10896)

### DIFF
--- a/anda/desktops/noctalia-qs/noctalia-qs.spec
+++ b/anda/desktops/noctalia-qs/noctalia-qs.spec
@@ -2,7 +2,7 @@
 
 Name:	       noctalia-qs
 Version:       0.0.10
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Flexible QtQuick based desktop shell toolkit
 License:       LGPL-3.0-only AND GPL-3.0-only
 URL:	       https://github.com/noctalia-dev/noctalia-qs
@@ -38,6 +38,9 @@ BuildRequires: polkit-devel
 Conflicts:    quickshell
 Provides:     quickshell
 
+Provides:     desktop-notification-daemon
+Provides:     PolicyKit-authentication-agent
+
 %description
 Flexible QtQuick based desktop shell toolkit.
 
@@ -70,6 +73,9 @@ Flexible QtQuick based desktop shell toolkit.
 %{_libdir}/qt6/qml/Quickshell
 
 %changelog
+* Sun Mar 29 2026 Willow C Reed <terra@willowidk.dev>
+- Add provides for a polkit agent and desktop notification daemon (so gnome doesn't get installed)
+
 * Thu Mar 05 2026 Willow C Reed <terra@willowidk.dev>
 - Fix reision to actually be defined as a specific git commit since it never gets initialized rn
 - Also fix that noctalia-qs is replacing quickshell overall and not just for noctlaia users


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(noctalia-qs): notification-daemon and polkit provides (#10896)](https://github.com/terrapkg/packages/pull/10896)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)