### PR TITLE
[f43] chore (deadbeef-mpris2-plugin): use %conf (#11389)

### DIFF
--- a/anda/multimedia/deadbeef-mpris2-plugin/deadbeef-mpris2-plugin.spec
+++ b/anda/multimedia/deadbeef-mpris2-plugin/deadbeef-mpris2-plugin.spec
@@ -30,13 +30,14 @@ will only support version two.
 
 %prep
 %autosetup
+
+%conf
 autoreconf -fiv
-
-
-%build
 %configure \
  --disable-silent-rules \
  --disable-static
+
+%build
 %{make_build}
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (deadbeef-mpris2-plugin): use %conf (#11389)](https://github.com/terrapkg/packages/pull/11389)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)