### PR TITLE
[el10] add: Google-Health-CLI (#12123)

### DIFF
--- a/anda/tools/Google-Health-CLI/Google-Health-CLI.spec
+++ b/anda/tools/Google-Health-CLI/Google-Health-CLI.spec
@@ -1,0 +1,45 @@
+%global goipath github.com/rudrankriyam/Google-Health-CLI
+Version:        1.0.0
+
+%gometa -f
+
+Name:           google-health-cli
+Release:        1%{?dist}
+Summary:        Unofficial Google-Health-CLI for the Google Health API, written in Go
+
+License:        MIT
+URL:            https://github.com/rudrankriyam/Google-Health-CLI
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+Requires:       glibc
+
+Provides:       Google-Health-CLI
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%autosetup -n Google-Health-CLI-%{version}
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/cmd/ghealth %{goipath}
+
+%install
+install -Dm 0755 %{gobuilddir}/cmd/ghealth %{buildroot}%{_bindir}/ghealth
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md CHANGELOG.md SECURITY.md
+%{_bindir}/ghealth
+
+%changelog
+* Sat May 09 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/Google-Health-CLI/anda.hcl
+++ b/anda/tools/Google-Health-CLI/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "Google-Health-CLI.spec"
+	}
+}

--- a/anda/tools/Google-Health-CLI/update.rhai
+++ b/anda/tools/Google-Health-CLI/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("rudrankriyam/Google-Health-CLI"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: Google-Health-CLI (#12123)](https://github.com/terrapkg/packages/pull/12123)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)