### PR TITLE
[f44] chore (chafa): use %conf (#11428)

### DIFF
--- a/anda/tools/chafa/chafa.spec
+++ b/anda/tools/chafa/chafa.spec
@@ -45,9 +45,11 @@ Requires:       %{name}-libs%{?_isa} = %{evr}
 %prep
 %autosetup -n chafa-%{version}
 
-%build
+%conf
 autoreconf -ivf
 %configure --disable-rpath
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (chafa): use %conf (#11428)](https://github.com/terrapkg/packages/pull/11428)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)