### PR TITLE
iio-niri: add automatic update definition and update to 2.0

### DIFF
--- a/anda/desktops/niri/iio-niri/iio-niri.spec
+++ b/anda/desktops/niri/iio-niri/iio-niri.spec
@@ -1,5 +1,5 @@
 Name:           iio-niri
-Version:        1.3.0
+Version:        2.0.0
 Release:        1%{?dist}
 Summary:        Autorotation daemon for niri
 URL:            https://github.com/Zhaith-Izaliel/iio-niri
@@ -30,5 +30,8 @@ Packager:       Tulip Blossom <tulilirockz@outlook.com>
 %{_bindir}/%{name}
 
 %changelog
+* Fri May 05 2026 Tulip Blossom <tulilirockz@outlook.com> - 2.0.0-1
+- Initial commit
+
 * Fri Mar 13 2026 Tulip Blossom <tulilirockz@outlook.com>
 - Initial commit

--- a/anda/desktops/niri/iio-niri/iio-niri.spec
+++ b/anda/desktops/niri/iio-niri/iio-niri.spec
@@ -31,7 +31,7 @@ Packager:       Tulip Blossom <tulilirockz@outlook.com>
 
 %changelog
 * Fri May 05 2026 Tulip Blossom <tulilirockz@outlook.com> - 2.0.0-1
-- Initial commit
+- Update package and add autoupdate definitions
 
 * Fri Mar 13 2026 Tulip Blossom <tulilirockz@outlook.com>
 - Initial commit

--- a/anda/desktops/niri/iio-niri/update.rhai
+++ b/anda/desktops/niri/iio-niri/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("Zhaith-Izaliel/iio-niri"));
+rpm.version(find(`version = "([\d.]+)"`, gh_rawfile("Zhaith-Izaliel/iio-niri", "master", "Cargo.toml"), 1));

--- a/anda/desktops/niri/iio-niri/update.rhai
+++ b/anda/desktops/niri/iio-niri/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("Zhaith-Izaliel/iio-niri"));


### PR DESCRIPTION

Turns out I forgot about the update.rhai file
