### PR TITLE
[f43] add: open-unmix-pytorch (#11939)

### DIFF
--- a/anda/langs/python/open-unmix-pytorch/anda.hcl
+++ b/anda/langs/python/open-unmix-pytorch/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "open-unmix-pytorch.spec"
+  }
+}

--- a/anda/langs/python/open-unmix-pytorch/open-unmix-pytorch.spec
+++ b/anda/langs/python/open-unmix-pytorch/open-unmix-pytorch.spec
@@ -1,0 +1,47 @@
+%global pypi_name openunmix
+%global _desc Open-Unmix - Music Source Separation for PyTorch.
+
+Name:			python-%{pypi_name}
+Version:		1.3.0
+Release:		1%{?dist}
+Summary:		Open-Unmix - Music Source Separation for PyTorch
+License:		MIT
+URL:			https://github.com/sigsep/open-unmix-pytorch
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-wheel
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/umx
+
+%changelog
+* Mon May 04 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/open-unmix-pytorch/update.rhai
+++ b/anda/langs/python/open-unmix-pytorch/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("openunmix"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: open-unmix-pytorch (#11939)](https://github.com/terrapkg/packages/pull/11939)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)