### PR TITLE
[el10] fix(ci): Fix broken workflow formatting on f42 and el10 (#11724)

### DIFF
--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
   autoupdate:
-    contents: write
-    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04-arm
     container:
       image: ghcr.io/terrapkg/builder:frawhide
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `f42` to `el10`:
 - [fix(ci): Fix broken workflow formatting on f42 and el10 (#11724)](https://github.com/terrapkg/packages/pull/11724)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)