### PR TITLE
[f42] chore (submarine): remove aarch64 bdeps (#12182)

### DIFF
--- a/anda/system/submarine/submarine.spec
+++ b/anda/system/submarine/submarine.spec
@@ -15,11 +15,6 @@ Summary:		Experimental bootloader for ChomeOS's depthcharge
 License:		GPL-3.0
 URL:			https://github.com/FyraLabs/submarine
 BuildRequires:	make gcc flex bison elfutils-devel parted vboot-utils golang xz bc openssl-devel git depthcharge-tools uboot-tools openssl-devel-engine
-%ifarch aarch64
-BuildRequires:  python3-importlib-metadata
-BuildRequires:  python3-packaging
-BuildRequires:  python3-importlib-resources
-%endif
 
 %description
 An experimental bootloader for ChomeOS's depthcharge.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (submarine): remove aarch64 bdeps (#12182)](https://github.com/terrapkg/packages/pull/12182)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)