### PR TITLE
[f44] fix (tdlib): use large runners (#12259)

### DIFF
--- a/anda/lib/tdlib/anda.hcl
+++ b/anda/lib/tdlib/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		nightly = 1
+    large = 1
 	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (tdlib): use large runners (#12259)](https://github.com/terrapkg/packages/pull/12259)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)