### PR TITLE
[f43] chore (dfu-programmer): use %conf (#11303)

### DIFF
--- a/anda/system/dfu-programmer/dfu-programmer.spec
+++ b/anda/system/dfu-programmer/dfu-programmer.spec
@@ -17,11 +17,13 @@ Atmel chips with USB support.
 
 %prep
 %autosetup -p1
+
+%conf
 touch ./ChangeLog
 autoreconf -fiv
+%configure
 
 %build
-%configure
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (dfu-programmer): use %conf (#11303)](https://github.com/terrapkg/packages/pull/11303)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)