### PR TITLE
[el10] chore (nim): use pcre2 (#12626)

### DIFF
--- a/anda/langs/nim/nim/nim.spec
+++ b/anda/langs/nim/nim/nim.spec
@@ -11,7 +11,7 @@ Source1:		nim.1
 Source2:		nimgrep.1
 Source3:		nimble.1
 Source4:		nimsuggest.1
-BuildRequires:	gcc mold git-core gcc-c++ nodejs openssl-devel pkgconfig(bash-completion) gc-devel pcre-devel
+BuildRequires:	gcc mold git-core gcc-c++ nodejs openssl-devel pkgconfig(bash-completion) gc-devel pcre2-devel
 BuildRequires:  redhat-rpm-config anda-srpm-macros
 Requires:		gcc
 Recommends:		nim-tools


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (nim): use pcre2 (#12626)](https://github.com/terrapkg/packages/pull/12626)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)