### PR TITLE
[f42] fix (themes folder): License identifiers, some source updates (#11094)

### DIFF
--- a/anda/themes/adwaita++-icons/adwaita++-icons.spec
+++ b/anda/themes/adwaita++-icons/adwaita++-icons.spec
@@ -3,10 +3,10 @@
 
 Name:           adwaita++-icons
 Version:        6.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        GNOME++, a third-party icons theme, based on new GNOME 3.32's Adwaita
 
-License:        GPL-3.0 and LGPL-3.0 and CC-BY-SA
+License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND CC-BY-SA
 URL:            https://github.com/Bonandry/adwaita-plus
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 BuildArch:      noarch

--- a/anda/themes/bibata-cursor-theme/bibata-cursor-theme.spec
+++ b/anda/themes/bibata-cursor-theme/bibata-cursor-theme.spec
@@ -1,11 +1,10 @@
 Name:		bibata-cursor-theme
 Version:	2.0.7
-Release:	1%?dist
+Release:	2%?dist
 URL:		https://github.com/ful1e5/Bibata_Cursor
 Source0:	%{url}/releases/download/v%{version}/Bibata.tar.xz
 Source1:	https://raw.githubusercontent.com/ful1e5/Bibata_Cursor/v%{version}/README.md
-Source2:	https://raw.githubusercontent.com/ful1e5/Bibata_Cursor/v%{version}/LICENSE
-License:	GPL-3.0
+License:	GPL-3.0-or-later
 Summary:	Open source, compact, and material designed cursor set
 BuildArch:	noarch
 BuildRequires:	rpm_macro(fdupes)
@@ -25,9 +24,8 @@ tar xf %{SOURCE0}
 %install
 mkdir -p %{buildroot}/%{_datadir}/icons/
 mv Bibata-* %{buildroot}/%{_datadir}/icons/
-mkdir -p %{buildroot}/%{_datadir}/{doc,licenses}/%{name}/
+mkdir -p %{buildroot}/%{_datadir}/doc/%{name}/
 cp %{SOURCE1} %{buildroot}/%{_datadir}/doc/%{name}/README.md
-cp %{SOURCE2} %{buildroot}/%{_datadir}/licenses/%{name}/LICENSE
 %fdupes %buildroot%_datadir/icons/
 
 %files

--- a/anda/themes/breeze-plus-icon-theme/breeze-plus-icon-theme.spec
+++ b/anda/themes/breeze-plus-icon-theme/breeze-plus-icon-theme.spec
@@ -1,10 +1,10 @@
 Name:           breeze-plus-icon-theme
 Version:        6.19.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Breeze icon theme with additional icons
 Packager:       Amy King <amy@amyrom.tech>
 
-License:        LGPL-2.1-only
+License:        LGPL-2.1-or-later
 URL:            https://github.com/mjkim0727/breeze-plus
 Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
 BuildArch:      noarch

--- a/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
+++ b/anda/themes/fluent-icon-theme/fluent-icon-theme.spec
@@ -2,10 +2,10 @@
 
 Name:           fluent-icon-theme
 Version:        20250821
-Release:        3%?dist
+Release:        4%?dist
 Summary:        Fluent icon theme for linux desktops
 
-License:        GPL-3.0
+License:        GPL-3.0-or-later
 URL:            https://github.com/vinceliuice/Fluent-icon-theme/
 Source0:        %url/archive/refs/tags/%tag.tar.gz
 

--- a/anda/themes/fluent-theme/fluent-theme.spec
+++ b/anda/themes/fluent-theme/fluent-theme.spec
@@ -2,10 +2,10 @@
 
 Name:           fluent-theme
 Version:        20250417
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Fluent design theme for GNOME/GTK based desktop environments
 
-License:        GPL-3.0
+License:        GPL-3.0-or-later
 URL:            https://github.com/vinceliuice/Fluent-gtk-theme
 Source0:        https://github.com/vinceliuice/Fluent-gtk-theme/archive/refs/tags/%{tag}.tar.gz
 

--- a/anda/themes/google-black-cursor-theme/google-black-cursor-theme.spec
+++ b/anda/themes/google-black-cursor-theme/google-black-cursor-theme.spec
@@ -1,12 +1,12 @@
 Name:		google-black-cursor-theme
 Version:	2.0.0
-Release:	1%{?dist}
+Release:	2%{?dist}
 URL:		https://github.com/ful1e5/Google_Cursor
 Source0:	%{url}/releases/download/v%{version}/GoogleDot-Black.tar.gz
 Source1:	https://raw.githubusercontent.com/ful1e5/Google_Cursor/v%{version}/README.md
 Source2:	https://raw.githubusercontent.com/ful1e5/Google_Cursor/v%{version}/LICENSE
-License:	GPL-3.0
-Summary:	An opensource cursor theme inspired by Google. 
+License:	GPL-3.0-or-later
+Summary:	An opensource cursor theme inspired by Google.
 BuildArch:	noarch
 BuildRequires:	rpm_macro(fdupes)
 

--- a/anda/themes/helium-gtk-theme/helium-gtk-theme.spec
+++ b/anda/themes/helium-gtk-theme/helium-gtk-theme.spec
@@ -3,8 +3,8 @@
 Summary:        tauOS GTK/GNOME Shell Themes
 Name:           helium-gtk-theme
 Version:        %(echo %ver | sed 's/-/./g')
-Release:        2%{?dist}
-License:        GPL-3.0
+Release:        3%{?dist}
+License:        GPL-3.0-or-later
 URL:            https://github.com/tau-OS/tau-helium
 Source0:        https://github.com/tau-OS/tau-helium/archive/refs/tags/%{ver}.tar.gz
 BuildArch:      noarch

--- a/anda/themes/hydrogen-icon-theme/hydrogen-icon-theme.spec
+++ b/anda/themes/hydrogen-icon-theme/hydrogen-icon-theme.spec
@@ -1,8 +1,8 @@
 Summary:        tauOS Icon Theme
 Name:           hydrogen-icon-theme
 Version:        1.0.16
-Release:        2%?dist
-License:        GPL-3.0
+Release:        3%?dist
+License:        GPL-3.0-or-later
 URL:            https://github.com/tau-OS/tau-hydrogen
 Source0:        https://github.com/tau-OS/tau-hydrogen/archive/refs/tags/%{version}.tar.gz
 BuildArch:      noarch

--- a/anda/themes/unity-asset-pool/unity-asset-pool.spec
+++ b/anda/themes/unity-asset-pool/unity-asset-pool.spec
@@ -3,7 +3,7 @@
 Name:    unity-asset-pool
 Summary: Assets and icons for Unity
 Version: 0.8.24
-Release: %autorelease
+Release: 1%?dist
 
 License:   CC-BY-SA
 URL:       https://launchpad.net/unity-asset-pool


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (themes folder): License identifiers, some source updates (#11094)](https://github.com/terrapkg/packages/pull/11094)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)