### PR TITLE
[f43] fix(breakpad): Use correct format for gh() (#11850)

### DIFF
--- a/anda/lib/breakpad/update.rhai
+++ b/anda/lib/breakpad/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("https://github.com/google/breakpad"));
+rpm.version(gh("google/breakpad"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(breakpad): Use correct format for gh() (#11850)](https://github.com/terrapkg/packages/pull/11850)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)