### PR TITLE
[el10] Update rs50 driver (#11794)

### DIFF
--- a/anda/lib/libtrueforce/anda.hcl
+++ b/anda/lib/libtrueforce/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+  arches = ["x86_64"]
+  rpm {
+    spec = "libtrueforce.spec"
+  }
+  labels {
+        updbranch = 1
+        mock = 1
+    }
+}

--- a/anda/lib/libtrueforce/libtrueforce.spec
+++ b/anda/lib/libtrueforce/libtrueforce.spec
@@ -1,0 +1,70 @@
+%global commit df7f1494f3bd584b8650304be7a37eca4bb49aa5
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260430
+%global debug_package %{nil}
+
+Name:           libtrueforce
+Version:        1.3.11^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Native Linux implementation of the Logitech Trueforce SDK
+License:        GPL-2.0-only
+URL:            https://github.com/mescon/logitech-rs50-linux-driver
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
+BuildRequires:  gcc
+BuildRequires:  make
+Requires:       logitech-rs50-linux-driver
+Provides:       trueforce-sdk = %{?epoch:%{epoch}:}%{version}
+Packager:       Luan V. <luanv.oliveira@outlook.com>
+
+
+%description
+Native Linux implementation of the Logitech Trueforce SDK
+(trueforce_sdk_x64.dll, version 1.3.11). Supports both the RS50 (046d:c276) and
+the G Pro Racing Wheel (046d:c272 / 046d:c268) the two wheels use byte-for-byte
+identical init and streaming packets, so the same library drives both. See
+docs/TRUEFORCE_PROTOCOL.md in the parent repo for the protocol documentation.
+
+%package static
+Summary:        Static library for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description static
+The %{name}-static package contains the static library for %{name}.
+
+
+%package devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+%prep
+%autosetup -c -n %{name}-%{commit}
+mv ./logitech-rs50-linux-driver-%{commit}/userspace/%{name}/* .
+mv ./logitech-rs50-linux-driver-%{commit}/docs/TRUEFORCE_PROTOCOL.md .
+rm -rf ./logitech-rs50-linux-driver-%{commit}
+
+%build
+%make_build PREFIX=%{_prefix} LIBDIR=%{_libdir} CFLAGS="%{build_cflags}"
+
+%install
+%make_install PREFIX=%{_prefix} LIBDIR=%{_libdir}
+install -D -m644 %{name}.a %{buildroot}%{_libdir}/
+
+%files
+%doc README.md TRUEFORCE_PROTOCOL.md
+%{_libdir}/*.so.*
+
+%files devel
+%{_libdir}/*.so
+%{_includedir}/trueforce.h
+
+%files static
+%{_libdir}/*.a
+
+
+%changelog
+* Fri May 01 2026 Luan V. <luanv.oliveira@outlook.com> - 1.3.11^20260430git.df7f149-1
+- Initial package

--- a/anda/lib/libtrueforce/update.rhai
+++ b/anda/lib/libtrueforce/update.rhai
@@ -1,0 +1,9 @@
+ let c = sh("cat anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec | grep '%global commit ' | sed -E 's/.+commit //'", #{"stdout": "piped"}).ctx.stdout;
+c.pop();
+rpm.global("commit", c);
+if rpm.changed() {
+    rpm.release();
+    let d = sh("cat anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec | grep '%global commitdate' | sed -E 's/.+commitdate //'", #{"stdout": "piped"}).ctx.stdout;
+    d.pop();
+    rpm.global("commitdate", d);
+}

--- a/anda/system/logitech-rs50-linux-driver/akmod/logitech-rs50-linux-driver-kmod.spec
+++ b/anda/system/logitech-rs50-linux-driver/akmod/logitech-rs50-linux-driver-kmod.spec
@@ -14,7 +14,7 @@
 
 Name:           %{modulename}-kmod
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276)
 License:        GPL-2.0-only
 URL:            https://github.com/mescon/logitech-rs50-linux-driver
@@ -23,6 +23,7 @@ BuildArch:      x86_64
 BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  kmodtool
+Packager:       Luan V. <luanv.oliveira@outlook.com>
 
 Requires:       akmods
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
@@ -66,4 +67,5 @@ done
 %{?akmod_install}
 
 %changelog
-%autochangelog
+* Fri May 01 2026 Luan V. <luanv.oliveira@outlook.com> - 1.0^20260430git.df7f149-2
+- fix spec warnings: add Packager tag and remove autochangelog

--- a/anda/system/logitech-rs50-linux-driver/dkms/dkms-logitech-rs50-linux-driver.spec
+++ b/anda/system/logitech-rs50-linux-driver/dkms/dkms-logitech-rs50-linux-driver.spec
@@ -6,7 +6,7 @@
 
 Name:           dkms-%{modulename}
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276)
 License:        GPL-2.0-only
 URL:            https://github.com/mescon/%{modulename}
@@ -20,6 +20,7 @@ Conflicts:      akmod-%{modulename}
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
 BuildArch:      x86_64
 Provides:       %{modulename}-kmod
+Packager:       Luan V. <luanv.oliveira@outlook.com>
 
 %description
 Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276).
@@ -37,13 +38,14 @@ Akmods modules for the akmod-%{name} package.
 
 %prep
 %autosetup -p1 -n %{modulename}-%{commit}
-mv mainline/* ./
+pushd mainline
 mkdir build
 sed -i -e 's/__VERSION_STRING/%{version}/g' dkms.conf
+popd
 
 %install
 mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}
-cp -fr ./ %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+cp -fr ./mainline/* %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
 
 %post
 dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
@@ -56,8 +58,9 @@ dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
 
 %files
 %{_usrsrc}/%{modulename}-%{version}
-%doc README.md rs-wheel-hub-button-layout.png docs/*
 
 
 %changelog
-%autochangelog
+* Fri May 01 2026 Luan V. <luanv.oliveira@outlook.com> - 1.0^20260430git.df7f149-2
+- fix build due to upstream changes
+- resolve spec warnings: add Packager tag, remove autochangelog

--- a/anda/system/logitech-rs50-linux-driver/dkms/fix-dkms-conf.patch
+++ b/anda/system/logitech-rs50-linux-driver/dkms/fix-dkms-conf.patch
@@ -1,7 +1,7 @@
-diff --git a/dkms.conf b/dkms.conf
+diff --git a/mainline/dkms.conf b/mainline/dkms.conf
 index 437e5fd..2c4f3a4 100644
---- a/dkms.conf
-+++ b/dkms.conf
+--- a/mainline/dkms.conf
++++ b/mainline/dkms.conf
 @@ -1,8 +1,8 @@
 -PACKAGE_NAME="hid-logitech-hidpp"
 -PACKAGE_VERSION="1.0"

--- a/anda/system/logitech-rs50-linux-driver/kmod-common/README.terra.md
+++ b/anda/system/logitech-rs50-linux-driver/kmod-common/README.terra.md
@@ -1,0 +1,4 @@
+# proton trueforce setup
+the original tools/install-tf-shim.sh is available on your path as logi-rs50-proton-setup,
+it will search for the logitech dlls at `/var/lib/logitech-rs50-linux-driver/`.
+for which files to place there and how to get them, see README.md

--- a/anda/system/logitech-rs50-linux-driver/kmod-common/logi-rs50-proton-setup.sh
+++ b/anda/system/logitech-rs50-linux-driver/kmod-common/logi-rs50-proton-setup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec /usr/share/logitech-rs50-linux-driver/tools/install-tf-shim.sh "$@"

--- a/anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec
+++ b/anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec
@@ -4,15 +4,19 @@
 
 Name:           logitech-rs50-linux-driver
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Linux kernel driver for the Logitech RS50 Direct Drive Wheel Base (USB ID 046d:c276)
 License:        GPL-2.0-only
 URL:            https://github.com/mescon/%{name}
 Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
 Source1:        com.github.rs50.metainfo.xml
+Source2:        logi-rs50-proton-setup.sh
+Source3:        README.terra.md
 BuildRequires:  systemd-rpm-macros
+Recommends:     trueforce-sdk
 Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Packager:       Luan V. <luanv.oliveira@outlook.com>
 BuildArch:      noarch
 
 %description
@@ -32,20 +36,49 @@ Akmods modules for the akmod-%{name} package.
 %autosetup -p1 -n %{name}-%{commit}
 
 echo hid-logitech-hidpp > %{name}.conf
+mv sdk/README.md README-SDK.md
+cp %{SOURCE3} README.terra.md
 
 %install
 install -Dm644 %{SOURCE1} %{buildroot}%{_datadir}/metainfo/com.github.rs50.metainfo.xml
 
+mkdir -p %{buildroot}%{_bindir}
+mkdir -p %{buildroot}%{_datadir}/%{name}/tools
+mkdir -p %{buildroot}%{_sharedstatedir}/%{name}/Logi
+ln -sr %_sharedstatedir/%{name} %{buildroot}%{_datadir}/%{name}/sdk
+
+install -Dm755 tools/install-tf-shim.sh %{buildroot}%{_datadir}/%{name}/tools/
+install -Dm755 %{SOURCE2} %{buildroot}%{_bindir}/logi-rs50-proton-setup
+
+install -Dm644 udev/70-logitech-rs50.rules -t %{buildroot}%{_udevrulesdir}/
+install -D -m644 userspace/libtrueforce/udev/99-logitech-rs50-trueforce.rules %{buildroot}%{_udevrulesdir}/70-logitech-rs50-trueforce.rules
+
 # Akmods modules
 install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
 
+%posttrans
+### Skip triggering if udevd isn't accessible
+if [ -S /run/udev/control ]; then
+    /usr/bin/udevadm control --reload
+    /usr/bin/udevadm trigger --subsystem-match=hidraw
+fi
+
 
 %files
-%doc README.md rs-wheel-hub-button-layout.png docs/*
+%doc README.terra.md README.md README-SDK.md CHANGELOG.md rs-wheel-hub-button-layout.png docs/*
 %{_datadir}/metainfo/com.github.rs50.metainfo.xml
+%{_udevrulesdir}/70-logitech-rs50.rules
+%{_udevrulesdir}/70-logitech-rs50-trueforce.rules
+%{_datadir}/%{name}/tools/*
+%{_bindir}/logi-rs50-proton-setup
+%{_datadir}/%{name}/sdk
+%dir %{_sharedstatedir}/%{name}/Logi
 
 %files akmod-modules
 %{_modulesloaddir}/%{name}.conf
 
 %changelog
-%autochangelog
+* Fri May 01 2026 Luan V. <luanv.oliveira@outlook.com> - 1.0^20260430git.df7f149-2
+- add logi-rs50-proton-setup script together with a readme which explains where to put the necessary files.
+- and add udev rules together with a posttrans script to reload and trigger devices on install
+- fix spec warnings: add Packager tag and remove autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [Update rs50 driver (#11794)](https://github.com/terrapkg/packages/pull/11794)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)