### PR TITLE
[f43] bump: nirius (#12427)

### DIFF
--- a/anda/desktops/niri/nirius/nirius.spec
+++ b/anda/desktops/niri/nirius/nirius.spec
@@ -1,5 +1,5 @@
 Name:           nirius
-Version:        0.6.1
+Version:        0.7.1
 Release:        1%{?dist}
 Summary:        Utility commands for niri
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [bump: nirius (#12427)](https://github.com/terrapkg/packages/pull/12427)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)