### PR TITLE
[f42] fix: gnome-shell-extension-vicinae (#12407)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-vicinae/gnome-shell-extension-vicinae.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-vicinae/gnome-shell-extension-vicinae.spec
@@ -22,7 +22,7 @@ Companion GNOME extension for Vicinae launcher with clipboard monitoring,
 window management APIs, and paste-to-active-window capabilities.
 
 %prep
-%autosetup -n vicinae-gnome-extension-%{version}
+%autosetup -n gnome-extension-%{version}
 
 %build
 %{__bun} i && %{__bun} run build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: gnome-shell-extension-vicinae (#12407)](https://github.com/terrapkg/packages/pull/12407)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)