### PR TITLE
[el10] chore (geis): use %conf (#11311)

### DIFF
--- a/anda/desktops/lomiri-unity/geis/geis.spec
+++ b/anda/desktops/lomiri-unity/geis/geis.spec
@@ -37,7 +37,7 @@ developing applications that use %{name}.
 %prep
 %autosetup -n geis-%{version}+16.04.20160126 -p1
 
-%build
+%conf
 NOCONFIGURE=1 \
 ./autogen.sh
 
@@ -48,6 +48,7 @@ export PYTHON
   --disable-silent-rules \
   --disable-static
 
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (geis): use %conf (#11311)](https://github.com/terrapkg/packages/pull/11311)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)