### PR TITLE
chore (vicinae): add layer-shell-qt runtime dependency

### DIFF
--- a/anda/system/vicinae/vicinae.spec
+++ b/anda/system/vicinae/vicinae.spec
@@ -6,7 +6,7 @@
 
 Name:           vicinae
 Version:        0.21.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-3.0
 URL:            https://docs.vicinae.com
 Source:         https://github.com/vicinaehq/%{name}/archive/refs/tags/v%{version}.tar.gz
@@ -41,6 +41,7 @@ BuildRequires:  qt6-qtbase-private-devel
 BuildRequires:  desktop-file-utils
 
 Requires:       nodejs-npm
+Requires:       layer-shell-qt
 
 %description
 Vicinae (pronounced "vih-SIN-ay") is a high-performance, native launcher for
@@ -93,6 +94,10 @@ install -Dm 644 extra/%{name}-url-handler.desktop -t %{buildroot}%{_appsdir}
 %dnl %{_udevrulesdir}/70-vicinae.rules
 
 %changelog
+* Sun May 24 2026 Aamir Ahmad <aamirahmad@outlook.com> - 0.21.1-2
+- Add layer-shell-qt runtime Requires (loaded as QML plugin, not
+  auto-detected by rpm dep generator)
+
 * Thu May 14 2026 Owen Zimmerman <owen@fyralabs.com> - 0.21.0-1
 - Update spec for 0.21.0
 

--- a/anda/system/vicinae/vicinae.spec
+++ b/anda/system/vicinae/vicinae.spec
@@ -95,8 +95,7 @@ install -Dm 644 extra/%{name}-url-handler.desktop -t %{buildroot}%{_appsdir}
 
 %changelog
 * Sun May 24 2026 Aamir Ahmad <aamirahmad@outlook.com> - 0.21.1-2
-- Add layer-shell-qt runtime Requires (loaded as QML plugin, not
-  auto-detected by rpm dep generator)
+- Add layer-shell-qt runtime Requires
 
 * Thu May 14 2026 Owen Zimmerman <owen@fyralabs.com> - 0.21.0-1
 - Update spec for 0.21.0


### PR DESCRIPTION
## Summary

- Adds `Requires: layer-shell-qt` to `anda/system/vicinae/vicinae.spec`.
- Bumps `Release` from `1` to `2` and adds a `%changelog` entry.

## Why

Vicinae imports `org.kde.layershell` as a **QML plugin** at runtime — not as a linked shared library. RPM's automatic dependency generator only inspects the binary's `NEEDED` entries, so the dependency on `layer-shell-qt` is invisible to it and never lands in `Requires`.

Without `layer-shell-qt` installed, the launcher silently fails:

```
QQmlApplicationEngine failed to load component
qrc:/Vicinae/LauncherWindowLayerShell.qml:1:1: module "org.kde.layershell" is not installed
```

The window is never created, but `vicinae-server` still marks itself as "open" — so `vicinae open` reports `Failed to open: Already opened` and the user sees nothing. Reported in #12588.

The build side already has `BuildRequires: cmake(LayerShellQt)`, so no build change is needed; only the missing runtime `Requires` is added.

The Vicinae upstream Copr packaging hit the same bug and resolved it the same way — see [vicinaehq/vicinae#1388](https://github.com/vicinaehq/vicinae/issues/1388).

## Test plan

- [ ] Build the package: `anda build -c terra-rawhide-x86_64 anda/system/vicinae`
- [ ] On a system without `layer-shell-qt` pre-installed: `sudo dnf install ./vicinae-0.21.1-2.*.rpm` — verify `layer-shell-qt` is pulled in automatically
- [ ] `rpm -q --requires vicinae | grep layer-shell-qt` returns the dep
- [ ] `systemctl --user start vicinae && vicinae toggle` — window appears on first invocation

Closes #12588