### PR TITLE
[f43] chore (asusctl/rog-cc): add more metainfo keywords (#12354)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -3,7 +3,7 @@
 
 Name:           asusctl
 Version:        6.3.7
-Release:        3%{?dist}
+Release:        4%{?dist}
 Epoch:          1
 Summary:        A control daemon, CLI tools, and a collection of crates for interacting with ASUS ROG laptops
 URL:            https://gitlab.com/asus-linux/asusctl

--- a/anda/system/asusctl/org.asus_linux.rog_control_center.metainfo.xml
+++ b/anda/system/asusctl/org.asus_linux.rog_control_center.metainfo.xml
@@ -41,6 +41,8 @@
     <keyword>ASUS</keyword>
     <keyword>ROG</keyword>
     <keyword>asusctl</keyword>
+    <keyword>Control Center</keyword>
+    <keyword>Armoury Crate</keyword>
   </keywords>
 
   <launchable type="desktop-id">rog-control-center.desktop</launchable>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (asusctl/rog-cc): add more metainfo keywords (#12354)](https://github.com/terrapkg/packages/pull/12354)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)