### PR TITLE
[f44] fix: tracy on f44+ (#11598)

### DIFF
--- a/anda/devs/tracy/tracy.spec
+++ b/anda/devs/tracy/tracy.spec
@@ -1,3 +1,9 @@
+%if 0%{?fedora} >= 44
+%global gcc_compat 15
+%global __cc gcc-%{gcc_compat}
+%global __cxx g++-%{gcc_compat}
+%endif
+
 Name:			tracy
 Version:		0.13.1
 Release:		3%?dist
@@ -5,8 +11,32 @@ Summary:		A real time, nanosecond resolution, remote telemetry, hybrid frame and
 License:		BSD-3-Clause
 URL:			https://github.com/wolfpld/tracy
 Source0:		https://github.com/wolfpld/tracy/archive/refs/tags/v%version.tar.gz
-BuildRequires:  pkgconfig(egl) pkgconfig(glfw3) pkgconfig(freetype2) pkgconfig(dbus-1) pkgconfig(libunwind) pkgconfig(libdebuginfod) pkgconfig(tbb) pkgconfig(wayland-client) pkgconfig(wayland-protocols) pkgconfig(xkbcommon) pkgconfig(capstone) pkgconfig(openssl) pkgconfig(pugixml) pkgconfig(libcurl) pkgconfig(libxslt) pkgconfig(libnghttp2) pkgconfig(libidn2) pkgconfig(libssh2) tbb expat libxml2 openssl-libs
-BuildRequires:  cmake gcc gcc-c++ meson
+BuildRequires:  pkgconfig(egl)
+BuildRequires:  pkgconfig(glfw3)
+BuildRequires:  pkgconfig(freetype2)
+BuildRequires:  pkgconfig(dbus-1)
+BuildRequires:  pkgconfig(libunwind)
+BuildRequires:  pkgconfig(libdebuginfod)
+BuildRequires:  pkgconfig(tbb)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-protocols)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(capstone)
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(pugixml)
+BuildRequires:  pkgconfig(libcurl)
+BuildRequires:  pkgconfig(libxslt)
+BuildRequires:  pkgconfig(libnghttp2)
+BuildRequires:  pkgconfig(libidn2)
+BuildRequires:  pkgconfig(libssh2)
+BuildRequires:  tbb
+BuildRequires:  expat
+BuildRequires:  libxml2
+BuildRequires:  openssl-libs
+BuildRequires:  cmake
+BuildRequires:  meson
+BuildRequires:  gcc%{?gcc_compat}
+BuildRequires:  gcc%{?gcc_compat}-c++
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
@@ -23,8 +53,10 @@ Development files for the tracy package.
 %prep
 %autosetup
 
-%build
+%conf
 %meson -Dcpp_std=c++17
+
+%build
 %meson_build
 for project in capture csvexport import update profiler
 do
@@ -73,6 +105,9 @@ install -Dm644 icon/application-tracy.svg %buildroot%_iconsdir/hicolor/scalable/
 %_includedir/tracy/*
 
 %changelog
+* Tue Apr 21 2026 Owen Zimmerman <owen@fyralabs.com> - 0.13.1-2
+- Make gcc15 the default compiler on Fedora 44+
+
 * Mon Jan 19 2026 Owen Zimmerman <owen@fyralabs.com> - 0.13.1-1
 - Fix compile issues, update for 0.13.1
 

--- a/anda/devs/tracy/tracy.spec
+++ b/anda/devs/tracy/tracy.spec
@@ -6,7 +6,7 @@
 
 Name:			tracy
 Version:		0.13.1
-Release:		3%?dist
+Release:		4%?dist
 Summary:		A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications
 License:		BSD-3-Clause
 URL:			https://github.com/wolfpld/tracy


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: tracy on f44+ (#11598)](https://github.com/terrapkg/packages/pull/11598)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)