### PR TITLE
[el10] fix(limine): Project moved to GitHub (#11657)

### DIFF
--- a/anda/system/limine/limine.spec
+++ b/anda/system/limine/limine.spec
@@ -1,11 +1,12 @@
 Name:		limine
-Version:	11.2.1
+Version:	12.0.2
 Release:	1%{?dist}
 Summary:	Modern, advanced, portable, multiprotocol bootloader
 License:	BSD-2-Clause
 URL:		https://limine-bootloader.org
-Source0:	https://codeberg.org/Limine/Limine/releases/download/v%version/limine-%version.tar.gz
-Source1:	https://codeberg.org/Limine/Limine/raw/tag/v%version/README.md
+Source0:	https://github.com/Limine-Bootloader/Limine/releases/download/v%{version}/%{name}-%{version}.tar.gz
+Source1:    https://github.com/Limine-Bootloader/Limine/releases/download/v%{version}/limine-%{version}.tar.gz.sig
+Source2:    https://raw.githubusercontent.com/Limine-Bootloader/Limine/refs/tags/v%{version}/README.md
 Packager:	madonuko <mado@fyralabs.com>
 BuildRequires:	nasm mtools llvm lld clang make
 
@@ -15,7 +16,9 @@ the reference implementation for the Limine boot protocol.
 
 %prep
 %autosetup
-cp %{S:1} .
+cp %{S:2} .
+gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 05D29860D0A0668AAEFB9D691F3C021BECA23821
+gpg --verify %{S:1} %{S:0} || exit 1
 
 %conf
 %configure --enable-all CC_FOR_TARGET=clang LD_FOR_TARGET=ld.lld
@@ -28,9 +31,9 @@ cp %{S:1} .
 
 
 %files
-%doc README.md 3RDPARTY.md FAQ.md CONFIG.md COPYING USAGE.md
+%doc README.md 3RDPARTY.md FAQ.md CONFIG.md COPYING USAGE.md ChangeLog
 %license %_datadir/doc/limine/LICENSES/LicenseRef-scancode-bsd-no-disclaimer-unmodified.txt
 %license COPYING
 %_bindir/limine
 %_datadir/limine/
-%_mandir/man1/limine.1.gz
+%_mandir/man1/limine.1.*

--- a/anda/system/limine/update.rhai
+++ b/anda/system/limine/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(codeberg("Limine/Limine"));
+rpm.version(gh("limine-bootloader/limine"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(limine): Project moved to GitHub (#11657)](https://github.com/terrapkg/packages/pull/11657)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)