### PR TITLE
[f43] add: bitsandbytes (#11980)

### DIFF
--- a/anda/langs/python/bitsandbytes/anda.hcl
+++ b/anda/langs/python/bitsandbytes/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "bitsandbytes.spec"
+  }
+}

--- a/anda/langs/python/bitsandbytes/bitsandbytes.spec
+++ b/anda/langs/python/bitsandbytes/bitsandbytes.spec
@@ -1,0 +1,49 @@
+%global pypi_name bitsandbytes
+%global _desc Accessible large language models via k-bit quantization for PyTorch.
+
+Name:			python-%{pypi_name}
+Version:		0.49.2
+Release:		1%{?dist}
+Summary:		Accessible large language models via k-bit quantization for PyTorch
+License:		MIT
+URL:			https://huggingface.co/docs/bitsandbytes/main/en/index
+Source0:		https://github.com/bitsandbytes-foundation/bitsandbytes/archive/refs/tags/%{version}.tar.gz
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-scikit-build-core
+BuildRequires:  python3-pip
+BuildRequires:  python3-hatchling
+BuildRequires:  python3-wheel
+BuildRequires:  python3-cmake
+BuildRequires:  gcc-c++
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+
+%files -n python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md
+%license LICENSE
+
+%changelog
+* Tue May 05 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/bitsandbytes/update.rhai
+++ b/anda/langs/python/bitsandbytes/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("bitsandbytes"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: bitsandbytes (#11980)](https://github.com/terrapkg/packages/pull/11980)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)