### PR TITLE
[f42] fix (pi-topd) (#12090)

### DIFF
--- a/anda/system/pi-topd/pi-topd.spec
+++ b/anda/system/pi-topd/pi-topd.spec
@@ -10,7 +10,7 @@ Summary:        Daemon for managing pi-top functionality by managing the pi-top 
 
 License:        Apache-2.0
 URL:            https://github.com/pi-top/pi-topd
-Source0:        %{url}/archive/refs/tags/%{ver}.tar.gz
+Source0:        %{url}/archive/refs/tags/v%{setup_ver}.tar.gz
 Source1:        Apache-2.0.txt
 BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (pi-topd) (#12090)](https://github.com/terrapkg/packages/pull/12090)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)