### PR TITLE
[f42] iio-niri: add automatic update definition and update to 2.0 (#11873)

### DIFF
--- a/anda/desktops/niri/iio-niri/iio-niri.spec
+++ b/anda/desktops/niri/iio-niri/iio-niri.spec
@@ -1,5 +1,5 @@
 Name:           iio-niri
-Version:        1.3.0
+Version:        2.0.0
 Release:        1%{?dist}
 Summary:        Autorotation daemon for niri
 URL:            https://github.com/Zhaith-Izaliel/iio-niri
@@ -30,5 +30,8 @@ Packager:       Tulip Blossom <tulilirockz@outlook.com>
 %{_bindir}/%{name}
 
 %changelog
+* Fri May 05 2026 Tulip Blossom <tulilirockz@outlook.com> - 2.0.0-1
+- Update package and add autoupdate definitions
+
 * Fri Mar 13 2026 Tulip Blossom <tulilirockz@outlook.com>
 - Initial commit

--- a/anda/desktops/niri/iio-niri/update.rhai
+++ b/anda/desktops/niri/iio-niri/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(find(`version = "([\d.]+)"`, gh_rawfile("Zhaith-Izaliel/iio-niri", "master", "Cargo.toml"), 1));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [iio-niri: add automatic update definition and update to 2.0 (#11873)](https://github.com/terrapkg/packages/pull/11873)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)