### PR TITLE
[el10] chore (limine): use %conf (#11291)

### DIFF
--- a/anda/system/limine/limine.spec
+++ b/anda/system/limine/limine.spec
@@ -17,8 +17,10 @@ the reference implementation for the Limine boot protocol.
 %autosetup
 cp %{S:1} .
 
-%build
+%conf
 %configure --enable-all CC_FOR_TARGET=clang LD_FOR_TARGET=ld.lld
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (limine): use %conf (#11291)](https://github.com/terrapkg/packages/pull/11291)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)