### PR TITLE
[f44] chore (blahaj): use pcre2 (#12623)

### DIFF
--- a/anda/langs/crystal/blahaj/blahaj.spec
+++ b/anda/langs/crystal/blahaj/blahaj.spec
@@ -5,7 +5,7 @@ Summary:        Gay sharks at your local terminal - lolcat-like CLI tool
 License:        BSD-2-Clause
 URL:            https://blahaj.geopjr.dev/
 Source0:        https://codeberg.org/GeopJr/BLAHAJ/archive/v%{version}.tar.gz
-BuildRequires:  crystal shards make gcc libyaml-devel pcre-devel libgc-devel libevent-devel bash
+BuildRequires:  crystal shards make gcc libyaml-devel pcre2-devel libgc-devel libevent-devel bash
 ExclusiveArch:  x86_64
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (blahaj): use pcre2 (#12623)](https://github.com/terrapkg/packages/pull/12623)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)