### PR TITLE
[f43] fix(hollywood): install to `/usr/lib` (#11810)

### DIFF
--- a/anda/misc/hollywood/hollywood.spec
+++ b/anda/misc/hollywood/hollywood.spec
@@ -48,6 +48,7 @@ background of any excellent schlock technothriller.
 
 %build
 
+%global _libdir /usr/lib
 %install
 mkdir -p %{buildroot}%{_libdir}/hollywood
 mkdir -p %{buildroot}%{_datadir}/wallstreet


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(hollywood): install to `/usr/lib` (#11810)](https://github.com/terrapkg/packages/pull/11810)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)