### PR TITLE
[f44] add smb-mount-manager to terra (#12311)

### DIFF
--- a/anda/apps/mount-manager/anda.hcl
+++ b/anda/apps/mount-manager/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+    rpm {
+        spec = "mount-manager.spec"
+    }
+}

--- a/anda/apps/mount-manager/mount-manager.spec
+++ b/anda/apps/mount-manager/mount-manager.spec
@@ -1,0 +1,40 @@
+Name:           mount-manager
+Version:        0.1.1
+Release:        1%{?dist}
+Summary:        SMB Mount Manager helps users mount SMB shares through a simple GTK interface. It checks the share, asks for credentials, tests the mount, and creates a startup mount managed by systemd.
+URL:            https://github.com/ublue-os/mount-manager
+Source0:        https://github.com/ublue-os/mount-manager/archive/refs/tags/v%{version}.tar.gz
+License:        GPL-3.0-only
+Requires:       cifs-utils
+Requires:       gtk4
+Requires:       polkit
+Requires:       python3-gobject
+Provides:       SMB-Mount-Manager
+BuildArch:      noarch
+Packager:       Zacharias Xenakis <xarishark@outlook.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n mount-manager-%{version}
+
+%build
+
+%install
+install -Dm 755 mount_manager.py %{buildroot}%{_bindir}/mount-manager
+install -Dm 644 data/applications/io.github.ublue_os.mount-manager.desktop %{buildroot}%{_appsdir}/io.github.ublue_os.mount-manager.desktop
+install -Dm 644 data/icons/hicolor/scalable/apps/io.github.ublue_os.mount-manager.svg %{buildroot}%{_scalableiconsdir}/io.github.ublue_os.mount-manager.svg
+install -Dm 644 data/metainfo/io.github.ublue_os.mount-manager.metainfo.xml %{buildroot}%{_metainfodir}/io.github.ublue_os.mount-manager.metainfo.xml
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/mount-manager
+%{_appsdir}/io.github.ublue_os.mount-manager.desktop
+%{_scalableiconsdir}/io.github.ublue_os.mount-manager.svg
+%{_metainfodir}/io.github.ublue_os.mount-manager.metainfo.xml
+
+%changelog
+* Fri May 15 2026 Zacharias Xenakis <xarishark@outlook.com>
+- Initial package

--- a/anda/apps/mount-manager/update.rhai
+++ b/anda/apps/mount-manager/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("ublue-os/mount-manager"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add smb-mount-manager to terra (#12311)](https://github.com/terrapkg/packages/pull/12311)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)