### PR TITLE
[f42] chore (libaudec): use %conf (#11558)

### DIFF
--- a/anda/lib/audec/libaudec.spec
+++ b/anda/lib/audec/libaudec.spec
@@ -32,8 +32,10 @@ This package contains the development files for the %name package.
 rm -r tests
 %endif
 
-%build
+%conf
 %meson
+
+%build
 %meson_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (libaudec): use %conf (#11558)](https://github.com/terrapkg/packages/pull/11558)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)