### PR TITLE
[f44] fix (asusctl): make directory in %{buildroot} (#11495)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -58,7 +58,7 @@ install -D -m 0644 rog-anime/data/diagonal-template.png %{buildroot}/%{_docdir}/
 
 desktop-file-validate %{buildroot}/%{_datadir}/applications/rog-control-center.desktop
 
-mkdir -p %{_sysconfdir}/asusd
+mkdir -p %{buildroot}%{_sysconfdir}/asusd
 
 %files
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (asusctl): make directory in %{buildroot} (#11495)](https://github.com/terrapkg/packages/pull/11495)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)