### PR TITLE
[f42] fix: readymade-git (#12530)

### DIFF
--- a/anda/system/readymade/git/readymade-git.spec
+++ b/anda/system/readymade/git/readymade-git.spec
@@ -13,6 +13,7 @@ Source1:        https://github.com/FyraLabs/rdms_proc_macros/archive/HEAD.tar.gz
 BuildRequires:	anda-srpm-macros rust-packaging mold
 BuildRequires:  pkgconfig(libhelium-1)
 BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(libacl)
 BuildRequires:  clang-devel
 BuildRequires:  gcc
 BuildRequires:  cmake


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: readymade-git (#12530)](https://github.com/terrapkg/packages/pull/12530)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)