### PR TITLE
[f42] Fix minimum required cmake verison (#12286)

### DIFF
--- a/anda/lib/cmark-gfm/cmark-gfm.spec
+++ b/anda/lib/cmark-gfm/cmark-gfm.spec
@@ -43,7 +43,7 @@ Development files for %{name}.
 %autosetup -p1
 
 %build
-%cmake
+%cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [Fix minimum required cmake verison (#12286)](https://github.com/terrapkg/packages/pull/12286)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)