### PR TITLE
[f42] chore (lomiri-unity): update license taga dn use %conf (#11304)

### DIFF
--- a/anda/desktops/lomiri-unity/unity-greeter/unity-greeter.spec
+++ b/anda/desktops/lomiri-unity/unity-greeter/unity-greeter.spec
@@ -2,10 +2,10 @@
 
 Name:           unity-greeter
 Version:        25.04.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Unity Greeter for Lightdm
 
-License:        GPL-3.0
+License:        GPL-3.0-or-later
 URL:            https://launchpad.net/unity-greeter
 Source0:        http://archive.ubuntu.com/ubuntu/pool/universe/u/unity-greeter/unity-greeter_%version-0ubuntu%rn.tar.xz
 Patch1:         0001-Remove-libido.patch
@@ -35,12 +35,13 @@ It is implemented as a LightDM greeter.
 %prep
 %autosetup -p1
 
-%build
+%conf
 NOCONFIGURE=1 \
 ./autogen.sh
 
 %configure --disable-static
 
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (lomiri-unity): update license taga dn use %conf (#11304)](https://github.com/terrapkg/packages/pull/11304)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)