### PR TITLE
[el10] fix(nvidia-driver-580xx): Deps (#12325)

### DIFF
--- a/anda/system/nvidia-580/nvidia-driver/nvidia-driver-580.spec
+++ b/anda/system/nvidia-580/nvidia-driver/nvidia-driver-580.spec
@@ -12,7 +12,7 @@
 
 Name:           %{real_name}-580xx
 Version:        580.159.03
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        NVIDIA's proprietary display driver for NVIDIA graphic cards
 Epoch:          3
 License:        NVIDIA License
@@ -45,7 +45,7 @@ BuildRequires:  systemd-rpm-macros
 BuildRequires:  wget
 BuildRequires:  coreutils
 
-Requires:       %{real_name}-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}
+Requires:       %{name}-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}
 Requires:       nvidia-580xx-kmod-common = %{?epoch:%{epoch}:}%{version}
 
 Conflicts:      nvidia-x11-drv


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(nvidia-driver-580xx): Deps (#12325)](https://github.com/terrapkg/packages/pull/12325)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)