### PR TITLE
[f43] fix (magic-wormhole): %pyproject_patch_dependency autobahn (#12410)

### DIFF
--- a/anda/langs/python/magic-wormhole/magic-wormhole.spec
+++ b/anda/langs/python/magic-wormhole/magic-wormhole.spec
@@ -3,7 +3,7 @@
 
 Name:			python-%{pypi_name}
 Version:		0.24.0
-Release:		1%{?dist}
+Release:		2%{?dist}
 Summary:		get things from one computer to another, safely
 License:		MIT
 URL:			https://github.com/magic-wormhole/magic-wormhole
@@ -33,6 +33,8 @@ Provides:       magic-wormhole
 
 %prep
 %autosetup -n magic-wormhole-%{version}
+
+%pyproject_patch_dependency autobahn:drop_constraints
 
 %build
 %pyproject_wheel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (magic-wormhole): %pyproject_patch_dependency autobahn (#12410)](https://github.com/terrapkg/packages/pull/12410)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)