### PR TITLE
[frawhide] fix: Correct issues with dependencies in xonedo and xonedo-nightly package, correct regression in xone nightly update script (#11068)

### DIFF
--- a/anda/system/xone/nightly/kmod-common/update.rhai
+++ b/anda/system/xone/nightly/kmod-common/update.rhai
@@ -1,8 +1,8 @@
-rpm.global("commit", gh_commit("OpenGamingCollective/xonedo"));
+rpm.global("commit", gh_commit("dlundqvist/xone"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commitdate", date());
-    let v = gh("OpenGamingCollective/xonedo");
+    let v = gh("dlundqvist/xone");
     v.crop(1);
     rpm.global("ver", v);
 }

--- a/anda/system/xonedo/nightly/akmod/xonedo-nightly-kmod.spec
+++ b/anda/system/xonedo/nightly/akmod/xonedo-nightly-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-nightly-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -25,6 +25,7 @@ Conflicts:      dkms-%{modulename}-nightly
 Conflicts:      %{modulename}-kmod
 Conflicts:      dkms-xone-nightly
 Conflicts:      xone-kmod
+Provides:       %{modulename}-nightly-kmod
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Obsoletes:      %{name} < %{?epoch:%{epoch}:}3.0^20250419git.c682b0c
 %endif

--- a/anda/system/xonedo/nightly/dkms/dkms-xonedo-nightly.spec
+++ b/anda/system/xonedo/nightly/dkms/dkms-xonedo-nightly.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif

--- a/anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec
+++ b/anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec
@@ -12,7 +12,7 @@
 
 Name:           xonedo-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif

--- a/anda/system/xonedo/stable/akmod/xonedo-kmod.spec
+++ b/anda/system/xonedo/stable/akmod/xonedo-kmod.spec
@@ -5,7 +5,7 @@
 
 Name:           %{modulename}-kmod
 Version:        0.5.7
-Release:        1%?dist
+Release:        2%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif
@@ -22,6 +22,7 @@ Conflicts:      dkms-%{modulename}
 Conflicts:      %{modulename}-nightly-kmod
 Conflicts:      dkms-xone
 Conflicts:      xone-nightly-kmod
+Provides:       %{modulename}-kmod
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Obsoletes:      %{name} < %{?epoch:%{epoch}:}0.3.4
 %endif

--- a/anda/system/xonedo/stable/dkms/dkms-xonedo.spec
+++ b/anda/system/xonedo/stable/dkms/dkms-xonedo.spec
@@ -4,7 +4,7 @@
 
 Name:           dkms-%{modulename}
 Version:        0.5.7
-Release:        1%?dist
+Release:        2%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif

--- a/anda/system/xonedo/stable/kmod-common/update.rhai
+++ b/anda/system/xonedo/stable/kmod-common/update.rhai
@@ -1,7 +1,3 @@
-let v = gh_tag("OpenGamingCollective/xonedo")
-v.crop(1);
-rpm.global("ver", v);
+let v = gh_tag("OpenGamingCollective/xonedo");
 
-if rpm.changed() {
-  rpm.release();
-}
+rpm.version(find(`([\d.]+)-ogc`, v, 1));

--- a/anda/system/xonedo/stable/kmod-common/xonedo.spec
+++ b/anda/system/xonedo/stable/kmod-common/xonedo.spec
@@ -3,11 +3,11 @@
 %global firmware_hash1 48084d9fa53b9bb04358f3bb127b7495dc8f7bb0b3ca1437bd24ef2b6eabdf66
 %global firmware_hash2 0023a7bae02974834500c665a281e25b1ba52c9226c84989f9084fa5ce591d9b
 %global firmware_hash3 e2710daf81e7b36d35985348f68a81d18bc537a2b0c508ffdfde6ac3eae1bad7
-%global ver 0.5.7-ogc1
+%global ogcversion 1
 
 Name:           xonedo
-Version:        %(echo %{ver} | sed 's/-/^/g')
-Release:        1%?dist
+Version:        0.5.7
+Release:        2%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `frawhide`:
 - [fix: Correct issues with dependencies in xonedo and xonedo-nightly package, correct regression in xone nightly update script (#11068)](https://github.com/terrapkg/packages/pull/11068)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)