### PR TITLE
[f43] Add f44 option to the bug issue template (#11765)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -29,6 +29,7 @@ body:
       description: Which version of Terra are you using?
       options:
         - frawhide
+        - f44
         - f43
         - f42
         - el10


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [Add f44 option to the bug issue template (#11765)](https://github.com/terrapkg/packages/pull/11765)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)