### PR TITLE
[f43] chore (lomiri frame): use %conf (#11387)

### DIFF
--- a/anda/desktops/lomiri-unity/frame/frame.spec
+++ b/anda/desktops/lomiri-unity/frame/frame.spec
@@ -33,7 +33,7 @@ developing applications that use %{name}.
 %prep
 %autosetup -c -p1
 
-%build
+%conf
 NOCONFIGURE=1 \
 ./autogen.sh
 
@@ -44,6 +44,7 @@ export PYTHON
   --disable-silent-rules \
   --disable-static
 
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (lomiri frame): use %conf (#11387)](https://github.com/terrapkg/packages/pull/11387)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)