### PR TITLE
[frawhide] fix(hid-tmff2): Remove hid-tminit (#11101)

### DIFF
--- a/anda/system/hid-tmff2/akmod/hid-tmff2-kmod.spec
+++ b/anda/system/hid-tmff2/akmod/hid-tmff2-kmod.spec
@@ -3,21 +3,17 @@
 %global commitdate 20260310
 %global ver 0.83
 
-%global tminit_commit 8c4547288a6c182ed4ff131e36f710f11a76c4a9
-%global tminit_shortcommit %(c=%{tminit_commit}; echo ${c:0:7})
-
 %define buildforkernels akmod
 %global debug_package %{nil}
 %global modulename hid-tmff2
 
 Name:           %{modulename}-kmod
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        4%{?dist}
 Summary:        Thrustmaster Force Feedback kernel module
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{modulename}
 Source0:        %{url}/archive/%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
-Source1:        https://github.com/Kimplul/hid-tminit/archive/%{tminit_commit}.tar.gz#/hid-tminit-%{tminit_shortcommit}.tar.gz
 BuildRequires:  kmodtool
 Requires:       akmods
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
@@ -36,9 +32,9 @@ kmodtool  --target %{_target_cpu}  --repo terrapkg.com --kmodname %{name} %{?bui
 
 %autosetup -p1 -n %{modulename}-%{commit}
 
-# Populate the hid-tminit submodule
+# Stub out the hid-tminit submodule (superseded by in-kernel hid-thrustmaster)
 mkdir -p deps/hid-tminit
-tar xf %{SOURCE1} --strip-components=1 -C deps/hid-tminit
+printf 'all:\ninstall:\nclean:\n' > deps/hid-tminit/Makefile
 
 for kernel_version in %{?kernel_versions}; do
     mkdir _kmod_build_${kernel_version%%___*}
@@ -57,8 +53,6 @@ done
 for kernel_version in %{?kernel_versions}; do
     mkdir -p %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
     install -p -m 0755 _kmod_build_${kernel_version%%___*}/*.ko \
-        %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
-    install -p -m 0755 _kmod_build_${kernel_version%%___*}/deps/hid-tminit/*.ko \
         %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
 done
 %{?akmod_install}

--- a/anda/system/hid-tmff2/akmod/update.rhai
+++ b/anda/system/hid-tmff2/akmod/update.rhai
@@ -9,7 +9,4 @@ if rpm.changed() {
     let v = sh("cat anda/system/hid-tmff2/kmod-common/hid-tmff2.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
     v.pop();
     rpm.global("ver", v);
-    let t = sh("cat anda/system/hid-tmff2/kmod-common/hid-tmff2.spec | grep '%global tminit_commit ' | sed -E 's/.+tminit_commit //'", #{"stdout": "piped"}).ctx.stdout;
-    t.pop();
-    rpm.global("tminit_commit", t);
 }

--- a/anda/system/hid-tmff2/dkms/dkms-hid-tmff2.conf
+++ b/anda/system/hid-tmff2/dkms/dkms-hid-tmff2.conf
@@ -5,13 +5,5 @@ AUTOINSTALL="yes"
 MAKE[0]="'make' KDIR=\"$kernel_source_dir\""
 CLEAN[0]=true
 
-BUILT_MODULE_LOCATION[0]="deps/hid-tminit/"
-BUILT_MODULE_NAME[0]="hid-tminit-new"
+BUILT_MODULE_NAME[0]="hid-tmff-new"
 DEST_MODULE_LOCATION[0]="/extra"
-
-BUILT_MODULE_LOCATION[1]="deps/hid-tminit/"
-BUILT_MODULE_NAME[1]="usb-tminit-new"
-DEST_MODULE_LOCATION[1]="/extra"
-
-BUILT_MODULE_NAME[2]="hid-tmff-new"
-DEST_MODULE_LOCATION[2]="/extra"

--- a/anda/system/hid-tmff2/dkms/dkms-hid-tmff2.spec
+++ b/anda/system/hid-tmff2/dkms/dkms-hid-tmff2.spec
@@ -3,22 +3,18 @@
 %global commitdate 20260310
 %global ver 0.83
 
-%global tminit_commit 8c4547288a6c182ed4ff131e36f710f11a76c4a9
-%global tminit_shortcommit %(c=%{tminit_commit}; echo ${c:0:7})
-
 %global debug_package %{nil}
 %global modulename hid-tmff2
 
 Name:           dkms-%{modulename}
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        4%{?dist}
 Summary:        Thrustmaster Force Feedback kernel module (DKMS)
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{modulename}
 Source0:        %{url}/archive/%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
-Source1:        https://github.com/Kimplul/hid-tminit/archive/%{tminit_commit}.tar.gz#/hid-tminit-%{tminit_shortcommit}.tar.gz
-Source2:        %{name}.conf
-Source3:        no-weak-modules.conf
+Source1:        %{name}.conf
+Source2:        no-weak-modules.conf
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
 Conflicts:      akmod-%{modulename}
@@ -32,11 +28,11 @@ T598, T-GT II and TS-XW wheels.
 %prep
 %autosetup -p1 -n %{modulename}-%{commit}
 
-# Populate the hid-tminit submodule
+# Stub out the hid-tminit submodule (superseded by in-kernel hid-thrustmaster)
 mkdir -p deps/hid-tminit
-tar xf %{SOURCE1} --strip-components=1 -C deps/hid-tminit
+printf 'all:\ninstall:\nclean:\n' > deps/hid-tminit/Makefile
 
-cp -f %{SOURCE2} dkms/dkms.conf
+cp -f %{SOURCE1} dkms/dkms.conf
 sed -i -e 's/__VERSION_STRING/%{version}/g' dkms/dkms.conf
 
 %build
@@ -49,7 +45,7 @@ install -Dpm644 dkms/dkms.conf %{buildroot}%{_usrsrc}/%{modulename}-%{version}/d
 
 %if 0%{?fedora}
 # Do not enable weak modules support in Fedora (no kABI):
-install -Dpm644 %{SOURCE3} %{buildroot}%{_sysconfdir}/dkms/%{modulename}.conf
+install -Dpm644 %{SOURCE2} %{buildroot}%{_sysconfdir}/dkms/%{modulename}.conf
 %endif
 
 %post

--- a/anda/system/hid-tmff2/dkms/update.rhai
+++ b/anda/system/hid-tmff2/dkms/update.rhai
@@ -9,7 +9,4 @@ if rpm.changed() {
     let v = sh("cat anda/system/hid-tmff2/kmod-common/hid-tmff2.spec | grep '%global ver' | sed -E 's/.+ver //'", #{"stdout": "piped"}).ctx.stdout;
     v.pop();
     rpm.global("ver", v);
-    let t = sh("cat anda/system/hid-tmff2/kmod-common/hid-tmff2.spec | grep '%global tminit_commit ' | sed -E 's/.+tminit_commit //'", #{"stdout": "piped"}).ctx.stdout;
-    t.pop();
-    rpm.global("tminit_commit", t);
 }

--- a/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
+++ b/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
@@ -3,17 +3,13 @@
 %global commitdate 20260310
 %global ver 0.83
 
-%global tminit_commit 8c4547288a6c182ed4ff131e36f710f11a76c4a9
-%global tminit_shortcommit %(c=%{tminit_commit}; echo ${c:0:7})
-
 Name:           hid-tmff2
 Version:        %{ver}^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        4%{?dist}
 Summary:        Thrustmaster Force Feedback driver common files
 License:        GPL-2.0-only
 URL:            https://github.com/Kimplul/%{name}
 Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
-Source1:        https://github.com/Kimplul/hid-tminit/archive/%{tminit_commit}.tar.gz#/hid-tminit-%{tminit_shortcommit}.tar.gz
 Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
 BuildArch:      noarch
@@ -36,7 +32,6 @@ Akmods modules for the akmod-%{name} package.
 
 # Extract module names from Kbuild for modules-load.d
 echo hid-tmff-new > %{name}.conf
-echo hid-tminit >> %{name}.conf
 
 %install
 # UDev rules:

--- a/anda/system/hid-tmff2/kmod-common/update.rhai
+++ b/anda/system/hid-tmff2/kmod-common/update.rhai
@@ -5,7 +5,4 @@ if rpm.changed() {
     let ver = gh("Kimplul/hid-tmff2");
     ver.crop(0);
     rpm.global("ver", ver);
-
-    let tminit = gh_commit("Kimplul/hid-tminit");
-    rpm.global("tminit_commit", tminit);
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `frawhide`:
 - [fix(hid-tmff2): Remove hid-tminit (#11101)](https://github.com/terrapkg/packages/pull/11101)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)