### PR TITLE
[f42] chore(anda): Use %{defined fedora} instead (#11084)

### DIFF
--- a/anda/tools/buildsys/anda/rust-anda.spec
+++ b/anda/tools/buildsys/anda/rust-anda.spec
@@ -18,7 +18,7 @@ ExclusiveArch:  %{rust_arches}
 BuildRequires:  rust-packaging >= 21
 BuildRequires:  anda-srpm-macros
 BuildRequires:  openssl-devel
-%if 0%{?fedora}
+%if %{defined fedora}
 BuildRequires:  openssl-devel-engine
 %endif
 BuildRequires:  git-core


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(anda): Use %{defined fedora} instead (#11084)](https://github.com/terrapkg/packages/pull/11084)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)