### PR TITLE
[f42] add: dirsync (#11924)

### DIFF
--- a/anda/langs/python/dirsync/anda.hcl
+++ b/anda/langs/python/dirsync/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "dirsync.spec"
+    }
+}

--- a/anda/langs/python/dirsync/dirsync.spec
+++ b/anda/langs/python/dirsync/dirsync.spec
@@ -1,0 +1,46 @@
+%global pypi_name dirsync
+%global _desc Advanced directory tree synchronisation tool.
+
+Name:			python-%{pypi_name}
+Version:		2.2.6
+Release:		1%{?dist}
+Summary:		Advanced directory tree synchronisation tool
+License:		MIT
+URL:			https://github.com/domdfcoding/deprecation-alias
+Source0:		%{pypi_source}
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildArch:      noarch
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.rst
+%license LICENSE.txt
+%{_bindir}/%{pypi_name}
+
+%changelog
+* Mon May 04 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/dirsync/update.rhai
+++ b/anda/langs/python/dirsync/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("dirsync"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: dirsync (#11924)](https://github.com/terrapkg/packages/pull/11924)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)