### PR TITLE
[f43] fix(terra-mock-configs): Remove dependency on terra-mock-gpg-keys (#11701)

### DIFF
--- a/anda/terra/mock-configs/terra-mock-configs.spec
+++ b/anda/terra/mock-configs/terra-mock-configs.spec
@@ -1,6 +1,6 @@
 Name:           terra-mock-configs
 Version:        2.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Epoch:          1
 Summary:        Mock configs for Terra repos
 
@@ -9,8 +9,7 @@ URL:            https://github.com/terrapkg/mock-configs
 Source0:        %url/archive/refs/tags/v%version.tar.gz
 
 BuildRequires:  mock-core-configs
-Requires:       mock-core-configs
-Requires:       terra-mock-gpg-keys
+Requires:       mock-core-configss
 BuildArch:      noarch
 
 Provides: anda-mock-configs = %{epoch}:%{version}-%{release}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(terra-mock-configs): Remove dependency on terra-mock-gpg-keys (#11701)](https://github.com/terrapkg/packages/pull/11701)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)