### PR TITLE
feat: cap noctalia-shell major version to v4

### DIFF
--- a/anda/desktops/noctalia-shell/update.rhai
+++ b/anda/desktops/noctalia-shell/update.rhai
@@ -1,1 +1,6 @@
-rpm.version(gh("noctalia-dev/noctalia-shell"));
+let v = gh("noctalia-dev/noctalia-shell");
+v.crop(1);
+
+if v < "5" {
+  rpm.version(v);
+}


### PR DESCRIPTION
I'll need to package Noctalia v5 separately since it's a rewrite. This makes sure that the major version for `noctalia-shell` doesn't go past 4.