### PR TITLE
[f42] chore (libbismuth): use %conf, clean spec (#11546)

### DIFF
--- a/anda/lib/libbismuth/libbismuth.spec
+++ b/anda/lib/libbismuth/libbismuth.spec
@@ -33,13 +33,13 @@ for writing applications with libbismuth.
 %prep
 %autosetup -n libbismuth-%{version}
 
-%build
+%conf
 %meson
+
+%build
 %meson_build
 
 %install
-# Install licenses
-mkdir -p licenses
 %meson_install
 
 rm -rf %{buildroot}%{_bindir}/blueprint-compiler


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (libbismuth): use %conf, clean spec (#11546)](https://github.com/terrapkg/packages/pull/11546)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)