### PR TITLE
[f43] fix(bsc): Build requires ghc-strict-concurrency-devel (#12139)

### DIFF
--- a/anda/buildsys/bsc/bsc.spec
+++ b/anda/buildsys/bsc/bsc.spec
@@ -16,6 +16,7 @@ BuildRequires:  ghc-regex-compat-devel
 BuildRequires:  ghc-syb-devel
 BuildRequires:  ghc-old-time-devel
 BuildRequires:  ghc-split-devel
+BuildRequires:  ghc-strict-concurrency-devel
 BuildRequires:  gperf
 BuildRequires:  gcc-c++
 BuildRequires:  autoconf


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(bsc): Build requires ghc-strict-concurrency-devel (#12139)](https://github.com/terrapkg/packages/pull/12139)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)