### PR TITLE
[f42] fix (sdbus-cpp.terra): remove temporary dnf5 fix (#12388)

### DIFF
--- a/anda/lib/sdbus-cpp/sdbus-cpp.terra.spec
+++ b/anda/lib/sdbus-cpp/sdbus-cpp.terra.spec
@@ -98,7 +98,7 @@ mv %{buildroot}%{_sysconfdir}/dbus-1/system.d/org.sdbuscpp.integrationtests.conf
 rm -rf %{buildroot}%{_sysconfdir}
 
 # temporary bundle sdbus-cpp-1 to allow dnf5 rebuild
-cp %{_libdir}/libsdbus-c++.so.1.* %{buildroot}%{_libdir}
+%dnl cp %{_libdir}/libsdbus-c++.so.1.* %{buildroot}%{_libdir}
 
 
 %files
@@ -111,7 +111,7 @@ cp %{_libdir}/libsdbus-c++.so.1.* %{buildroot}%{_libdir}
 %{_libdir}/libsdbus-c++.so.%{libso_major}{,.*}
 
 # temporary bundle sdbus-cpp-1 to allow dnf5 rebuild
-%{_libdir}/libsdbus-c++.so.1{,.*}
+%dnl %{_libdir}/libsdbus-c++.so.1{,.*}
 
 
 %files devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix (sdbus-cpp.terra): remove temporary dnf5 fix (#12388)](https://github.com/terrapkg/packages/pull/12388)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)