### PR TITLE
[f43] add: ratelimit (#10912)

### DIFF
--- a/anda/langs/python/ratelimit/anda.hcl
+++ b/anda/langs/python/ratelimit/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "ratelimit.spec"
+  }
+}

--- a/anda/langs/python/ratelimit/ratelimit.spec
+++ b/anda/langs/python/ratelimit/ratelimit.spec
@@ -1,0 +1,45 @@
+%global pypi_name ratelimit
+%global _desc API Rate Limit Decorator.
+
+Name:			python-%{pypi_name}
+Version:		2.2.1
+Release:		1%?dist
+Summary:		API Rate Limit Decorator
+License:		MIT
+URL:			https://github.com/tomasbasham/ratelimit
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+
+%changelog
+* Sun Mar 29 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/ratelimit/update.rhai
+++ b/anda/langs/python/ratelimit/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("ratelimit"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: ratelimit (#10912)](https://github.com/terrapkg/packages/pull/10912)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)