### PR TITLE
[f44] fix(protonplus): Build requires Vala (#11914)

### DIFF
--- a/anda/games/protonplus/protonplus.spec
+++ b/anda/games/protonplus/protonplus.spec
@@ -12,7 +12,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 BuildRequires:  meson
 BuildRequires:  ninja-build
 BuildRequires:  gcc
-BuildRequires:  valac
+BuildRequires:  vala
 BuildRequires:  pkgconfig(gtk4)
 BuildRequires:  pkgconfig(libadwaita-1)
 BuildRequires:  pkgconfig(json-glib-1.0)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(protonplus): Build requires Vala (#11914)](https://github.com/terrapkg/packages/pull/11914)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)