### PR TITLE
[f44] bump: noctalia-qs release (#11167)

### DIFF
--- a/anda/desktops/noctalia-qs/noctalia-qs.spec
+++ b/anda/desktops/noctalia-qs/noctalia-qs.spec
@@ -2,7 +2,7 @@
 
 Name:	       noctalia-qs
 Version:       0.0.12
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Flexible QtQuick based desktop shell toolkit
 License:       LGPL-3.0-only AND GPL-3.0-only
 URL:	       https://github.com/noctalia-dev/noctalia-qs


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `f44`:
 - [bump: noctalia-qs release (#11167)](https://github.com/terrapkg/packages/pull/11167)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)