### PR TITLE
[el10] fix (gnome-shell-extension packages): drop requiring below gnome-shell version 50 (#11785)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-appmenu-is-back/gnome-shell-extension-appmenu-is-back.spec
@@ -3,7 +3,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        12
-Release:        3%?dist
+Release:        4%{?dist}
 Summary:        GNOME Shell extension to bring back the app menu
 License:        GPL-3.0-only
 URL:            https://github.com/fthx/appmenu-is-back
@@ -12,7 +12,7 @@ BuildArch:      noarch
 
 Source0:        https://github.com/fthx/appmenu-is-back/archive/refs/tags/v%{version}.tar.gz
 
-Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
+Requires:       gnome-shell >= 48~
 Recommends:     gnome-extensions-app
 
 %description

--- a/anda/desktops/gnome/gnome-shell-extension-battery_time/gnome-shell-extension-battery_time.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-battery_time/gnome-shell-extension-battery_time.spec
@@ -7,7 +7,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        2%?dist
+Release:        3%{?dist}
 Summary:        Battery remaining time extension for GNOME Shell
 License:        GPL-2.0-only
 URL:            https://github.com/pomoke/battery_time
@@ -18,7 +18,7 @@ Source0:        %url/archive/%commit/battery_time-%commit.tar.gz
 # License declared in README
 Source1:        https://scancode-licensedb.aboutcode.org/gpl-2.0.LICENSE
 
-Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
+Requires:       gnome-shell >= 48~
 Recommends:     gnome-extensions-app
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>

--- a/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/gnome-shell-extension-gpu-supergfxctl-switch.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-gpu-supergfxctl-switch/gnome-shell-extension-gpu-supergfxctl-switch.spec
@@ -7,17 +7,21 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        %ver^%commit_date.%shortcommit
-Release:        2%?dist
+Release:        3%{?dist}
 Summary:        GPU Profile switcher Gnome-Shell-Extension for ASUS laptops using Supergfxctl
 License:        GPL-3.0-only
 URL:            https://github.com/chikobara/GPU-Switcher-Supergfxctl
 
 Source0:        %url/archive/%commit.tar.gz
 
-Requires:       (gnome-shell >= 48~ with gnome-shell < 50~) asusctl supergfxctl
+Requires:       gnome-shell >= 48~
+Requires:       asusctl
+Requires:       supergfxctl
 Recommends:     gnome-extensions-app
 
 BuildArch:	noarch
+
+Packager:       june-fish <june@fyralabs.com>
 
 %description
 GPU Profile switcher Gnome-Shell-Extension for ASUS laptops using Supergfxctl

--- a/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
@@ -3,7 +3,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        10
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        GNOME extension that removes the 'Window is ready' notification and brings the window into focus instead
 License:        AGPL-3.0-only
 URL:            https://github.com/zalckos/GrandTheftFocus
@@ -12,7 +12,7 @@ BuildArch:      noarch
 
 Source0:        https://github.com/zalckos/GrandTheftFocus/archive/refs/tags/v%version.tar.gz
 
-Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
+Requires:       gnome-shell >= 48~
 Recommends:     gnome-extensions-app
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>

--- a/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/gnome-shell-extension-multi-monitors-bar.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-multi-monitors-bar/gnome-shell-extension-multi-monitors-bar.spec
@@ -7,7 +7,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Add multiple monitors overview and panel for GNOME Shell. This is an updated fork with GNOME 46 compatibility
 License:        GPL-2.0-or-later
 URL:            https://github.com/FrederykAbryan/multi-monitors-bar_fapv2
@@ -17,7 +17,7 @@ BuildArch:      noarch
 Source0:        %url/archive/%commit/multi-monitors-bar_fapv2-%commit.tar.gz
 # README declared the license, but they do not provide a license file
 
-Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
+Requires:       gnome-shell >= 48~
 Recommends:     gnome-extensions-app
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>

--- a/anda/desktops/gnome/gnome-shell-extension-vicinae/gnome-shell-extension-vicinae.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-vicinae/gnome-shell-extension-vicinae.spec
@@ -2,7 +2,7 @@
 
 Name:           gnome-shell-extension-vicinae
 Version:        1.6.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        MIT
 URL:            https://github.com/dagimg-dot/vicinae-gnome-extension
 Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
@@ -12,7 +12,7 @@ Packager:       metcya <metcya@gmail.com>
 BuildArch:      noarch
 
 BuildRequires:  bun-bin glib2-devel
-Requires:       (gnome-shell >= 48~ with gnome-shell < 50~)
+Requires:       gnome-shell >= 48~
 Requires:       vicinae
 Recommends:     gnome-extensions-app
 Provides:       gnome-shell-extension-vicinae-gnome-extension


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (gnome-shell-extension packages): drop requiring below gnome-shell version 50 (#11785)](https://github.com/terrapkg/packages/pull/11785)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)