### PR TITLE
[f43] chore (rtaudio-nightly): use %conf (#11295)

### DIFF
--- a/anda/multimedia/rtaudio/rtaudio-nightly.spec
+++ b/anda/multimedia/rtaudio/rtaudio-nightly.spec
@@ -53,6 +53,8 @@ Provides:       rtaudio-devel = %version-%release
 
 %prep
 %autosetup -n rtaudio-%commit
+
+%conf
 # Fix encoding issues
 for file in tests/teststops.cpp; do
    sed 's|\r||' $file > $file.tmp
@@ -61,11 +63,11 @@ for file in tests/teststops.cpp; do
    mv -f $file.tmp2 $file
 done
 
-
-%build
 export CFLAGS="%optflags -fPIC"
 NOCONFIGURE=1 ./autogen.sh
 %configure --with-jack --with-alsa --with-pulse --enable-shared --disable-static --verbose
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (rtaudio-nightly): use %conf (#11295)](https://github.com/terrapkg/packages/pull/11295)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)