### PR TITLE
[f42] fix(satty): add autoupdate definition (#11883)

### DIFF
--- a/anda/desktop/satty/update.rhai
+++ b/anda/desktop/satty/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Satty-org/Satty"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(satty): add autoupdate definition (#11883)](https://github.com/terrapkg/packages/pull/11883)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)