### PR TITLE
[f43] chore(yarn-berry): Bootstrap build (#12529)

### DIFF
--- a/anda/devs/yarn-berry/yarnpkg-berry.spec
+++ b/anda/devs/yarn-berry/yarnpkg-berry.spec
@@ -1,4 +1,4 @@
-%bcond bootstrap 0
+%bcond bootstrap 1
 
 Name:          yarnpkg-berry
 Version:       4.15.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore(yarn-berry): Bootstrap build (#12529)](https://github.com/terrapkg/packages/pull/12529)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)