### PR TITLE
[f43] chore (xavs2): use %conf (#11310)

### DIFF
--- a/anda/lib/xavs2/xavs2.spec
+++ b/anda/lib/xavs2/xavs2.spec
@@ -49,7 +49,7 @@ This package contains the shared library development files.
 %autosetup 
 %endif
 
-%build
+%conf
 cd build/linux
 export CFLAGS="%{optflags} -Wno-incompatible-pointer-types"
 %configure \
@@ -67,6 +67,8 @@ sed -i \
     -e 's|CFLAGS=.*%{optflags}|CFLAGS=%{optflags}|g' \
     config.mak
 
+%build
+cd build/linux
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (xavs2): use %conf (#11310)](https://github.com/terrapkg/packages/pull/11310)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)