### PR TITLE
[f44] fix: driftwm (#12393)

### DIFF
--- a/anda/desktops/driftwm/driftwm.spec
+++ b/anda/desktops/driftwm/driftwm.spec
@@ -38,7 +38,9 @@ export PREFIX=/usr
 %{_bindir}/driftwm-session
 %{_datadir}/wayland-sessions/driftwm.desktop
 %{_datadir}/xdg-desktop-portal/driftwm-portals.conf
-%{_sysconfdir}/driftwm/config.toml
+%{_sysconfdir}/driftwm/config.reference.toml
+%{_datadir}/driftwm/wallpapers/animated/*.glsl
+%{_datadir}/driftwm/wallpapers/static/*.glsl
 %{_datadir}/driftwm/wallpapers/*.glsl
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: driftwm (#12393)](https://github.com/terrapkg/packages/pull/12393)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)