### PR TITLE
[f43] polkit policy and desktop file for vencord (#10207)

### DIFF
--- a/anda/misc/vencord-installer/dev.vencord.Installer.desktop
+++ b/anda/misc/vencord-installer/dev.vencord.Installer.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Vencord Installer
+Type=Application
+GenericName=Discord Mod Installer
+Comment=Install and manage Vencord on your Discord installation
+Exec=vencord-installer
+Icon=dev.vencord.Installer
+Categories=Network;InstantMessaging;
+Keywords=discord;vencord;mod;
+StartupNotify=true

--- a/anda/misc/vencord-installer/dev.vencord.Installer.policy
+++ b/anda/misc/vencord-installer/dev.vencord.Installer.policy
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>Vencord</vendor>
+  <vendor_url>https://vencord.dev</vendor_url>
+
+  <action id="dev.vencord.Installer.run">
+    <description>Run the Vencord Installer</description>
+    <message>Authentication is required to patch Discord with Vencord</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/vencord-installer</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+</policyconfig>

--- a/anda/misc/vencord-installer/vencord-installer.spec
+++ b/anda/misc/vencord-installer/vencord-installer.spec
@@ -20,14 +20,18 @@ A cross platform gui/cli app for installing Vencord.}
 %global godocs          README.md
 
 Name:           vencord-installer
-Release:        1%{?dist}
+Release:        2%{?dist}
 Provides:       golang-github-vencord-installer = %{version}-%{release}
 Summary:        A cross platform gui/cli app for installing Vencord
 Packager:       Cappy Ishihara <cappy@fyralabs.com>
 License:        GPL-3.0-only
 URL:            %{gourl}
+
 Source:         %{gosource}
 Source1:        %appid.metainfo.xml
+Source2:        dev.vencord.Installer.desktop
+Source3:        dev.vencord.Installer.policy
+
 BuildRequires:  go-rpm-macros
 BuildRequires:  go-srpm-macros
 BuildRequires:  anda-srpm-macros
@@ -43,6 +47,7 @@ BuildRequires:  wayland-devel
 BuildRequires:  libxkbcommon-devel
 BuildRequires:  wayland-protocols-devel
 BuildRequires:  extra-cmake-modules
+BuildRequires:  desktop-file-utils
 
 %description %{common_description}
 
@@ -122,12 +127,17 @@ export CGO_LDFLAGS="${LDFLAGS}"
 install -m 0755 -vd                     %{buildroot}%{_bindir}
 install -m 0755 -vp %{gobuilddir}/bin/* %{buildroot}%{_bindir}/
 %terra_appstream -o %{SOURCE1}
+%desktop_file_install %{S:2}
+install -Dm644 %{SOURCE3} %{buildroot}%{_datadir}/polkit-1/actions/%{appid}
 
 %files
 %license LICENSE
 %doc README.md
 %{_bindir}/vencord-installer
 %{_datadir}/metainfo/%appid.metainfo.xml
+%{_datadir}/applications/%{appid}.desktop
+%{_datadir}/polkit-1/actions/%{appid}
+
 
 %files cli
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [polkit policy and desktop file for vencord (#10207)](https://github.com/terrapkg/packages/pull/10207)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)