### PR TITLE
[el10] fix (binsider): license (#12118)

### DIFF
--- a/anda/tools/binsider/binsider.spec
+++ b/anda/tools/binsider/binsider.spec
@@ -1,8 +1,8 @@
 Name:          binsider
 Version:       0.3.2
-Release:       1%?dist
+Release:       2%?dist
 Summary:       Analyze ELF binaries like a boss 😼🕵️‍♂️
-License:       Apache-2.0 AND MIT
+License:       Apache-2.0 OR MIT
 URL:           https://github.com/orhun/binsider
 Source0:       %url/archive/refs/tags/v%{version}.tar.gz
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (binsider): license (#12118)](https://github.com/terrapkg/packages/pull/12118)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)