### PR TITLE
[f42] chore (hydra-colorlog): use java-latest (#11934)

### DIFF
--- a/anda/langs/python/hydra-colorlog/hydra-colorlog.spec
+++ b/anda/langs/python/hydra-colorlog/hydra-colorlog.spec
@@ -14,7 +14,7 @@ Source0:		%url/archive/refs/tags/v%version.tar.gz
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools
-BuildRequires:  java-21-openjdk-devel
+BuildRequires:  java-latest-openjdk-devel
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (hydra-colorlog): use java-latest (#11934)](https://github.com/terrapkg/packages/pull/11934)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)