### PR TITLE
[el10] chore (asusctl): package /etc/asusd (#11485)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -3,7 +3,7 @@
 
 Name:           asusctl
 Version:        6.3.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Epoch:          1
 Summary:        A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops
 URL:            https://gitlab.com/asus-linux/asusctl
@@ -58,6 +58,8 @@ install -D -m 0644 rog-anime/data/diagonal-template.png %{buildroot}/%{_docdir}/
 
 desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.desktop
 
+mkdir -p %{_sysconfdir}/asusd
+
 %files
 %license LICENSE
 %license LICENSE.dependencies
@@ -69,7 +71,7 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.d
 %{_unitdir}/asusd.service
 %{_unitdir}/asus-shutdown.service
 %{_udevrulesdir}/99-asusd.rules
-%dnl %{_sysconfdir}/asusd/
+%dir %{_sysconfdir}/asusd
 %{_datadir}/asusd/aura_support.ron
 %{_datadir}/dbus-1/system.d/asusd.conf
 %{_datadir}/icons/hicolor/512x512/apps/asus_notif_yellow.png


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (asusctl): package /etc/asusd (#11485)](https://github.com/terrapkg/packages/pull/11485)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)