### PR TITLE
[f44] chore (sway-audio-idle-inhibit): use %conf (#11559)

### DIFF
--- a/anda/desktops/waylands/sway-audio-idle-inhibit/sway-audio-idle-inhibit.spec
+++ b/anda/desktops/waylands/sway-audio-idle-inhibit/sway-audio-idle-inhibit.spec
@@ -15,8 +15,10 @@ BuildRequires:	pkgconfig(libsystemd)
 %prep
 %autosetup -n SwayAudioIdleInhibit-%version
 
-%build
+%conf
 %meson -Dlogind-provider=systemd
+
+%build
 %meson_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (sway-audio-idle-inhibit): use %conf (#11559)](https://github.com/terrapkg/packages/pull/11559)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)