### PR TITLE
[f42] fix: libsingularity (#12494)

### DIFF
--- a/anda/desktops/singularity/libsingularity/libsingularity.spec
+++ b/anda/desktops/singularity/libsingularity/libsingularity.spec
@@ -18,6 +18,7 @@ BuildRequires:  pkgconfig(gtk4-layer-shell-0)
 BuildRequires:  pkgconfig(gee-0.8)
 BuildRequires:  pkgconfig(json-glib-1.0)
 BuildRequires:  pkgconfig(libpeas-2)
+BuildRequires:  pkgconfig(libsoup-3.0)
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: libsingularity (#12494)](https://github.com/terrapkg/packages/pull/12494)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)