### PR TITLE
[f43] fix: opentabletdriver (#12202)

### DIFF
--- a/anda/system/opentabletdriver/opentabletdriver.spec
+++ b/anda/system/opentabletdriver/opentabletdriver.spec
@@ -5,7 +5,7 @@
 # We aren't using Mono but RPM expected Mono
 %global __requires_exclude_from ^/usr/lib/opentabletdriver/.*$
 %global __os_install_post %{nil}
-%global dotnet_sdk_version 8.0
+%global dotnet_sdk_version 10.0
 %global dotnet_runtime_version 8.0
 
 Name: opentabletdriver
@@ -41,12 +41,12 @@ git clone -b v%version %url .
 
 %build
 cd %{otddir}
-./eng/linux/package.sh --output bin
+./eng/bash/package.sh --output bin
 
 %install
 cd %{otddir}
 export DONT_STRIP=1
-PREFIX="%{_prefix}" ./eng/linux/package.sh --package Generic --build false
+PREFIX="%{_prefix}" ./eng/bash/package.sh --package Generic --build false
 mkdir -p "%{buildroot}"
 mv ./dist/files/* "%{buildroot}"/
 rm -rf ./dist


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: opentabletdriver (#12202)](https://github.com/terrapkg/packages/pull/12202)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)