### PR TITLE
[el10] add: tail-tray (#12516)

### DIFF
--- a/anda/misc/tail-tray/anda.hcl
+++ b/anda/misc/tail-tray/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "tail-tray.spec"
+    }
+}

--- a/anda/misc/tail-tray/tail-tray.spec
+++ b/anda/misc/tail-tray/tail-tray.spec
@@ -1,0 +1,46 @@
+Name:       tail-tray
+Version:    0.2.32
+Release:    1%{?dist}
+Summary:    Tailscale tray menu and UI for the KDE Plasma Desktop
+License:    GPL-3.0-or-later
+URL:        https://github.com/SneWs/tail-tray
+Source0:    %{url}/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires: cmake
+BuildRequires: gcc-c++
+BuildRequires: glib2-devel
+BuildRequires: gettext
+BuildRequires: qt6-qtbase-devel
+BuildRequires: qt6-qttools-devel
+
+Requires:       tailscale
+Suggests:       davfs2
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup
+
+%conf
+%cmake
+
+%build
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}
+%{_appsdir}/%{name}.desktop
+%{_scalableiconsdir}/tail-tray-dark.svg
+%{_scalableiconsdir}/tail-tray.svg
+
+%changelog
+* Sat May 23 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/misc/tail-tray/update.rhai
+++ b/anda/misc/tail-tray/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("SneWs/tail-tray"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: tail-tray (#12516)](https://github.com/terrapkg/packages/pull/12516)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)