### PR TITLE
[f44] chore (libbacktrace-nightly): use %conf (#11388)

### DIFF
--- a/anda/lib/backtrace/libbacktrace-nightly.spec
+++ b/anda/lib/backtrace/libbacktrace-nightly.spec
@@ -36,13 +36,15 @@ This package contains the development files for the %name package.
 %prep
 %autosetup -n libbacktrace-%commit
 
-%build
+%conf
 autoreconf -fiv
 %configure \
   --disable-static \
   --enable-shared \
   --with-system-libunwind \
   --enable-silent-rules
+
+%build
 %make_build
 
 %check


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (libbacktrace-nightly): use %conf (#11388)](https://github.com/terrapkg/packages/pull/11388)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)