### PR TITLE
[f43] fix: readymade (#12482)

### DIFF
--- a/anda/system/readymade/stable/readymade.spec
+++ b/anda/system/readymade/stable/readymade.spec
@@ -1,6 +1,6 @@
 %global crate readymade
 Name:           readymade
-Version:        0.14.0
+Version:        0.14.1
 Release:        1%{?dist}
 Summary:        Install ready-made distribution images!
 License:        GPL-3.0-or-later
@@ -9,6 +9,9 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 Source1:        https://github.com/FyraLabs/rdms_proc_macros/archive/HEAD.tar.gz
 BuildRequires:	anda-srpm-macros rust-packaging mold
 BuildRequires:  pkgconfig(libhelium-1)
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  glibc-all-langpacks
+BuildRequires:  pkgconfig(libacl)
 BuildRequires:  clang-devel
 BuildRequires:  cmake
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: readymade (#12482)](https://github.com/terrapkg/packages/pull/12482)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)