### PR TITLE
[f43] chore (luamake): add Packager: line (#11678)

### DIFF
--- a/anda/langs/lua/luamake/luamake.spec
+++ b/anda/langs/lua/luamake/luamake.spec
@@ -2,13 +2,15 @@
 
 Name:           luamake
 Version:        1.7
-Release:        1%?dist
+Release:        2%{?dist}
 License:        MIT
 URL:            https://github.com/actboy168/luamake
 Source:         https://github.com/actboy168/luamake/archive/refs/tags/v%version.tar.gz
 Summary:        A platform independent configuration and build system that uses the standard Lua command-line interpreter
 
 BuildRequires:  gcc-c++ make ninja-build glibc lua gcc cmake libstdc++-devel libstdc++-static libcxx libcxx-devel
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %description
 %summary.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (luamake): add Packager: line (#11678)](https://github.com/terrapkg/packages/pull/11678)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)