### PR TITLE
[f43] fix: vicinae (#12285)

### DIFF
--- a/anda/system/vicinae/vicinae.spec
+++ b/anda/system/vicinae/vicinae.spec
@@ -27,6 +27,7 @@ BuildRequires:  cmake(Qt6Quick)
 BuildRequires:  cmake(Qt6Svg)
 BuildRequires:  cmake(Qt6Keychain)
 BuildRequires:  cmake(LayerShellQt)
+BuildRequires:  cmake(Qt6ShaderTools)
 BuildRequires:  pkgconfig(libqalculate)
 BuildRequires:  pkgconfig(protobuf)
 BuildRequires:  pkgconfig(icu-uc)
@@ -79,22 +80,27 @@ install -Dm 644 extra/%{name}-url-handler.desktop -t %{buildroot}%{_appsdir}
 %{_appsdir}/%{name}.desktop
 %{_appsdir}/%{name}-url-handler.desktop
 %{_hicolordir}/512x512/apps/%{name}.png
-%{_sysconfdir}/chromium/native-messaging-hosts/com.vicinae.vicinae.json
-%{_prefix}/lib/mozilla/native-messaging-hosts/com.vicinae.vicinae.json
-%{_datadir}/%{name}/native-messaging-hosts/com.vicinae.vicinae.chromium.json.in
-%{_datadir}/%{name}/native-messaging-hosts/com.vicinae.vicinae.firefox.json.in
+%{_datadir}/%{name}/native-host/chromium/com.vicinae.vicinae.json
+%{_datadir}/%{name}/native-host/com.vicinae.vicinae.chromium.json.in
+%{_datadir}/%{name}/native-host/com.vicinae.vicinae.firefox.json.in
+%{_datadir}/%{name}/native-host/firefox/com.vicinae.vicinae.json
 %{_libexecdir}/%{name}/vicinae-browser-link
 %{_libexecdir}/%{name}/vicinae-data-control-server
 %{_libexecdir}/%{name}/vicinae-server
-%{_libexecdir}/%{name}/vicinae-snippet-server
+%dnl %{_libexecdir}/%{name}/vicinae-snippet-server
+%{_libexecdir}/%{name}/vicinae-input-server
 %{_modulesloaddir}/vicinae.conf
-%{_udevrulesdir}/70-vicinae.rules
+%dnl %{_udevrulesdir}/70-vicinae.rules
 
 %changelog
+* Thu May 14 2026 Owen Zimmerman <owen@fyralabs.com> - 0.21.0-1
+- Update spec for 0.21.0
+
 * Sat May 09 2026 Olivia <git@olivia.sh> - 0.20.15-2
 - fix missing files
 
 * Wed Feb 18 2026 Jaiden Riordan <jade@fyralabs.com> - 0.19.8
 - Fixup desktop file and xdgpp
+
 * Fri Dec 26 2025 metcya <metcya@gmail.com> - 0.17.3
 - Package vicinae


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: vicinae (#12285)](https://github.com/terrapkg/packages/pull/12285)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)