### PR TITLE
[el10] fix: upiano (#12561)

### DIFF
--- a/anda/langs/python/upiano/upiano.spec
+++ b/anda/langs/python/upiano/upiano.spec
@@ -3,7 +3,7 @@
 
 Name:			python-%{pypi_name}
 Version:		0.1.2
-Release:		1%?dist
+Release:		2%?dist
 Summary:		Terminal Piano App
 License:		MIT
 URL:			https://github.com/eliasdorneles/upiano
@@ -32,6 +32,9 @@ Summary:        %{summary}
 %prep
 %autosetup -n upiano-%{version}
 cp %{SOURCE1} .
+
+%pyproject_patch_dependency pyfluidsynth:drop_constraints
+%pyproject_patch_dependency textual:drop_constraints
 
 %build
 %pyproject_wheel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: upiano (#12561)](https://github.com/terrapkg/packages/pull/12561)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)