### PR TITLE
[f42] fix: Use -kmod package as a requirement for akmod-modules (#11073)

### DIFF
--- a/anda/system/hid-fanatecff/akmod/hid-fanatecff-kmod.spec
+++ b/anda/system/hid-fanatecff/akmod/hid-fanatecff-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:        Fanatec force feedback kernel module
 License:        GPL-2.0-only
 URL:            https://github.com/gotzl/%{modulename}

--- a/anda/system/hid-fanatecff/dkms/dkms-hid-fanatecff.spec
+++ b/anda/system/hid-fanatecff/dkms/dkms-hid-fanatecff.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Fanatec force feedback kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/gotzl/%{modulename}

--- a/anda/system/hid-fanatecff/kmod-common/hid-fanatecff.spec
+++ b/anda/system/hid-fanatecff/kmod-common/hid-fanatecff.spec
@@ -5,7 +5,7 @@
 
 Name:           hid-fanatecff
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Fanatec force feedback driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/gotzl/%{name}
@@ -21,7 +21,7 @@ akmod and dkms variants.
 
 %package       akmod-modules
 Summary:       Modules for Akmods
-Requires:      akmod-%{name}
+Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:     noarch
 
 %description   akmod-modules

--- a/anda/system/hid-tmff2/akmod/hid-tmff2-kmod.spec
+++ b/anda/system/hid-tmff2/akmod/hid-tmff2-kmod.spec
@@ -12,7 +12,7 @@
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Thrustmaster Force Feedback kernel module
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{modulename}

--- a/anda/system/hid-tmff2/dkms/dkms-hid-tmff2.spec
+++ b/anda/system/hid-tmff2/dkms/dkms-hid-tmff2.spec
@@ -11,7 +11,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Thrustmaster Force Feedback kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{modulename}

--- a/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
+++ b/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
@@ -8,7 +8,7 @@
 
 Name:           hid-tmff2
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Thrustmaster Force Feedback driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{name}
@@ -25,7 +25,7 @@ between the akmod and dkms variants.
 
 %package       akmod-modules
 Summary:       Modules for Akmods
-Requires:      akmod-%{name}
+Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:     noarch
 
 %description   akmod-modules

--- a/anda/system/new-lg4ff/akmod/new-lg4ff-kmod.spec
+++ b/anda/system/new-lg4ff/akmod/new-lg4ff-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:        Logitech force feedback kernel module
 License:        GPL-2.0-only
 URL:            https://github.com/berarma/%{modulename}

--- a/anda/system/new-lg4ff/dkms/dkms-new-lg4ff.spec
+++ b/anda/system/new-lg4ff/dkms/dkms-new-lg4ff.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Logitech force feedback kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/berarma/%{modulename}

--- a/anda/system/new-lg4ff/kmod-common/new-lg4ff.spec
+++ b/anda/system/new-lg4ff/kmod-common/new-lg4ff.spec
@@ -5,7 +5,7 @@
 
 Name:           new-lg4ff
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Logitech force feedback driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/berarma/%{name}
@@ -20,7 +20,7 @@ common files shared between the akmod and dkms variants.
 
 %package       akmod-modules
 Summary:       Modules for Akmods
-Requires:      akmod-%{name}
+Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:     noarch
 
 %description   akmod-modules

--- a/anda/system/t150-driver/akmod/t150-driver-kmod.spec
+++ b/anda/system/t150-driver/akmod/t150-driver-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:        Thrustmaster T150 steering wheel kernel module
 License:        GPL-2.0-only
 URL:            https://github.com/scarburato/t150_driver

--- a/anda/system/t150-driver/dkms/dkms-t150-driver.spec
+++ b/anda/system/t150-driver/dkms/dkms-t150-driver.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Thrustmaster T150 steering wheel kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/scarburato/t150_driver

--- a/anda/system/t150-driver/kmod-common/t150-driver.spec
+++ b/anda/system/t150-driver/kmod-common/t150-driver.spec
@@ -5,7 +5,7 @@
 
 Name:           t150-driver
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Thrustmaster T150 steering wheel driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/scarburato/t150_driver
@@ -20,7 +20,7 @@ common files shared between the akmod and dkms variants.
 
 %package       akmod-modules
 Summary:       Modules for Akmods
-Requires:      akmod-%{name}
+Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:     noarch
 
 %description   akmod-modules

--- a/anda/system/v4l2loopback/akmod/v4l2loopback-kmod.spec
+++ b/anda/system/v4l2loopback/akmod/v4l2loopback-kmod.spec
@@ -18,7 +18,7 @@ This module allows you to create \"virtual video devices.\" Normal \(v4l2\) appl
 Name:           %{modulename}-kmod
 Summary:        Kernel module (kmod) for V4L2 loopback devices
 Version:        0.15.3
-Release:        2%?dist
+Release:        3%?dist
 License:        GPL-2.0-or-later
 URL:            https://github.com/v4l2loopback/v4l2loopback
 Source0:        %{url}/archive/v%{version}/%{modulename}-%{version}.tar.gz

--- a/anda/system/v4l2loopback/dkms/dkms-v4l2loopback.spec
+++ b/anda/system/v4l2loopback/dkms/dkms-v4l2loopback.spec
@@ -5,7 +5,7 @@ This module allows you to create \"virtual video devices.\" Normal \(v4l2\) appl
 
 Name:           dkms-%{modulename}
 Version:        0.15.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Utils for V4L2 loopback devices
 License:        GPL-2.0-or-later
 URL:            https://github.com/v4l2loopback/v4l2loopback

--- a/anda/system/v4l2loopback/kmod-common/v4l2loopback.spec
+++ b/anda/system/v4l2loopback/kmod-common/v4l2loopback.spec
@@ -6,7 +6,7 @@
 Name:           v4l2loopback
 Summary:        Utils for V4L2 loopback devices
 Version:        0.15.3
-Release:        1%?dist
+Release:        2%?dist
 License:        GPL-2.0-or-later
 URL:            https://github.com/v4l2loopback/v4l2loopback
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
@@ -29,7 +29,7 @@ Allows you to create "virtual video devices". Normal (v4l2) applications will re
 
 %package        akmod-modules
 Summary:        Modules for Akmods
-Requires:       akmod-%{name}
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
 
 %description    akmod-modules

--- a/anda/system/xone/nightly/akmod/xone-nightly-kmod.spec
+++ b/anda/system/xone/nightly/akmod/xone-nightly-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-nightly-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif

--- a/anda/system/xone/nightly/dkms/dkms-xone-nightly.spec
+++ b/anda/system/xone/nightly/dkms/dkms-xone-nightly.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif

--- a/anda/system/xone/nightly/kmod-common/xone-nightly.spec
+++ b/anda/system/xone/nightly/kmod-common/xone-nightly.spec
@@ -11,7 +11,7 @@
 
 Name:           xone-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -45,7 +45,7 @@ Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.
 
 %package        akmod-modules
 Summary:        Modules for Akmods
-Requires:       akmod-%{name}
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
 
 %description    akmod-modules

--- a/anda/system/xone/stable/akmod/xone-kmod.spec
+++ b/anda/system/xone/stable/akmod/xone-kmod.spec
@@ -4,7 +4,7 @@
 
 Name:           %{modulename}-kmod
 Version:        0.5.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif

--- a/anda/system/xone/stable/dkms/dkms-xone.spec
+++ b/anda/system/xone/stable/dkms/dkms-xone.spec
@@ -3,7 +3,7 @@
 
 Name:           dkms-%{modulename}
 Version:        0.5.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif

--- a/anda/system/xone/stable/kmod-common/xone.spec
+++ b/anda/system/xone/stable/kmod-common/xone.spec
@@ -6,7 +6,7 @@
 
 Name:           xone
 Version:        0.5.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif
@@ -44,7 +44,7 @@ Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.
 
 %package        akmod-modules
 Summary:        Modules for Akmods
-Requires:       akmod-%{name}
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
 
 %description    akmod-modules

--- a/anda/system/xonedo/nightly/akmod/xonedo-nightly-kmod.spec
+++ b/anda/system/xonedo/nightly/akmod/xonedo-nightly-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-nightly-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif

--- a/anda/system/xonedo/nightly/dkms/dkms-xonedo-nightly.spec
+++ b/anda/system/xonedo/nightly/dkms/dkms-xonedo-nightly.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif

--- a/anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec
+++ b/anda/system/xonedo/nightly/kmod-common/xonedo-nightly.spec
@@ -12,7 +12,7 @@
 
 Name:           xonedo-nightly
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          1
 %endif
@@ -47,7 +47,7 @@ Linux kernel driver for Xbox One and Xbox Series X|S accessories common files. C
 
 %package        akmod-modules
 Summary:        Modules for Akmods
-Requires:       akmod-%{name}
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
 
 %description    akmod-modules

--- a/anda/system/xonedo/stable/akmod/xonedo-kmod.spec
+++ b/anda/system/xonedo/stable/akmod/xonedo-kmod.spec
@@ -5,7 +5,7 @@
 
 Name:           %{modulename}-kmod
 Version:        0.5.7
-Release:        2%?dist
+Release:        3%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif

--- a/anda/system/xonedo/stable/dkms/dkms-xonedo.spec
+++ b/anda/system/xonedo/stable/dkms/dkms-xonedo.spec
@@ -4,7 +4,7 @@
 
 Name:           dkms-%{modulename}
 Version:        0.5.7
-Release:        2%?dist
+Release:        3%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif

--- a/anda/system/xonedo/stable/kmod-common/xonedo.spec
+++ b/anda/system/xonedo/stable/kmod-common/xonedo.spec
@@ -7,7 +7,7 @@
 
 Name:           xonedo
 Version:        0.5.7
-Release:        2%?dist
+Release:        3%?dist
 %if 0%{?fedora} <= 43 || 0%{?rhel} <= 10
 Epoch:          2
 %endif
@@ -47,7 +47,7 @@ Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.
 
 %package        akmod-modules
 Summary:        Modules for Akmods
-Requires:       akmod-%{name}
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
 
 %description    akmod-modules

--- a/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
+++ b/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
@@ -10,7 +10,7 @@ This is the original upstream xpad driver from the Linux kernel with support for
 
 Name:          %{modulename}-kmod
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       4%{?dist}
+Release:       5%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
 URL:           https://github.com/medusalix/xpad-noone

--- a/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
+++ b/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
@@ -8,7 +8,7 @@ This is the original upstream xpad driver from the Linux kernel with support for
 
 Name:          dkms-%{modulename}
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       3%{?dist}
+Release:       4%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
 URL:           https://github.com/medusalix/xpad-noone

--- a/anda/system/xpad-noone/kmod-common/xpad-noone.spec
+++ b/anda/system/xpad-noone/kmod-common/xpad-noone.spec
@@ -7,7 +7,7 @@ This is the original upstream xpad driver from the Linux kernel with support for
 
 Name:          xpad-noone
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       2%{?dist}
+Release:       3%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
 URL:           https://github.com/medusalix/xpad-noone
@@ -25,7 +25,7 @@ Packager:      Gilver E. <roachy@fyralabs.com>
 
 %package      akmod-modules
 Summary:      Modules for Akmods
-Requires:     akmod-%{name}
+Requires:     %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:    noarch
 
 %description   akmod-modules

--- a/anda/system/xpadneo/akmod/xpadneo-kmod.spec
+++ b/anda/system/xpadneo/akmod/xpadneo-kmod.spec
@@ -8,7 +8,7 @@
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/xpadneo

--- a/anda/system/xpadneo/dkms/dkms-xpadneo.spec
+++ b/anda/system/xpadneo/dkms/dkms-xpadneo.spec
@@ -7,7 +7,7 @@
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/%{modulename}

--- a/anda/system/xpadneo/kmod-common/xpadneo.spec
+++ b/anda/system/xpadneo/kmod-common/xpadneo.spec
@@ -5,7 +5,7 @@
 
 Name:           xpadneo
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Advanced Linux Driver for Xbox One Wireless Gamepad common files
 License:        GPL-3.0
 URL:            https://atar-axis.github.io/%{name}
@@ -24,7 +24,7 @@ Advanced Linux Driver for Xbox One Wireless Gamepad common files.
 
 %package       akmod-modules
 Summary:       Modules for Akmods
-Requires:      akmod-%{name}
+Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:     noarch
 
 %description   akmod-modules

--- a/anda/system/zenergy/akmod/zenergy-kmod.spec
+++ b/anda/system/zenergy/akmod/zenergy-kmod.spec
@@ -14,7 +14,7 @@
 
 Name:           %{modulename}-kmod
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) via the hardware monitor (HWMON) sysfs interface.
 License:        GPL-2.0
 URL:            https://github.com/BoukeHaarsma23/zenergy

