### PR TITLE
[f42] backport: fix (muon): install licenses and readme (#11639)

### DIFF
--- a/anda/buildsys/muon/muon.spec
+++ b/anda/buildsys/muon/muon.spec
@@ -1,6 +1,6 @@
 Name:           muon
 Version:        0.5.0
-Release:        3%?dist
+Release:        4%?dist
 Summary:        A meson-compatible build system
 
 # https://git.sr.ht/~lattis/muon/tree/master/item/LICENSES
@@ -52,6 +52,8 @@ An implementation of the meson build system in c99 with minimal dependencies.
 %meson_install
 
 %files
+%license LICENSES/
+%doc README.md
 %{_bindir}/muon
 %{_mandir}/man1/muon*
 %{_mandir}/man5/meson*


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `f42`:
 - [backport: fix (muon): install licenses and readme (#11639)](https://github.com/terrapkg/packages/pull/11639)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)