### PR TITLE
[el10] add: vetro and desktops/singularity folder (#12359)

### DIFF
--- a/anda/desktops/singularity/vetro/anda.hcl
+++ b/anda/desktops/singularity/vetro/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "vetro.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/desktops/singularity/vetro/update.rhai
+++ b/anda/desktops/singularity/vetro/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("singularityos-lab/vetro"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}

--- a/anda/desktops/singularity/vetro/vetro.spec
+++ b/anda/desktops/singularity/vetro/vetro.spec
@@ -1,0 +1,42 @@
+%global commit 751ccb251d9fb2c472e193bc478c3b928e3514c9
+%global commit_date 20260405
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global goipath github.com/singularityos-lab/vetro
+Version:        0~%{commit_date}git.%{shortcommit}
+
+%gometa -f
+
+Name:           vetro
+Release:        1%{?dist}
+Summary:        Declarative GTK4 UI transpiler with a built-in Language Server Protocol (LSP) server
+URL:            https://github.com/singularityos-lab/vetro
+Source0:        %{url}/archive/%{commit}/vetro-%{commit}.tar.gz
+License:        MIT
+BuildRequires:  golang
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%autosetup -n vetro-%{commit}
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/vetro .
+
+%install
+install -Dm755 %{gobuilddir}/bin/vetro %{buildroot}%{_bindir}/vetro
+
+%files
+%{_bindir}/vetro
+%license LICENSE
+%doc README.md
+
+%changelog
+* Sat May 16 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: vetro and desktops/singularity folder (#12359)](https://github.com/terrapkg/packages/pull/12359)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)