### PR TITLE
[f42] chore: (ueberzugpp): use %conf and proper license identifier (#12402)

### DIFF
--- a/anda/tools/ueberzugpp/ueberzugpp.spec
+++ b/anda/tools/ueberzugpp/ueberzugpp.spec
@@ -1,7 +1,7 @@
 Name:       ueberzugpp
 Version:    2.9.10
-Release:    1%{?dist}
-License:    GPL-3.0
+Release:    2%{?dist}
+License:    GPL-3.0-or-later
 Summary:    Drop in replacement for ueberzug written in C++ 
 URL:        https://github.com/jstkdng/%{name}
 Source:     %{url}/archive/v%{version}.tar.gz
@@ -32,9 +32,11 @@ on terminals by using X11/wayland child windows, sixels, kitty and iterm2.
 %prep
 %autosetup
 
-%build
+%conf
 %cmake . -DENABLE_WAYLAND=ON    \
          -DENABLE_XCB_ERROR=ON
+
+%build
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: (ueberzugpp): use %conf and proper license identifier (#12402)](https://github.com/terrapkg/packages/pull/12402)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)