### PR TITLE
[f44] chore (kotlin): remove BuildRoot: tag (#12434)

### DIFF
--- a/anda/langs/kotlin/kotlin/kotlin.spec
+++ b/anda/langs/kotlin/kotlin/kotlin.spec
@@ -1,4 +1,3 @@
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Name:           kotlin
 Version:        2.3.21


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (kotlin): remove BuildRoot: tag (#12434)](https://github.com/terrapkg/packages/pull/12434)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)