### PR TITLE
[f42] chore: Update Komikku update script (#11210)

### DIFF
--- a/anda/apps/komikku/komikku.spec
+++ b/anda/apps/komikku/komikku.spec
@@ -3,7 +3,6 @@
 %global gtk4_version        4.14.4
 %global libadwaita_version  1.5.1
 %global pure_protobuf_version 2.0.0
-%global raw_ver v50.2.0
 
 Name:           komikku
 Version:        50.2.0
@@ -15,7 +14,7 @@ BuildArch:      noarch
 
 License:        GPL-3.0-or-later
 URL:            https://apps.gnome.org/Komikku/
-Source0:        https://codeberg.org/valos/%{appname}/archive/%{raw_ver}.tar.gz#/%{name}-%{version}.tar.gz
+Source0:        https://codeberg.org/valos/%{appname}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  intltool

--- a/anda/apps/komikku/update.rhai
+++ b/anda/apps/komikku/update.rhai
@@ -1,4 +1,1 @@
-let latest_tag = get("https://codeberg.org/api/v1/repos/valos/Komikku/tags").json_arr()[0].name;
-let new_version = find("([\\.\\d]+)", latest_tag, 1);
-rpm.global("raw_ver", latest_tag);
-rpm.version(new_version);
+rpm.version(codeberg("valos/Komikku"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: Update Komikku update script (#11210)](https://github.com/terrapkg/packages/pull/11210)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)