### PR TITLE
[el10] fix(gamescope-session-opemgamepadui): Update script (#11100)

### DIFF
--- a/anda/games/gamescope-session-opengamepadui/update.rhai
+++ b/anda/games/gamescope-session-opengamepadui/update.rhai
@@ -1,7 +1,5 @@
-if filters.contains("nightly") {
-    rpm.global("commit", gh_commit("OpenGamingCollective/gamescope-session-steam"));
-    if rpm.changed() {
+rpm.global("commit", gh_commit("OpenGamingCollective/gamescope-session-opengamepadui"));    
+if rpm.changed() {
         rpm.release();
         rpm.global("commit_date", date());
-    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(gamescope-session-opemgamepadui): Update script (#11100)](https://github.com/terrapkg/packages/pull/11100)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)