### PR TITLE
[f42] chore (xbps): use %conf (#11288)

### DIFF
--- a/anda/system/xbps/xbps.spec
+++ b/anda/system/xbps/xbps.spec
@@ -37,8 +37,10 @@ featureful and portable as much as possible.
 %prep
 %autosetup
 
-%build
+%conf
 %configure
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (xbps): use %conf (#11288)](https://github.com/terrapkg/packages/pull/11288)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)