### PR TITLE
[f44] fix (zsh-autocomplete): make noarch (#12248)

### DIFF
--- a/anda/devs/zsh-autocomplete/anda.hcl
+++ b/anda/devs/zsh-autocomplete/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+        arches = ["x86_64"]
     rpm {
         spec = "zsh-autocomplete.spec"
     }

--- a/anda/devs/zsh-autocomplete/zsh-autocomplete.spec
+++ b/anda/devs/zsh-autocomplete/zsh-autocomplete.spec
@@ -1,5 +1,3 @@
-%define debug_package %nil
-
 Name:           zsh-autocomplete
 Version:        25.03.19
 Release:        1%?dist
@@ -8,6 +6,7 @@ License:        MIT
 URL:            https://github.com/marlonrichert/zsh-autocomplete
 Source0:        %url/archive/refs/tags/%version.tar.gz
 Packager:       madonuko <mado@fyralabs.com>
+BuildArch:      noarch
 
 %description
 This plugin for Zsh adds real-time type-ahead autocompletion to your command


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (zsh-autocomplete): make noarch (#12248)](https://github.com/terrapkg/packages/pull/12248)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)