### PR TITLE
[f42] chore (crystal): revert bootstrap (#12613)

### DIFF
--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -1,9 +1,9 @@
-%bcond bootstrap 1
+%bcond bootstrap 0
 %global bootstrap_version 1.17.1
 
 Name:          crystal
 Version:       1.20.2
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       A general-purpose, object-oriented programming language
 License:       Apache-2.0
 Packager:      Carl Hörberg <carl@84codes.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (crystal): revert bootstrap (#12613)](https://github.com/terrapkg/packages/pull/12613)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)