### PR TITLE
[f42] fix(scrcpy): try to use existing java ver (#11776)

### DIFF
--- a/anda/apps/scrcpy/scrcpy.spec
+++ b/anda/apps/scrcpy/scrcpy.spec
@@ -46,7 +46,7 @@ BuildRequires:  python3-sdkmanager
 Requires:       %{name}-server
 # Gradle here really wants Java 21-23 to work properly
 # Java 25 breaks the build
-BuildRequires:  java-21-openjdk-devel
+BuildRequires:  java-latest-openjdk-devel
 BuildConflicts:	dkms-nvidia akmod-nvidia
 Requires:       android-tools
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `f42`:
 - [fix(scrcpy): try to use existing java ver (#11776)](https://github.com/terrapkg/packages/pull/11776)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)