### PR TITLE
[f43] fix (numba): patch llvmlite version (#11817)

### DIFF
--- a/anda/langs/python/numba/numba.spec
+++ b/anda/langs/python/numba/numba.spec
@@ -2,12 +2,13 @@
 
 Name:			python-%{pypi_name}
 Version:		0.65.1
-Release:		1%{?dist}
+Release:		2%{?dist}
 Summary:	    NumPy aware dynamic Python compiler using LLVM
 License:		BSD-2-Clause AND MIT AND BSD-3-Clause
 URL:			https://numba.pydata.org
 # PyPi source does not include all files
 Source0:		https://github.com/numba/numba/archive/refs/tags/%version.tar.gz
+Patch0:		    remove-llvmlite-version-req.patch
 # This package is intentionally not noarch
 
 BuildRequires:  python3-devel
@@ -36,7 +37,7 @@ Numba is an open source, NumPy-aware optimizing compiler for Python sponsored by
 Numba can compile a large subset of numerically-focused Python, including many NumPy functions. Additionally, Numba has support for automatic parallelization of loops, generation of GPU-accelerated code, and creation of ufuncs and C callbacks.
 
 %prep
-%autosetup -n numba-%{version}
+%autosetup -n numba-%{version} -p1
 
 %build
 %pyproject_wheel

--- a/anda/langs/python/numba/remove-llvmlite-version-req.patch
+++ b/anda/langs/python/numba/remove-llvmlite-version-req.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 282b8f42e..24c865f0a 100644
+--- a/setup.py
++++ b/setup.py
+@@ -24,7 +24,7 @@ max_python_version = "3.15"  # exclusive
+ min_numpy_build_version = "2.0.0rc1"
+ min_numpy_run_version = "1.22"
+ max_numpy_run_version = "2.5"
+-min_llvmlite_version = "0.47.0dev0"
++min_llvmlite_version = "0.44"
+ max_llvmlite_version = "0.48"
+ 
+ if sys.platform.startswith('linux'):


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (numba): patch llvmlite version (#11817)](https://github.com/terrapkg/packages/pull/11817)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)