### PR TITLE
[f44] chore(gpg-keys): Bump (#11745)

### DIFF
--- a/anda/terra/gpg-keys/terra-gpg-keys.spec
+++ b/anda/terra/gpg-keys/terra-gpg-keys.spec
@@ -2,7 +2,7 @@
 
 Name:           terra-gpg-keys
 Version:        %{?fedora:%{fedora}}%{?rhel:%{rhel}}
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        GPG keys for Terra
 Requires:       filesystem >= 3.18-6
 
@@ -52,6 +52,7 @@ Source39:       RPM-GPG-KEY-terra44-source
 Source40:       RPM-GPG-KEY-terrael10
 Source41:       RPM-GPG-KEY-terrael10-source
 BuildArch:      noarch
+Obsoletes:      terra-mock-gpg-keys < %{version}-6
 
 Packager:       Terra Packaging Team <terra@fyralabs.com>
 
@@ -72,13 +73,6 @@ Terra GPG key copies for use in Mock.
 install -d -m 755 $RPM_BUILD_ROOT/etc/pki/rpm-gpg
 install -m 644 %{_sourcedir}/RPM-GPG-KEY* $RPM_BUILD_ROOT/etc/pki/rpm-gpg/
 
-install -d -m 755 $RPM_BUILD_ROOT/etc/pki/mock
-install -m 644 %{_sourcedir}/RPM-GPG-KEY* $RPM_BUILD_ROOT/etc/pki/mock/
-
 %files
 %dir /etc/pki/rpm-gpg
 /etc/pki/rpm-gpg/RPM-GPG-KEY-*
-
-%files -n terra-mock-gpg-keys
-%dir /etc/pki/mock
-/etc/pki/mock/RPM-GPG-KEY-*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(gpg-keys): Bump (#11745)](https://github.com/terrapkg/packages/pull/11745)

<!--- Backport version: 11.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)