### PR TITLE
[f42] fix: python-wget (#12601)

### DIFF
--- a/anda/langs/python/wget/wget.spec
+++ b/anda/langs/python/wget/wget.spec
@@ -16,6 +16,9 @@ BuildArch:      noarch
 
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
+BuildRequires:  python3-importlib-metadata
+BuildRequires:  python3-wheel
+BuildRequires:  python3-setuptools
 
 Packager:	    Its-J <jonah@fyralabs.com>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: python-wget (#12601)](https://github.com/terrapkg/packages/pull/12601)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)