### PR TITLE
[f44] chore (gmenuharness): use proper license identifier and Release field (#11246)

### DIFF
--- a/anda/lib/gmenuharness/gmenuharness.spec
+++ b/anda/lib/gmenuharness/gmenuharness.spec
@@ -4,9 +4,9 @@
 
 Name:       gmenuharness
 Version:    0.1.4
-Release:    %autorelease
+Release:    2%{?dist}
 Summary:    GMenu harness library
-License:    LGPLv3
+License:    LGPL-3.0-or-later
 URL:        https://gitlab.com/ubports/development/core/gmenuharness
 Source0:    %{url}/-/archive/%commit/gmenuharness-%commit.tar.gz
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (gmenuharness): use proper license identifier and Release field (#11246)](https://github.com/terrapkg/packages/pull/11246)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)