### PR TITLE
[f44] build(deps): bump github/codeql-action from 4.35.1 to 4.35.2 (#11616)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [build(deps): bump github/codeql-action from 4.35.1 to 4.35.2 (#11616)](https://github.com/terrapkg/packages/pull/11616)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)