### PR TITLE
[f44] Upgrade dependency from GTK3 to GTK4 (#11518)

### DIFF
--- a/anda/apps/bazzite-portal/bazzite-portal.spec
+++ b/anda/apps/bazzite-portal/bazzite-portal.spec
@@ -7,7 +7,7 @@ Source0:        https://github.com/ublue-os/yafti-gtk/archive/refs/tags/v%{versi
 License:        GPL-3.0-only
 Requires:       python3-gobject
 Requires:       python3-PyYAML
-Requires:       gtk3
+Requires:       gtk4
 Provides:       Bazzite-Portal
 BuildArch:      noarch
 Packager:       Zacharias Xenakis <xarishark@outlook.com>
@@ -35,5 +35,8 @@ install -Dm 644 io.github.ublue_os.yafti_gtk.metainfo.xml %{buildroot}%{_metainf
 %{_metainfodir}/io.github.ublue_os.yafti_gtk.metainfo.xml
 
 %changelog
+* Sun Apr 19 2026 Xarishark <xarishark@outlook.com>
+- Upgraded to GTK4
+
 * Wed Jan 28 2026 Xarishark <xarishark@outlook.com>
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [Upgrade dependency from GTK3 to GTK4 (#11518)](https://github.com/terrapkg/packages/pull/11518)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)