### PR TITLE
[f44] build(deps): bump actions/upload-artifact from 7.0.0 to 7.0.1 (#11270)

### DIFF
--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -102,7 +102,7 @@ jobs:
           x=${NAME//\//@}
           echo "name=$x" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.art.outputs.name }}
           compression-level: 0 # The RPMs are already compressed :p

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [build(deps): bump actions/upload-artifact from 7.0.0 to 7.0.1 (#11270)](https://github.com/terrapkg/packages/pull/11270)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)