### PR TITLE
[el10] chore (libayatana-appindicator-glib): use %conf (#11625)

### DIFF
--- a/anda/lib/libayatana-appindicator-glib/libayatana-appindicator-glib.spec
+++ b/anda/lib/libayatana-appindicator-glib/libayatana-appindicator-glib.spec
@@ -3,7 +3,7 @@
 Name:       libayatana-appindicator-glib
 Summary:    Ayatana Application Indicators Shared Library
 Version:    2.0.1
-Release:    2%?dist
+Release:    3%?dist
 License:    GPL-3.0-or-later
 Packager:   veuxit <erroor234@gmail.com>
 URL:        https://github.com/AyatanaIndicators/libayatana-appindicator-glib
@@ -25,8 +25,10 @@ Ayatana Application Indicators Shared Library (GLib-2.0 reimplementation, 100% G
 %prep
 %autosetup -n %{name}-%{version}
 
+%conf
+%cmake
+
 %build
-%cmake 
 %cmake_build
 
 %install

--- a/anda/lib/libayatana-appindicator-glib/libayatana-appindicator-glib.spec
+++ b/anda/lib/libayatana-appindicator-glib/libayatana-appindicator-glib.spec
@@ -3,7 +3,7 @@
 Name:       libayatana-appindicator-glib
 Summary:    Ayatana Application Indicators Shared Library
 Version:    2.0.1
-Release:    3%?dist
+Release:    4%?dist
 License:    GPL-3.0-or-later
 Packager:   veuxit <erroor234@gmail.com>
 URL:        https://github.com/AyatanaIndicators/libayatana-appindicator-glib


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (libayatana-appindicator-glib): use %conf (#11625)](https://github.com/terrapkg/packages/pull/11625)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)