### PR TITLE
[f42] fix: Correct dependency issue in tmff2 akmod as well (#11028)

### DIFF
--- a/anda/system/hid-tmff2/dkms/dkms-hid-tmff2.spec
+++ b/anda/system/hid-tmff2/dkms/dkms-hid-tmff2.spec
@@ -11,7 +11,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Thrustmaster Force Feedback kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{modulename}
@@ -22,6 +22,7 @@ Source3:        no-weak-modules.conf
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
 Conflicts:      akmod-%{modulename}
+Provides:       %{modulename}-kmod
 BuildArch:      noarch
 
 %description

--- a/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
+++ b/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
@@ -8,13 +8,13 @@
 
 Name:           hid-tmff2
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Thrustmaster Force Feedback driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{name}
 Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
 Source1:        https://github.com/Kimplul/hid-tminit/archive/%{tminit_commit}.tar.gz#/hid-tminit-%{tminit_shortcommit}.tar.gz
-Requires:       (akmod-%{name} = %{?epoch:%{epoch}:}%{version} or dkms-%{name} = %{?epoch:%{epoch}:}%{version})
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [fix: Correct dependency issue in tmff2 akmod as well (#11028)](https://github.com/terrapkg/packages/pull/11028)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)