### PR TITLE
[f43] fix: wails3 (#11830)

### DIFF
--- a/anda/lib/wails/v3/wails3.spec
+++ b/anda/lib/wails/v3/wails3.spec
@@ -32,7 +32,7 @@ Provides:       wails-v3
 %gopkg
 
 %prep
-%git_clone https://github.com/wailsapp/wails v3-alpha
+%git_clone https://github.com/wailsapp/wails v3-beta
 
 %build
 pushd v3/cmd/wails3


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: wails3 (#11830)](https://github.com/terrapkg/packages/pull/11830)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)