### PR TITLE
[el10] fix: Let xapp-symbolic-icons only exist on lower branches (#11138)

### DIFF
--- a/anda/misc/xapp-symbolic-icons/anda.hcl
+++ b/anda/misc/xapp-symbolic-icons/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
   rpm {
 	spec = "xapp-symbolic-icons.spec"
   }
+  labels {
+    updbranch = 1
+  }
 }

--- a/anda/misc/xapp-symbolic-icons/update.rhai
+++ b/anda/misc/xapp-symbolic-icons/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh_tag("xapp-project/xapp-symbolic-icons"));
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::bodhi("xapp-symbolic-icons", bump::as_bodhi_ver("f44")));


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [fix: Let xapp-symbolic-icons only exist on lower branches (#11138)](https://github.com/terrapkg/packages/pull/11138)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)