### PR TITLE
[f44] cap noctalia-shell major version to v4 (#12513)

### DIFF
--- a/anda/desktops/noctalia-shell/update.rhai
+++ b/anda/desktops/noctalia-shell/update.rhai
@@ -1,1 +1,6 @@
-rpm.version(gh("noctalia-dev/noctalia-shell"));
+let v = gh("noctalia-dev/noctalia-shell");
+v.crop(1);
+
+if v < "5" {
+  rpm.version(v);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [cap noctalia-shell major version to v4 (#12513)](https://github.com/terrapkg/packages/pull/12513)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)