### PR TITLE
[f42] fix (awww): obsolete swww (#12161)

### DIFF
--- a/anda/desktops/waylands/awww/awww.spec
+++ b/anda/desktops/waylands/awww/awww.spec
@@ -1,6 +1,6 @@
 Name:           awww
 Version:        0.12.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Wallpaper daemon for Wayland
 SourceLicense:  GPL-3.0-only
 License:        (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-3-Clause AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
@@ -14,6 +14,8 @@ BuildRequires:  pkgconfig(liblz4)
 BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols)
+
+Obsoletes:      swww < %{evr}
 
 %description
 awww is a wallpaper daemon for Wayland that is controlled


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (awww): obsolete swww (#12161)](https://github.com/terrapkg/packages/pull/12161)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)