### PR TITLE
[f44] chore (libunity-misc): use %conf (#11426)

### DIFF
--- a/anda/desktops/lomiri-unity/libunity-misc/libunity-misc.spec
+++ b/anda/desktops/lomiri-unity/libunity-misc/libunity-misc.spec
@@ -32,14 +32,17 @@ developing applications that use %{name}.
 
 %prep
 %autosetup -n libunity-misc-%{version}+14.04.20140115
+
+%conf
 find ./ -type f -exec sed -i 's/-Werror//' {} \;
 NOCONFIGURE=1 \
 ./autogen.sh
 
-%build
 %configure \
 	--disable-silent-rules \
 	--disable-static
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (libunity-misc): use %conf (#11426)](https://github.com/terrapkg/packages/pull/11426)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)