### PR TITLE
[f44] chore (gsettings-ubuntu-touch-schemas): use %conf and dont use %autorelease (#11317)

### DIFF
--- a/anda/misc/gsettings-ubuntu-touch-schemas/gsettings-ubuntu-touch-schemas.spec
+++ b/anda/misc/gsettings-ubuntu-touch-schemas/gsettings-ubuntu-touch-schemas.spec
@@ -1,6 +1,6 @@
 Name:           gsettings-ubuntu-touch-schemas
 Version:        0.0.7+21.10.20210712
-Release:        %autorelease
+Release:        1%{?dist}
 Summary:        Shared GSettings schemas for Ubuntu touch and Unity
 BuildArch:      noarch
 
@@ -23,11 +23,13 @@ settings shared by various components of a Ubuntu environment.
 %prep
 %autosetup -c
 
-%build
+%conf
 NOCONFIGURE=1 \
 ./autogen.sh
 
 %configure
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (gsettings-ubuntu-touch-schemas): use %conf and dont use %autorelease (#11317)](https://github.com/terrapkg/packages/pull/11317)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)