### PR TITLE
[f43] add: terra-scripts (#12503)

### DIFF
--- a/anda/terra/terra-scripts/anda.hcl
+++ b/anda/terra/terra-scripts/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["x86_64"]
+    rpm {
+        spec = "terra-scripts.spec"
+    }
+}

--- a/anda/terra/terra-scripts/terra-scripts.spec
+++ b/anda/terra/terra-scripts/terra-scripts.spec
@@ -1,0 +1,32 @@
+Name:           terra-scripts
+Version:        0.1.2
+Release:        1%{?dist}
+Summary:        Helpful scripts for contributing to Terra
+License:        GPL-3.0-or-later
+URL:            https://github.com/terrapkg/cli-tools
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+Requires:       bash
+BuildArch:      noarch
+Packager:       Its-J <jonah@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n cli-tools-%{version}
+
+%install
+install -Dm 755 format-license.sh %{buildroot}%{_bindir}/format-license
+install -Dm 755 ldd-dnf.sh %{buildroot}%{_bindir}/ldd-dnf
+install -Dm 755 changelog.sh %{buildroot}%{_bindir}/changelog
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/format-license
+%{_bindir}/ldd-dnf
+%{_bindir}/changelog
+
+%changelog
+* Sat May 23 2026 Its-J <jonah@fyralabs.com>
+- Package terra-scripts

--- a/anda/terra/terra-scripts/update.rhai
+++ b/anda/terra/terra-scripts/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("terrapkg/cli-tools"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: terra-scripts (#12503)](https://github.com/terrapkg/packages/pull/12503)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)