### PR TITLE
[f44] fix (lact): use VERGEN_GIT_SHA=454a6e2 (#12162)

### DIFF
--- a/anda/system/lact/lact.spec
+++ b/anda/system/lact/lact.spec
@@ -1,8 +1,11 @@
+%global commit 454a6e24af830a1f434385fc3faebec19c0cbefa
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
 %define appid io.github.ilya_zlobintsev.LACT
 
 Name:           lact
 Version:        0.9.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Linux GPU Configuration And Monitoring Tool
 URL:            https://github.com/ilya-zlobintsev/LACT
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
@@ -40,7 +43,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %cargo_prep_online
 
 %build
-%cargo_build
+VERGEN_GIT_SHA=%{shortcommit} %cargo_build
 
 %install
 install -Dm755 target/rpm/lact %{buildroot}%{_bindir}/lact

--- a/anda/system/lact/update.rhai
+++ b/anda/system/lact/update.rhai
@@ -1,1 +1,7 @@
-rpm.version(gh("ilya-zlobintsev/LACT"));
+let r = get("https://api.github.com/repos/ilya-zlobintsev/LACT/tags").json_arr();
+
+rpm.version(r[0].name);
+
+if rpm.changed() {
+  rpm.global("commit", r[0].commit.sha);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (lact): use VERGEN_GIT_SHA=454a6e2 (#12162)](https://github.com/terrapkg/packages/pull/12162)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)