### PR TITLE
[f42] fix: mpv-nightly (#12230)

### DIFF
--- a/anda/apps/mpv/mpv-nightly.spec
+++ b/anda/apps/mpv/mpv-nightly.spec
@@ -21,6 +21,7 @@ BuildRequires:  gcc
 BuildRequires:  libappstream-glib
 BuildRequires:  libatomic
 BuildRequires:  meson
+BuildRequires:  cmake
 BuildRequires:  python3-docutils
 
 BuildRequires:  perl(Encode)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: mpv-nightly (#12230)](https://github.com/terrapkg/packages/pull/12230)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)