### PR TITLE
[el10] fix: Use correct repo for xone nightly updater (#11062)

### DIFF
--- a/anda/system/xone/nightly/kmod-common/update.rhai
+++ b/anda/system/xone/nightly/kmod-common/update.rhai
@@ -1,8 +1,8 @@
-rpm.global("commit", gh_commit("dlundqvist/xone"));
+rpm.global("commit", gh_commit("OpenGamingCollective/xonedo"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commitdate", date());
-    let v = gh("dlundqvist/xone");
+    let v = gh("OpenGamingCollective/xonedo");
     v.crop(1);
     rpm.global("ver", v);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [fix: Use correct repo for xone nightly updater (#11062)](https://github.com/terrapkg/packages/pull/11062)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)