### PR TITLE
[f42] chore (gstreamer1-plugin-icamerasrc): use %conf (#11429)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugin-icamerasrc/gstreamer1-plugin-icamerasrc.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugin-icamerasrc/gstreamer1-plugin-icamerasrc.spec
@@ -44,12 +44,14 @@ Development files for the GStreamer IPU6 camera plugin.
 
 %prep
 %autosetup -p1 -n icamerasrc-%{commit}
-autoreconf -vif
 
-%build
+%conf
+autoreconf -vif
 export CHROME_SLIM_CAMHAL=ON
 export STRIP_VIRTUAL_CHANNEL_CAMHAL=ON
 %configure --enable-gstdrmformat --with-haladaptor
+
+%build
 %make_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (gstreamer1-plugin-icamerasrc): use %conf (#11429)](https://github.com/terrapkg/packages/pull/11429)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)