### PR TITLE
[f42] fix: gpu-screen-recorder (#12220)

### DIFF
--- a/anda/multimedia/gpu-screen-recorder/gpu-screen-recorder.spec
+++ b/anda/multimedia/gpu-screen-recorder/gpu-screen-recorder.spec
@@ -29,6 +29,7 @@ BuildRequires:  meson
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(libspa-0.2)
 BuildRequires:  pkgconfig(libglvnd)
+BuildRequires:  pkgconfig(vulkan)
 Requires(post): libcap
 BuildRequires:  systemd-rpm-macros
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: gpu-screen-recorder (#12220)](https://github.com/terrapkg/packages/pull/12220)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)