### PR TITLE
[f42] chore (x264): use %conf (#11309)

### DIFF
--- a/anda/multimedia/x264/x264.spec
+++ b/anda/multimedia/x264/x264.spec
@@ -51,7 +51,7 @@ applications that use %{name}.
 %prep
 %git_clone https://code.videolan.org/videolan/x264.git %{commit}
 
-%build
+%conf
 %configure \
     --enable-bashcompletion \
     --enable-debug \
@@ -60,6 +60,7 @@ applications that use %{name}.
     --bit-depth=all \
     --system-libx264
 
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (x264): use %conf (#11309)](https://github.com/terrapkg/packages/pull/11309)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)