### PR TITLE
[f44] fix(nvidia-driver-580xx): Deps (#12320)

### DIFF
--- a/anda/system/nvidia-580/nvidia-driver/nvidia-driver-580.spec
+++ b/anda/system/nvidia-580/nvidia-driver/nvidia-driver-580.spec
@@ -12,7 +12,7 @@
 
 Name:           %{real_name}-580xx
 Version:        580.159.03
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        NVIDIA's proprietary display driver for NVIDIA graphic cards
 Epoch:          3
 License:        NVIDIA License
@@ -46,7 +46,7 @@ BuildRequires:  wget
 BuildRequires:  coreutils
 
 Requires:       %{real_name}-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}
-Requires:       nvidia-kmod-common = %{?epoch:%{epoch}:}%{version}
+Requires:       nvidia-580xx-kmod-common = %{?epoch:%{epoch}:}%{version}
 
 Conflicts:      nvidia-x11-drv
 Conflicts:      nvidia-x11-drv-470xx


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(nvidia-driver-580xx): Deps (#12320)](https://github.com/terrapkg/packages/pull/12320)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)