### PR TITLE
[f43] chore(discord): Include TOS as license file, fix script locations (#11900)

### DIFF
--- a/anda/apps/discord/discord.spec
+++ b/anda/apps/discord/discord.spec
@@ -1,15 +1,11 @@
 Name:			discord
 Version:		1.0.136
-Release:		2%{?dist}
+Release:		3%{?dist}
 Summary:		Free Voice and Text Chat for Gamers
 URL:			https://discord.com
 Source0:		https://dl.discordapp.net/apps/linux/%{version}/discord-%{version}.tar.gz
-License:		https://discord.com/terms
-Requires:		glibc GConf2
-Requires:		nspr >= 4.13
-Requires:		nss >= 3.27
-Requires:		libX11 >= 1.6
-Requires:		libXtst >= 1.2
+Source1:    https://discord.com/terms#/terms.html
+License:		Proprietary
 Group:			Applications/Internet
 ExclusiveArch:	x86_64
 
@@ -26,16 +22,18 @@ both your desktop and phone.
 
 %install
 mkdir -p %{buildroot}%{_bindir}
-install -Dpm755 ./* -t %{buildroot}%{_libdir}/discord
+install -Dpm755 ./* -t %{buildroot}%{_datadir}/discord
 mkdir -p %{buildroot}%{_appsdir}
 mkdir -p %{buildroot}%{_datadir}/pixmaps
-mv %{buildroot}%{_libdir}/discord/discord.desktop -t %{buildroot}%{_appsdir}
-mv %{buildroot}%{_libdir}/discord/discord.png -t %{buildroot}%{_datadir}/pixmaps
-ln -s %{_libdir}/discord/discord %{buildroot}%{_bindir}/discord
+mv %{buildroot}%{_datadir}/discord/discord.desktop -t %{buildroot}%{_appsdir}
+mv %{buildroot}%{_datadir}/discord/discord.png -t %{buildroot}%{_datadir}/pixmaps
+mv %{buildroot}%{_datadir}/discord/discord -t %{buildroot}%{_bindir}
+cp %{SOURCE1} -t .
 
 %files
+%license terms.html
 %{_bindir}/discord
-%{_libdir}/discord/
+%{_datadir}/discord/
 %{_appsdir}/discord.desktop
 %{_datadir}/pixmaps/discord.png
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore(discord): Include TOS as license file, fix script locations (#11900)](https://github.com/terrapkg/packages/pull/11900)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)