### PR TITLE
[f42] chore (vala-nightly): use %conf (#11386)

### DIFF
--- a/anda/langs/vala/vala-nightly/vala-nightly.spec
+++ b/anda/langs/vala/vala-nightly/vala-nightly.spec
@@ -138,12 +138,15 @@ cd %{real_name}-%{commit}
 git checkout %{commit}
 
 
-%build
+%conf
 cd %{real_name}-%{commit}
 ./autogen.sh --help
 %configure
 # Don't use rpath!
 sed -i 's|/lib /usr/lib|/lib /usr/lib /lib64 /usr/lib64|' libtool
+
+%build
+cd %{real_name}-%{commit}
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (vala-nightly): use %conf (#11386)](https://github.com/terrapkg/packages/pull/11386)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)