### PR TITLE
[f43] chore: Swap Codeberg update functions to upstreamed Anda ones (#10948)

### DIFF
--- a/anda/langs/crystal/blahaj/update.rhai
+++ b/anda/langs/crystal/blahaj/update.rhai
@@ -1,3 +1,1 @@
-import "andax/bump_extras.rhai" as bump;
-
-rpm.version(bump::codeberg("GeopJr/BLAHAJ"));
+rpm.version(codeberg("GeopJr/BLAHAJ"));

--- a/anda/langs/nim/grabnim/update.rhai
+++ b/anda/langs/nim/grabnim/update.rhai
@@ -1,6 +1,4 @@
-import "andax/bump_extras.rhai" as bump;
-
-rpm.global("commit", bump::codeberg_commit("janAkali/grabnim"));
+rpm.global("commit", codeberg_commit("janAkali/grabnim"));
 if rpm.changed() {
     rpm.global("commit_date", date());
 }

--- a/anda/misc/exquisite-linux-templates/update.rhai
+++ b/anda/misc/exquisite-linux-templates/update.rhai
@@ -1,6 +1,4 @@
-import "andax/bump_extras.rhai" as bump;
-
-rpm.global("commit", bump::codeberg_commit("nathandyer/exquisite-linux-templates"));
+rpm.global("commit", codeberg_commit("nathandyer/exquisite-linux-templates"));
 if rpm.changed() {
     rpm.global("commit_date", date());
 }

--- a/anda/system/limine/update.rhai
+++ b/anda/system/limine/update.rhai
@@ -1,3 +1,1 @@
-import "andax/bump_extras.rhai" as bump;
-
-rpm.version(bump::codeberg("Limine/Limine"));
+rpm.version(codeberg("Limine/Limine"));

--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -29,14 +29,6 @@ fn alma(pkg, repo, branch) {
   return(vr[1]);
 }
 
-fn codeberg_commit(repo) {
-    return get(`https://codeberg.org/api/v1/repos/${repo}/commits?stat=false&verification=false&files=false&limit=1`).json_arr()[0].sha;
-}
-
-fn codeberg(repo) {
-    return get(`https://codeberg.org/api/v1/repos/${repo}/releases/latest`).json().tag_name;
-}
-
 fn as_bodhi_ver(branch) {
     if branch.starts_with("el") {
         branch.crop(2);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: Swap Codeberg update functions to upstreamed Anda ones (#10948)](https://github.com/terrapkg/packages/pull/10948)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)