### PR TITLE
[el10] fic(ci): Remove leftover `done` (#11217)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -77,7 +77,6 @@ jobs:
           echo '```xml' >> $GITHUB_STEP_SUMMARY
           appstreamcli validate output/test.xml.gz >> $GITHUB_STEP_SUMMARY || true
           echo "" >> $GITHUB_STEP_SUMMARY
-          done
           echo '```' >> $GITHUB_STEP_SUMMARY
           
       - name: Export logs


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fic(ci): Remove leftover `done` (#11217)](https://github.com/terrapkg/packages/pull/11217)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)