### PR TITLE
[f44] chore (rpcc): use %conf (#11432)

### DIFF
--- a/anda/apps/rpcc/rpcc.spec
+++ b/anda/apps/rpcc/rpcc.spec
@@ -36,8 +36,10 @@ A number of packages contain plugins which are installed as standard on Raspberr
 %prep
 %autosetup -n rpcc-%commit
 
-%build
+%conf
 %meson
+
+%build
 %meson_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (rpcc): use %conf (#11432)](https://github.com/terrapkg/packages/pull/11432)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)