### PR TITLE
[f42] fix(modern-colorthief): Upstream dropped Poetry tests (#11161)

### DIFF
--- a/anda/tools/modern-colorthief/modern-colorthief.spec
+++ b/anda/tools/modern-colorthief/modern-colorthief.spec
@@ -1,7 +1,6 @@
 %global pypi_name modern_colorthief
 %bcond bootstrap 0
 %bcond docs %{without bootstrap}
-%bcond test %{without bootstrap}
 
 # The srcrpm is not prefixed with Python because the source is mostly Rust
 Name:          modern-colorthief
@@ -26,15 +25,6 @@ BuildRequires: python3dist(modern-colorthief)
 BuildRequires: python3dist(myst-parser)
 BuildRequires: python3dist(shibuya)
 BuildRequires: python3dist(sphinx)
-%endif
-%if %{with test}
-%if 0%{?fedora} > 40
-BuildRequires: poetry
-BuildRequires: python3dist(poetry)
-%endif
-BuildRequires: python3dist(colorthief)
-BuildRequires: python3dist(fast-colorthief)
-BuildRequires: python3dist(pytest)
 %endif
 
 %description
@@ -78,25 +68,13 @@ done
 
 %{cargo_license_online} > LICENSE.dependencies
 
-%if %{with test}
-%check
-# Poetry doesn't exist on EL and is too old on 40
-%if 0%{?fedora} <= 40 || 0%{?rhel}
-%pytest tests/*.py
-%else
-# This is in the wrong spot in pyproject.toml and Poetry hates it
-# May seem like defeating the purpose of testing but the other tests can be useful
-sed -iE 's/python = ">=3.9,<3.14"//' pyproject.toml
-poetry run pytest
-%endif
-%endif
-
 %files -n python3-%{name}
 %doc DIFFERENCES.md
 %doc PKG-INFO
 %doc README.md
 %license LICENSE
 %license LICENSE.dependencies
+%{_bindir}/%{name}
 %{python3_sitearch}/%{pypi_name}
 %{python3_sitearch}/%{pypi_name}-%{version}.dist-info/
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(modern-colorthief): Upstream dropped Poetry tests (#11161)](https://github.com/terrapkg/packages/pull/11161)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)