### PR TITLE
[f43] add: python-opencc (#10906)

### DIFF
--- a/anda/langs/python/opencc/anda.hcl
+++ b/anda/langs/python/opencc/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+	spec = "opencc.spec"
+  }
+}

--- a/anda/langs/python/opencc/opencc.spec
+++ b/anda/langs/python/opencc/opencc.spec
@@ -1,0 +1,47 @@
+%global pypi_name opencc
+%global _desc Open Chinese Convert.
+
+Name:			python-%{pypi_name}
+Version:		1.2.0
+Release:		1%?dist
+Summary:		Open Chinese Convert
+License:		Apache-2.0
+URL:			https://github.com/BYVoid/OpenCC
+Source0:		%{pypi_source}
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+BuildRequires:  gcc-c++
+BuildRequires:  cmake
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md AUTHORS
+%license LICENSE
+
+%changelog
+* Sun Mar 29 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/opencc/update.rhai
+++ b/anda/langs/python/opencc/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("opencc"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: python-opencc (#10906)](https://github.com/terrapkg/packages/pull/10906)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)