### PR TITLE
[el10] [f43] add: logitech-rs50-linux-driver  (#11082)

### DIFF
--- a/anda/system/logitech-rs50-linux-driver/akmod/anda.hcl
+++ b/anda/system/logitech-rs50-linux-driver/akmod/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "logitech-rs50-linux-driver-kmod.spec"
+	}
+	labels {
+		mock = 1
+		updbranch = 1
+	}
+}

--- a/anda/system/logitech-rs50-linux-driver/akmod/logitech-rs50-linux-driver-kmod.spec
+++ b/anda/system/logitech-rs50-linux-driver/akmod/logitech-rs50-linux-driver-kmod.spec
@@ -1,0 +1,69 @@
+# The reason why this package is a separate from the main one despite using the same sources
+# is because akmods use the srpm to build the kmod package, and if the kmod package is included
+# in the main package, akmods will reinstall the userspace package every time the kernel is updated.
+
+%if 0%{?fedora}
+%global buildforkernels akmod
+%global debug_package %{nil}
+%endif
+
+%global commit 34eb21e66a687ea8961f185ecd54bc7e7edae0f8
+%global commitdate 20260407
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global modulename logitech-rs50-linux-driver
+
+Name:           %{modulename}-kmod
+Version:        1.0^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276)
+License:        GPL-2.0-only
+URL:            https://github.com/mescon/logitech-rs50-linux-driver
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
+BuildArch:      x86_64
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  kmodtool
+
+Requires:       akmods
+Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
+Requires:       %{modulename}-akmod-modules = %{?epoch:%{epoch}:}%{version}
+Requires:       kernel-devel
+Conflicts:      dkms-%{modulename}
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276).
+This is a patched version of the hid-logitech-hidpp driver that adds RS50 support with force feedback (FF_CONSTANT) and exposes all G Hub settings via sysfs for runtime configuration.
+Note: This driver replaces the in-kernel hid-logitech-hidpp module and continues to support all other Logitech HID++ devices (mice, keyboards, other racing wheels like the G29, G920, G923, etc.).
+
+%prep
+# error out if there was something wrong with kmodtool
+%{?kmodtool_check}
+
+# print kmodtool output for debugging purposes:
+kmodtool --target %{_target_cpu} --repo terra.fyralabs.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%setup -q -c -n %{modulename}-%{commit}
+
+mv %{modulename}-%{commit}/mainline/* %{modulename}-%{commit}/
+
+for kernel_version  in %{?kernel_versions} ; do
+  cp -a %{modulename}-%{commit} _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version  in %{?kernel_versions} ; do
+  make V=1 %{?_smp_mflags} -C ${kernel_version##*___} M=${PWD}/_kmod_build_${kernel_version%%___*} VERSION=v%{version} modules
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+ mkdir -p %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ install -D -m 755 _kmod_build_${kernel_version%%___*}/hid-logitech-hidpp.ko %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ chmod a+x %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/hid-logitech-hidpp.ko
+done
+%{?akmod_install}
+
+%changelog
+%autochangelog

--- a/anda/system/logitech-rs50-linux-driver/akmod/update.rhai
+++ b/anda/system/logitech-rs50-linux-driver/akmod/update.rhai
@@ -1,0 +1,9 @@
+ let c = sh("cat anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec | grep '%global commit ' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commitdate", d);
+}

--- a/anda/system/logitech-rs50-linux-driver/dkms/anda.hcl
+++ b/anda/system/logitech-rs50-linux-driver/dkms/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "dkms-logitech-rs50-linux-driver.spec"
+	}
+	labels {
+		updbranch = 1
+		mock = 1
+	}
+}

--- a/anda/system/logitech-rs50-linux-driver/dkms/dkms-logitech-rs50-linux-driver.spec
+++ b/anda/system/logitech-rs50-linux-driver/dkms/dkms-logitech-rs50-linux-driver.spec
@@ -1,0 +1,63 @@
+%global commit 34eb21e66a687ea8961f185ecd54bc7e7edae0f8
+%global debug_package %{nil}
+%global modulename logitech-rs50-linux-driver
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260407
+
+Name:           dkms-%{modulename}
+Version:        1.0^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276)
+License:        GPL-2.0-only
+URL:            https://github.com/mescon/%{modulename}
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
+Patch0:         fix-dkms-conf.patch
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
+Requires:       dkms
+Conflicts:      akmod-%{modulename}
+Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+BuildArch:      x86_64
+Provides:       %{modulename}-kmod
+
+%description
+Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276).
+This is a patched version of the hid-logitech-hidpp driver that adds RS50 support with force feedback (FF_CONSTANT) and exposes all G Hub settings via sysfs for runtime configuration.
+Note: This driver replaces the in-kernel hid-logitech-hidpp module and continues to support all other Logitech HID++ devices (mice, keyboards, other racing wheels like the G29, G920, G923, etc.).
+
+
+%package       akmod-modules
+Summary:       Modules for Akmods
+Requires:      akmod-%{name}
+BuildArch:     noarch
+
+%description   akmod-modules
+Akmods modules for the akmod-%{name} package.
+
+%prep
+%autosetup -p1 -n %{modulename}-%{commit}
+mv mainline/* ./
+mkdir build
+sed -i -e 's/__VERSION_STRING/%{version}/g' dkms.conf
+
+%install
+mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}
+cp -fr ./ %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+
+%post
+dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{modulename} -v %{version} -q || :
+dkms install -m %{modulename} -v %{version} -q --force || :
+
+%preun
+dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
+
+%files
+%{_usrsrc}/%{modulename}-%{version}
+%doc README.md rs-wheel-hub-button-layout.png docs/*
+
+
+%changelog
+%autochangelog

--- a/anda/system/logitech-rs50-linux-driver/dkms/fix-dkms-conf.patch
+++ b/anda/system/logitech-rs50-linux-driver/dkms/fix-dkms-conf.patch
@@ -1,0 +1,17 @@
+diff --git a/dkms.conf b/dkms.conf
+index 437e5fd..2c4f3a4 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -1,8 +1,8 @@
+-PACKAGE_NAME="hid-logitech-hidpp"
+-PACKAGE_VERSION="1.0"
++PACKAGE_NAME="logitech-rs50-linux-driver"
++PACKAGE_VERSION="__VERSION_STRING"
+ MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
+ CLEAN="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+ BUILT_MODULE_NAME[0]="hid-logitech-hidpp"
+ DEST_MODULE_NAME[0]="hid-logitech-hidpp"
+ DEST_MODULE_LOCATION[0]="/updates/dkms"
+-AUTOINSTALL="yes"
+\ No newline at end of file
++AUTOINSTALL="yes"

--- a/anda/system/logitech-rs50-linux-driver/dkms/update.rhai
+++ b/anda/system/logitech-rs50-linux-driver/dkms/update.rhai
@@ -1,0 +1,9 @@
+ let c = sh("cat anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec | grep '%global commit ' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commitdate", d);
+}

--- a/anda/system/logitech-rs50-linux-driver/kmod-common/anda.hcl
+++ b/anda/system/logitech-rs50-linux-driver/kmod-common/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "logitech-rs50-linux-driver.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/system/logitech-rs50-linux-driver/kmod-common/com.github.rs50.metainfo.xml
+++ b/anda/system/logitech-rs50-linux-driver/kmod-common/com.github.rs50.metainfo.xml
@@ -1,0 +1,26 @@
+<component type="driver">
+  <id>com.github.rs50</id>
+  <name>logitech rs50 linux driver</name>
+  <pkgname>logitech-rs50-linux-driver</pkgname>
+  <summary>Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276).</summary>
+  <description>
+    <p>
+    Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276).
+    This is a patched version of the hid-logitech-hidpp driver that adds RS50 support with force feedback (FF_CONSTANT) and exposes all G Hub settings via sysfs for runtime configuration.
+    Note: This driver replaces the in-kernel hid-logitech-hidpp module and continues to support all other Logitech HID++ devices (mice, keyboards, other racing wheels like the G29, G920, G923, etc.).
+    </p>
+  </description>
+  <url type="homepage">https://github.com/mescon/logitech-rs50-linux-driver</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <!-- gplv2-only -->
+  <project_license>GPL-2.0-only</project_license>
+
+  <developer id="com.github.rs50">
+    <name>mescon</name>
+  </developer>
+
+
+  <provides>
+    <modalias>usb:v046dpc276*</modalias>
+  </provides>
+</component>

--- a/anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec
+++ b/anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec
@@ -1,0 +1,51 @@
+%global commit 34eb21e66a687ea8961f185ecd54bc7e7edae0f8
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260407
+
+Name:           logitech-rs50-linux-driver
+Version:        1.0^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276)
+License:        GPL-2.0-only
+URL:            https://github.com/mescon/%{name}
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
+Source1:        com.github.rs50.metainfo.xml
+BuildRequires:  systemd-rpm-macros
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
+Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+BuildArch:      noarch
+
+%description
+Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276).
+This is a patched version of the hid-logitech-hidpp driver that adds RS50 support with force feedback (FF_CONSTANT) and exposes all G Hub settings via sysfs for runtime configuration.
+Note: This driver replaces the in-kernel hid-logitech-hidpp module and continues to support all other Logitech HID++ devices (mice, keyboards, other racing wheels like the G29, G920, G923, etc.).
+
+%package       akmod-modules
+Summary:       Modules for Akmods
+Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
+BuildArch:     noarch
+
+%description   akmod-modules
+Akmods modules for the akmod-%{name} package.
+
+%prep
+%autosetup -p1 -n %{name}-%{commit}
+
+echo hid-logitech-hidpp > %{name}.conf
+
+%install
+install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/metainfo/com.github.rs50.metainfo.xml
+
+# Akmods modules
+install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
+
+
+%files
+%doc README.md rs-wheel-hub-button-layout.png docs/*
+%{_datadir}/metainfo/com.github.rs50.metainfo.xml
+
+%files akmod-modules
+%{_modulesloaddir}/%{name}.conf
+
+%changelog
+%autochangelog

--- a/anda/system/logitech-rs50-linux-driver/kmod-common/update.rhai
+++ b/anda/system/logitech-rs50-linux-driver/kmod-common/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("mescon/logitech-rs50-linux-driver"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [[f43] add: logitech-rs50-linux-driver  (#11082)](https://github.com/terrapkg/packages/pull/11082)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)