### PR TITLE
[f44] nct6687d: fix module not loading by default (#12011)

### DIFF
--- a/anda/system/nct6687d/kmod-common/nct6687d.spec
+++ b/anda/system/nct6687d/kmod-common/nct6687d.spec
@@ -4,15 +4,17 @@
 
 Name:           nct6687d
 Version:        1.0^%{commitdate}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Linux kernel driver for the NCT6687D hardware monitoring chip
 License:        GPL-2.0-or-later
 URL:            https://github.com/Fred78290/%{name}
 Source0:        %{url}/archive/%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
 Source1:        com.github.nct6687d.metainfo.xml
 BuildRequires:  systemd-rpm-macros
+BuildRequires:  anda-srpm-macros
 Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
 Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+Obsoletes:      %{name}-akmods-modules < %{evr}
 BuildArch:      noarch
 
 %description
@@ -20,18 +22,10 @@ Linux kernel driver for the NCT6687D hardware monitoring chip.
 This kernel module permit to recognize the chipset Nuvoton NCT6687-R in lm-sensors package. This sensor is present on some B550 motherboard such as MSI or ASUS.
 The implementation is minimalist and was done by reverse coding of Windows 10 source code from LibreHardwareMonitor
 
-%package       akmod-modules
-Summary:       Modules for Akmods
-Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
-BuildArch:     noarch
-
-%description   akmod-modules
-Akmods modules for the akmod-%{name} package.
-
 %prep
 %autosetup -p1 -n %{name}-%{commit}
 
-echo %{name} > %{name}.conf
+echo nct6687 > %{name}.conf
 echo "blacklist nct6683" > nct6683_blacklist.conf
 
 %install
@@ -46,10 +40,10 @@ install -Dm 0644 nct6683_blacklist.conf -t %{buildroot}%{_modprobedir}
 %doc README.md images/* TESTING_RESULTS.md
 %{_modprobedir}/nct6683_blacklist.conf
 %{_datadir}/metainfo/com.github.nct6687d.metainfo.xml
-
-%files akmod-modules
 %{_modulesloaddir}/%{name}.conf
 
 %changelog
+* Wed May 06 2026 Luan Oliveira <luanv.oliveira@outlook.com> - 1.0^20260411git.cedda8b-2
+- fix module load file
 * Sat Apr 11 2026 Luan Oliveira <luanv.oliveira@outlook.com> - 1.0^20260411git.cedda8b-1
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [nct6687d: fix module not loading by default (#12011)](https://github.com/terrapkg/packages/pull/12011)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)