### PR TITLE
[f44] chore (consolekit): clean up anda.hcl (#12591)

### DIFF
--- a/anda/langs/python/consolekit/anda.hcl
+++ b/anda/langs/python/consolekit/anda.hcl
@@ -3,6 +3,4 @@ project pkg {
     rpm {
         spec = "consolekit.spec"
     }
-   	labels {
-	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (consolekit): clean up anda.hcl (#12591)](https://github.com/terrapkg/packages/pull/12591)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)