### PR TITLE
[el10] add: publicdotcom-cli (#12053)

### DIFF
--- a/anda/langs/python/publicdotcom-cli/anda.hcl
+++ b/anda/langs/python/publicdotcom-cli/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "publicdotcom-cli.spec"
+  }
+}

--- a/anda/langs/python/publicdotcom-cli/publicdotcom-cli.spec
+++ b/anda/langs/python/publicdotcom-cli/publicdotcom-cli.spec
@@ -1,0 +1,47 @@
+%global pypi_name publicdotcom_cli
+%global real_name publicdotcom-cli
+%global _desc Command-line client for the Public.com Trading API.
+
+Name:			python-%{real_name}
+Version:		1.1.0
+Release:		1%?dist
+Summary:		Command-line client for the Public.com Trading API
+License:		Apache-2.0
+URL:			https://github.com/PublicDotCom/publicdotcom-cli
+Source0:		%{pypi_source}
+BuildArch:      noarch
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-hatchling
+
+Packager:	    Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%_desc
+
+%package -n     python3-%{real_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{real_name}}
+
+%description -n python3-%{real_name}
+%_desc
+
+%prep
+%autosetup -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+
+%files -n python3-%{real_name} -f %{pyproject_files}
+%doc README.md
+%{_bindir}/public
+
+%changelog
+* Thu May 07 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/langs/python/publicdotcom-cli/update.rhai
+++ b/anda/langs/python/publicdotcom-cli/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("publicdotcom-cli"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: publicdotcom-cli (#12053)](https://github.com/terrapkg/packages/pull/12053)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)