### PR TITLE
[el10] chore (zlib): use %conf and %configure (#11603)

### DIFF
--- a/anda/lib/zlib/zlib.spec
+++ b/anda/lib/zlib/zlib.spec
@@ -19,14 +19,10 @@ BuildRequires:  gcc
 %pkg_static_files
 
 %prep
-%autosetup 
-export CFLAGS="%optflags"
-export LDFLAGS="%build_ldflags"
-./configure --libdir=%_libdir \
-            --includedir=%_includedir \
-            --sysconfdir=%_sysconfdir \
-            --localstatedir=%_localstatedir \
-            --prefix=%_prefix
+%autosetup
+
+%conf
+%configure
 
 %build
 %make_build
@@ -41,5 +37,8 @@ export LDFLAGS="%build_ldflags"
 %_libdir/libz.so.*
 
 %changelog
+* Tue Apr 21 2026 Owen Zimmerman <owen@fyralabs.com>
+- Use %conf and %configure
+
 * Wed Nov 26 2025 metcya <metcya@gmail.com>
 - package zlib


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (zlib): use %conf and %configure (#11603)](https://github.com/terrapkg/packages/pull/11603)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)