### PR TITLE
[f43] fix (swayfx): update script for swayVersion (#11218)

### DIFF
--- a/anda/desktops/swayfx/update.rhai
+++ b/anda/desktops/swayfx/update.rhai
@@ -1,1 +1,3 @@
 rpm.version(gh("willPower3309/swayfx"));
+
+rpm.global("swayVersion", gh("swaywm/sway"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (swayfx): update script for swayVersion (#11218)](https://github.com/terrapkg/packages/pull/11218)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)