### PR TITLE
[f43] chore (mate-dock-applet): use %conf (#11320)

### DIFF
--- a/anda/desktops/mate/dock-applet/mate-dock-applet.spec
+++ b/anda/desktops/mate/dock-applet/mate-dock-applet.spec
@@ -17,10 +17,12 @@ Packager:       madonuko <mado@fyralabs.com>
 
 %prep
 %autosetup
+
+%conf
 autoreconf -fi
+%configure --with-gtk3
 
 %build
-%configure --with-gtk3
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (mate-dock-applet): use %conf (#11320)](https://github.com/terrapkg/packages/pull/11320)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)