### PR TITLE
[frawhide] chore (crystal): bootstrap on 44 (#12607)

### DIFF
--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -1,4 +1,4 @@
-%bcond bootstrap 0
+%bcond bootstrap 1
 %global bootstrap_version 1.17.1
 
 Name:          crystal


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `frawhide`:
 - [chore (crystal): bootstrap on 44 (#12607)](https://github.com/terrapkg/packages/pull/12607)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)