### PR TITLE
[el10] chore (ghc-strict-concurrency): use my name in the changelog (#11680)

### DIFF
--- a/anda/langs/haskell/ghc-strict-concurrency/ghc-strict-concurrency.spec
+++ b/anda/langs/haskell/ghc-strict-concurrency/ghc-strict-concurrency.spec
@@ -115,5 +115,5 @@ dos2unix -k -n %{SOURCE1} %{pkg_name}.cabal
 
 
 %changelog
-* Sun Apr 26 2026 Owen-sz <owen@fyralabs.com> - 0.2.4.3-1
+* Sun Apr 26 2026 Owen Zimmerman <owen@fyralabs.com> - 0.2.4.3-1
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (ghc-strict-concurrency): use my name in the changelog (#11680)](https://github.com/terrapkg/packages/pull/11680)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)