### PR TITLE
[el10] chore (curl-impersonate-chrome): use %conf (#11313)

### DIFF
--- a/anda/tools/curl-impersonate/curl-impersonate-chrome.spec
+++ b/anda/tools/curl-impersonate/curl-impersonate-chrome.spec
@@ -50,8 +50,10 @@ This package contains the object files necessary to develop %{name}.
 %prep
 %autosetup -n curl-impersonate-%{version} -p1
 
-%build
+%conf
 %configure
+
+%build
 %{__make} chrome-build
 
 %check


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (curl-impersonate-chrome): use %conf (#11313)](https://github.com/terrapkg/packages/pull/11313)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)