### PR TITLE
[el10] chore (fdk-aac): use %conf (#11319)

### DIFF
--- a/anda/lib/fdk-aac/fdk-aac.spec
+++ b/anda/lib/fdk-aac/fdk-aac.spec
@@ -35,9 +35,11 @@ This package contains libraries and header files for developing applications tha
 %prep
 %autosetup -n %{name}-%{version}
 
-%build
+%conf
 autoreconf -vif
 %configure --disable-static
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (fdk-aac): use %conf (#11319)](https://github.com/terrapkg/packages/pull/11319)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)