### PR TITLE
[f42] chore: Update release of various packages (#11023)

### DIFF
--- a/anda/system/hid-fanatecff/dkms/dkms-hid-fanatecff.spec
+++ b/anda/system/hid-fanatecff/dkms/dkms-hid-fanatecff.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Fanatec force feedback kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/gotzl/%{modulename}

--- a/anda/system/hid-fanatecff/kmod-common/hid-fanatecff.spec
+++ b/anda/system/hid-fanatecff/kmod-common/hid-fanatecff.spec
@@ -5,7 +5,7 @@
 
 Name:           hid-fanatecff
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Fanatec force feedback driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/gotzl/%{name}

--- a/anda/system/hid-tmff2/akmod/hid-tmff2-kmod.spec
+++ b/anda/system/hid-tmff2/akmod/hid-tmff2-kmod.spec
@@ -12,7 +12,7 @@
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Thrustmaster Force Feedback kernel module
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{modulename}

--- a/anda/system/new-lg4ff/dkms/dkms-new-lg4ff.spec
+++ b/anda/system/new-lg4ff/dkms/dkms-new-lg4ff.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Logitech force feedback kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/berarma/%{modulename}

--- a/anda/system/new-lg4ff/kmod-common/new-lg4ff.spec
+++ b/anda/system/new-lg4ff/kmod-common/new-lg4ff.spec
@@ -5,7 +5,7 @@
 
 Name:           new-lg4ff
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Logitech force feedback driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/berarma/%{name}

--- a/anda/system/t150-driver/dkms/dkms-t150-driver.spec
+++ b/anda/system/t150-driver/dkms/dkms-t150-driver.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Thrustmaster T150 steering wheel kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/scarburato/t150_driver

--- a/anda/system/t150-driver/kmod-common/t150-driver.spec
+++ b/anda/system/t150-driver/kmod-common/t150-driver.spec
@@ -5,7 +5,7 @@
 
 Name:           t150-driver
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Thrustmaster T150 steering wheel driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/scarburato/t150_driver

--- a/anda/system/zenergy/dkms/dkms-zenergy.spec
+++ b/anda/system/zenergy/dkms/dkms-zenergy.spec
@@ -6,7 +6,7 @@
 
 Name:           dkms-%{modulename}
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) via the hardware monitor (HWMON) sysfs interface.
 License:        GPL-2.0
 URL:            https://github.com/BoukeHaarsma23/zenergy

--- a/anda/system/zenergy/kmod-common/zenergy.spec
+++ b/anda/system/zenergy/kmod-common/zenergy.spec
@@ -4,7 +4,7 @@
 
 Name:           zenergy
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) via the hardware monitor (HWMON) sysfs interface.
 License:        GPL-2.0
 URL:            https://github.com/BoukeHaarsma23/zenergy


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [chore: Update release of various packages (#11023)](https://github.com/terrapkg/packages/pull/11023)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)