### PR TITLE
[el10] feat: switch cuda-cudnn to cuda 13 (#11816)

### DIFF
--- a/anda/lib/nvidia/cuda-cudnn/cuda-cudnn.spec
+++ b/anda/lib/nvidia/cuda-cudnn/cuda-cudnn.spec
@@ -2,11 +2,11 @@
 %global         __strip /bin/true
 %global         _missing_build_ids_terminate_build 0
 %global         _build_id_links none
-%global         cuda_version 12
+%global         cuda_version 13
 
 Name:           cuda-cudnn
 Version:        9.21.1.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Epoch:          1
 Summary:        NVIDIA CUDA Deep Neural Network library (cuDNN)
 License:        NVIDIA Software Development Kit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat: switch cuda-cudnn to cuda 13 (#11816)](https://github.com/terrapkg/packages/pull/11816)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)