### PR TITLE
[f43] chore (libde265): use %conf (#11316)

### DIFF
--- a/anda/lib/libde265/libde265.spec
+++ b/anda/lib/libde265/libde265.spec
@@ -41,9 +41,11 @@ Various sample and test applications using %{name} are provided by this package.
 %prep
 %autosetup
 
-%build
+%conf
 autoreconf -vif
 %configure --disable-silent-rules --disable-static --enable-encoder
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (libde265): use %conf (#11316)](https://github.com/terrapkg/packages/pull/11316)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)