### PR TITLE
[el10] bump(f43): plasma6-applet-appgrid (#11648)

### DIFF
--- a/anda/desktops/kde/plasma6-applet-appgrid/plasma6-applet-appgrid.spec
+++ b/anda/desktops/kde/plasma6-applet-appgrid/plasma6-applet-appgrid.spec
@@ -64,5 +64,8 @@ macOS Launchpad, COSMIC, and Pantheon.
 %{_metainfodir}/dev.xarbit.appgrid.metainfo.xml
 
 %changelog
+* Sat Apr 25 2026 hilltty <49129010+hilltty@users.noreply.github.com> - 1.7.8-1
+- Update to 1.7.8
+
 * Thu Apr 24 2026 hilltty <49129010+hilltty@users.noreply.github.com> - 1.2.1-1
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `el10`:
 - [bump(f43): plasma6-applet-appgrid (#11648)](https://github.com/terrapkg/packages/pull/11648)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)