### PR TITLE
[f44] chore (anda-srpm-macros): install license and readme (#12084)

### DIFF
--- a/anda/terra/srpm-macros/anda-srpm-macros.spec
+++ b/anda/terra/srpm-macros/anda-srpm-macros.spec
@@ -1,6 +1,6 @@
 Name:           anda-srpm-macros
 Version:        0.3.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        SRPM macros for extra Fedora packages
 
 License:        GPL-3.0-or-later
@@ -31,6 +31,8 @@ install -Dpm755 *.sh -t %buildroot%_libexecdir/%name/
 
 %files
 %attr(0755, root, root) %_libexecdir/%name/*.sh
+%doc README.md
+%license LICENSE
 %{_rpmmacrodir}/macros.anda
 %{_rpmmacrodir}/macros.caching
 %{_rpmmacrodir}/macros.cargo_extra


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (anda-srpm-macros): install license and readme (#12084)](https://github.com/terrapkg/packages/pull/12084)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)