### PR TITLE
[f44] chore (muon): remove Tracy base package as a dep, add me as packager (#11592)

### DIFF
--- a/anda/buildsys/muon/muon.spec
+++ b/anda/buildsys/muon/muon.spec
@@ -36,7 +36,7 @@ BuildRequires:  python3-pyyaml
 BuildRequires:  mandoc
 BuildRequires:  mdbook
 
-BuildRequires:  tracy
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 An implementation of the meson build system in c99 with minimal dependencies.
@@ -46,7 +46,6 @@ An implementation of the meson build system in c99 with minimal dependencies.
 
 %conf
 %meson --wrap-mode=nofallback \
-
 %if %{?fedora} >= 44
 -Dtracy=disabled
 %endif

--- a/anda/buildsys/muon/muon.spec
+++ b/anda/buildsys/muon/muon.spec
@@ -1,6 +1,6 @@
 Name:           muon
 Version:        0.5.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A meson-compatible build system
 
 # https://git.sr.ht/~lattis/muon/tree/master/item/LICENSES


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (muon): remove Tracy base package as a dep, add me as packager (#11592)](https://github.com/terrapkg/packages/pull/11592)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)