### PR TITLE
[f43] fix: pixi (#12225)

### DIFF
--- a/anda/system/pixi/pixi.spec
+++ b/anda/system/pixi/pixi.spec
@@ -38,7 +38,7 @@ install -Dm 644 completions.fish %{buildroot}%{fish_completions_dir}/%{name}.fis
 install -Dm 644 completions.zsh %{buildroot}%{zsh_completions_dir}/_%{name}
 
 %files
-%doc README.md SECURITY.md CHANGELOG.md CODE_OF_CONDUCT.md CONTRIBUTING.md
+%doc README.md CHANGELOG.md
 %license LICENSE
 %{_bindir}/%{name}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: pixi (#12225)](https://github.com/terrapkg/packages/pull/12225)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)