### PR TITLE
[f44] chore (juce): use proper license identifier, use %conf (#11614)

### DIFF
--- a/anda/apps/juce/juce.spec
+++ b/anda/apps/juce/juce.spec
@@ -1,7 +1,7 @@
 Name:           juce
 Version:        8.0.12
-Release:        3%{?dist}
-License:        AGPL-3.0
+Release:        4%{?dist}
+License:        AGPL-3.0-or-later
 Summary:        framework for audio application and plug-in development
 URL:            https://juce.com
 Source:         https://github.com/juce-framework/JUCE/archive/refs/tags/%{version}.tar.gz
@@ -46,10 +46,12 @@ Documentation files for %{name}
 %prep
 %autosetup -p1 -n JUCE-%{version}
 
-%build
+%conf
 %cmake -DJUCER_ENABLE_GPL_MODE=1    \
        -DJUCE_BUILD_EXTRAS=ON       \
        -DJUCE_TOOL_INSTALL_DIR=bin
+
+%build
 %cmake_build
 
 pushd docs/doxygen


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (juce): use proper license identifier, use %conf (#11614)](https://github.com/terrapkg/packages/pull/11614)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)