### PR TITLE
[el10] fix(rio): Build requires glslc (#11861)

### DIFF
--- a/anda/devs/rio/rio.spec
+++ b/anda/devs/rio/rio.spec
@@ -1,7 +1,7 @@
 %global crate rioterm
+%global appid com.rioterm.Rio
 %global _description %{expand:
 A hardware-accelerated terminal emulator focusing to run in desktops and browsers.}
-%bcond docs 1
 
 Name:          rio
 Version:       0.4.2
@@ -17,6 +17,7 @@ BuildRequires: desktop-file-utils
 BuildRequires: freetype-devel
 BuildRequires: cmake
 BuildRequires: gcc-c++
+BuildRequires: glslc
 BuildRequires: libxcb-devel
 BuildRequires: libxkbcommon-devel
 BuildRequires: mold
@@ -25,10 +26,9 @@ BuildRequires: pkgconfig(alsa)
 Requires:      freetype
 Requires:      fontconfig
 Requires:      hicolor-icon-theme
+Requires:      ncurses-term
 Obsoletes:     %{crate} < %{version}-%{release}
-%if %{with docs}
-Suggests:      %{name}-doc = %{version}-%{release}
-%endif
+Obsoletes:     %{name}-doc < %{evr}
 Packager:      Gilver E. <roachy@fyralabs.com>
 
 %description %_description
@@ -39,14 +39,6 @@ Requires:      %{name} = %{version}-%{release}
 
 %description   devel
 This package contains the development libraries for Rio.
-
-%if %{with docs}
-%package       doc
-Summary:       Documentation for Rio
-
-%description   doc
-This package contains all official documentation files for the Rio terminal.
-%endif
 
 %prep
 %autosetup -n %{name}-%{version}
@@ -59,7 +51,8 @@ sed -i 's/Exec=.*/Exec=%{crate}/g' misc/%{name}.desktop
 %install
 install -Dm755 target/rpm/%{name} %{buildroot}%{_bindir}/%{crate}
 install -Dm755 target/rpm/*.so -t %{buildroot}%{_libdir}
-install -Dm644 docs/static/assets/%{name}-logo.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/%{name}.svg
+install -Dm644 misc/logo.svg %{buildroot}%{_scalableiconsdir}/%{name}.svg
+install -Dm644 misc/%{appid}.metainfo.xml -t %{buildroot}%{_metainfodir}
 desktop-file-install misc/%{name}.desktop
 %{cargo_license_online -a} > LICENSE.dependencies
 
@@ -73,16 +66,12 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_bindir}/%{crate}
 %{_datadir}/applications/%{name}.desktop
 %{_iconsdir}/hicolor/scalable/apps/%{name}.svg
+%{_metainfodir}/%{appid}.metainfo.xml
 
 %files devel
 %{_libdir}/librio_backend.so
 %{_libdir}/librio_proc_macros.so
 %{_libdir}/libsugarloaf.so
-
-%if %{with docs}
-%files doc
-%doc docs/docs/*
-%endif
 
 %changelog
 * Mon May 5 2025 Gilver E. <rockgrub@disroot.org> - 0.2.13-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(rio): Build requires glslc (#11861)](https://github.com/terrapkg/packages/pull/11861)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)