### PR TITLE
[f42] chore (vo-aacenc): use %conf (#11312)

### DIFF
--- a/anda/lib/vo-aacenc/vo-aacenc.spec
+++ b/anda/lib/vo-aacenc/vo-aacenc.spec
@@ -24,8 +24,10 @@ developing applications that use %{name}.
 %prep
 %autosetup -n %{name}-%{version}
 
-%build
+%conf
 %configure --disable-static
+
+%build
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (vo-aacenc): use %conf (#11312)](https://github.com/terrapkg/packages/pull/11312)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)