### PR TITLE
[el10] chore (signal-cli): use java-25 (#11991)

### DIFF
--- a/anda/misc/signal-cli/signal-cli.spec
+++ b/anda/misc/signal-cli/signal-cli.spec
@@ -14,8 +14,8 @@ BuildArch:        noarch
 BuildRequires:    gcc-c++
 BuildRequires:    gradle
 BuildRequires:    anda-srpm-macros
-BuildRequires:    java-21-openjdk
-BuildRequires:    java-21-openjdk-devel
+BuildRequires:    java-25-openjdk
+BuildRequires:    java-25-openjdk-devel
 BuildRequires:    systemd-rpm-macros
 BuildRequires:    make
 BuildRequires:    asciidoc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (signal-cli): use java-25 (#11991)](https://github.com/terrapkg/packages/pull/11991)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)