### PR TITLE
[f42] fix(srpm-macros): License tag (#11890)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -1,9 +1,9 @@
 Name:           anda-srpm-macros
 Version:        0.3.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        SRPM macros for extra Fedora packages
 
-License:        MIT
+License:        GPL-3.0-or-later
 URL:            https://github.com/terrapkg/srpm-macros
 Source0:        %url/archive/refs/tags/v%{version}.tar.gz
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(srpm-macros): License tag (#11890)](https://github.com/terrapkg/packages/pull/11890)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)