### PR TITLE
[el10] chore (muon): remove version dependant tracy callouts (#11604)

### DIFF
--- a/anda/buildsys/muon/muon.spec
+++ b/anda/buildsys/muon/muon.spec
@@ -20,9 +20,7 @@ BuildRequires:  libarchive-devel
 BuildRequires:  libpkgconf-devel
 BuildRequires:  scdoc
 BuildRequires:  git-core
-%if %{?fedora} < 44
-BuildRequires:  pkgconfig(tracy) %dnl Temporary fix while Tracy does not build for 44+
-%endif
+BuildRequires:  pkgconfig(tracy)
 BuildRequires:  pkgconfig(libattr)
 BuildRequires:  pkgconfig(bzip2)
 BuildRequires:  pkgconfig(libb2)
@@ -45,10 +43,7 @@ An implementation of the meson build system in c99 with minimal dependencies.
 %autosetup -p1
 
 %conf
-%meson --wrap-mode=nofallback \
-%if %{?fedora} >= 44
--Dtracy=disabled
-%endif
+%meson --wrap-mode=nofallback
 
 %build
 %meson_build

--- a/anda/buildsys/muon/muon.spec
+++ b/anda/buildsys/muon/muon.spec
@@ -1,6 +1,6 @@
 Name:           muon
 Version:        0.5.0
-Release:        2%?dist
+Release:        3%?dist
 Summary:        A meson-compatible build system
 
 # https://git.sr.ht/~lattis/muon/tree/master/item/LICENSES


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (muon): remove version dependant tracy callouts (#11604)](https://github.com/terrapkg/packages/pull/11604)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)