### PR TITLE
[f42] add: cardwire (#12013)

### DIFF
--- a/anda/system/cardwire/anda.hcl
+++ b/anda/system/cardwire/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "cardwire.spec"
+  }
+}

--- a/anda/system/cardwire/cardwire.spec
+++ b/anda/system/cardwire/cardwire.spec
@@ -1,0 +1,52 @@
+Name:           cardwire
+Version:        0.6.0
+Release:        1%{?dist}
+Summary:        A GPU Manager for linux that uses eBPF LSM hooks to block GPUs
+URL:            https://opengamingcollective.github.io/cardwire/
+Source0:        https://github.com/OpenGamingCollective/cardwire/archive/refs/tags/v%{version}.tar.gz
+License:	GPL-3.0-or-later AND (Apache-2.0 OR MIT) AND BSD-3-Clause AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND ISC AND MIT (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND Zlib
+BuildRequires:  cargo-rpm-macros
+BuildRequires:	systemd-rpm-macros
+BuildRequires:	libbpf-devel
+BuildRequires:	clang-devel
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+install -Dm0755 target/rpm/cardwire %{buildroot}%{_bindir}/cardwire
+install -Dm0755 target/rpm/cardwired %{buildroot}%{_bindir}/cardwired
+install -Dm0644 assets/cardwired.service %{buildroot}%{_unitdir}/cardwired.service
+install -Dm0644 assets/com.github.opengamingcollective.cardwire.conf %{buildroot}%{_datadir}/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf
+	
+%{cargo_license_online} > LICENSE.dependencies
+
+%post
+%systemd_post cardwired.service
+
+%preun
+%systemd_preun cardwired.service
+
+%postun
+%systemd_postun_with_restart cardwired.service
+
+%files
+%license LICENSE
+%license LICENSE.dependencies
+%{_bindir}/cardwire
+%{_bindir}/cardwired
+%{_unitdir}/cardwired.service
+%{_datadir}/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf
+
+%changelog
+* Wed May 06 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/system/cardwire/update.rhai
+++ b/anda/system/cardwire/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("OpenGamingCollective/cardwire"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: cardwire (#12013)](https://github.com/terrapkg/packages/pull/12013)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)