### PR TITLE
[f44] fix(dkms-rtl8821cu): Update kmod build files (#11190)

### DIFF
--- a/anda/system/rtl8821cu/dkms/anda.hcl
+++ b/anda/system/rtl8821cu/dkms/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+        arches = ["x86_64"]
     rpm {
         spec = "dkms-rtl8821cu.spec"
     }

--- a/anda/system/rtl8821cu/dkms/dkms-rtl8821cu.spec
+++ b/anda/system/rtl8821cu/dkms/dkms-rtl8821cu.spec
@@ -4,13 +4,12 @@
 %global ver 5.12.0.4
 %global modulename rtl8821cu
 %global git_name 8821cu-20210916
-%global debug_package %{nil}
 %global _description %{expand:
 Linux Driver for USB Wi-Fi Adapters that are based on the RTL8811CU, RTL8821CU, RTL8821CUH, and RTL8731AU chipsets.}
 
 Name:          dkms-%{modulename}
 Version:       %{ver}^%{commit_date}git.%{shortcommit}
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       Linux Driver for USB Wi-Fi Adapters using RTL8821 chipsets
 License:       GPL-2.0-only
 URL:           https://github.com/morrownr/8821cu-20210916
@@ -26,6 +25,7 @@ Requires:      bc
 Requires:      make
 Provides:      %{modulename}-kmod
 Conflicts:     akmod-%{modulename}
+BuildArch:     noarch
 Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description %_description
@@ -50,7 +50,7 @@ sed -i 's/CONFIG_PLATFORM_ARM64_RPI = n/CONFIG_PLATFORM_ARM64_RPI = y/g' Makefil
 
 %install
 mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
-cp -fr core hal include os_dep platform Kconfig Makefile halmac.mk dkms-make.sh dkms.conf %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+cp -fr core hal include os_dep platform Kconfig Makefile halmac.mk rtl8821c.mk dkms-make.sh dkms.conf %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
 
 %if 0%{?fedora}
 # Do not enable weak modules support in Fedora (no kABI):

--- a/anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec
+++ b/anda/system/rtl8821cu/kmod-common/rtl8821cu-kmod-common.spec
@@ -4,7 +4,6 @@
 %global ver 5.12.0.4
 %global modulename rtl8821cu
 %global git_name 8821cu-20210916
-%global debug_package %{nil}
 
 Name:           %{modulename}-kmod-common
 Version:        %{ver}^%{commit_date}git.%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(dkms-rtl8821cu): Update kmod build files (#11190)](https://github.com/terrapkg/packages/pull/11190)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)