### PR TITLE
[f43] (noctalia-qs) bump release for qt update (#12446)

### DIFF
--- a/anda/desktops/noctalia-qs/noctalia-qs.spec
+++ b/anda/desktops/noctalia-qs/noctalia-qs.spec
@@ -2,7 +2,7 @@
 
 Name:	       noctalia-qs
 Version:       0.0.12
-Release:       3%{?dist}
+Release:       4%{?dist}
 Summary:       Flexible QtQuick based desktop shell toolkit
 License:       LGPL-3.0-only AND GPL-3.0-only
 URL:	       https://github.com/noctalia-dev/noctalia-qs


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [(noctalia-qs) bump release for qt update (#12446)](https://github.com/terrapkg/packages/pull/12446)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)