### PR TITLE
[el10] chore (kotlin-native): remove BuildRoot: tag (#12435)

### DIFF
--- a/anda/langs/kotlin/kotlin-native/kotlin-native.spec
+++ b/anda/langs/kotlin/kotlin-native/kotlin-native.spec
@@ -1,6 +1,5 @@
 %define _binaries_in_noarch_packages_terminate_build   0
 
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Name:           kotlin-native
 Version:        2.3.21
 Release:        1%{?dist}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (kotlin-native): remove BuildRoot: tag (#12435)](https://github.com/terrapkg/packages/pull/12435)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)