### PR TITLE
[f43] build(deps): bump sorenlouv/backport-github-action from 11.0.0 to 12.0.0 (#11993)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -27,7 +27,7 @@ jobs:
           git config --global commit.gpgsign true
 
       - name: Backport Action
-        uses: sorenlouv/backport-github-action@9460b7102fea25466026ce806c9ebf873ac48721 # v11.0.0
+        uses: sorenlouv/backport-github-action@85813678d776774a19ec5af56bd3a04305946f8a # v12.0.0
         with:
           github_token: ${{ secrets.RABONEKO_BACKPORT_GITHUB_TOKEN }}
           auto_backport_label_prefix: sync-


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [build(deps): bump sorenlouv/backport-github-action from 11.0.0 to 12.0.0 (#11993)](https://github.com/terrapkg/packages/pull/11993)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)