### PR TITLE
[f42] chore (breakpad): use %conf (#11301)

### DIFF
--- a/anda/lib/breakpad/breakpad.spec
+++ b/anda/lib/breakpad/breakpad.spec
@@ -32,11 +32,13 @@ mkdir -p src/third_party/lss
 cd src/third_party/lss
 tar -xzf %{SOURCE1} --strip-components=0
 
-%build
+%conf
 export CFLAGS="$CFLAGS -Wno-error"
 export CXXFLAGS="$CXXFLAGS -Wno-error"
 
 %configure
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (breakpad): use %conf (#11301)](https://github.com/terrapkg/packages/pull/11301)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)