### PR TITLE
[f43] chore (publicdotcom-cli): bump and install license (#12284)

### DIFF
--- a/anda/langs/python/publicdotcom-cli/publicdotcom-cli.spec
+++ b/anda/langs/python/publicdotcom-cli/publicdotcom-cli.spec
@@ -3,7 +3,7 @@
 %global _desc Command-line client for the Public.com Trading API.
 
 Name:			python-%{real_name}
-Version:		1.1.0
+Version:		1.2.0
 Release:		1%?dist
 Summary:		Command-line client for the Public.com Trading API
 License:		Apache-2.0
@@ -40,6 +40,7 @@ Summary:        %{summary}
 
 %files -n python3-%{real_name} -f %{pyproject_files}
 %doc README.md
+%license LICENSE
 %{_bindir}/public
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (publicdotcom-cli): bump and install license (#12284)](https://github.com/terrapkg/packages/pull/12284)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)