### PR TITLE
[el10] fix(mesa-compat): Update patches and build (#11658)

### DIFF
--- a/anda/lib/mesa-compat/0001-c11-threads-fix-build-on-fedora-44.patch
+++ b/anda/lib/mesa-compat/0001-c11-threads-fix-build-on-fedora-44.patch
@@ -1,0 +1,47 @@
+From 6e3646c81143477008e448d3b0b5c349169e4112 Mon Sep 17 00:00:00 2001
+From: Dave Airlie <airlied@redhat.com>
+Date: Fri, 7 Nov 2025 13:14:56 +1000
+Subject: [PATCH] c11/threads: fix build on fedora 44.
+
+glibc is now including once_init in stdlib.h
+
+https://patchwork.sourceware.org/project/glibc/patch/78061085-f04a-0c45-107b-5a8a15521083@redhat.com/#213088
+
+Just fix up our use of it.
+---
+ src/c11/impl/threads_posix.c | 2 +-
+ src/c11/threads.h            | 3 +++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/c11/impl/threads_posix.c b/src/c11/impl/threads_posix.c
+index 3b8692482bb..4769c029bad 100644
+--- a/src/c11/impl/threads_posix.c
++++ b/src/c11/impl/threads_posix.c
+@@ -49,7 +49,7 @@ impl_thrd_routine(void *p)
+ void
+ call_once(once_flag *flag, void (*func)(void))
+ {
+-    pthread_once(flag, func);
++    pthread_once((pthread_once_t *)flag, func);
+ }
+ 
+ 
+diff --git a/src/c11/threads.h b/src/c11/threads.h
+index dbcb3459a9b..053636f6674 100644
+--- a/src/c11/threads.h
++++ b/src/c11/threads.h
+@@ -118,8 +118,11 @@ typedef pthread_cond_t  cnd_t;
+ typedef pthread_t       thrd_t;
+ typedef pthread_key_t   tss_t;
+ typedef pthread_mutex_t mtx_t;
++#ifndef __once_flag_defined
++#define __once_flag_defined 1
+ typedef pthread_once_t  once_flag;
+ #  define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
++#endif
+ #  ifdef PTHREAD_DESTRUCTOR_ITERATIONS
+ #    define TSS_DTOR_ITERATIONS PTHREAD_DESTRUCTOR_ITERATIONS
+ #  else
+-- 
+2.51.1
+

--- a/anda/lib/mesa-compat/cd129dbf8af2d16b1243f2ce287ff69c6a5dc557.patch
+++ b/anda/lib/mesa-compat/cd129dbf8af2d16b1243f2ce287ff69c6a5dc557.patch
@@ -1,0 +1,54 @@
+From cd129dbf8af2d16b1243f2ce287ff69c6a5dc557 Mon Sep 17 00:00:00 2001
+From: no92 <no92.mail@gmail.com>
+Date: Wed, 27 Aug 2025 16:02:31 +0200
+Subject: [PATCH] gallivm: support LLVM 21
+
+LLVM PR#146819 changed the signature of `setObjectLinkingLayerCreator`,
+dropping the Triple argument. The PR was first included in the LLVM 21
+series, and the new signature is gated behind a version check for that.
+
+`LLVMOrcThreadSafeContextGetContext` was removed in LLVM commit b18e5b6,
+and the ORC examples in the LLVM tree seem to just create a context
+instead, which we replicate here.
+
+With this commit, mesa successfully builds the llvmpipe gallium driver
+on riscv64 with LLVM 21.1.0.
+
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/13785
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/13852
+
+Reviewed-by: David Heidelberg <david@ixit.cz>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37027>
+---
+ src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
+index 6651ea439da86..e5d8e461dd6c0 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
++++ b/src/gallium/auxiliary/gallivm/lp_bld_init_orc.cpp
+@@ -339,7 +339,12 @@ LPJit::LPJit() :jit_dylib_count(0) {
+          .setJITTargetMachineBuilder(std::move(JTMB))
+ #ifdef USE_JITLINK
+          .setObjectLinkingLayerCreator(
++#if LLVM_VERSION_MAJOR >= 21
++            /* LLVM 21 removed the Triple argument */
++            [&](ExecutionSession &ES) {
++#else
+             [&](ExecutionSession &ES, const llvm::Triple &TT) {
++#endif
+                return std::make_unique<ObjectLinkingLayer>(
+                   ES, ExitOnErr(llvm::jitlink::InProcessMemoryManager::Create()));
+             })
+@@ -551,7 +556,7 @@ init_gallivm_state(struct gallivm_state *gallivm, const char *name,
+    gallivm->cache = cache;
+ 
+    gallivm->_ts_context = context->ref;
+-   gallivm->context = LLVMOrcThreadSafeContextGetContext(context->ref);
++   gallivm->context = LLVMContextCreate();
+ 
+    gallivm->module_name = LPJit::get_unique_name(name);
+    gallivm->module = LLVMModuleCreateWithNameInContext(gallivm->module_name,
+-- 
+GitLab
+

--- a/anda/lib/mesa-compat/mesa-compat.spec
+++ b/anda/lib/mesa-compat/mesa-compat.spec
@@ -10,6 +10,7 @@ Summary:        Mesa graphics libraries - legacy compatibility libraries
 %global ver 25.0.7
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
 Release:        3%{?dist}
+Epoch:          1
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
 Source0:        https://archive.mesa3d.org/mesa-%{ver}.tar.xz

--- a/anda/lib/mesa-compat/mesa-compat.spec
+++ b/anda/lib/mesa-compat/mesa-compat.spec
@@ -1,21 +1,29 @@
 %global origname mesa
 
+# We've gotten a report that enabling LTO for mesa breaks some games. See
+# https://bugzilla.redhat.com/show_bug.cgi?id=1862771 for details.
+# Disable LTO for now
+%global _lto_cflags %nil
+
 Name:           %{origname}-compat
 Summary:        Mesa graphics libraries - legacy compatibility libraries
 %global ver 25.0.7
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        2%{?dist}
-Epoch:          1
+Release:        3%{?dist}
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            http://www.mesa3d.org
-
 Source0:        https://archive.mesa3d.org/mesa-%{ver}.tar.xz
 # src/gallium/auxiliary/postprocess/pp_mlaa* have an ... interestingly worded license.
 # Source1 contains email correspondence clarifying the license terms.
 # Fedora opts to ignore the optional part of clause 2 and treat that code as 2 clause BSD.
 Source1:        Mesa-MLAA-License-Clarification-Email.txt
-# Keep Mesa builds relatively the same
-Patch0:         bazzite.patch
+# fix c11/threads builds problem on f44
+Patch0:        0001-c11-threads-fix-build-on-fedora-44.patch
+# Support LLVM 21
+Patch1:        cd129dbf8af2d16b1243f2ce287ff69c6a5dc557.patch
+
+# Older version of the Bazzite/OGC patches
+Patch2:        bazzite.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc
@@ -44,7 +52,9 @@ BuildRequires:  python3-pyyaml
 Summary:        Mesa XA state tracker
 Provides:       libxatracker%{?_isa}
 Provides:       mesa-libxatracker%{?_isa}
-Obsoletes:      mesa-libxatracker < %{?epoch:%{epoch}:}25.3
+Obsoletes:      mesa-libxatracker < 25.3
+# New things should not rely on this as this library is dead upstream
+Provides:       deprecated()
 
 %description libxatracker
 %{summary}.
@@ -52,7 +62,9 @@ Obsoletes:      mesa-libxatracker < %{?epoch:%{epoch}:}25.3
 %package libxatracker-devel
 Summary:        Mesa XA state tracker development package
 Requires: %{name}-libxatracker%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Obsoletes:      mesa-libxatracker-devel < %{?epoch:%{epoch}:}25.3
+Obsoletes:      mesa-libxatracker-devel < 25.3
+# New things should not rely on this as this library is dead upstream
+Provides:       deprecated()
 
 %description libxatracker-devel
 %{summary}.
@@ -81,11 +93,6 @@ Provides:       deprecated()
 cp %{SOURCE1} docs/
 
 %build
-# We've gotten a report that enabling LTO for mesa breaks some games. See
-# https://bugzilla.redhat.com/show_bug.cgi?id=1862771 for details.
-# Disable LTO for now
-%define _lto_cflags %{nil}
-
 %meson \
   -Dplatforms= \
   -Dosmesa=true \
@@ -149,4 +156,5 @@ rm -rf %{buildroot}%{_includedir}/KHR
 %{_libdir}/pkgconfig/xatracker.pc
 
 %changelog
-%autochangelog
+* Sun Apr 26 2026 Gilver E. <roachy@fyralabs.com> - 25.0.7-3
+- Updated build for Fedora 44


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(mesa-compat): Update patches and build (#11658)](https://github.com/terrapkg/packages/pull/11658)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)