### PR TITLE
[f43] fix: HeadsetControl-nightly (#12228)

### DIFF
--- a/anda/tools/HeadsetControl-nightly/CMAKE_INSTALL_LIBDIR.patch
+++ b/anda/tools/HeadsetControl-nightly/CMAKE_INSTALL_LIBDIR.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2e9d6f8..75f8cf9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -292,7 +292,7 @@ if(PROJECT_IS_TOP_LEVEL)
+     # ------------------------------------------------------------------------------
+ 
+     install(TARGETS headsetcontrol DESTINATION bin)
+-    install(TARGETS headsetcontrol_lib DESTINATION lib)
++    install(TARGETS headsetcontrol_lib DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+     # Install shared library if built
+     if(BUILD_SHARED_LIBRARY)

--- a/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
+++ b/anda/tools/HeadsetControl-nightly/HeadsetControl-nightly.spec
@@ -10,22 +10,32 @@ Release:        1%{?dist}
 Summary:        A tool to control certain aspects of USB-connected headsets on Linux
 URL:            https://github.com/Sapd/HeadsetControl
 Source:         %{url}/archive/%{commit}.tar.gz
-License:        GPL-3.0
+Patch0:         CMAKE_INSTALL_LIBDIR.patch
+License:        GPL-3.0-or-later
 Provides:       headsetcontrol-nightly
 Conflicts:      headsetcontrol
 
-BuildRequires:  cmake gcc hidapi-devel
+BuildRequires:  cmake gcc gcc-c++ hidapi-devel
 
 %description
 A tool to control certain aspects of USB-connected headsets on Linux.
 Currently, support is provided for adjusting sidetone, getting battery
 state, controlling LEDs, and setting the inactive time.
 
+%package devel
+%pkg_devel_files
+
+%package static
+%pkg_static_files
+
 %prep
-%autosetup -n HeadsetControl-%{commit}
+%autosetup -n HeadsetControl-%{commit} -p1
+
+%conf
+%cmake \
+     -DCMAKE_INSTALL_LIBDIR=%{_lib}
 
 %build
-%cmake
 %cmake_build
 
 %install
@@ -38,5 +48,8 @@ state, controlling LEDs, and setting the inactive time.
 %{_udevrulesdir}/70-headsets.rules
 
 %changelog
+* Wed May 13 2026 Owen Zimmerman <owen@fyralabs.com>
+- Add devel and static subpackages, add patch, fix license
+
 * Wed Nov 26 2025 metcya <metcya@gmail.com>
 - package HeadsetControl


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: HeadsetControl-nightly (#12228)](https://github.com/terrapkg/packages/pull/12228)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)