### PR TITLE
[f44] chore(zig-master): Update for Fedora changes (#11468)

### DIFF
--- a/anda/langs/zig/bootstrap/0000-remove-native-lib-directories-from-rpath.patch
+++ b/anda/langs/zig/bootstrap/0000-remove-native-lib-directories-from-rpath.patch
@@ -1,6 +1,18 @@
---- a/src/main.zig	2025-12-27 19:19:30.000000000 -0600
-+++ b/src/main.zig	2025-12-31 08:25:12.962257290 -0600
-@@ -3998,6 +3998,15 @@
+From a865b3569ace118cc1c1cd8d5d130ec316b0307d Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Tue, 14 Apr 2026 19:04:40 +0200
+Subject: [PATCH 1/2] remove native lib directories from rpath
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ src/main.zig | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/main.zig b/src/main.zig
+index 0395a21a5f..86b6d9f86b 100644
+--- a/src/main.zig
++++ b/src/main.zig
+@@ -4102,6 +4102,15 @@ fn createModule(
  
              try create_module.lib_directories.ensureUnusedCapacity(arena, paths.lib_dirs.items.len);
              for (paths.lib_dirs.items) |path| addLibDirectoryWarn2(io, &create_module.lib_directories, path, true);
@@ -16,3 +28,6 @@
          }
  
          if (create_module.libc_paths_file) |paths_file| {
+-- 
+2.53.0
+

--- a/anda/langs/zig/bootstrap/0001-Remove-unsupported-LLVM-targets-for-EPEL.patch
+++ b/anda/langs/zig/bootstrap/0001-Remove-unsupported-LLVM-targets-for-EPEL.patch
@@ -1,0 +1,254 @@
+From 803935baf6a4730426afbb746adfd00c0ffc0f39 Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Tue, 14 Apr 2026 19:20:26 +0200
+Subject: [PATCH 2/2] Remove unsupported LLVM targets for RHEL
+
+LLVM for RHEL is only build with a subset of targets
+this blocks zig at the configuration stage.
+This commit simply swaps them out with the one from
+https://src.fedoraproject.org/rpms/llvm/blob/rawhide/f/llvm.spec
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ cmake/Findllvm.cmake |  2 +-
+ src/codegen/llvm.zig | 97 ++++++++++----------------------------------
+ src/target.zig       | 43 +++++++++++---------
+ 3 files changed, 45 insertions(+), 97 deletions(-)
+
+diff --git a/cmake/Findllvm.cmake b/cmake/Findllvm.cmake
+index 0c08d4f0ac..ed4da12044 100644
+--- a/cmake/Findllvm.cmake
++++ b/cmake/Findllvm.cmake
+@@ -83,7 +83,7 @@ if(ZIG_USE_LLVM_CONFIG)
+       OUTPUT_STRIP_TRAILING_WHITESPACE)
+     string(REPLACE " " ";" LLVM_TARGETS_BUILT "${LLVM_TARGETS_BUILT_SPACES}")
+ 
+-    set(ZIG_LLVM_REQUIRED_TARGETS "AArch64;AMDGPU;ARM;AVR;BPF;Hexagon;Lanai;LoongArch;Mips;MSP430;NVPTX;PowerPC;RISCV;SPIRV;Sparc;SystemZ;VE;WebAssembly;X86;XCore")
++    set(ZIG_LLVM_REQUIRED_TARGETS "X86;AMDGPU;PowerPC;NVPTX;SystemZ;AArch64;BPF;WebAssembly;RISCV")
+ 
+     set(ZIG_LLVM_REQUIRED_TARGETS_ENABLED TRUE)
+     foreach(TARGET_NAME IN LISTS ZIG_LLVM_REQUIRED_TARGETS)
+diff --git a/src/codegen/llvm.zig b/src/codegen/llvm.zig
+index 1ba3b272da..1ac1f6adc8 100644
+--- a/src/codegen/llvm.zig
++++ b/src/codegen/llvm.zig
+@@ -4736,20 +4736,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+             bindings.LLVMInitializeAMDGPUAsmPrinter();
+             bindings.LLVMInitializeAMDGPUAsmParser();
+         },
+-        .thumb, .thumbeb, .arm, .armeb => {
+-            bindings.LLVMInitializeARMTarget();
+-            bindings.LLVMInitializeARMTargetInfo();
+-            bindings.LLVMInitializeARMTargetMC();
+-            bindings.LLVMInitializeARMAsmPrinter();
+-            bindings.LLVMInitializeARMAsmParser();
+-        },
+-        .avr => {
+-            bindings.LLVMInitializeAVRTarget();
+-            bindings.LLVMInitializeAVRTargetInfo();
+-            bindings.LLVMInitializeAVRTargetMC();
+-            bindings.LLVMInitializeAVRAsmPrinter();
+-            bindings.LLVMInitializeAVRAsmParser();
+-        },
+         .bpfel, .bpfeb => {
+             bindings.LLVMInitializeBPFTarget();
+             bindings.LLVMInitializeBPFTargetInfo();
+@@ -4757,34 +4743,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+             bindings.LLVMInitializeBPFAsmPrinter();
+             bindings.LLVMInitializeBPFAsmParser();
+         },
+-        .hexagon => {
+-            bindings.LLVMInitializeHexagonTarget();
+-            bindings.LLVMInitializeHexagonTargetInfo();
+-            bindings.LLVMInitializeHexagonTargetMC();
+-            bindings.LLVMInitializeHexagonAsmPrinter();
+-            bindings.LLVMInitializeHexagonAsmParser();
+-        },
+-        .lanai => {
+-            bindings.LLVMInitializeLanaiTarget();
+-            bindings.LLVMInitializeLanaiTargetInfo();
+-            bindings.LLVMInitializeLanaiTargetMC();
+-            bindings.LLVMInitializeLanaiAsmPrinter();
+-            bindings.LLVMInitializeLanaiAsmParser();
+-        },
+-        .mips, .mipsel, .mips64, .mips64el => {
+-            bindings.LLVMInitializeMipsTarget();
+-            bindings.LLVMInitializeMipsTargetInfo();
+-            bindings.LLVMInitializeMipsTargetMC();
+-            bindings.LLVMInitializeMipsAsmPrinter();
+-            bindings.LLVMInitializeMipsAsmParser();
+-        },
+-        .msp430 => {
+-            bindings.LLVMInitializeMSP430Target();
+-            bindings.LLVMInitializeMSP430TargetInfo();
+-            bindings.LLVMInitializeMSP430TargetMC();
+-            bindings.LLVMInitializeMSP430AsmPrinter();
+-            bindings.LLVMInitializeMSP430AsmParser();
+-        },
+         .nvptx, .nvptx64 => {
+             bindings.LLVMInitializeNVPTXTarget();
+             bindings.LLVMInitializeNVPTXTargetInfo();
+@@ -4806,13 +4764,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+             bindings.LLVMInitializeRISCVAsmPrinter();
+             bindings.LLVMInitializeRISCVAsmParser();
+         },
+-        .sparc, .sparc64 => {
+-            bindings.LLVMInitializeSparcTarget();
+-            bindings.LLVMInitializeSparcTargetInfo();
+-            bindings.LLVMInitializeSparcTargetMC();
+-            bindings.LLVMInitializeSparcAsmPrinter();
+-            bindings.LLVMInitializeSparcAsmParser();
+-        },
+         .s390x => {
+             bindings.LLVMInitializeSystemZTarget();
+             bindings.LLVMInitializeSystemZTargetInfo();
+@@ -4843,13 +4794,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+                 bindings.LLVMInitializeXtensaAsmParser();
+             }
+         },
+-        .xcore => {
+-            bindings.LLVMInitializeXCoreTarget();
+-            bindings.LLVMInitializeXCoreTargetInfo();
+-            bindings.LLVMInitializeXCoreTargetMC();
+-            bindings.LLVMInitializeXCoreAsmPrinter();
+-            // There is no LLVMInitializeXCoreAsmParser function.
+-        },
+         .m68k => {
+             if (build_options.llvm_has_m68k) {
+                 bindings.LLVMInitializeM68kTarget();
+@@ -4868,13 +4812,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+                 bindings.LLVMInitializeCSKYAsmParser();
+             }
+         },
+-        .ve => {
+-            bindings.LLVMInitializeVETarget();
+-            bindings.LLVMInitializeVETargetInfo();
+-            bindings.LLVMInitializeVETargetMC();
+-            bindings.LLVMInitializeVEAsmPrinter();
+-            bindings.LLVMInitializeVEAsmParser();
+-        },
+         .arc => {
+             if (build_options.llvm_has_arc) {
+                 bindings.LLVMInitializeARCTarget();
+@@ -4884,21 +4821,29 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+                 // There is no LLVMInitializeARCAsmParser function.
+             }
+         },
+-        .loongarch32, .loongarch64 => {
+-            bindings.LLVMInitializeLoongArchTarget();
+-            bindings.LLVMInitializeLoongArchTargetInfo();
+-            bindings.LLVMInitializeLoongArchTargetMC();
+-            bindings.LLVMInitializeLoongArchAsmPrinter();
+-            bindings.LLVMInitializeLoongArchAsmParser();
+-        },
++
++        // Disabled LLVM targets
++        .thumb,
++        .thumbeb,
++        .arm,
++        .armeb,
++        .avr,
++        .hexagon,
++        .lanai,
++        .mips,
++        .mipsel,
++        .mips64,
++        .mips64el,
++        .msp430,
++        .sparc,
++        .sparc64,
++        .xcore,
++        .ve,
++        .loongarch32,
++        .loongarch64,
+         .spirv32,
+         .spirv64,
+-        => {
+-            bindings.LLVMInitializeSPIRVTarget();
+-            bindings.LLVMInitializeSPIRVTargetInfo();
+-            bindings.LLVMInitializeSPIRVTargetMC();
+-            bindings.LLVMInitializeSPIRVAsmPrinter();
+-        },
++        => unreachable,
+ 
+         // LLVM does does not have a backend for these.
+         .alpha,
+diff --git a/src/target.zig b/src/target.zig
+index 3d04c06f5e..9e19836815 100644
+--- a/src/target.zig
++++ b/src/target.zig
+@@ -185,23 +185,12 @@ pub fn hasLlvmSupport(target: *const std.Target, ofmt: std.Target.ObjectFormat)
+     }
+ 
+     return switch (target.cpu.arch) {
+-        .arm,
+-        .armeb,
+         .aarch64,
+         .aarch64_be,
+         .arc,
+-        .avr,
+         .bpfel,
+         .bpfeb,
+-        .hexagon,
+-        .loongarch32,
+-        .loongarch64,
+         .m68k,
+-        .mips,
+-        .mipsel,
+-        .mips64,
+-        .mips64el,
+-        .msp430,
+         .powerpc,
+         .powerpcle,
+         .powerpc64,
+@@ -211,24 +200,38 @@ pub fn hasLlvmSupport(target: *const std.Target, ofmt: std.Target.ObjectFormat)
+         .riscv32be,
+         .riscv64,
+         .riscv64be,
+-        .sparc,
+-        .sparc64,
+-        .spirv32,
+-        .spirv64,
+         .s390x,
+-        .thumb,
+-        .thumbeb,
+         .x86,
+         .x86_64,
+-        .xcore,
+         .nvptx,
+         .nvptx64,
+-        .lanai,
+         .wasm32,
+         .wasm64,
+-        .ve,
+         => true,
+ 
++        // Disabled LLVM targets
++        .thumb,
++        .thumbeb,
++        .arm,
++        .armeb,
++        .avr,
++        .hexagon,
++        .lanai,
++        .mips,
++        .mipsel,
++        .mips64,
++        .mips64el,
++        .msp430,
++        .sparc,
++        .sparc64,
++        .xcore,
++        .ve,
++        .loongarch32,
++        .loongarch64,
++        .spirv32,
++        .spirv64,
++        => false,
++
+         // LLVM backend exists but can produce neither assembly nor object files.
+         .csky,
+         .xtensa,
+-- 
+2.53.0
+

--- a/anda/langs/zig/bootstrap/update.rhai
+++ b/anda/langs/zig/bootstrap/update.rhai
@@ -10,5 +10,8 @@ if rpm.changed() {
    sh(`sed -i 's|version=.*|version=${v}|' setup.sh`, #{ "cwd": dir });
    // Update the needed LLVM version
    let rawfile = codeberg_rawfile("ziglang/zig", "master", "README.md");
-   rpm.global("llvm_version", find(`download.html#([\d.]+)`, rawfile, 1));
+   let l = find(`releases\.llvm\.org/download\.html#([\d.]+)`, rawfile, 1);
+   rpm.global("llvm_version", l);
+   l.truncate(2);
+   rpm.global("llvm_compat", l);
 }

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -3,13 +3,19 @@
 # Signing key from https://ziglang.org/download/
 %global         public_key RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 %if 0%{?fedora} >= 44
-%define         llvm_compat 21
+%define         llvm_compat 22
 %endif
-%global         llvm_version 21.0.0
+%global         llvm_version 22.0.0
 %global         ver 0.17.0-dev.131+73c51c142
 %bcond bootstrap 1
 %bcond docs      %{without bootstrap}
 %bcond test      1
+# GCC < 16.0 miscompiles on RISC-V
+%ifarch riscv64
+%if 0%{?fedora} < 44
+%global toolchain clang
+%endif
+%endif
 %global archive_name zig-%{ver}.tar.xz
 %global zig_cache_dir %{builddir}/zig-cache
 %global zig_build_options %{shrink: \
@@ -39,16 +45,23 @@
 
 Name:           zig-master
 Version:        %(echo %{ver} | sed 's/-/~/g')
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Bootstrapped build of Zig from master.
 License:        MIT AND NCSA AND LGPL-2.1-or-later AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND GPL-2.0-or-later AND GPL-2.0-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND Inner-Net-2.0 AND ISC AND LicenseRef-Fedora-Public-Domain AND GFDL-1.1-or-later AND ZPL-2.1
 URL:            https://ziglang.org
 Source0:        %{archive_name}
 Source1:        %{archive_name}.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
+%if %{defined rhel}
+Patch1:         0001-Remove-unsupported-LLVM-targets-for-EPEL.patch
+%endif
 BuildRequires:  cmake
+%if %["%{toolchain}" == "clang"]
+BuildRequires:  clang
+%else
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
+%endif
 BuildRequires:  libxml2-devel
 BuildRequires:  llvm%{?llvm_compat}-devel
 BuildRequires:  clang%{?llvm_compat}-devel
@@ -72,7 +85,7 @@ Requires:       %{name}-libs = %{version}
 # Apache-2.0 WITH LLVM-exception OR NCSA OR MIT
 Provides:       bundled(compiler-rt) = %{llvm_version}
 # LGPL-2.1-or-later AND SunPro AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND GPL-2.0-or-later AND LGPL-2.1-or-later WITH GNU-compiler-exception AND GPL-2.0-only AND ISC AND LicenseRef-Fedora-Public-Domain AND HPND AND CMU-Mach AND LGPL-2.0-or-later AND Unicode-3.0 AND GFDL-1.1-or-later AND GPL-1.0-or-later AND FSFUL AND MIT AND Inner-Net-2.0 AND X11 AND GPL-2.0-or-later WITH GCC-exception-2.0 AND GFDL-1.3-only AND GFDL-1.1-only
-Provides:       bundled(glibc) = 2.41
+Provides:       bundled(glibc) = 2.43
 # Apache-2.0 WITH LLVM-exception OR MIT OR NCSA
 Provides:       bundled(libcxx) = %{llvm_version}
 # Apache-2.0 WITH LLVM-exception OR MIT OR NCSA
@@ -111,7 +124,7 @@ Zig Standard Library
 rm -f stage1/zig1.wasm
 %endif
 
-%build
+%conf
 # Force the correct LLVM version
 %if %{defined llvm_compat}
 export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
@@ -126,7 +139,7 @@ export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
     -DCMAKE_C_FLAGS_RELWITHDEBINFO:STRING="-DNDEBUG -Wno-unused" \
     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-DNDEBUG -Wno-unused" \
     \
-    -DZIG_EXTRA_BUILD_ARGS:STRING="--verbose;--build-id=sha1" \
+    -DZIG_EXTRA_BUILD_ARGS:STRING="--verbose;--build-id=sha1;-Dno-langref=true" \
     -DZIG_SHARED_LLVM:BOOL=true \
     -DZIG_PIE:BOOL=true \
     \
@@ -135,6 +148,7 @@ export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
     \
     -DZIG_VERSION:STRING="%(v=%{ver}; echo ${v:0:6})"
 
+%build
 %if %{with bootstrap}
 %cmake_build --target stage3
 %else
@@ -152,14 +166,16 @@ help2man --no-discard-stderr --no-info "./zig-out/bin/zig" --version-option=vers
 # Zig has an extremely annoying issue with transitive failures when trying to build the docs, retry until it succeeds
 max=3
 attempt=1
-while ./zig-out/bin/zig build docs \
+while
+  ./zig-out/bin/zig build docs \
     --verbose \
     --global-cache-dir "%{zig_cache_dir}" \
-    -Dversion-string="%(v=%{ver}; echo ${v:0:6})"; [[ $? -ne 0 ]];
+    -Dversion-string="%(v=%{ver}; echo ${v:0:6})"
+  [[ $? != 0 ]]
 do
-  echo "Transitive failure. Trying again."
+  echo "Transitive failure. Trying again." >&2
 
-  if [[ $attempt -eq $max ]]
+  if [[ $attempt == $max ]]
   then
     break
   fi

--- a/anda/langs/zig/master/0000-remove-native-lib-directories-from-rpath.patch
+++ b/anda/langs/zig/master/0000-remove-native-lib-directories-from-rpath.patch
@@ -1,6 +1,18 @@
---- a/src/main.zig	2025-12-27 19:19:30.000000000 -0600
-+++ b/src/main.zig	2025-12-31 08:25:12.962257290 -0600
-@@ -3998,6 +3998,15 @@
+From a865b3569ace118cc1c1cd8d5d130ec316b0307d Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Tue, 14 Apr 2026 19:04:40 +0200
+Subject: [PATCH 1/2] remove native lib directories from rpath
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ src/main.zig | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/main.zig b/src/main.zig
+index 0395a21a5f..86b6d9f86b 100644
+--- a/src/main.zig
++++ b/src/main.zig
+@@ -4102,6 +4102,15 @@ fn createModule(
  
              try create_module.lib_directories.ensureUnusedCapacity(arena, paths.lib_dirs.items.len);
              for (paths.lib_dirs.items) |path| addLibDirectoryWarn2(io, &create_module.lib_directories, path, true);
@@ -16,3 +28,6 @@
          }
  
          if (create_module.libc_paths_file) |paths_file| {
+-- 
+2.53.0
+

--- a/anda/langs/zig/master/0001-Remove-unsupported-LLVM-targets-for-EPEL.patch
+++ b/anda/langs/zig/master/0001-Remove-unsupported-LLVM-targets-for-EPEL.patch
@@ -1,0 +1,254 @@
+From 803935baf6a4730426afbb746adfd00c0ffc0f39 Mon Sep 17 00:00:00 2001
+From: Jan200101 <sentrycraft123@gmail.com>
+Date: Tue, 14 Apr 2026 19:20:26 +0200
+Subject: [PATCH 2/2] Remove unsupported LLVM targets for RHEL
+
+LLVM for RHEL is only build with a subset of targets
+this blocks zig at the configuration stage.
+This commit simply swaps them out with the one from
+https://src.fedoraproject.org/rpms/llvm/blob/rawhide/f/llvm.spec
+
+Signed-off-by: Jan200101 <sentrycraft123@gmail.com>
+---
+ cmake/Findllvm.cmake |  2 +-
+ src/codegen/llvm.zig | 97 ++++++++++----------------------------------
+ src/target.zig       | 43 +++++++++++---------
+ 3 files changed, 45 insertions(+), 97 deletions(-)
+
+diff --git a/cmake/Findllvm.cmake b/cmake/Findllvm.cmake
+index 0c08d4f0ac..ed4da12044 100644
+--- a/cmake/Findllvm.cmake
++++ b/cmake/Findllvm.cmake
+@@ -83,7 +83,7 @@ if(ZIG_USE_LLVM_CONFIG)
+       OUTPUT_STRIP_TRAILING_WHITESPACE)
+     string(REPLACE " " ";" LLVM_TARGETS_BUILT "${LLVM_TARGETS_BUILT_SPACES}")
+ 
+-    set(ZIG_LLVM_REQUIRED_TARGETS "AArch64;AMDGPU;ARM;AVR;BPF;Hexagon;Lanai;LoongArch;Mips;MSP430;NVPTX;PowerPC;RISCV;SPIRV;Sparc;SystemZ;VE;WebAssembly;X86;XCore")
++    set(ZIG_LLVM_REQUIRED_TARGETS "X86;AMDGPU;PowerPC;NVPTX;SystemZ;AArch64;BPF;WebAssembly;RISCV")
+ 
+     set(ZIG_LLVM_REQUIRED_TARGETS_ENABLED TRUE)
+     foreach(TARGET_NAME IN LISTS ZIG_LLVM_REQUIRED_TARGETS)
+diff --git a/src/codegen/llvm.zig b/src/codegen/llvm.zig
+index 1ba3b272da..1ac1f6adc8 100644
+--- a/src/codegen/llvm.zig
++++ b/src/codegen/llvm.zig
+@@ -4736,20 +4736,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+             bindings.LLVMInitializeAMDGPUAsmPrinter();
+             bindings.LLVMInitializeAMDGPUAsmParser();
+         },
+-        .thumb, .thumbeb, .arm, .armeb => {
+-            bindings.LLVMInitializeARMTarget();
+-            bindings.LLVMInitializeARMTargetInfo();
+-            bindings.LLVMInitializeARMTargetMC();
+-            bindings.LLVMInitializeARMAsmPrinter();
+-            bindings.LLVMInitializeARMAsmParser();
+-        },
+-        .avr => {
+-            bindings.LLVMInitializeAVRTarget();
+-            bindings.LLVMInitializeAVRTargetInfo();
+-            bindings.LLVMInitializeAVRTargetMC();
+-            bindings.LLVMInitializeAVRAsmPrinter();
+-            bindings.LLVMInitializeAVRAsmParser();
+-        },
+         .bpfel, .bpfeb => {
+             bindings.LLVMInitializeBPFTarget();
+             bindings.LLVMInitializeBPFTargetInfo();
+@@ -4757,34 +4743,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+             bindings.LLVMInitializeBPFAsmPrinter();
+             bindings.LLVMInitializeBPFAsmParser();
+         },
+-        .hexagon => {
+-            bindings.LLVMInitializeHexagonTarget();
+-            bindings.LLVMInitializeHexagonTargetInfo();
+-            bindings.LLVMInitializeHexagonTargetMC();
+-            bindings.LLVMInitializeHexagonAsmPrinter();
+-            bindings.LLVMInitializeHexagonAsmParser();
+-        },
+-        .lanai => {
+-            bindings.LLVMInitializeLanaiTarget();
+-            bindings.LLVMInitializeLanaiTargetInfo();
+-            bindings.LLVMInitializeLanaiTargetMC();
+-            bindings.LLVMInitializeLanaiAsmPrinter();
+-            bindings.LLVMInitializeLanaiAsmParser();
+-        },
+-        .mips, .mipsel, .mips64, .mips64el => {
+-            bindings.LLVMInitializeMipsTarget();
+-            bindings.LLVMInitializeMipsTargetInfo();
+-            bindings.LLVMInitializeMipsTargetMC();
+-            bindings.LLVMInitializeMipsAsmPrinter();
+-            bindings.LLVMInitializeMipsAsmParser();
+-        },
+-        .msp430 => {
+-            bindings.LLVMInitializeMSP430Target();
+-            bindings.LLVMInitializeMSP430TargetInfo();
+-            bindings.LLVMInitializeMSP430TargetMC();
+-            bindings.LLVMInitializeMSP430AsmPrinter();
+-            bindings.LLVMInitializeMSP430AsmParser();
+-        },
+         .nvptx, .nvptx64 => {
+             bindings.LLVMInitializeNVPTXTarget();
+             bindings.LLVMInitializeNVPTXTargetInfo();
+@@ -4806,13 +4764,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+             bindings.LLVMInitializeRISCVAsmPrinter();
+             bindings.LLVMInitializeRISCVAsmParser();
+         },
+-        .sparc, .sparc64 => {
+-            bindings.LLVMInitializeSparcTarget();
+-            bindings.LLVMInitializeSparcTargetInfo();
+-            bindings.LLVMInitializeSparcTargetMC();
+-            bindings.LLVMInitializeSparcAsmPrinter();
+-            bindings.LLVMInitializeSparcAsmParser();
+-        },
+         .s390x => {
+             bindings.LLVMInitializeSystemZTarget();
+             bindings.LLVMInitializeSystemZTargetInfo();
+@@ -4843,13 +4794,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+                 bindings.LLVMInitializeXtensaAsmParser();
+             }
+         },
+-        .xcore => {
+-            bindings.LLVMInitializeXCoreTarget();
+-            bindings.LLVMInitializeXCoreTargetInfo();
+-            bindings.LLVMInitializeXCoreTargetMC();
+-            bindings.LLVMInitializeXCoreAsmPrinter();
+-            // There is no LLVMInitializeXCoreAsmParser function.
+-        },
+         .m68k => {
+             if (build_options.llvm_has_m68k) {
+                 bindings.LLVMInitializeM68kTarget();
+@@ -4868,13 +4812,6 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+                 bindings.LLVMInitializeCSKYAsmParser();
+             }
+         },
+-        .ve => {
+-            bindings.LLVMInitializeVETarget();
+-            bindings.LLVMInitializeVETargetInfo();
+-            bindings.LLVMInitializeVETargetMC();
+-            bindings.LLVMInitializeVEAsmPrinter();
+-            bindings.LLVMInitializeVEAsmParser();
+-        },
+         .arc => {
+             if (build_options.llvm_has_arc) {
+                 bindings.LLVMInitializeARCTarget();
+@@ -4884,21 +4821,29 @@ pub fn initializeLLVMTarget(arch: std.Target.Cpu.Arch) void {
+                 // There is no LLVMInitializeARCAsmParser function.
+             }
+         },
+-        .loongarch32, .loongarch64 => {
+-            bindings.LLVMInitializeLoongArchTarget();
+-            bindings.LLVMInitializeLoongArchTargetInfo();
+-            bindings.LLVMInitializeLoongArchTargetMC();
+-            bindings.LLVMInitializeLoongArchAsmPrinter();
+-            bindings.LLVMInitializeLoongArchAsmParser();
+-        },
++
++        // Disabled LLVM targets
++        .thumb,
++        .thumbeb,
++        .arm,
++        .armeb,
++        .avr,
++        .hexagon,
++        .lanai,
++        .mips,
++        .mipsel,
++        .mips64,
++        .mips64el,
++        .msp430,
++        .sparc,
++        .sparc64,
++        .xcore,
++        .ve,
++        .loongarch32,
++        .loongarch64,
+         .spirv32,
+         .spirv64,
+-        => {
+-            bindings.LLVMInitializeSPIRVTarget();
+-            bindings.LLVMInitializeSPIRVTargetInfo();
+-            bindings.LLVMInitializeSPIRVTargetMC();
+-            bindings.LLVMInitializeSPIRVAsmPrinter();
+-        },
++        => unreachable,
+ 
+         // LLVM does does not have a backend for these.
+         .alpha,
+diff --git a/src/target.zig b/src/target.zig
+index 3d04c06f5e..9e19836815 100644
+--- a/src/target.zig
++++ b/src/target.zig
+@@ -185,23 +185,12 @@ pub fn hasLlvmSupport(target: *const std.Target, ofmt: std.Target.ObjectFormat)
+     }
+ 
+     return switch (target.cpu.arch) {
+-        .arm,
+-        .armeb,
+         .aarch64,
+         .aarch64_be,
+         .arc,
+-        .avr,
+         .bpfel,
+         .bpfeb,
+-        .hexagon,
+-        .loongarch32,
+-        .loongarch64,
+         .m68k,
+-        .mips,
+-        .mipsel,
+-        .mips64,
+-        .mips64el,
+-        .msp430,
+         .powerpc,
+         .powerpcle,
+         .powerpc64,
+@@ -211,24 +200,38 @@ pub fn hasLlvmSupport(target: *const std.Target, ofmt: std.Target.ObjectFormat)
+         .riscv32be,
+         .riscv64,
+         .riscv64be,
+-        .sparc,
+-        .sparc64,
+-        .spirv32,
+-        .spirv64,
+         .s390x,
+-        .thumb,
+-        .thumbeb,
+         .x86,
+         .x86_64,
+-        .xcore,
+         .nvptx,
+         .nvptx64,
+-        .lanai,
+         .wasm32,
+         .wasm64,
+-        .ve,
+         => true,
+ 
++        // Disabled LLVM targets
++        .thumb,
++        .thumbeb,
++        .arm,
++        .armeb,
++        .avr,
++        .hexagon,
++        .lanai,
++        .mips,
++        .mipsel,
++        .mips64,
++        .mips64el,
++        .msp430,
++        .sparc,
++        .sparc64,
++        .xcore,
++        .ve,
++        .loongarch32,
++        .loongarch64,
++        .spirv32,
++        .spirv64,
++        => false,
++
+         // LLVM backend exists but can produce neither assembly nor object files.
+         .csky,
+         .xtensa,
+-- 
+2.53.0
+

--- a/anda/langs/zig/master/update.rhai
+++ b/anda/langs/zig/master/update.rhai
@@ -8,5 +8,8 @@ if rpm.changed() {
   rpm.release(r + 1);
   // Update the needed LLVM version
   let rawfile = codeberg_rawfile("ziglang/zig", "master", "README.md");
-  rpm.global("llvm_version", find(`download.html#([\d.]+)`, rawfile, 1));
+  let l = find(`releases\.llvm\.org/download\.html#([\d.]+)`, rawfile, 1);
+  rpm.global("llvm_version", l);
+  l.truncate(2);
+  rpm.global("llvm_compat", l);
 }

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -3,12 +3,18 @@
 # Signing key from https://ziglang.org/download/
 %global         public_key RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
 %if 0%{?fedora} >= 44
-%define         llvm_compat 21
+%define         llvm_compat 22
 %endif
-%global         llvm_version 21.0.0
+%global         llvm_version 22.0.0
 %bcond bootstrap 0
 %bcond docs      %{without bootstrap}
 %bcond test      1
+# GCC < 16.0 miscompiles on RISC-V
+%ifarch riscv64
+%if 0%{?fedora} < 44
+%global toolchain clang
+%endif
+%endif
 %global zig_cache_dir %{builddir}/zig-cache
 
 Name:           zig-master
@@ -21,9 +27,16 @@ URL:            https://ziglang.org
 Source0:        %{archive_name}
 Source1:        %{archive_name}.minisig
 Patch0:         0000-remove-native-lib-directories-from-rpath.patch
+%if %{defined rhel}
+Patch1:         0001-Remove-unsupported-LLVM-targets-for-EPEL.patch
+%endif
 BuildRequires:  cmake
+%if %["%{toolchain}" == "clang"]
+BuildRequires:  clang
+%else
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
+%endif
 BuildRequires:  libxml2-devel
 BuildRequires:  llvm%{?llvm_compat}-devel
 BuildRequires:  clang%{?llvm_compat}-devel
@@ -47,7 +60,7 @@ Requires:       %{name}-libs = %{version}
 # Apache-2.0 WITH LLVM-exception OR NCSA OR MIT
 Provides:       bundled(compiler-rt) = %{llvm_version}
 # LGPL-2.1-or-later AND SunPro AND LGPL-2.1-or-later WITH GCC-exception-2.0 AND BSD-3-Clause AND GPL-2.0-or-later AND LGPL-2.1-or-later WITH GNU-compiler-exception AND GPL-2.0-only AND ISC AND LicenseRef-Fedora-Public-Domain AND HPND AND CMU-Mach AND LGPL-2.0-or-later AND Unicode-3.0 AND GFDL-1.1-or-later AND GPL-1.0-or-later AND FSFUL AND MIT AND Inner-Net-2.0 AND X11 AND GPL-2.0-or-later WITH GCC-exception-2.0 AND GFDL-1.3-only AND GFDL-1.1-only
-Provides:       bundled(glibc) = 2.41
+Provides:       bundled(glibc) = 2.43
 # Apache-2.0 WITH LLVM-exception OR MIT OR NCSA
 Provides:       bundled(libcxx) = %{llvm_version}
 # Apache-2.0 WITH LLVM-exception OR MIT OR NCSA
@@ -123,7 +136,7 @@ Documentation for Zig. For more information, visit %{url}
 rm -f stage1/zig1.wasm
 %endif
 
-%build
+%conf
 # Force the correct LLVM version
 %if %{defined llvm_compat}
 export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
@@ -138,7 +151,7 @@ export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
     -DCMAKE_C_FLAGS_RELWITHDEBINFO:STRING="-DNDEBUG -Wno-unused" \
     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-DNDEBUG -Wno-unused" \
     \
-    -DZIG_EXTRA_BUILD_ARGS:STRING="--verbose;--build-id=sha1" \
+    -DZIG_EXTRA_BUILD_ARGS:STRING="--verbose;--build-id=sha1;-Dno-langref=true" \
     -DZIG_SHARED_LLVM:BOOL=true \
     -DZIG_PIE:BOOL=true \
     \
@@ -147,6 +160,8 @@ export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
     \
     -DZIG_VERSION:STRING="%(v=%{version_no_tilde}; echo ${v:0:6})"
 
+
+%build
 %if %{with bootstrap}
 %cmake_build --target stage3
 %else
@@ -164,14 +179,16 @@ help2man --no-discard-stderr --no-info "./zig-out/bin/zig" --version-option=vers
 # Zig has an extremely annoying issue with transitive failures when trying to build the docs, retry until it succeeds
 max=3
 attempt=1
-while ./zig-out/bin/zig build docs \
+while
+  ./zig-out/bin/zig build docs \
     --verbose \
     --global-cache-dir "%{zig_cache_dir}" \
-    -Dversion-string="%(v=%{version_no_tilde}; echo ${v:0:6})"; [[ $? -ne 0 ]];
+    -Dversion-string="%(v=%{version_no_tilde}; echo ${v:0:6})"
+  [[ $? != 0 ]]
 do
-  echo "Transitive failure. Trying again."
+  echo "Transitive failure. Trying again." >&2
 
-  if [[ $attempt -eq $max ]]
+  if [[ $attempt == $max ]]
   then
     break
   fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(zig-master): Update for Fedora changes (#11468)](https://github.com/terrapkg/packages/pull/11468)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)