### PR TITLE
[f42] fix(zig-master): Use rpm.define() for llvm_compat (#11851)

### DIFF
--- a/anda/langs/zig/bootstrap/update.rhai
+++ b/anda/langs/zig/bootstrap/update.rhai
@@ -13,5 +13,5 @@ if rpm.changed() {
    let l = find(`releases\.llvm\.org/download\.html#([\d.]+)`, rawfile, 1);
    rpm.global("llvm_version", l);
    l.truncate(2);
-   rpm.global("llvm_compat", l);
+   rpm.define("llvm_compat", l);
 }

--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -2,7 +2,7 @@
 %global         zig_arches x86_64 aarch64 riscv64 %{mips64}
 # Signing key from https://ziglang.org/download/
 %global         public_key RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
-%if 0%{?fedora} >= 44
+%if 0%{?fedora} >= 46
 %define         llvm_compat 22
 %endif
 %global         llvm_version 22.0.0

--- a/anda/langs/zig/master/update.rhai
+++ b/anda/langs/zig/master/update.rhai
@@ -11,5 +11,5 @@ if rpm.changed() {
   let l = find(`releases\.llvm\.org/download\.html#([\d.]+)`, rawfile, 1);
   rpm.global("llvm_version", l);
   l.truncate(2);
-  rpm.global("llvm_compat", l);
+  rpm.define("llvm_compat", l);
 }

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -2,7 +2,7 @@
 %global         zig_arches x86_64 aarch64 riscv64 %{mips64}
 # Signing key from https://ziglang.org/download/
 %global         public_key RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
-%if 0%{?fedora} >= 44
+%if 0%{?fedora} >= 46
 %define         llvm_compat 22
 %endif
 %global         llvm_version 22.0.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(zig-master): Use rpm.define() for llvm_compat (#11851)](https://github.com/terrapkg/packages/pull/11851)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)