### PR TITLE
[el10] fix: zipstream-ng (#12383)

### DIFF
--- a/anda/langs/python/zipstream-ng/zipstream-ng.spec
+++ b/anda/langs/python/zipstream-ng/zipstream-ng.spec
@@ -1,3 +1,5 @@
+%global __brp_mangle_shebangs_exclude_from /usr/lib/python3.14/site-packages/zipstream/
+
 %global pypi_name zipstream-ng
 %global _desc 🔉 A modern and easy to use streamable zip file generator
 
@@ -14,6 +16,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-wheel
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-pip
+BuildRequires:  python3-hatchling
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
@@ -42,9 +45,6 @@ Provides:       zipstream-ng
 %doc README.md CHANGELOG.md docs/zipserver.rst
 %license LICENSE
 %{_bindir}/zipserver
-%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
-%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
-%python3_sitelib/zipstream_ng-%version.dist-info/*
 
 %changelog
 * Mon Nov 03 2025 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: zipstream-ng (#12383)](https://github.com/terrapkg/packages/pull/12383)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)