### PR TITLE
[f42] fix: rio (#12076)

### DIFF
--- a/anda/devs/rio/rio.spec
+++ b/anda/devs/rio/rio.spec
@@ -70,7 +70,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 %files devel
 %{_libdir}/librio_backend.so
-%{_libdir}/librio_proc_macros.so
 %{_libdir}/libsugarloaf.so
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: rio (#12076)](https://github.com/terrapkg/packages/pull/12076)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)