### PR TITLE
[el10] fix: use proper cirun arm64 label (#11282)

### DIFF
--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -37,7 +37,7 @@ jobs:
         pkg: ${{ fromJson(inputs.packages) }}
         version: ["10"]
       fail-fast: false
-    runs-on: ${{ inputs.custom_builder && inputs.custom_builder || (matrix.pkg.arch == 'aarch64' && matrix.pkg.labels['large']) && 'cirun-arm64-lg' || matrix.pkg.arch == 'aarch64' && 'ubuntu-22.04-arm' || matrix.pkg.labels['large'] && format('cirun-x86-64-lg--{0}', github.run_id) || 'ubuntu-22.04' }}
+    runs-on: ${{ inputs.custom_builder && inputs.custom_builder || (matrix.pkg.arch == 'aarch64' && matrix.pkg.labels['large']) && format('cirun-arm64-lg--{0}', github.run_id) || matrix.pkg.arch == 'aarch64' && 'ubuntu-22.04-arm' || matrix.pkg.labels['large'] && format('cirun-x86-64-lg--{0}', github.run_id) || 'ubuntu-22.04' }}
     container:
       image: ghcr.io/terrapkg/builder:el${{ matrix.version }}
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: use proper cirun arm64 label (#11282)](https://github.com/terrapkg/packages/pull/11282)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)