### PR TITLE
[f42] chore (apparmor): use %conf, bdep libzstd-devel (#11308)

### DIFF
--- a/anda/lib/apparmor/apparmor.spec
+++ b/anda/lib/apparmor/apparmor.spec
@@ -38,6 +38,7 @@ BuildRequires:  systemd-rpm-macros
 BuildRequires:  autoconf-archive
 BuildRequires:  gawk
 BuildRequires:  which
+BuildRequires:  libzstd-devel
 %if %{with tests}
 BuildRequires:  %{_bindir}/runtest
 BuildRequires:  %{_bindir}/prove
@@ -143,10 +144,11 @@ changehat abilities exposed through libapparmor.
 
 %prep
 %autosetup -p1 -n %name-v%normver
+
+%conf
 sed -i 's/@VERSION@/%normver/g' libraries/libapparmor/swig/python/setup.py.in
 sed -i 's/${VERSION}/%normver/g' utils/Makefile
 
-%build
 export PYTHON=%{__python3}
 export PYTHON_VERSION=3
 export PYTHON_VERSIONS=python3
@@ -154,8 +156,12 @@ export PYTHON_VERSIONS=python3
 pushd libraries/libapparmor
 ./autogen.sh
 %configure \
-    --with-python \
+    --with-python
+popd
 
+%build
+
+pushd libraries/libapparmor
 %make_build VERSION=%normver
 popd
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (apparmor): use %conf, bdep libzstd-devel (#11308)](https://github.com/terrapkg/packages/pull/11308)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)