### PR TITLE
[f44] chore (grail): use %conf (#11318)

### DIFF
--- a/anda/lib/grail/grail.spec
+++ b/anda/lib/grail/grail.spec
@@ -38,7 +38,7 @@ developing applications that use %{name}.
 %prep
 %autosetup -n grail-%{version}
 
-%build
+%conf
 autoreconf --force --install
 PYTHON=%{__python3}
 export PYTHON
@@ -49,6 +49,7 @@ export PYTHON
 	--with-x11 \
 	--disable-static
 
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (grail): use %conf (#11318)](https://github.com/terrapkg/packages/pull/11318)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)