### PR TITLE
[f42] fix (mangowm): bdep (#10969)

### DIFF
--- a/anda/desktops/mangowm/mangowm.spec
+++ b/anda/desktops/mangowm/mangowm.spec
@@ -2,7 +2,7 @@
 
 Name:           mangowm
 Version:        0.12.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A modern, lightweight, high-performance Wayland compositor built on dwl
 License:        GPL-3.0-or-later AND MIT AND X11 AND CC0-1.0
 Packager:       metcya <metcya@gmail.com>
@@ -21,7 +21,7 @@ BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(libinput)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(libpcre2-8)
-BuildRequires:  pkgconfig(scenefx-0.4)
+BuildRequires:  scenefx-devel
 
 Conflicts:      mangowc < %{mangowc_ver}
 Obsoletes:      mangowc < %{mangowc_ver}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (mangowm): bdep (#10969)](https://github.com/terrapkg/packages/pull/10969)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)