### PR TITLE
[el10] chore (ops2deb): use modern python packaging (#11635)

### DIFF
--- a/anda/buildsys/ops2deb/ops2deb.spec
+++ b/anda/buildsys/ops2deb/ops2deb.spec
@@ -1,43 +1,50 @@
-%global debug_package %nil
-%define _python_dist_allow_version_zero # upstream issue?
+%global pypi_name ops2deb
+%global _desc Generate Debian packages for common devops tools such as kubectl, kustomize, helm.
 
-Name:			python3-ops2deb
+Name:			python-%{pypi_name}
 Version:		2.7.0
 Release:		1%?dist
-Summary:		Generate Debian packages for common devops tools
+Summary:		Generate Debian packages for common devops tools such as kubectl, kustomize, helm
 License:		MIT
 URL:			https://github.com/upciti/ops2deb
-Source0:		%url/archive/refs/tags/%version.tar.gz
-BuildRequires:	python3-devel poetry python3.10
-BuildRequires:	python3dist(setuptools)
-BuildArch:		noarch
+Source0:		%{pypi_source}
+Patch0:			versions.patch
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-poetry
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
 %description
-ops2deb is designed to generate Debian packages for common devops tools, but
-can be used to package any portable application. It consumes a configuration
-file and outputs .deb packages. ops2deb can also track new releases of upstream
-applications and automatically bump application versions in its configuration
-file.
+%_desc
 
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
 
 %prep
-%autosetup -n ops2deb-%version
+%autosetup -n %{pypi_name}-%{version} -p1
 
 %build
-poetry build
+%pyproject_wheel
 
 %install
-python3.10 -m ensurepip
-python3.10 -m pip install installer
-python3.10 -m installer --destdir=%buildroot dist/*.whl
-rm -rf %buildroot/%python3_sitelib/*/__pycache__
+%pyproject_install
+%pyproject_save_files %{pypi_name}
 
-%files
-%license LICENSE
+%files -n python3-%{pypi_name} -f %{pyproject_files}
 %doc README.md
-/usr/bin/ops2deb
-/usr/lib/python3*/site-packages/ops2deb*
+%license LICENSE
+%{_bindir}/ops2deb
 
 %changelog
+* Thu Apr 23 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to modern python packaging methods
+
 * Fri Apr 28 2023 madonuko <mado@fyralabs.com> - 2.4.1-1
 - Initial package.

--- a/anda/buildsys/ops2deb/versions.patch
+++ b/anda/buildsys/ops2deb/versions.patch
@@ -1,0 +1,18 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 29b753f..926abf8 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -18,10 +18,10 @@ packages = [
+ ]
+ 
+ [tool.poetry.dependencies]
+-python = ">=3.10,<3.12"
++python = ">=3.10"
+ httpx = ">=0.20.0"
+-semver = "3.0.2"
+-"ruamel.yaml" = "0.18.14"
++semver = ">3.0.2"
++"ruamel.yaml" = ">0.18.14"
+ python-debian = ">=0.1.42"
+ PyYAML = "^6"
+ typer = ">=0.6.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (ops2deb): use modern python packaging (#11635)](https://github.com/terrapkg/packages/pull/11635)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)