### PR TITLE
[f42] fix(prismlauncher): rename modrinth-mrpack-mime.xml to org.prismlauncher.PrismLauncher.xml (#11191)

### DIFF
--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -134,7 +134,7 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
 %{_appsdir}/org.prismlauncher.PrismLauncher.desktop
 %{_scalableiconsdir}/org.prismlauncher.PrismLauncher.svg
 %{_hicolordir}/256x256/apps/org.prismlauncher.PrismLauncher.png
-%{_datadir}/mime/packages/modrinth-mrpack-mime.xml
+%{_datadir}/mime/packages/org.prismlauncher.PrismLauncher.xml
 %{_datadir}/qlogging-categories%{qt_version}/prismlauncher.categories
 %{_mandir}/man?/prismlauncher.*
 %{_metainfodir}/org.prismlauncher.PrismLauncher.metainfo.xml


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(prismlauncher): rename modrinth-mrpack-mime.xml to org.prismlauncher.PrismLauncher.xml (#11191)](https://github.com/terrapkg/packages/pull/11191)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)