### PR TITLE
[el10] add: peft (#11944)

### DIFF
--- a/anda/langs/python/peft/anda.hcl
+++ b/anda/langs/python/peft/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "peft.spec"
+  }
+}

--- a/anda/langs/python/peft/peft.spec
+++ b/anda/langs/python/peft/peft.spec
@@ -1,0 +1,45 @@
+%global pypi_name peft
+%global _desc PEFT: State-of-the-art Parameter-Efficient Fine-Tuning.
+
+Name:			python-%{pypi_name}
+Version:		0.19.1
+Release:		1%{?dist}
+Summary:		PEFT: State-of-the-art Parameter-Efficient Fine-Tuning
+License:		Apache-2.0
+URL:			https://github.com/huggingface/peft
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pip
+BuildRequires:  python3-devel
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+
+%changelog
+* Mon May 04 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/peft/update.rhai
+++ b/anda/langs/python/peft/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("peft"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: peft (#11944)](https://github.com/terrapkg/packages/pull/11944)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)