### PR TITLE
[f43] chore (dataclasses-json): clean up build (#11933)

### DIFF
--- a/anda/langs/python/dataclasses-json/dataclasses-json.spec
+++ b/anda/langs/python/dataclasses-json/dataclasses-json.spec
@@ -1,23 +1,21 @@
 %global pypi_name dataclasses-json
 %global _desc Easily serialize Data Classes to and from JSON.
 
-%define _python_dist_allow_version_zero %{nil}
-
 Name:			python-%{pypi_name}
 Version:		0.6.7
-Release:		1%?dist
+Release:		1%{?dist}
 Summary:		Easily serialize Data Classes to and from JSON
 License:		MIT
 URL:			https://github.com/lidatong/dataclasses-json
-Source0:		%url/archive/refs/tags/v%version.tar.gz
+Source0:		%{url}/archive/refs/tags/v%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
+BuildRequires:  python3-build
 BuildRequires:  python3-pip
+BuildRequires:  python3-poetry-core
 BuildRequires:  python3-poetry-dynamic-versioning
-
-Requires:       python3-marshmallow
-Requires:       python3-typing-inspect
+BuildRequires:  python3-pyproject-metadata
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
@@ -31,15 +29,8 @@ Summary:        %{summary}
 %description -n python3-%{pypi_name}
 %_desc
 
-%package -n     python3-%{pypi_name}-doc
-Summary:        documentation for python3-%{pypi_name}
-
-%description -n python3-%{pypi_name}-doc
-documentation for python3-%{pypi_name}.
-
 %prep
-%autosetup -n dataclasses-json-%{version}
-sed -i '/\[tool.poetry-dynamic-versioning\]/,+1d' pyproject.toml
+%git_clone %{url}.git v%{version}
 
 %build
 %pyproject_wheel
@@ -53,5 +44,8 @@ sed -i '/\[tool.poetry-dynamic-versioning\]/,+1d' pyproject.toml
 %license LICENSE
 
 %changelog
+* Mon May 04 2026 Owen Zimmerman <owen@fyralabs.com>
+- Switch to git source, clean up spec
+
 * Wed Jan 07 2026 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (dataclasses-json): clean up build (#11933)](https://github.com/terrapkg/packages/pull/11933)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)