### PR TITLE
[f44] chore (unity-scope-home): use %conf and stop using %autorelease (#11315)

### DIFF
--- a/anda/desktops/lomiri-unity/unity-scope-home/unity-scope-home.spec
+++ b/anda/desktops/lomiri-unity/unity-scope-home/unity-scope-home.spec
@@ -1,7 +1,7 @@
 Name:    unity-scope-home
 Summary: Home scope that aggregates results from multiple scopes
 Version: 19.04.20190412
-Release: %autorelease
+Release: 1%{?dist}
 License: GPL-3.0
 URL:     https://launchpad.net/unity-scope-home
 Source0: http://archive.ubuntu.com/ubuntu/pool/universe/u/unity-scope-home/unity-scope-home_6.8.2+%{version}.orig.tar.gz
@@ -32,12 +32,14 @@ Theme and icons for Unity.
 %prep
 %autosetup -c -p1
 
-%build
+%conf
 NOCONFIGURE=1 \
 ./autogen.sh
 
 # Cannot build with Fedora's libunity
 %configure --disable-static
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (unity-scope-home): use %conf and stop using %autorelease (#11315)](https://github.com/terrapkg/packages/pull/11315)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)