### PR TITLE
[f42] chore(yarn-berry): Unbootstrap (#12540)

### DIFF
--- a/anda/devs/yarn-berry/yarnpkg-berry.spec
+++ b/anda/devs/yarn-berry/yarnpkg-berry.spec
@@ -1,8 +1,8 @@
-%bcond bootstrap 1
+%bcond bootstrap 0
 
 Name:          yarnpkg-berry
 Version:       4.15.0
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Active development version of Yarn
 License:       BSD-2-Clause
 URL:           https://yarnpkg.com


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(yarn-berry): Unbootstrap (#12540)](https://github.com/terrapkg/packages/pull/12540)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)