--- a/anda/system/zenergy/dkms/dkms-zenergy.spec
+++ b/anda/system/zenergy/dkms/dkms-zenergy.spec
@@ -6,7 +6,7 @@
 
 Name:           dkms-%{modulename}
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) via the hardware monitor (HWMON) sysfs interface.
 License:        GPL-2.0
 URL:            https://github.com/BoukeHaarsma23/zenergy

--- a/anda/system/zenergy/kmod-common/zenergy.spec
+++ b/anda/system/zenergy/kmod-common/zenergy.spec
@@ -4,7 +4,7 @@
 
 Name:           zenergy
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Exposes the energy counters that are reported via the Running Average Power Limit (RAPL) Model-specific Registers (MSRs) via the hardware monitor (HWMON) sysfs interface.
 License:        GPL-2.0
 URL:            https://github.com/BoukeHaarsma23/zenergy
@@ -25,7 +25,7 @@ via the hardware monitor (HWMON) sysfs interface.
 
 %package       akmod-modules
 Summary:       Modules for Akmods
-Requires:      akmod-%{name}
+Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 BuildArch:     noarch
 
 %description   akmod-modules


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f42`:
 - [fix: Use -kmod package as a requirement for akmod-modules (#11073)](https://github.com/terrapkg/packages/pull/11073)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)