### PR TITLE
[el10] chore: update license identifiers in lib folder, use %conf and some other small changes (#11507)

### DIFF
--- a/anda/lib/cmake-extras/cmake-extras.spec
+++ b/anda/lib/cmake-extras/cmake-extras.spec
@@ -4,9 +4,9 @@
 
 Name:       cmake-extras
 Version:    1.9
-Release:    1%?dist
+Release:    2%?dist
 Summary:    A collection of add-ons for the CMake build tool
-License:    GPL-3.0
+License:    GPL-3.0-or-later
 URL:        https://gitlab.com/ubports/development/core/cmake-extras
 Source0:    %{url}/-/archive/%commit/cmake-extras-%commit.tar.gz
 BuildArch:  noarch
@@ -31,8 +31,14 @@ sed -i 's/#!\/bin\/sh/#!\/usr\/bin\/sh/' src/CopyrightTest/check_copyright.sh
 sed -i 's/python/python3/' src/IncludeChecker/include_checker.py
 sed -i 'sX/usr/lib/qt5X${CMAKE_LIBDIR}/qt5X' src/QmlPlugins/QmlPluginsConfig.cmake
 
+%conf
+%if 0%{?fedora} >= 44
+      %cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+%else
+			%cmake
+%endif
+
 %build
-%cmake
 %cmake_build
 
 %install

--- a/anda/lib/deviceinfo/deviceinfo.spec
+++ b/anda/lib/deviceinfo/deviceinfo.spec
@@ -4,17 +4,18 @@
 
 Name:       deviceinfo
 Version:    0.2.4
-Release:    1%?dist
+Release:    2%?dist
 Summary:    Library to detect and configure devices
-License:    GPLv3+
+License:    GPL-3.0-or-later
 URL:        https://gitlab.com/ubports/development/core/deviceinfo
 Source0:    %{url}/-/archive/%commit/deviceinfo-%commit.tar.gz
-Source1:    https://salsa.debian.org/ubports-team/deviceinfo/-/raw/master/debian/device-info.1
 
 BuildRequires: cmake
 BuildRequires: cmake-extras
 BuildRequires: pkgconfig(yaml-cpp)
 BuildRequires: gcc-c++
+BuildRequires: gtest-devel
+BuildRequires: gmock-devel
 
 %description
 Library to detect and configure devices for Lomiri.
@@ -30,13 +31,15 @@ developing applications that use %{name}.
 %prep
 %autosetup -n deviceinfo-%commit
 
-%build
+%conf
 %cmake
+
+%build
 %cmake_build
 
 %install
 %cmake_install
-install -Dm644 '%{SOURCE1}' %{buildroot}%{_mandir}/man1/device-info.1
+install -Dm644 tools/device-info.1 %{buildroot}%{_mandir}/man1/device-info.1
 
 %files
 %license LICENSE

--- a/anda/lib/libayatana-common/libayatana-common.spec
+++ b/anda/lib/libayatana-common/libayatana-common.spec
@@ -1,8 +1,8 @@
 Name:       libayatana-common
 Summary:    Common functions for Ayatana System Indicators
 Version:    0.9.11
-Release:    2%?dist
-License:    GPL-3.0
+Release:    3%?dist
+License:    GPL-3.0-or-later
 URL:        https://github.com/AyatanaIndicators/libayatana-common
 Source0:    %{url}/archive/refs/tags/%{version}.tar.gz
 
@@ -17,6 +17,8 @@ BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  vala-devel
 BuildRequires:  vala
 BuildRequires:  intltool
+BuildRequires:  gcc-c++
+BuildRequires:  gtest-devel
 
 %description
 The Ayatana Indicators project is the continuation of Application Indicators
@@ -33,11 +35,12 @@ This package contains the development header files for %{name}.
 %prep
 %autosetup -n %{name}-%{version}
 
-%build
+%conf
 %cmake -DENABLE_LOMIRI_FEATURES=ON \
        -DENABLE_TESTS=ON \
        -DENABLE_COVERAGE=OFF
 
+%build
 %cmake_build
 
 %install

--- a/anda/lib/libfiber/libfiber.spec
+++ b/anda/lib/libfiber/libfiber.spec
@@ -7,12 +7,12 @@ The library enables developers to write highly concurrent applications using syn
 
 Name:           libfiber-devel
 Version:        1.1.0
-Release:        1%?dist
+Release:        2%?dist
 URL:            https://deepwiki.com/iqiyi/libfiber
 Source0:        https://github.com/iqiyi/libfiber/archive/refs/tags/v%version.tar.gz
 Patch0:         add-missing-header.patch
 Summary:        The high performance c/c++ coroutine/fiber library for Linux/FreeBSD/MacOS/Windows, supporting select/poll/epoll/kqueue/iouring/iocp/windows GUI
-License:        LGPL-3.0
+License:        LGPL-3.0-or-later
 ExclusiveArch:  x86_64
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>

--- a/anda/lib/libusermetrics/libusermetrics.spec
+++ b/anda/lib/libusermetrics/libusermetrics.spec
@@ -1,8 +1,8 @@
 Name:       libusermetrics
 Version:    1.4.1
-Release:    1%?dist
+Release:    2%?dist
 Summary:    library for retrieving anonymous metrics about users
-License:    GPLv3 AND LGPLv3 AND LGPLv2
+License:    GPL-3.0-or-later AND LGPL-3.0-or-later AND LGPL-2.1-or-later
 URL:        https://gitlab.com/ubports/development/core/libusermetrics
 Source0:    %url/-/archive/%version/libusermetrics-%version.tar.gz
 
@@ -20,6 +20,8 @@ BuildRequires: pkgconfig(libqtdbustest-1)
 BuildRequires: pkgconfig(libapparmor)
 BuildRequires: qdjango-devel
 BuildRequires: fdupes
+BuildRequires: gmock-devel
+BuildRequires: gtest-devel
 
 %description
 library for retrieving anonymous metrics about users
@@ -55,7 +57,7 @@ The %{name}-doc contains documentation for %{name}.
 %files -f %{name}.lang
 %doc ChangeLog
 %license LGPL_EXCEPTION.txt LICENSE.GPL LICENSE.LGPL LICENSE.LGPL-3
-%{_sysconfdir}/dbus-1/system.d/com.lomiri.UserMetrics.conf
+%{_datadir}/dbus-1/system.d/com.lomiri.UserMetrics.conf
 %{_bindir}/usermetricsinput
 %{_bindir}/usermetricsinput-increment
 %{_libdir}/libusermetricsinput.so.*

--- a/anda/lib/nvidia/cuda-gdb/cuda-gdb.spec
+++ b/anda/lib/nvidia/cuda-gdb/cuda-gdb.spec
@@ -8,9 +8,9 @@
 Name:           %(echo %real_name | tr '_' '-')
 Epoch:          1
 Version:        13.2.75
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        CUDA GDB
-License:        GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL
+License:        GPL-3.0-or-later AND GPL-3.0-or-later with exceptions AND GPL-2.0-or-later AND GPL-2.0-or-later with exceptions AND GPL-1.0-or-later AND LGPL-2.0-or-later AND LGPL-3.0-or-later AND BSD AND LicenseRef-Fedora-Public-Domain AND GFDL
 URL:            https://developer.nvidia.com/cuda-toolkit
 ExclusiveArch:  x86_64 aarch64
 

--- a/anda/lib/qmenumodel/qmenumodel.spec
+++ b/anda/lib/qmenumodel/qmenumodel.spec
@@ -1,8 +1,8 @@
 Name:       qmenumodel
 Version:    0.9.2
-Release:    %autorelease
+Release:    2%{?dist}
 Summary:    Qt5 renderer for Ayatana Indicators
-License:    LGPL-3.0
+License:    LGPL-3.0-or-later
 URL:        https://github.com/AyatanaIndicators/qmenumodel
 Source0:    https://releases.ayatana-indicators.org/source/qmenumodel/qmenumodel-%{version}.tar.gz
 
@@ -32,8 +32,10 @@ developing applications that use %{name}.
 %prep
 %autosetup -n qmenumodel-%{version} -p1
 
-%build
+%conf
 %cmake -DENABLE_TESTS=ON -DENABLE_COVERAGE=ON -DGENERATE_DOC=ON
+
+%build
 %cmake_build
 
 %install
@@ -43,12 +45,10 @@ developing applications that use %{name}.
 %doc README
 %license COPYING.LGPL
 %{_libdir}/libqmenumodel.so.*
-%dir %{_qt5_qmldir}/QMenuModel.1
 %{_qt5_qmldir}/QMenuModel.1/libqmenumodel-qml.so
 %{_qt5_qmldir}/QMenuModel.1/qmldir
 
 %files devel
-%dir %{_includedir}/qmenumodel
 %{_includedir}/qmenumodel/*.h
 %{_libdir}/libqmenumodel.so
 %{_libdir}/pkgconfig/qmenumodel.pc

--- a/anda/lib/qt5-qtsystems/anda.hcl
+++ b/anda/lib/qt5-qtsystems/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "qt5-qtsystems.spec"
 	}
+  labels {
+    mock = 1
+  }
 }

--- a/anda/lib/qt5-qtsystems/qt5-qtsystems.spec
+++ b/anda/lib/qt5-qtsystems/qt5-qtsystems.spec
@@ -4,9 +4,9 @@
 Name:    qt5-qtsystems
 Summary: Qt5 Mobility Framework
 Version: 5.15
-Release: %autorelease
+Release: 2%{?dist}
 
-License: GPL-3.0
+License: GPL-3.0-or-later
 URL:     https://invent.kde.org/qt/qt/qtsystems
 Source0: %{url}/-/archive/%commit/qt5-mobility-%commit.tar.gz
 Source1: https://salsa.debian.org/qt-kde-team/qt/qtsystems/-/archive/master/qtsystems-master.tar.gz
@@ -136,15 +136,12 @@ cp -a ./include/* %{buildroot}%{_qt5_includedir}
 %{_libdir}/libQt5SystemInfo.so.*
 %{_qt5_bindir}/servicefw
 %{_qt5_bindir}/sfwlisten
-%dir %{_qt5_qmldir}/QtPublishSubscribe
 %{_qt5_qmldir}/QtPublishSubscribe/*.so
 %{_qt5_qmldir}/QtPublishSubscribe/qmldir
 %{_qt5_qmldir}/QtPublishSubscribe/*.qmltypes
-%dir %{_qt5_qmldir}/QtServiceFramework
 %{_qt5_qmldir}/QtServiceFramework/*.so
 %{_qt5_qmldir}/QtServiceFramework/qmldir
 %{_qt5_qmldir}/QtServiceFramework/*.qmltypes
-%dir %{_qt5_qmldir}/QtSystemInfo
 %{_qt5_qmldir}/QtSystemInfo/*.so
 %{_qt5_qmldir}/QtSystemInfo/qmldir
 %{_qt5_qmldir}/QtSystemInfo/*.qmltypes
@@ -156,11 +153,8 @@ cp -a ./include/* %{buildroot}%{_qt5_includedir}
 %{_libdir}/libQt5ServiceFramework.so
 %{_libdir}/libQt5SystemInfo.so
 %{_libdir}/pkgconfig/*.pc
-%dir %{_libdir}/cmake/Qt5PublishSubscribe
 %{_libdir}/cmake/Qt5PublishSubscribe/*.cmake
-%dir %{_libdir}/cmake/Qt5ServiceFramework
 %{_libdir}/cmake/Qt5ServiceFramework/*.cmake
-%dir %{_libdir}/cmake/Qt5SystemInfo
 %{_libdir}/cmake/Qt5SystemInfo/*.cmake
 %{_qt5_archdatadir}/mkspecs/modules/*.pri
 %{_qt5_includedir}/QtPublishSubscribe/
@@ -175,7 +169,6 @@ cp -a ./include/* %{buildroot}%{_qt5_includedir}
 %{_qt5_docdir}/html/qtsysteminfo/
 
 %files examples
-%dir %{_qt5_examplesdir}/systeminfo
 %{_qt5_examplesdir}/systeminfo/*.pro
 %{_qt5_examplesdir}/systeminfo/inputinfo/
 %{_qt5_examplesdir}/systeminfo/qml-battery/

--- a/anda/lib/rtmpdump/rtmpdump.spec
+++ b/anda/lib/rtmpdump/rtmpdump.spec
@@ -4,10 +4,9 @@
 
 Name:           rtmpdump
 Version:        2.6^%{commit_date}git%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Toolkit for RTMP streams
-# The tools are GPLv2+, but the he library is LGPLv2+.
-License:        GPLv2+
+License:        GPL-2.0-or-later AND LGPL-2.0-or-later
 URL:            https://git.ffmpeg.org/gitweb/%{name}.git
 BuildRequires:  gcc
 BuildRequires:  git


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: update license identifiers in lib folder, use %conf and some other small changes (#11507)](https://github.com/terrapkg/packages/pull/11507)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)