### PR TITLE
[f42] fix: Add some missing selinux rules for steamos-manager-powerstation (#12477)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -4,7 +4,7 @@
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          3%{?dist}
+Release:          4%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager

--- a/anda/games/steamos-manager-powerstation/steamos_manager.te
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.te
@@ -19,6 +19,9 @@ files_config_file(steamos_manager_conf_t)
 # Allow systemd to manage the service (start/stop/status)
 init_dbus_chat(steamos_manager_t)
 
+# Query systemd and overall system status (init_t:system status)
+init_status(steamos_manager_t)
+
 ########################################
 # Process permissions
 ########################################
@@ -76,6 +79,18 @@ domain_read_all_domains_state(steamos_manager_t)
 # debugfs access: /sys/kernel/debug/ath11k/
 kernel_read_debugfs(steamos_manager_t)
 kernel_manage_debugfs(steamos_manager_t)
+
+gen_require(`
+	type tracefs_t;
+')
+allow steamos_manager_t tracefs_t:dir search;
+
+########################################
+# Cgroup access
+########################################
+
+# Search the cgroup hierarchy under /sys/fs/cgroup
+fs_search_cgroup_dirs(steamos_manager_t)
 
 ########################################
 # Device access
@@ -184,6 +199,27 @@ corenet_tcp_connect_all_ports(steamos_manager_t)
 ########################################
 
 logging_send_syslog_msg(steamos_manager_t)
+
+########################################
+# bootupd (bootloader management)
+########################################
+
+# steamos-manager invokes bootupctl, which runs in its own bootupd_t domain.
+optional_policy(`
+	gen_require(`
+		type bootupd_t;
+		type mount_var_run_t;
+	')
+
+	# NSS user/group lookups: /etc/passwd, systemd-userdbd, systemd-homed
+	auth_use_nsswitch(bootupd_t)
+
+	# Read /proc system state
+	kernel_read_system_state(bootupd_t)
+
+	# Search the mount runtime directory under /run
+	allow bootupd_t mount_var_run_t:dir search;
+')
 
 ########################################
 # Miscellaneous


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: Add some missing selinux rules for steamos-manager-powerstation (#12477)](https://github.com/terrapkg/packages/pull/12477)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)