### PR TITLE
[el10] sec(ci): Backport security changes to <= 42 (#11586)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set workspace as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Generate build matrix
@@ -51,7 +51,7 @@ jobs:
       image: ghcr.io/terrapkg/appstream-generator:main
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
           path: ./artifacts

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -24,7 +24,7 @@ jobs:
           dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${{ matrix.version }}.noarch.rpm
           dnf install -y mock wget git-core openssl-devel cargo podman fuse-overlayfs rpm-build mock gzip
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: el${{ matrix.version }}
           fetch-depth: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Git

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -43,12 +43,24 @@ jobs:
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up git repository
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Configure sccache
+        id: sccache
+        if: ${{ !contains(matrix.pkg.labels.sccache, '0') }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SCCACHE_GHA_VERSION: ${{ matrix.version }}-${{ matrix.pkg.arch }}-${{ matrix.pkg.pkg }}
+          SCCACHE_GHA_CACHE_FROM: ${{ matrix.version }}-${{ matrix.pkg.arch }}-${{ matrix.pkg.pkg }}
+        with:
+          script: |
+            const script = require('./.github/scripts/configure-sccache.js')
+            await script({github, context, core, exec})
 
       - name: CI Setup Script
         if: ${{ !contains(matrix.pkg.labels, 'mock') }}
@@ -67,6 +79,14 @@ jobs:
       - name: Build with Andaman
         run: anda build -D "vendor Terra" ${{ matrix.pkg.pkg }} -c terra-el${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
 
+      - name: Report Cache Summary
+        if: steps.sccache.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const script = require('./.github/scripts/sccache-stats.js')
+            await script({github, context, core, exec})
+
       - name: Generating artifact name
         id: art
         run: |
@@ -74,7 +94,7 @@ jobs:
           x=${NAME//\//@}
           echo "name=$x" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.art.outputs.name }}
           compression-level: 0 # The RPMs are already compressed :p

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,13 +1,15 @@
 name: Automatic backport/sync action
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 on:
   pull_request_target:
     types: ["labeled", "closed"]
 
 jobs:
   backport:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Backport/sync PR
     runs-on: ubuntu-22.04
     if: github.event.pull_request.merged

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -1,6 +1,6 @@
 name: Update per branch
 permissions:
-  contents: write
+  contents: read
 on:
   schedule:
     - cron: "*/30 * * * *"
@@ -8,7 +8,9 @@ on:
 
 jobs:
   autoupdate:
-    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         branch:
@@ -22,7 +24,7 @@ jobs:
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: ghcr.io/terrapkg/builder:frawhide
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Push to subatomic
         run: |
           branch=${{ github.ref_name }}

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -1,6 +1,6 @@
 name: Nightly Update
 permissions:
-  contents: write
+  contents: read
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -8,13 +8,14 @@ on:
 
 jobs:
   autoupdate:
-    runs-on: ubuntu-latest
+    contents: write
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/terrapkg/builder:frawhide
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.SSH_AUTHENTICATION_KEY }}

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -1,6 +1,6 @@
 name: Weekly Update
 permissions:
-  contents: write
+  contents: read
 on:
   schedule:
     - cron: "0 0 * * 0"
@@ -8,13 +8,15 @@ on:
 
 jobs:
   autoupdate:
-    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/terrapkg/builder:frawhide
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.SSH_AUTHENTICATION_KEY }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,6 @@
 name: Update
 permissions:
-  contents: write
+  contents: read
 on:
   schedule:
     - cron: "*/10 * * * *"
@@ -8,13 +8,15 @@ on:
 
 jobs:
   autoupdate:
-    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/terrapkg/builder:frawhide
       options: --cap-add=SYS_ADMIN --privileged
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.SSH_AUTHENTICATION_KEY }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [sec(ci): Backport security changes to <= 42 (#11586)](https://github.com/terrapkg/packages/pull/11586)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)