### PR TITLE
[f44] fix(zig-master): Update LLVM requirements for Rawhide and 44 (#10947)

### DIFF
--- a/anda/langs/zig/bootstrap/update.rhai
+++ b/anda/langs/zig/bootstrap/update.rhai
@@ -8,4 +8,7 @@ if rpm.changed() {
    // Update the Zig version in the script
    let dir = sub(`/[^/]+$`, "", __script_path);
    sh(`sed -i 's|version=.*|version=${v}|' setup.sh`, #{ "cwd": dir });
+   // Update the needed LLVM version
+   let rawfile = codeberg_rawfile("ziglang/zig", "master", "README.md");
+   rpm.global("llvm_version", find(`download.html#([\d.]+)`, rawfile, 1));
 }

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -2,11 +2,10 @@
 %global         zig_arches x86_64 aarch64 riscv64 %{mips64}
 # Signing key from https://ziglang.org/download/
 %global         public_key RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
-# Not needed yet
-%if 0%{?fedora} >= 42 || 0%{?rhel} >= 9
-%define         llvm_compat 20
+%if 0%{?fedora} >= 44
+%define         llvm_compat 21
 %endif
-%global         llvm_version 20.0.0
+%global         llvm_version 21.0.0
 %global         ver 0.16.0-dev.3039+b490412cd
 %bcond bootstrap 1
 %bcond docs      %{without bootstrap}
@@ -51,9 +50,9 @@ BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  libxml2-devel
-BuildRequires:  llvm-devel
-BuildRequires:  clang-devel
-BuildRequires:  lld-devel
+BuildRequires:  llvm%{?llvm_compat}-devel
+BuildRequires:  clang%{?llvm_compat}-devel
+BuildRequires:  lld%{?llvm_compat}-devel
 BuildRequires:  zlib-devel
 # for man page generation
 BuildRequires:  help2man
@@ -113,6 +112,10 @@ rm -f stage1/zig1.wasm
 %endif
 
 %build
+# Force the correct LLVM version
+%if %{defined llvm_compat}
+export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
+%endif
 # zig doesn't know how to dynamically link llvm on its own so we need cmake to generate a header ahead of time
 # if we provide the header we need to also build zigcpp
 

--- a/anda/langs/zig/master/update.rhai
+++ b/anda/langs/zig/master/update.rhai
@@ -6,4 +6,7 @@ if rpm.changed() {
   let r = bump::madoguchi_json("zig-master", labels.branch).rel;
   let r = sub(`(?m)(\.fc.*?|)$`, "", r).parse_int();
   rpm.release(r + 1);
+  // Update the needed LLVM version
+  let rawfile = codeberg_rawfile("ziglang/zig", "master", "README.md");
+  rpm.global("llvm_version", find(`download.html#([\d.]+)`, rawfile, 1));
 }

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -2,18 +2,17 @@
 %global         zig_arches x86_64 aarch64 riscv64 %{mips64}
 # Signing key from https://ziglang.org/download/
 %global         public_key RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
-# Not needed yet
-%if 0%{?fedora} >= 42 || 0%{?rhel} >= 9
-%define         llvm_compat 20
+%if 0%{?fedora} >= 44
+%define         llvm_compat 21
 %endif
-%global         llvm_version 20.0.0
+%global         llvm_version 21.0.0
 %bcond bootstrap 0
 %bcond docs      %{without bootstrap}
 %bcond test      1
 %global zig_cache_dir %{builddir}/zig-cache
 
 Name:           zig-master
-Version:        0.16.0~dev.2736+3b515fbed
+Version:        0.16.0~dev.2694+74f361a5c
 Release:        2%{?dist}
 Summary:        Master builds of the Zig language
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
@@ -125,6 +124,10 @@ rm -f stage1/zig1.wasm
 %endif
 
 %build
+# Force the correct LLVM version
+%if %{defined llvm_compat}
+export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
+%endif
 # zig doesn't know how to dynamically link llvm on its own so we need cmake to generate a header ahead of time
 # if we provide the header we need to also build zigcpp
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(zig-master): Update LLVM requirements for Rawhide and 44 (#10947)](https://github.com/terrapkg/packages/pull/10947)

<!--- Backport version: 11.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)