### PR TITLE
[f44] fix (prismlauncher): recommend Java-25-openjdk, use %conf, add flag for GCC16 warning system (#12008)

### DIFF
--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -14,7 +14,7 @@
 
 Name:             prismlauncher
 Version:          11.0.2
-Release:          1%{?dist}
+Release:          2%{?dist}
 Summary:          Minecraft launcher with ability to manage multiple instances
 # see COPYING.md for more information
 # each file in the source also contains a SPDX-License-Identifier header that declares its license
@@ -63,7 +63,7 @@ Requires(postun): desktop-file-utils
 Requires:         qt%{qt_version}-qtimageformats
 Requires:         qt%{qt_version}-qtsvg
 Requires:         javapackages-filesystem
-Recommends:       java-21-openjdk
+Recommends:       java-25-openjdk
 # See note above
 %if 0%{?fedora} && 0%{?fedora} < 42
 Recommends:       java-17-openjdk
@@ -91,8 +91,7 @@ multiple installations of Minecraft at once (Fork of MultiMC)
 # Do not set RPATH
 sed -i "s|\$ORIGIN/||" CMakeLists.txt
 
-
-%build
+%conf
 %cmake \
   -DLauncher_QT_VERSION_MAJOR="%{qt_version}" \
   -DLauncher_BUILD_PLATFORM="%{build_platform}" \
@@ -105,8 +104,10 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
   %if "%{curseforge_key}" != "default"
   -DLauncher_CURSEFORGE_API_KEY="%{curseforge_key}" \
   %endif
-  -DBUILD_TESTING=OFF
+  -DBUILD_TESTING=OFF \
+  -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=sfinae-incomplete"
 
+%build
 %cmake_build
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (prismlauncher): recommend Java-25-openjdk, use %conf, add flag for GCC16 warning system (#12008)](https://github.com/terrapkg/packages/pull/12008)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)