### PR TITLE
[el10] Update requirements and retry folder placement in twintaillauncher.spec (#10839)

### DIFF
--- a/anda/apps/twintaillauncher/twintaillauncher.spec
+++ b/anda/apps/twintaillauncher/twintaillauncher.spec
@@ -7,18 +7,29 @@
 Name:           twintaillauncher
 
 Version:        2.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A multi-platform launcher for your anime games
 Packager:        Yoong Jin <solomoncyj@gmail.com>
 
-SourceLicense: GPL-3.0-or-later
-License:        GPL-3.0-or-later AND (((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR Apache-2.0 OR MIT) AND (Apache-2.0) AND (Apache-2.0 AND ISC) AND (Apache-2.0 AND MIT) AND (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR CC0-1.0) AND (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT) AND (Apache-2.0 OR BSD-2-Clause OR MIT) AND (Apache-2.0 OR BSD-3-Clause) AND (Apache-2.0 OR BSD-3-Clause OR MIT) AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR CC0-1.0 OR MIT-0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR LGPL-2.1-or-later OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 OR MIT OR Zlib) AND (Apache-2.0 WITH LLVM-exception) AND (BSD-2-Clause) AND (BSD-3-Clause) AND (BSD-3-Clause AND MIT) AND (BSD-3-Clause OR MIT) AND CC0-1.0 AND (CC0-1.0 OR MIT-0) AND (CDLA-Permissive-2.0) AND ISC AND (ISC AND (Apache-2.0 OR ISC)) AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (LGPL-3.0-or-later OR MIT) AND MIT AND (MIT OR Unlicense) AND MPL-2.0 AND  Unicode-3.0 AND Zlib AND bzip2-1.0.6)
+SourceLicense: GPL-3.0-only
+License:        GPL-3.0-only AND (((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR Apache-2.0 OR MIT) AND (Apache-2.0) AND (Apache-2.0 AND ISC) AND (Apache-2.0 AND MIT) AND (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR CC0-1.0) AND (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT) AND (Apache-2.0 OR BSD-2-Clause OR MIT) AND (Apache-2.0 OR BSD-3-Clause) AND (Apache-2.0 OR BSD-3-Clause OR MIT) AND (Apache-2.0 OR BSL-1.0 OR MIT) AND (Apache-2.0 OR CC0-1.0 OR MIT-0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR LGPL-2.1-or-later OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 OR MIT OR Zlib) AND (Apache-2.0 WITH LLVM-exception) AND (BSD-2-Clause) AND (BSD-3-Clause) AND (BSD-3-Clause AND MIT) AND (BSD-3-Clause OR MIT) AND CC0-1.0 AND (CC0-1.0 OR MIT-0) AND (CDLA-Permissive-2.0) AND ISC AND (ISC AND (Apache-2.0 OR ISC)) AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (LGPL-3.0-or-later OR MIT) AND MIT AND (MIT OR Unlicense) AND MPL-2.0 AND  Unicode-3.0 AND Zlib AND bzip2-1.0.6)
 URL:            https://twintaillauncher.app/
 Source0:        https://github.com/TwintailTeam/TwintailLauncher/archive/refs/tags/ttl-v%{version}.tar.gz
 
 ExclusiveArch: x86_64
 
+Requires:       cairo
+Requires:       desktop-file-utils
+Requires:       gdk-pixbuf2
+Requires:       glib2
+Requires:       gtk3
 Requires:       hicolor-icon-theme
+Requires:       libappindicator-gtk3
+Requires:       libayatana-appindicator-gtk3
+Requires:       pango
+Requires:       webkit2gtk4.1
+Requires:       mangohud
+Requires:       gamemode
 
 # Build requires
 BuildRequires:  pnpm
@@ -40,19 +51,19 @@ TTL is an all-in-one tool for downloading, managing, and launching your favorite
 
 %prep
 %autosetup -n TwintailLauncher-ttl-v%{version}
-cd src-tauri
-cargo update
-cd ..
 %tauri_prep
+%{__pnpm} import
 
 %build
-%pnpm_build
+%pnpm_build -F
 
 
 %install
 %tauri_install
-mkdir -p %{buildroot}/%{_libdir}/twintaillauncher/resources
-mv %{buildroot}/%{_datadir}/cargo/registry/twintaillauncher-%{version}/resources/ %{buildroot}/%{_libdir}/twintaillauncher/resources
+mkdir -p %{buildroot}/usr/lib/twintaillauncher/resources
+
+#app expects files to be present there
+mv  %{buildroot}/%{_datadir}/cargo/registry/twintaillauncher-%{version}/resources %{buildroot}/usr/lib/twintaillauncher/resources
 rm -rf %{buildroot}/%{_datadir}/cargo/registry/twintaillauncher-%{version}
 
 
@@ -72,7 +83,7 @@ install -Dm644 public/launcher-icon-128.png %{buildroot}%{_hicolordir}/128x128/a
 %doc README.md
 
 %{_bindir}/twintaillauncher
-%{_libdir}/twintaillauncher/resources
+/usr/lib/twintaillauncher/resources
 %{_hicolordir}/512x512/apps/%{name}.png
 %{_hicolordir}/128x128/apps/%{name}.png
 %_appsdir/twintaillauncher.desktop
@@ -81,6 +92,9 @@ install -Dm644 public/launcher-icon-128.png %{buildroot}%{_hicolordir}/128x128/a
 
 
 %changelog
+* Sat Apr 4 2026 Yoong Jin <solomoncyj@gmail.com> - 2.0.0-2
+- Fix folders
+- Update License
 * Thu Feb 19 2026 Yoong Jin <solomoncyj@gmail.com> - 1.1.15-1
 - Fix resources
 * Tue Feb 3 2026 Yoong Jin <solomoncyj@gmail.com> - 1.1.15-0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Update requirements and retry folder placement in twintaillauncher.spec (#10839)](https://github.com/terrapkg/packages/pull/10839)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)