### PR TITLE
[f42] fix (Tracy): devel package needs to dep on the main one (#11579)

### DIFF
--- a/anda/devs/tracy/tracy.spec
+++ b/anda/devs/tracy/tracy.spec
@@ -1,6 +1,6 @@
 Name:			tracy
 Version:		0.13.1
-Release:		2%?dist
+Release:		3%?dist
 Summary:		A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications
 License:		BSD-3-Clause
 URL:			https://github.com/wolfpld/tracy
@@ -15,6 +15,7 @@ Tracy is a real time, nanosecond resolution, remote telemetry, hybrid frame and 
 
 %package devel
 Summary: Development files for the tracy package
+Requires:    tracy = %{evr}
 
 %description devel
 Development files for the tracy package.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (Tracy): devel package needs to dep on the main one (#11579)](https://github.com/terrapkg/packages/pull/11579)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)