### PR TITLE
[el10] chore (kcgroups-dmemcg): update license info (#12483)

### DIFF
--- a/anda/system/kcgroups-dmemcg/kcgroups-dmemcg.spec
+++ b/anda/system/kcgroups-dmemcg/kcgroups-dmemcg.spec
@@ -3,14 +3,15 @@
 
 Name:           kcgroups-dmemcg
 Version:        0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        KDE library to manipulate cgroups - fork adding dmem cgroup support
 Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
-License:        LGPL-2.1-or-later
+License:        LGPL-2.1-or-later AND MIT AND CC0-1.0
 URL:            https://github.com/pixelcluster/kcgroups
 
 Source0:        %{url}/archive/refs/tags/kcgroups-dmemcg-experimental.tar.gz
 Source1:        %{url}/archive/refs/tags/booster-dmemcg-experimental.tar.gz
+Source2:        %{url}/tree/dmemcg/LICENSES
 
 BuildRequires:  cmake
 BuildRequires:  extra-cmake-modules
@@ -83,6 +84,10 @@ popd
 pushd booster-build
 make DESTDIR=%{buildroot} install
 
+mkdir -p %{buildroot}%{_defaultlicensedir}/%{name}
+
+cp -r %{S:2} %{buildroot}%{_defaultlicensedir}/%{name}/
+
 %post -n plasma-foreground-booster-dmemcg
 %systemd_user_post plasma-foreground-booster.service
 
@@ -93,6 +98,7 @@ make DESTDIR=%{buildroot} install
 %systemd_user_postun_with_restart plasma-foreground-booster.service
 
 %files
+%license %{_defaultlicensedir}/%{name}/LICENSES
 %{_libdir}/libKF5CGroups.so.5*
 %{_datadir}/qlogging-categories6/kcgroups.*
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (kcgroups-dmemcg): update license info (#12483)](https://github.com/terrapkg/packages/pull/12483)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)