### PR TITLE
[f43] feat: replace swww with awww (#12138)

### DIFF
--- a/anda/desktops/waylands/awww/anda.hcl
+++ b/anda/desktops/waylands/awww/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
     rpm {
-        spec = "swww.spec"
+        spec = "awww.spec"
     }
 }

--- a/anda/desktops/waylands/awww/awww.spec
+++ b/anda/desktops/waylands/awww/awww.spec
@@ -1,11 +1,11 @@
-Name:           swww
-Version:        0.11.2
+Name:           awww
+Version:        0.12.1
 Release:        1%?dist
 Summary:        Wallpaper daemon for Wayland
 SourceLicense:  GPL-3.0-only
 License:        (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-3-Clause AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
-URL:            https://github.com/LGFae/swww
-Source0:		%url/archive/refs/tags/v%version.tar.gz
+URL:            https://codeberg.org/LGFae/awww
+Source0:		%url/archive/v%version.tar.gz
 Packager:       madonuko <mado@fyralabs.com>
 BuildRequires:  anda-srpm-macros rust-packaging rpm_macro(bash_completions_dir) mold
 BuildRequires:  scdoc
@@ -16,7 +16,7 @@ BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols)
 
 %description
-swww is a wallpaper daemon for Wayland that is controlled
+awww is a wallpaper daemon for Wayland that is controlled
 at runtime. It uses LZ4 compression for frame animations
 for animated wallpapers.
 
@@ -50,7 +50,7 @@ BuildArch:      noarch
 Zsh command-line completion support for %{name}.
 
 %prep
-%autosetup
+%autosetup -n %{name}
 %cargo_prep_online
 
 %build
@@ -62,34 +62,30 @@ Zsh command-line completion support for %{name}.
 (cd client && %{cargo_install}) &
 (cd daemon && %{cargo_install}) &
 wait
-install -Dm644 -T completions/swww.bash %buildroot%bash_completions_dir/swww
-install -Dm644 -T completions/swww.fish %buildroot%fish_completions_dir/swww.fish
-install -Dm644 -T completions/_swww %buildroot%zsh_completions_dir/_swww
-install -Dm644 -t %buildroot%_mandir/man1 doc/generated/swww*1
+install -Dm644 -T completions/awww.bash %buildroot%bash_completions_dir/awww
+install -Dm644 -T completions/awww.fish %buildroot%fish_completions_dir/awww.fish
+install -Dm644 -T completions/_awww %buildroot%zsh_completions_dir/_awww
+install -Dm644 -t %buildroot%_mandir/man1 doc/generated/awww*1
 
 %files
 %doc CHANGELOG.md README.md
 %license LICENSE LICENSE.dependencies
-%_bindir/swww
-%_bindir/swww-daemon
-%_mandir/man1/%name-clear-cache.1.gz
-%_mandir/man1/%name-clear.1.gz
-%_mandir/man1/%name-daemon.1.gz
-%_mandir/man1/%name-img.1.gz
-%_mandir/man1/%name-kill.1.gz
-%_mandir/man1/%name-query.1.gz
-%_mandir/man1/%name-restore.1.gz
-%_mandir/man1/%name.1.gz
+%{_bindir}/awww
+%{_bindir}/awww-daemon
+%{_mandir}/man1/%name.1.gz
+%{_mandir}/man1/%name-*.1.gz
 
 %files bash-completion
-%bash_completions_dir/swww
+%bash_completions_dir/awww
 
 %files fish-completion
-%fish_completions_dir/swww.fish
+%fish_completions_dir/awww.fish
 
 %files zsh-completion
-%zsh_completions_dir/_swww
+%zsh_completions_dir/_awww
 
 %changelog
+* Sat May 09 2026 <aagarwalpdx@gmail.com> - 0.12.1-1
+- replace swww with awww
 * Tue Dec 24 2024 madonuko <mado@fyralabs.com> - 0.9.5-1
 - Initial package

--- a/anda/desktops/waylands/awww/update.rhai
+++ b/anda/desktops/waylands/awww/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(codeberg("LGFae/awww"));

--- a/anda/desktops/waylands/swww/update.rhai
+++ b/anda/desktops/waylands/swww/update.rhai
@@ -1,1 +1,0 @@
-rpm.version(gh("LGFae/swww"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: replace swww with awww (#12138)](https://github.com/terrapkg/packages/pull/12138)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)