### PR TITLE
[el10] add: framework-tool-tui (#11630)

### DIFF
--- a/anda/apps/framework-tool-tui/anda.hcl
+++ b/anda/apps/framework-tool-tui/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+      arches = ["x86_64"]
+    rpm {
+      spec = "framework-tool-tui.spec"
+    }
+}

--- a/anda/apps/framework-tool-tui/framework-tool-tui.spec
+++ b/anda/apps/framework-tool-tui/framework-tool-tui.spec
@@ -1,0 +1,53 @@
+%undefine __brp_mangle_shebangs
+
+Name:           framework-tool-tui
+Version:        0.8.3
+Release:        1%{?dist}
+Summary:        A TUI for controlling and monitoring Framework Computers hardware built in Rust
+URL:            https://github.com/grouzen/framework-tool-tui
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+License:        MIT AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (MIT OR Apache-2.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-3-Clause AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Zlib AND (Unlicense OR MIT)
+BuildRequires:  anda-srpm-macros
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  pkgconfig(libudev)
+BuildArch:      x86_64
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+A snappy TUI dashboard for controlling and monitoring your Framework Laptop
+hardware — charging, privacy, lighting, USB PD ports, and more.
+
+%package doc
+Summary:	Documentations for %{name}
+BuildArch:	noarch
+
+%description doc
+Documentations for %{name}.
+
+%prep
+%autosetup
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+install -Dm755 target/rpm/framework-tool-tui %{buildroot}%{_bindir}/framework-tool-tui
+%{cargo_license_online} > LICENSE.dependencies
+
+mkdir -p %{buildroot}%{_docdir}/%{name}/
+cp -r docs/*.md %{buildroot}%{_docdir}/%{name}/
+
+%files
+%{_bindir}/framework-tool-tui
+%license LICENSE
+%license LICENSE.dependencies
+%doc README.md
+
+%files doc
+%{_docdir}/%{name}/
+
+%changelog
+* Thu Apr 23 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/apps/framework-tool-tui/update.rhai
+++ b/anda/apps/framework-tool-tui/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("grouzen/framework-tool-tui"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: framework-tool-tui (#11630)](https://github.com/terrapkg/packages/pull/11630)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)