### PR TITLE
[f43] chore(discord): Update builds for bootstrap method (#11979)

### DIFF
--- a/anda/apps/discord-canary/discord-canary.spec
+++ b/anda/apps/discord-canary/discord-canary.spec
@@ -1,20 +1,17 @@
-%define debug_package %{nil}
-%global _build_id_links none
-
-# Exclude private libraries
-%global __requires_exclude libffmpeg.so
-%global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
-
 Name:           discord-canary
 Version:        1.0.1065
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Free Voice and Text Chat for Gamers
 URL:            discord.com
-Source0:        https://dl-canary.discordapp.net/apps/linux/%{version}/discord-canary-%{version}.tar.gz
-License:        https://discord.com/terms
-Requires:       glibc GConf2 nspr >= 4.13 nss >= 3.27 libX11 >= 1.6 libXtst >= 1.2
+Source0:        https://dl-canary.discordapp.net/apps/linux/%{version}/%{name}-%{version}.tar.gz
+Source1:        https://discord.com/terms#/terms.html
+License:        Proprietary
+Requires:       zenity
 Group:          Applications/Internet
 ExclusiveArch:  x86_64
+
+%electronmeta -D
+
 %description
 All-in-one voice and text chat for gamers that's free, secure, and works on
 both your desktop and phone.
@@ -25,23 +22,23 @@ both your desktop and phone.
 %build
 
 %install
-rm -rf $RPM_BUILD_ROOT
-mkdir -p %{buildroot}%{_bindir}
-mkdir -p %{buildroot}%{_datadir}/discord-canary
-cp -rv * %{buildroot}%{_datadir}/discord-canary
-mkdir -p %{buildroot}%{_datadir}/applications/
-mkdir -p %{buildroot}%{_datadir}/pixmaps
-ln -s %_datadir/discord-canary/discord-canary.desktop %{buildroot}%{_datadir}/applications/
-ln -s %_datadir/discord-canary/discord.png %{buildroot}%{_datadir}/pixmaps/discord-canary.png
-ln -s %_datadir/discord-canary/DiscordCanary %buildroot%_bindir/discord-canary
+install -Dpm755 updater_bootstrap -t %{buildroot}%{_datadir}/%{name}
+install -Dpm755 %{name} -t %{buildroot}%{_bindir}
+install -Dpm644 discord.png %{buildroot}%{_datadir}/pixmaps/%{name}.png
+%desktop_file_install %{name}.desktop
+cp %{SOURCE1} -t .
 
 %files
-%_bindir/discord-canary
-%{_datadir}/discord-canary/
-%{_datadir}/applications/discord-canary.desktop
-%{_datadir}/pixmaps/discord-canary.png
+%license terms.html
+%{_bindir}/%{name}
+%{_datadir}/%{name}/
+%{_appsdir}/%{name}.desktop
+%{_datadir}/pixmaps/%{name}.png
 
 %changelog
+* Tue May 5 2026 Gilver E. <roachy@fyralabs.com> - 1.0.1025-2
+- Update build for new bootstrap format
+
 * Thu Dec 01 2022 root - 0.0.144-1
 - new version
 

--- a/anda/apps/discord-ptb/discord-ptb.spec
+++ b/anda/apps/discord-ptb/discord-ptb.spec
@@ -1,24 +1,17 @@
-%define debug_package %{nil}
-%global _build_id_links none
-
-# Exclude private libraries
-%global __requires_exclude libffmpeg.so
-%global __provides_exclude_from %{_datadir}/%{name}/.*\\.so
-
 Name:           discord-ptb
 Version:        1.0.190
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Free Voice and Text Chat for Gamers.
 URL:            https://discord.com
-Source0:        https://dl-ptb.discordapp.net/apps/linux/%{version}/discord-ptb-%{version}.tar.gz
-License:        https://discord.com/terms
-Requires:       glibc GConf2
-Requires:       nspr >= 4.13
-Requires:       nss >= 3.27
-Requires:       libX11 >= 1.6
-Requires:       libXtst >= 1.2
+Source0:        https://dl-ptb.discordapp.net/apps/linux/%{version}/%{name}-%{version}.tar.gz
+Source1:        https://discord.com/terms#/terms.html
+License:        Proprietary
+Requires:       zenity
 Group:          Applications/Internet
 ExclusiveArch:  x86_64
+
+%electronmeta -D
+
 %description
 All-in-one voice and text chat for gamers that's free, secure, and works on
 both your desktop and phone.
@@ -29,23 +22,23 @@ both your desktop and phone.
 %build
 
 %install
-rm -rf $RPM_BUILD_ROOT
-mkdir -p %{buildroot}%{_bindir}
-mkdir -p %{buildroot}%{_datadir}/discord-ptb
-cp -rv * %{buildroot}%{_datadir}/discord-ptb
-mkdir -p %{buildroot}%{_datadir}/applications/
-mkdir -p %{buildroot}%{_datadir}/pixmaps
-ln -s %_datadir/discord-ptb/discord-ptb.desktop %{buildroot}%{_datadir}/applications/
-ln -s %_datadir/discord-ptb/discord.png %{buildroot}%{_datadir}/pixmaps/discord-ptb.png
-ln -s %_datadir/discord-ptb/discord-ptb %buildroot%_bindir/discord-ptb
+install -Dpm755 updater_bootstrap -t %{buildroot}%{_datadir}/%{name}
+install -Dpm755 %{name} -t %{buildroot}%{_bindir}
+install -Dpm644 discord.png %{buildroot}%{_datadir}/pixmaps/%{name}.png
+%desktop_file_install %{name}.desktop
+cp %{SOURCE1} -t .
 
 %files
-%_bindir/discord-ptb
-%{_datadir}/discord-ptb/
-%{_datadir}/applications/discord-ptb.desktop
-%{_datadir}/pixmaps/discord-ptb.png
+%license terms.html
+%{_bindir}/%{name}
+%{_datadir}/%{name}/
+%{_appsdir}/%{name}.desktop
+%{_datadir}/pixmaps/%{name}.png
 
 %changelog
+* Tue May 5 2026 Gilver E. <roachy@fyralabs.com> - 1.0.189-2
+- Update build for new bootstrap format
+
 * Thu Nov 17 2022 madonuko <mado@fyralabs.com> - 0.0.35-1
 - new version
 

--- a/anda/apps/discord/discord.spec
+++ b/anda/apps/discord/discord.spec
@@ -1,13 +1,14 @@
-Name:			discord
-Version:		1.0.138
-Release:		1%{?dist}
-Summary:		Free Voice and Text Chat for Gamers
-URL:			https://discord.com
-Source0:		https://dl.discordapp.net/apps/linux/%{version}/discord-%{version}.tar.gz
-Source1:    https://discord.com/terms#/terms.html
-License:		Proprietary
-Group:			Applications/Internet
-ExclusiveArch:	x86_64
+Name:           discord
+Version:        1.0.138
+Release:        2%{?dist}
+Summary:        Free Voice and Text Chat for Gamers
+URL:            https://discord.com
+Source0:        https://dl.discordapp.net/apps/linux/%{version}/%{name}-%{version}.tar.gz
+Source1:        https://discord.com/terms#/terms.html
+License:        Proprietary
+Requires:       zenity
+Group:          Applications/Internet
+ExclusiveArch:  x86_64
 
 %electronmeta -D
 
@@ -21,23 +22,22 @@ both your desktop and phone.
 %build
 
 %install
-mkdir -p %{buildroot}%{_bindir}
-install -Dpm755 ./* -t %{buildroot}%{_datadir}/discord
-mkdir -p %{buildroot}%{_appsdir}
-mkdir -p %{buildroot}%{_datadir}/pixmaps
-mv %{buildroot}%{_datadir}/discord/discord.desktop -t %{buildroot}%{_appsdir}
-mv %{buildroot}%{_datadir}/discord/discord.png -t %{buildroot}%{_datadir}/pixmaps
-mv %{buildroot}%{_datadir}/discord/discord -t %{buildroot}%{_bindir}
+install -Dpm755 updater_bootstrap -t %{buildroot}%{_datadir}/%{name}
+install -Dpm755 %{name} -t %{buildroot}%{_bindir}
+install -Dpm644 %{name}.png -t %{buildroot}%{_datadir}/pixmaps
+%desktop_file_install %{name}.desktop
 cp %{SOURCE1} -t .
 
 %files
 %license terms.html
-%{_bindir}/discord
-%{_datadir}/discord/
-%{_appsdir}/discord.desktop
-%{_datadir}/pixmaps/discord.png
+%{_bindir}/%{name}
+%{_datadir}/%{name}/
+%{_appsdir}/%{name}.desktop
+%{_datadir}/pixmaps/%{name}.png
 
 %changelog
+* Tue May 5 2026 Gilver E. <roachy@fyralabs.com> - 1.0.136-4
+- Remove unused files from package
 * Mon May 4 2026 Gilver E. <roachy@fyralabs.com> - 1.0.136-2
 - Updated /usr/bin symlink
 * Thu Jan 19 2023 madonuko <mado@fyralabs.com> - 0.0.143-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore(discord): Update builds for bootstrap method (#11979)](https://github.com/terrapkg/packages/pull/11979)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)