### PR TITLE
[f42] chore (xavs): use %conf (#11289)

### DIFF
--- a/anda/lib/xavs/xavs.spec
+++ b/anda/lib/xavs/xavs.spec
@@ -39,12 +39,14 @@ svn co https://svn.code.sf.net/p/xavs/code/trunk %{name}
 %setup -T -D -n %{name}
 %autopatch -p1
 
-%build
+%conf
 %configure \
     --disable-asm \
     --enable-pic \
     --enable-shared \
     --extra-cflags="-Wno-int-conversion -Wno-declaration-missing-parameter-type"
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (xavs): use %conf (#11289)](https://github.com/terrapkg/packages/pull/11289)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)