### PR TITLE
[f43] fix (turbowarp): echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt (#12583)

### DIFF
--- a/anda/devs/turbowarp/turbowarp.spec
+++ b/anda/devs/turbowarp/turbowarp.spec
@@ -94,6 +94,7 @@ Packager:         junefish <june@fyralabs.com>
 
 %build
 %npm_build -c -B -r fetch,webpack:prod
+echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt
 
 %install
 %electron_install -i %appid -I build/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (turbowarp): echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt (#12583)](https://github.com/terrapkg/packages/pull/12583)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)