### PR TITLE
[el10] fix (somewm): use %conf, fix source and license tag, update build for newest version (#11593)

### DIFF
--- a/anda/desktops/somewm/somewm.spec
+++ b/anda/desktops/somewm/somewm.spec
@@ -2,16 +2,17 @@ Name:           somewm
 Version:        1.4.1
 Release:        1%{?dist}
 Summary:        Wayland compositor that brings AwesomeWM's Lua API to Wayland
-License:        GPL-3.0
+License:        GPL-3.0-or-later
 URL:            https://github.com/trip-zip/somewm
-Source:         %{url}/archive/%{version}.tar.gz
+Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  meson
-BuildRequires:  pkgconfig(wlroots)
+BuildRequires:  cmake
+BuildRequires:  pkgconfig(pam)
 BuildRequires:  pkgconfig(luajit)
 BuildRequires:  lua-lgi-compat
 BuildRequires:  pkgconfig(wlroots-0.19)
@@ -34,23 +35,44 @@ The goal is 100% compatibility with AwesomeWM's Lua configuration.
 %prep
 %autosetup
 
-%build
+%package devel
+%pkg_devel_files
+
+%conf
 %meson -Dwerror=false
+
+%build
 %meson_build
 
 %install
 %meson_install
+
+%post
+%systemd_post somewm.service
+
+%preun
+%systemd_preun somewm.service
+
+%postun
+%systemd_postun_with_restart somewm.service
 
 %files
 %doc README.md CHANGELOG.md
 %license LICENSE licenses/
 %{_bindir}/%{name}
 %{_bindir}/%{name}-client
+%{_bindir}/somewm-session
 %{_sysconfdir}/xdg/%{name}/rc.lua
 %{_datadir}/%{name}/
 %{_datadir}/wayland-sessions/%{name}.desktop
+%{_datadir}/xdg-desktop-portal/portals/somewm.portal
 %{_mandir}/man1/somewm.1.*
+%{_userunitdir}/somewm-shutdown.target
+%{_userunitdir}/somewm.service
 
 %changelog
+* Sun May 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Update spec for 1.4.1
+
 * Sun Jan 04 2026 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (somewm): use %conf, fix source and license tag, update build for newest version (#11593)](https://github.com/terrapkg/packages/pull/11593)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)