### PR TITLE
[f44] fix(prismlauncher): Only pass sfinae flags on Fedora >= 44 (#12032)

### DIFF
--- a/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
+++ b/anda/games/prismlauncher-nightly/prismlauncher-nightly.spec
@@ -103,7 +103,9 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
   -DLauncher_CURSEFORGE_API_KEY="%{curseforge_key}" \
   %endif
   -DBUILD_TESTING=OFF \
+%if 0%{?fedora} > 43
   -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=sfinae-incomplete"
+%endif
   
 %build
 %cmake_build

--- a/anda/games/prismlauncher/prismlauncher.spec
+++ b/anda/games/prismlauncher/prismlauncher.spec
@@ -96,7 +96,9 @@ sed -i "s|\$ORIGIN/||" CMakeLists.txt
   -DLauncher_CURSEFORGE_API_KEY="%{curseforge_key}" \
   %endif
   -DBUILD_TESTING=OFF \
+%if 0%{?fedora} > 43
   -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=sfinae-incomplete"
+%endif
 
 %build
 %cmake_build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(prismlauncher): Only pass sfinae flags on Fedora >= 44 (#12032)](https://github.com/terrapkg/packages/pull/12032)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)