### PR TITLE
[f44] chore(nvidia-driver): Update build (#10979)

### DIFF
--- a/anda/system/nvidia/nvidia-driver/70-nvidia-driver.preset
+++ b/anda/system/nvidia/nvidia-driver/70-nvidia-driver.preset
@@ -1,11 +1,3 @@
-# Enable complete power management. From:
-# file:///usr/share/doc/nvidia-driver/html/powermanagement.html
-
-enable nvidia-hibernate.service
-enable nvidia-resume.service
-enable nvidia-suspend.service
-enable nvidia-suspend-then-hibernate.service
-
 # Enable Dynamic Boost. From:
 # file:///usr/share/doc/nvidia-driver/html/dynamicboost.html
 

--- a/anda/system/nvidia/nvidia-driver/nvidia-driver.spec
+++ b/anda/system/nvidia/nvidia-driver/nvidia-driver.spec
@@ -1,6 +1,5 @@
 %global debug_package %{nil}
-%global __strip %{nil}
-%global __brp_strip_comment_note %{nil}
+%global __brp_strip %{nil}
 %global __brp_ldconfig %{nil}
 %define _build_id_links none
 
@@ -223,6 +222,13 @@ rm -f libnvidia-pkcs11.so.%{version}
 %endif
 %endif
 
+# Avoid harmless Vulkan loader message:
+# WARNING: [Loader Message] Code 0 : Path to given binary /usr/lib64/libGLX_nvidia.so.590.48.01
+# was found to differ from OS loaded path /usr/lib64/libGLX_nvidia.so.0
+# See also https://github.com/negativo17/nvidia-driver/issues/195
+mv libGLX_nvidia.so.%{version} libGLX_nvidia.so.0
+ln -sf libGLX_nvidia.so.0 libGLX_nvidia.so.%{version}
+
 # Create symlinks for shared objects
 ldconfig -vn .
 
@@ -293,7 +299,7 @@ install -p -m 0644 nvidia-{smi,cuda-mps-control}*.gz %{buildroot}%{_mandir}/man1
 
 %if 0%{?fedora} || 0%{?rhel} < 10
 # X stuff
-install -p -m 0644 -D %{SOURCE10} %{buildroot}%{_sysconfdir}/X11/xorg.conf.d/10-nvidia.conf
+install -p -m 0644 -D nvidia-drm-outputclass.conf %{buildroot}%{_sysconfdir}/X11/xorg.conf.d/10-nvidia.conf
 install -p -m 0755 -D nvidia_drv.so %{buildroot}%{_libdir}/xorg/modules/drivers/nvidia_drv.so
 install -p -m 0755 -D libglxserver_nvidia.so.%{version} %{buildroot}%{_libdir}/xorg/modules/extensions/libglxserver_nvidia.so
 %endif
@@ -312,9 +318,7 @@ install -p -m 0644 nvoptix.bin %{buildroot}%{_datadir}/nvidia/
 mkdir -p %{buildroot}%{_systemd_util_dir}/system-preset/
 install -p -m 0644 %{SOURCE8} %{SOURCE9} %{buildroot}%{_systemd_util_dir}/system-preset/
 mkdir -p %{buildroot}%{_unitdir}/
-install -p -m 0644 systemd/system/*.service %{buildroot}%{_unitdir}/
-install -p -m 0755 systemd/nvidia-sleep.sh %{buildroot}%{_bindir}/
-install -p -m 0755 -D systemd/system-sleep/nvidia %{buildroot}%{_systemd_util_dir}/system-sleep/nvidia
+cp -frv systemd/system/systemd-* systemd/system/nvidia-powerd.service %{buildroot}%{_unitdir}/
 install -p -m 0644 -D nvidia-dbus.conf %{buildroot}%{_datadir}/dbus-1/system.d/nvidia-dbus.conf
 
 # Ignore powerd binary exiting if hardware is not present
@@ -351,25 +355,13 @@ appstream-util validate --nonet %{buildroot}%{_metainfodir}/com.nvidia.driver.me
 %ifarch x86_64 aarch64
 
 %post
-%systemd_post nvidia-hibernate.service
 %systemd_post nvidia-powerd.service
-%systemd_post nvidia-resume.service
-%systemd_post nvidia-suspend.service
-%systemd_post nvidia-suspend-then-hibernate.service
 
 %preun
-%systemd_preun nvidia-hibernate.service
 %systemd_preun nvidia-powerd.service
-%systemd_preun nvidia-resume.service
-%systemd_preun nvidia-suspend.service
-%systemd_preun nvidia-suspend-then-hibernate.service
 
 %postun
-%systemd_postun nvidia-hibernate.service
 %systemd_postun nvidia-powerd.service
-%systemd_postun nvidia-resume.service
-%systemd_postun nvidia-suspend.service
-%systemd_postun nvidia-suspend-then-hibernate.service
 
 %endif
 
@@ -384,18 +376,20 @@ appstream-util validate --nonet %{buildroot}%{_metainfodir}/com.nvidia.driver.me
 %{_bindir}/nvidia-pcc
 %endif
 %{_bindir}/nvidia-powerd
-%{_bindir}/nvidia-sleep.sh
 %{_metainfodir}/com.nvidia.driver.metainfo.xml
 %{_datadir}/dbus-1/system.d/nvidia-dbus.conf
 %{_datadir}/nvidia/nvidia-application-profiles*
 %{_datadir}/pixmaps/com.nvidia.driver.png
 %{_systemd_util_dir}/system-preset/70-nvidia-driver.preset
-%{_systemd_util_dir}/system-sleep/nvidia
-%{_unitdir}/nvidia-hibernate.service
 %{_unitdir}/nvidia-powerd.service
-%{_unitdir}/nvidia-resume.service
-%{_unitdir}/nvidia-suspend.service
-%{_unitdir}/nvidia-suspend-then-hibernate.service
+%dir %{_unitdir}/systemd-suspend.service.d
+%{_unitdir}/systemd-suspend.service.d/nvidia-suspend-nofreeze.conf
+%dir %{_unitdir}/systemd-hibernate.service.d
+%{_unitdir}/systemd-hibernate.service.d/nvidia-suspend-nofreeze.conf
+%dir %{_unitdir}/systemd-suspend-then-hibernate.service.d
+%{_unitdir}/systemd-suspend-then-hibernate.service.d/nvidia-suspend-nofreeze.conf
+%dir %{_unitdir}/systemd-hybrid-sleep.service.d
+%{_unitdir}/systemd-hybrid-sleep.service.d/nvidia-suspend-nofreeze.conf
 %if 0%{?fedora} < 42 || 0%{?rhel}
 %{_sysconfdir}/dnf/plugins/needs-restarting.d/%{name}.conf
 %endif
@@ -465,7 +459,6 @@ appstream-util validate --nonet %{buildroot}%{_metainfodir}/com.nvidia.driver.me
 %endif
 %ifarch x86_64
 %{_datadir}/vulkansc/icd.d/nvidia_icd.%{_target_cpu}.json
-%{_libdir}/libnvidia-present.so.%{version}
 %{_libdir}/libnvidia-vksc-core.so.1
 %{_libdir}/libnvidia-vksc-core.so.%{version}
 %dir %{_libdir}/nvidia

--- a/anda/system/nvidia/nvidia-driver/nvidia-generate-tarballs.sh
+++ b/anda/system/nvidia/nvidia-driver/nvidia-generate-tarballs.sh
@@ -17,7 +17,17 @@ set_vars() {
 
 run_file_get() {
     printf "Downloading installer ${RUN_FILE}... "
-    [[ -f $RUN_FILE ]] || wget -c -q ${DL_SITE}/${PLATFORM}/${VERSION}/$RUN_FILE
+    if [[ ! -f $RUN_FILE ]]; then
+        # Orgininal comment from Negativo: "This is getting ridiculous"
+        # My comment: It sure fucking is.
+        if wget -q -S --spider https://download.nvidia.com/XFree86/${PLATFORM}/${VERSION}/$RUN_FILE; then
+            wget -q https://download.nvidia.com/XFree86/${PLATFORM}/${VERSION}/$RUN_FILE
+        elif wget -q -S --spider https://us.download.nvidia.com/XFree86/${PLATFORM}/${VERSION}/$RUN_FILE; then
+            wget -q https://us.download.nvidia.com/XFree86/${PLATFORM}/${VERSION}/$RUN_FILE
+        else
+            wget -q https://us.download.nvidia.com/tesla/${VERSION}/$RUN_FILE
+        fi
+    fi
     printf "OK\n"
 }
 
@@ -26,8 +36,8 @@ run_file_extract() {
     sh ${RUN_FILE} --extract-only --target ${TEMP_UNPACK}
 }
 
-cleanup_folder() {
 
+cleanup_folder() {
     printf "Cleaning up binaries... "
 
     cd ${TEMP_UNPACK}
@@ -36,7 +46,9 @@ cleanup_folder() {
     #   - Compiled from source
     #   - Interactive installer files
     #   - GLVND GL libraries
-    #   - Internal development only libraries
+    #   - GLVND test scripts
+    #   - Closed source modules
+    #   - Open source modules with precompiled c++ code
     rm -r \
         nvidia-xconfig* \
         nvidia-persistenced* \
@@ -49,7 +61,7 @@ cleanup_folder() {
         libEGL.so.${VERSION} \
         nvidia-installer* .manifest make* mk* libglvnd_install_checker \
         15_nvidia_gbm.json 10_nvidia_wayland.json 20_nvidia_xcb.json 20_nvidia_xlib.json \
-        99_nvidia_wayland2.json \
+        09_nvidia_wayland2.json \
         kernel kernel-open
 
     if [ "${ARCH}" == x86_64 ]; then
@@ -70,7 +82,6 @@ cleanup_folder() {
 }
 
 create_tarball() {
-
     KMOD_COMMON=nvidia-kmod-common-${VERSION}
     USR_64=nvidia-driver-${VERSION}-${ARCH}
     USR_32=nvidia-driver-${VERSION}-i386
@@ -80,7 +91,7 @@ create_tarball() {
     mv ${TEMP_UNPACK}/firmware ${TEMP_UNPACK}/nvidia-bug-report.sh ${KMOD_COMMON}/
 
     if [ "$ARCH" == x86_64 ]; then
-        mkdir ${USR_32}
+        mkdir ${USR_32} 
         mv ${TEMP_UNPACK}/32/* ${USR_32}/
         rm -fr ${TEMP_UNPACK}/32
     else


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(nvidia-driver): Update build (#10979)](https://github.com/terrapkg/packages/pull/10979)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)