### PR TITLE
[f42] chore(wl-kmod): sync with rpmfusion patches so it builds on new kernels (#11052)

### DIFF
--- a/anda/system/wl-kmod/wl-kmod-031_replace_EXTRA_CFLAGS_EXTRA_LDFLAGS_with_ccflags-y_ldflags-y.patch
+++ b/anda/system/wl-kmod/wl-kmod-031_replace_EXTRA_CFLAGS_EXTRA_LDFLAGS_with_ccflags-y_ldflags-y.patch
@@ -1,0 +1,63 @@
+From 26597004c02ca97d4ff620ed11091cf0dd68a92d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Tue, 17 Jun 2025 14:34:24 +0200
+Subject: [PATCH] makefile: replace EXTRA_CFLAGS and EXTRA_LDFLAGS with
+ ccflags-y and ldflags-y from commit "kbuild: remove EXTRA_*FLAGS support"
+ (Masahiro Yamada, 6 Feb 2025) saying they have been deprecated since 2007
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ Makefile | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 296162c..6e90afb 100644
+--- a/Makefile
++++ b/Makefile
+@@ -131,15 +131,15 @@ GCCVERSION := $(subst $(space),$(empty),$(GCCVERSION))
+ GCCVERSION := $(shell expr `echo $(GCCVERSION)` | cut -b1-3)
+ GE_49 := $(shell expr `echo $(GCCVERSION)` \>= 490)
+ 
+-EXTRA_CFLAGS :=
++ccflags-y :=
+ 
+ ifeq ($(APIFINAL),CFG80211)
+-  EXTRA_CFLAGS += -DUSE_CFG80211
++  ccflags-y += -DUSE_CFG80211
+   $(info Using CFG80211 API)
+ endif
+ 
+ ifeq ($(APIFINAL),WEXT)
+-  EXTRA_CFLAGS += -DUSE_IW
++  ccflags-y += -DUSE_IW
+   $(info Using Wireless Extension API)
+ endif
+ 
+@@ -151,15 +151,15 @@ wl-objs            += src/wl/sys/wl_linux.o
+ wl-objs            += src/wl/sys/wl_iw.o
+ wl-objs            += src/wl/sys/wl_cfg80211_hybrid.o
+ 
+-EXTRA_CFLAGS       += -I$(src)/src/include -I$(src)/src/common/include
+-EXTRA_CFLAGS       += -I$(src)/src/wl/sys -I$(src)/src/wl/phy -I$(src)/src/wl/ppr/include
+-EXTRA_CFLAGS       += -I$(src)/src/shared/bcmwifi/include
+-#EXTRA_CFLAGS       += -DBCMDBG_ASSERT -DBCMDBG_ERR
++ccflags-y          += -I$(src)/src/include -I$(src)/src/common/include
++ccflags-y          += -I$(src)/src/wl/sys -I$(src)/src/wl/phy -I$(src)/src/wl/ppr/include
++ccflags-y          += -I$(src)/src/shared/bcmwifi/include
++#ccflags-y          += -DBCMDBG_ASSERT -DBCMDBG_ERR
+ ifeq "$(GE_49)" "1"
+-EXTRA_CFLAGS       += -Wno-date-time
++ccflags-y          += -Wno-date-time
+ endif
+ 
+-EXTRA_LDFLAGS      := $(src)/lib/wlc_hybrid.o_shipped
++ldflags-y          := $(src)/lib/wlc_hybrid.o_shipped
+ 
+ KBASE              ?= /lib/modules/`uname -r`
+ KBUILD_DIR         ?= $(KBASE)/build
+-- 
+2.49.0
+

--- a/anda/system/wl-kmod/wl-kmod-032_add_MODULE_DESCRIPTION_macro.patch
+++ b/anda/system/wl-kmod/wl-kmod-032_add_MODULE_DESCRIPTION_macro.patch
@@ -1,0 +1,30 @@
+From 3b780d05b0f9a3b36196c0cfedb57cb2241f87f8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Tue, 17 Jun 2025 14:49:31 +0200
+Subject: [PATCH] wl_linux.c: add MODULE_DESCRIPTION macro related to commit
+ "modpost: require a MODULE_DESCRIPTION()" (Jeff Johnson, 11 Mar 2025)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ src/wl/sys/wl_linux.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 3c25ce4..0c08fe7 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -164,6 +164,8 @@ static int wl_set_radio_block(void *data, bool blocked);
+ static void wl_report_radio_state(wl_info_t *wl);
+ #endif
+ 
++// Related to commit "modpost: require a MODULE_DESCRIPTION()" (Jeff Johnson, 11 Mar 2025)
++MODULE_DESCRIPTION("Broadcom STA wireless driver [unmaintained, out-of-tree]");
+ MODULE_LICENSE("MIXED/Proprietary");
+ 
+ static struct pci_device_id wl_id_table[] =
+-- 
+2.49.0
+

--- a/anda/system/wl-kmod/wl-kmod-033_disable_objtool_add_warning_unmaintained.patch
+++ b/anda/system/wl-kmod/wl-kmod-033_disable_objtool_add_warning_unmaintained.patch
@@ -1,0 +1,64 @@
+From 642f61c3ff369e5938eb6b70bf5cc9566a7e04ae Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Tue, 17 Jun 2025 15:04:16 +0200
+Subject: [PATCH] =?UTF-8?q?wl=5Flinux.c=20and=20makefile:=20added=20warnin?=
+ =?UTF-8?q?g=20when=20the=20module=20is=20loaded=20about=20unmaintained=20?=
+ =?UTF-8?q?state=20of=20driver=20and=20its=20provided=20binary=20blob=20an?=
+ =?UTF-8?q?d=20possible=20security=20risks=20related=20to=20current=20Linu?=
+ =?UTF-8?q?x=20kernel=20security=20standards=20(e.g.=20IBT)=20-=20disablin?=
+ =?UTF-8?q?g=20objtool=20accordingly=20as=20well=20-=20thanks=20to=20Joan?=
+ =?UTF-8?q?=20Bruguera=20Mic=C3=B3?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ Makefile              | 15 +++++++++++++++
+ src/wl/sys/wl_linux.c |  4 ++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 6e90afb..c38c3ee 100644
+--- a/Makefile
++++ b/Makefile
+@@ -169,6 +169,21 @@ MDEST_DIR          ?= $(KBASE)/kernel/drivers/net/wireless
+ CROSS_TOOLS        = /path/to/tools
+ CROSS_KBUILD_DIR   = /path/to/kernel/tree
+ 
++# Rel. commit "objtool: Always fail on fatal errors" (Josh Poimboeuf, 31 Mar 2025)
++# This is a *ugly* hack to disable objtool during the final processing of wl.o.
++# Since is embeds the proprietary blob (wlc_hybrid.o_shipped), objtool can't
++# process it, as it does not follow the requirements of current kernels,
++# including support for critical security features. As of Linux v6.15+, it causes
++# a build error. Disable it, at your own risk. Note the MIT license applies:
++# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++# SOFTWARE.
++wl.o: override objtool-enabled =
++
+ all:
+ 	KBUILD_NOPEDANTIC=1 make -C $(KBUILD_DIR) M=`pwd`
+ 
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 0c08fe7..59873e1 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -922,6 +922,10 @@ static struct pci_driver wl_pci_driver __refdata = {
+ static int __init
+ wl_module_init(void)
+ {
++	printk(KERN_WARNING "You are using the Broadcom STA wireless driver, which is "
++		"not maintained and is incompatible with Linux kernel security mitigations. "
++		"It is heavily recommended to replace the hardware and remove the driver. "
++		"Proceed at your own risk!");
+ 	int error = -ENODEV;
+ 
+ #ifdef BCMDBG
+-- 
+2.49.0
+

--- a/anda/system/wl-kmod/wl-kmod-034_kernel_6.15_adaptation_replace_del_timer_with_timer_delete.patch
+++ b/anda/system/wl-kmod/wl-kmod-034_kernel_6.15_adaptation_replace_del_timer_with_timer_delete.patch
@@ -1,0 +1,35 @@
+From ddfac506c7060e7514952c6ec340b34ee0273864 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Tue, 17 Jun 2025 15:12:03 +0200
+Subject: [PATCH] wl_linux.c: fix compatibility with kernel >= 6.15 replace
+ del_timer function with timer_delete function - related to commit "treewide:
+ Switch/rename to timer_delete[_sync]()" (Thomas Gleixner, 5 Apr 2025)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ src/wl/sys/wl_linux.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 59873e1..4512f73 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -2501,7 +2501,12 @@ wl_del_timer(wl_info_t *wl, wl_timer_t *t)
+ 	ASSERT(t);
+ 	if (t->set) {
+ 		t->set = FALSE;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++		// Rel. commit "treewide: Switch/rename to timer_delete[_sync]()" (Thomas Gleixner, 5 Apr 2025)
++		if (!timer_delete(&t->timer)) {
++#else
+ 		if (!del_timer(&t->timer)) {
++#endif
+ #ifdef BCMDBG
+ 			WL_INFORM(("wl%d: Failed to delete timer %s\n", wl->unit, t->name));
+ #endif
+-- 
+2.49.0
+

--- a/anda/system/wl-kmod/wl-kmod-035_kernel_6.17_adaptation_fix_functions_prototypes.patch
+++ b/anda/system/wl-kmod/wl-kmod-035_kernel_6.17_adaptation_fix_functions_prototypes.patch
@@ -1,0 +1,102 @@
+From 564dc0af953480b3155266b388637e51fb8c6fc8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Thu, 18 Sep 2025 16:01:05 +0200
+Subject: [PATCH] wl_cfg80211_hybrid.c: fix compatibility with kernel >= 6.17
+ in funtions prototypes for wl_cfg80211_set_wiphy_params,
+ wl_cfg80211_set_tx_power and wl_cfg80211_get_tx_power - related to commit
+ "wifi: cfg80211/mac80211: Add support to get radio index" (Roopni Devanathan,
+ 15 Jun 2025)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ src/wl/sys/wl_cfg80211_hybrid.c | 34 +++++++++++++++++++++++++++++----
+ 1 file changed, 30 insertions(+), 4 deletions(-)
+
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index 5a7f0c4..58f1023 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -70,7 +70,12 @@ wl_cfg80211_scan(struct wiphy *wiphy,
+ static s32 wl_cfg80211_scan(struct wiphy *wiphy, struct net_device *ndev,
+            struct cfg80211_scan_request *request);
+ #endif
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, int radio_idx,
++                                        u32 changed);
++#else
+ static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed);
++#endif
+ static s32 wl_cfg80211_join_ibss(struct wiphy *wiphy, struct net_device *dev,
+            struct cfg80211_ibss_params *params);
+ static s32 wl_cfg80211_leave_ibss(struct wiphy *wiphy, struct net_device *dev);
+@@ -89,7 +94,12 @@ static int wl_cfg80211_connect(struct wiphy *wiphy, struct net_device *dev,
+            struct cfg80211_connect_params *sme);
+ static s32 wl_cfg80211_disconnect(struct wiphy *wiphy, struct net_device *dev, u16 reason_code);
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32
++wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++                         int radio_idx,
++                         enum nl80211_tx_power_setting type, s32 dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32
+ wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
+                          enum nl80211_tx_power_setting type, s32 dbm);
+@@ -101,7 +111,10 @@ static s32 wl_cfg80211_set_tx_power(struct wiphy *wiphy,
+            enum tx_power_setting type, s32 dbm);
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++                                    int radio_idx, unsigned int link_id, s32 *dbm);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
+                                     unsigned int link_id, s32 *dbm);
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+@@ -732,7 +745,12 @@ static s32 wl_set_retry(struct net_device *dev, u32 retry, bool l)
+ 	return err;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, int radio_idx,
++                                        u32 changed)
++#else
+ static s32 wl_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
++#endif
+ {
+ 	struct wl_cfg80211_priv *wl = wiphy_to_wl(wiphy);
+ 	struct net_device *ndev = wl_to_ndev(wl);
+@@ -1167,7 +1185,12 @@ wl_cfg80211_disconnect(struct wiphy *wiphy, struct net_device *dev, u16 reason_c
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32
++wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++                         int radio_idx,
++                         enum nl80211_tx_power_setting type, s32 dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+ static s32
+ wl_cfg80211_set_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
+                          enum nl80211_tx_power_setting type, s32 dbm)
+@@ -1228,7 +1251,10 @@ wl_cfg80211_set_tx_power(struct wiphy *wiphy, enum tx_power_setting type, s32 db
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
++                                    int radio_idx, unsigned int link_id, s32 *dbm)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+ static s32 wl_cfg80211_get_tx_power(struct wiphy *wiphy, struct wireless_dev *wdev,
+                                     unsigned int link_id, s32 *dbm)
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+-- 
+2.51.0
+

--- a/anda/system/wl-kmod/wl-kmod.spec
+++ b/anda/system/wl-kmod/wl-kmod.spec
@@ -10,7 +10,7 @@
 
 Name:       wl-kmod
 Version:    6.30.223.271
-Release:    4%{?dist}
+Release:    5%{?dist}
 Summary:    Kernel module for Broadcom wireless devices
 Group:      System Environment/Kernel
 License:    Redistributable, no modification permitted
@@ -27,7 +27,7 @@ Patch5:     wl-kmod-007_kernel_4.8_add_cfg80211_scan_info_struct.patch
 Patch6:     wl-kmod-008_fix_kernel_warnings.patch
 Patch7:     wl-kmod-009_kernel_4.11_remove_last_rx_in_net_device_struct.patch
 Patch8:     wl-kmod-010_kernel_4.12_add_cfg80211_roam_info_struct.patch
-Patch9:     wl-kmod-011_kernel_4.14_new_kernel_read_function_prototype.patch
+Patch9:    wl-kmod-011_kernel_4.14_new_kernel_read_function_prototype.patch
 Patch10:    wl-kmod-012_kernel_4.15_new_timer.patch
 Patch11:    wl-kmod-013_gcc8_fix_bounds_check_warnings.patch
 Patch12:    wl-kmod-014_kernel_read_pos_increment_fix.patch
@@ -47,6 +47,11 @@ Patch25:    wl-kmod-027_wpa_supplicant-2.11_add_max_scan_ie_len.patch
 Patch26:    wl-kmod-028_kernel_6.12_adaptation.patch
 Patch27:    wl-kmod-029_kernel_6.13_adaptation.patch
 Patch28:    wl-kmod-030_kernel_6.14_adaptation.patch
+Patch29:    wl-kmod-031_replace_EXTRA_CFLAGS_EXTRA_LDFLAGS_with_ccflags-y_ldflags-y.patch
+Patch30:    wl-kmod-032_add_MODULE_DESCRIPTION_macro.patch
+Patch31:    wl-kmod-033_disable_objtool_add_warning_unmaintained.patch
+Patch32:    wl-kmod-034_kernel_6.15_adaptation_replace_del_timer_with_timer_delete.patch
+Patch33:    wl-kmod-035_kernel_6.17_adaptation_fix_functions_prototypes.patch
 ExclusiveArch:  i686 x86_64
 BuildRequires:  kmodtool
 BuildRequires:  elfutils-libelf-devel
@@ -81,7 +86,7 @@ pushd %{name}-%{version}-src
 %patch -P 6  -p1 -b .fix_kernel_warnings
 %patch -P 7  -p1 -b .kernel_4.11_remove_last_rx_in_net_device_struct
 %patch -P 8  -p1 -b .kernel_4.12_add_cfg80211_roam_info_struct
-%patch -P 9  -p1 -b .kernel_4.14_new_kernel_read_function_prototype
+%patch -P 9 -p1 -b .kernel_4.14_new_kernel_read_function_prototype
 %patch -P 10 -p1 -b .kernel_4.15_new_timer
 %patch -P 11 -p1 -b .gcc8_fix_bounds_check_warnings
 %patch -P 12 -p1 -b .kernel_read_pos_increment_fix
@@ -101,30 +106,296 @@ pushd %{name}-%{version}-src
 %patch -P 26 -p1 -b .kernel_6.12_adaptation
 %patch -P 27 -p1 -b .kernel_6.13_adaptation
 %patch -P 28 -p1 -b .kernel_6.14_adaptation
+%patch -P 29 -p1 -b .EXTRA_CFLAGS_EXTRA_LDFLAGS
+%patch -P 30 -p1 -b .MODULE_DESCRIPTION
+%patch -P 31 -p1 -b .disable_objtool
+%patch -P 32 -p1 -b .kernel_6.15_adaptation
+%patch -P 33 -p1 -b .kernel_6.17_adaptation
 
-### NOTE: These MUST be added to as new EL versions are released.
-%if 0%{?rhel} == 9
+# Manual patching to build for RHEL - inspired by CentOS wl-kmod.spec
+# Actually works for RHEL 6.x and 7.x
+%if 0%{?rhel} == 6
+ # Define kvl (linux) & kvr (release) for use in "patching" logical
  %define kvl %(echo %{kernel_versions} | cut -d"-" -f1)
  %define kvr %(echo %{kernel_versions} | cut -d"-" -f2 | cut -d"." -f1)
 
-### Patching for various point release kernels.
+ # Perform "patching" edits to the src/wl/sys/wl_cfg80211_hybrid.c file.
+ #  Note: Using this method, as opposed to making a patch, allows
+ #        the src.rpm to be compiled under various point release kernels.
+ #  Note: Use [ >][>=] where both >= & > are present
+ %if "%{kvl}" == "2.6.32"
+  %if %{kvr} >= 71
+   #  Apply to EL 6.0 point release and later
+   %{__sed} -i 's/ >= KERNEL_VERSION(3, 6, 0)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 131
+   #  Apply to EL 6.1 point release and later (2.6.32-131.0.15)
+   #   >  No changes currently needed for EL 6.1 point release
+  %endif
+  %if %{kvr} >= 220
+   #  Apply to EL 6.2 point release and later
+   #   >  No changes currently needed for EL 6.2 point release
+  %endif
+  %if %{kvr} >= 279
+   #  Apply to EL 6.3 point release and later
+   %{__sed} -i 's/ >= KERNEL_VERSION(2, 6, 36)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(2, 6, 37)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(2, 6, 38)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i  's/ > KERNEL_VERSION(2, 6, 39)/ > KERNEL_VERSION(2, 6, 31)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(2, 6, 39)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(3, 1, 0)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} == 358
+   #  Only apply to EL 6.4 point release
+   if $(grep -q "/lib/modules/kabi/kabi_whitelist" /usr/lib/rpm/redhat/find-requires.ksyms 2>/dev/null) ; then
+    %{__sed} -i 's@/lib/modules/kabi/kabi_whitelist@/lib/modules/kabi-current/kabi_whitelist@g' /usr/lib/rpm/redhat/find-requires.ksyms
+   fi
+  %endif
+  %if %{kvr} >= 358
+   #  Apply to EL 6.4 point release and later
+   #   >  No changes currently needed for EL 6.4 point release
+  %endif
+  %if %{kvr} == 431
+   #  Only apply to EL 6.5 point release
+   if $(grep -q "/lib/modules/kabi/kabi_whitelist" /usr/lib/rpm/redhat/find-requires.ksyms 2>/dev/null) ; then
+    %{__sed} -i 's@/lib/modules/kabi/kabi_whitelist@/lib/modules/kabi-current/kabi_whitelist@g' /usr/lib/rpm/redhat/find-requires.ksyms
+   fi
+  %endif
+  %if %{kvr} >= 431
+   #  Apply to EL 6.5 point release and later
+   %{__sed} -i 's/ >= KERNEL_VERSION(3, 8, 0)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(3, 9, 0)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} == 504
+   #  Only apply to EL 6.6 point release
+   if $(grep -q "/lib/modules/kabi/kabi_whitelist" /usr/lib/rpm/redhat/find-requires.ksyms 2>/dev/null) ; then
+    %{__sed} -i 's@/lib/modules/kabi/kabi_whitelist@/lib/modules/kabi-current/kabi_whitelist@g' /usr/lib/rpm/redhat/find-requires.ksyms
+   fi
+  %endif
+  %if %{kvr} >= 504
+   #  Apply to EL 6.6 point release and later
+   #   >  No changes currently needed for EL 6.6 point release
+  %endif
+  %if %{kvr} >= 573
+   #  Apply to EL 6.7 point release and later
+   %{__sed} -i 's/ >= KERNEL_VERSION(3, 11, 0)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i  's/ < KERNEL_VERSION(3, 16, 0)/ < KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i  's/ < KERNEL_VERSION(3, 18, 0)/ < KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(3, 15, 0)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 642
+   #  Apply to EL 6.8 point release and later
+   %{__sed} -i 's/ >= KERNEL_VERSION(4, 0, 0)/ >= KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i  's/ < KERNEL_VERSION(4,2,0)/ < KERNEL_VERSION(2, 6, 32)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 696
+   #  Apply to EL 6.9 point release and later
+   #   >  No changes currently needed for EL 6.9 point release
+  %endif
+  %if %{kvr} >= 754
+   #  Apply to EL 6.10 point release and later
+   #   >  No changes currently needed for EL 6.10 point release
+  %endif
+ %endif
+%endif
+%if 0%{?rhel} == 7
+ # Define kvl (linux) & kvr (release) for use in "patching" logical
+ %define kvl %(echo %{kernel_versions} | cut -d"-" -f1)
+ %define kvr %(echo %{kernel_versions} | cut -d"-" -f2 | cut -d"." -f1)
+
+ # Perform "patching" edits to the src/wl/sys/wl_cfg80211_hybrid.c file.
+ #  Note: Using this method, as opposed to making a patch, allows
+ #        the src.rpm to be compiled under various point release kernels.
+ #  Note: Use [ >][>=] where both >= & > are present
+ %if "%{kvl}" == "3.10.0"
+  %if %{kvr} == 123
+   #  Only apply to EL 7.0 point release
+   if $(grep -q "/lib/modules/kabi/kabi_whitelist" /usr/lib/rpm/redhat/find-requires.ksyms 2>/dev/null) ; then
+    %{__sed} -i 's@/lib/modules/kabi/kabi_whitelist@/lib/modules/kabi-rhel70/kabi_whitelist@g' /usr/lib/rpm/redhat/find-requires.ksyms
+   fi
+  %endif
+  %if %{kvr} >= 123
+   #  Apply to EL 7.0 point release and later
+   #   >  No changes currently needed for EL 7.0 point release
+  %endif
+  %if %{kvr} >= 229
+   #  Apply to EL 7.1 point release and later
+   %{__sed} -i 's/ >= KERNEL_VERSION(3, 11, 0)/ >= KERNEL_VERSION(3, 10, 0)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(3, 15, 0)/ >= KERNEL_VERSION(3, 10, 0)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i  's/ < KERNEL_VERSION(3, 16, 0)/ < KERNEL_VERSION(3, 10, 0)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 327
+   #  Apply to EL 7.2 point release and later
+   %{__sed} -i  's/ < KERNEL_VERSION(3, 18, 0)/ < KERNEL_VERSION(3, 9, 0)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(4, 0, 0)/ >= KERNEL_VERSION(3, 10, 0)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 514
+   #  Apply to EL 7.3 point release and later
+   %{__sed} -i  's/ < KERNEL_VERSION(4,2,0)/ < KERNEL_VERSION(3, 9, 0)/' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(4, 7, 0)/ >= KERNEL_VERSION(3, 10, 0)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 693
+   #  Apply to EL 7.4 point release and later
+   %{__sed} -i 's/ >= KERNEL_VERSION(4, 8, 0)/ >= KERNEL_VERSION(3, 10, 0)/' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 862
+   #  Apply to EL 7.5 point release and later
+   %{__sed} -i 's/ <= KERNEL_VERSION(4, 10, 0)/ <= KERNEL_VERSION(3, 9, 0)/' src/wl/sys/wl_linux.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(4, 11, 0)/ >= KERNEL_VERSION(3, 10, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i  's/ < KERNEL_VERSION(4, 12, 0)/ < KERNEL_VERSION(3, 10, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(4, 12, 0)/ >= KERNEL_VERSION(3, 10, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 957
+   #  Apply to EL 7.6 point release and later
+   #   >  No changes currently needed for EL 7.6 point release
+  %endif
+  %if %{kvr} >= 1062
+   #  Apply to EL 7.7 point release and later
+   %{__sed} -i -e 's@__attribute__((__fallthrough__));.*@/* fall through */@g' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 1127
+   #  Apply to EL 7.8 point release and later
+   #   >  No changes currently needed for EL 7.8 point release
+  %endif
+  %if %{kvr} >= 1160
+   #  Apply to EL 7.9 point release and later
+   #   >  No changes currently needed for EL 7.9 point release
+  %endif
+ %endif
+%endif
+%if 0%{?rhel} == 8
+ # Define kvl (linux) & kvr (release) for use in "patching" logical
+ %define kvl %(echo %{kernel_versions} | cut -d"-" -f1)
+ %define kvr %(echo %{kernel_versions} | cut -d"-" -f2 | cut -d"." -f1)
+
+ # Perform "patching" edits to the src/wl/sys/wl_cfg80211_hybrid.c file.
+ #  Note: Using this method, as opposed to making a patch, allows
+ #        the src.rpm to be compiled under various point release kernels.
+ #  Note: Use [ >][>=] where both >= & > are present
+ %if "%{kvl}" == "4.18.0"
+  %if %{kvr} == 80
+   #  Only apply to EL 8.0 point release
+   #   >  No changes currently needed for EL 8.0 point release
+  %endif
+  %if %{kvr} >= 80
+   #  Apply to EL 8.0 point release and later
+   #   >  No changes currently needed for EL 8.0 point release
+  %endif
+  %if %{kvr} >= 147
+   #  Apply to EL 8.1 point release and later
+   #   >  No changes currently needed for EL 8.1 point release
+  %endif
+  %if %{kvr} >= 193
+   #  Apply to EL 8.2 point release and later
+   #   >  No changes currently needed for EL 8.2 point release
+  %endif
+  %if %{kvr} >= 240
+   #  Apply to EL 8.3 point release and later
+   #   >  No changes currently needed for EL 8.3 point release
+  %endif
+  %if %{kvr} >= 305
+   #  Apply to EL 8.4 point release and later
+   #   >  No changes currently needed for EL 8.4 point release
+  %endif
+  %if %{kvr} >= 348
+   #  Apply to EL 8.5 point release and later
+   #   >  No changes currently needed for EL 8.5 point release
+  %endif
+  %if %{kvr} >= 372
+   #  Apply to EL 8.6 point release and later
+   #   >  No changes currently needed for EL 8.6 point release
+  %endif
+  %if %{kvr} >= 425
+   #  Apply to EL 8.7 point release and later
+   #   >  No changes currently needed for EL 8.7 point release
+  %endif
+  %if %{kvr} >= 477
+   #  Apply to EL 8.8 point release and later
+   %{__sed} -i 's/ >= KERNEL_VERSION(6, 0, 0)/ >= KERNEL_VERSION(4, 18, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i 's/ >= KERNEL_VERSION(6, 1, 0)/ >= KERNEL_VERSION(4, 18, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+  %if %{kvr} >= 513
+   #  Apply to EL 8.9 point release and later
+   #   >  No changes currently needed for EL 8.9 point release
+  %endif
+  %if %{kvr} >= 553
+   #  Apply to EL 8.10 point release and later
+   #   >  No changes currently needed for EL 8.10 point release
+  %endif
+ %endif
+%endif
+%if 0%{?rhel} == 9
+ # Define kvl (linux) & kvr (release) for use in "patching" logical
+ %define kvl %(echo %{kernel_versions} | cut -d"-" -f1)
+ %define kvr %(echo %{kernel_versions} | cut -d"-" -f2 | cut -d"." -f1)
+
+ # Perform "patching" edits to the src/wl/sys/wl_cfg80211_hybrid.c file.
+ #  Note: Using this method, as opposed to making a patch, allows
+ #        the src.rpm to be compiled under various point release kernels.
+ #  Note: Use [ >][>=] where both >= & > are present
  %if "%{kvl}" == "5.14.0"
   %if %{kvr} == 70
+   #  Only apply to EL 9.0 point release
+   #   >  No changes currently needed for EL 9.0 point release
   %endif
   %if %{kvr} >= 70
+   #  Apply to EL 9.0 point release and later
    %{__sed} -i  's/ < KERNEL_VERSION(5, 17, 0)/ < KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_iw.h
    %{__sed} -i 's/ >= KERNEL_VERSION(5, 17, 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_linux.c
   %endif
   %if %{kvr} >= 162
+   #  Apply to EL 9.1 point release and later
+   #   >  No changes currently needed for EL 9.1 point release
   %endif
   %if %{kvr} >= 284
+   #  Apply to EL 9.2 point release and later
+   #   >  No changes currently needed for EL 9.2 point release
   %endif
   %if %{kvr} >= 362
+   #  Apply to EL 9.3 point release and later
    %{__sed} -i 's/ >= KERNEL_VERSION(6, [01], 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
   %endif
   %if %{kvr} >= 427
+   #  Apply to EL 9.4 point release and later
+   #   >  No changes currently needed for EL 9.4 point release
   %endif
   %if %{kvr} >= 503
+   #  Apply to EL 9.5 point release and later
+   #   >  No changes currently needed for EL 9.5 point release
+  %endif
+  %if %{kvr} >= 570
+   #  Apply to EL 9.6 point release and later
+   #   >  No changes currently needed for EL 9.6 point release
+  %endif
+  %if %{kvr} >= 611
+   #  Apply to EL 9.7 point release and later
+   %{__sed} -i  's/ < KERNEL_VERSION(6, 13, 0)/ < KERNEL_VERSION(5, 14, 0)/g' src/include/linuxver.h
+   %{__sed} -i  's/ >= KERNEL_VERSION(6, 14, 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
+   %{__sed} -i  's/ >= KERNEL_VERSION(6, 17, 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
+  %endif
+ %endif
+%endif
+%if 0%{?rhel} == 10
+ # Define kvl (linux) & kvr (release) for use in "patching" logical
+ %define kvl %(echo %{kernel_versions} | cut -d"-" -f1)
+ %define kvr %(echo %{kernel_versions} | cut -d"-" -f2 | cut -d"." -f1)
+
+ # Perform "patching" edits to the src/wl/sys/wl_cfg80211_hybrid.c file.
+ #  Note: Using this method, as opposed to making a patch, allows
+ #        the src.rpm to be compiled under various point release kernels.
+ #  Note: Use [ >][>=] where both >= & > are present
+ %if "%{kvl}" == "6.12.0"
+  %if %{kvr} == 55
+   #  Only apply to EL 10.0 point release
+   #   >  No changes currently needed for EL 10.0 point release
+  %endif
+  %if %{kvr} >= 55
+   #  Apply to EL 10.0 point release and later
+   %{__sed} -i  's/ < KERNEL_VERSION(6, 13, 0)/ < KERNEL_VERSION(6, 12, 0)/g' src/include/linuxver.h
+  %endif
+  %if %{kvr} >= 124
+   #  Apply to EL 10.1 point release and later
+   %{__sed} -i  's/ >= KERNEL_VERSION(6, 14, 0)/ >= KERNEL_VERSION(6, 12, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
   %endif
  %endif
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(wl-kmod): sync with rpmfusion patches so it builds on new kernels (#11052)](https://github.com/terrapkg/packages/pull/11052)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)