### PR TITLE
[el10] fix: keyd (#12275)

### DIFF
--- a/anda/tools/keyd/keyd.spec
+++ b/anda/tools/keyd/keyd.spec
@@ -22,7 +22,7 @@ EOF
 %make_build PREFIX=%_prefix LDFLAGS="$LDFLAGS -fuse-ld=mold"
 
 %install
-%make_install PREFIX=%_prefix LDFLAGS="$LDFLAGS -fuse-ld=mold"
+%make_install PREFIX=%_prefix LDFLAGS="$LDFLAGS -fuse-ld=mold" FORCE_SYSTEMD=1
 install -Dm644 keyd.service %buildroot%_unitdir/keyd.service
 install -Dm644 keyd.conf -t %buildroot%_sysusersdir
 install -Dm755 scripts/dump-xkb-config -t %buildroot%_datadir/keyd/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: keyd (#12275)](https://github.com/terrapkg/packages/pull/12275)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)