### PR TITLE
[el10] feat (terra-obsolete): obsolete supergfxctl packages (#12665)

### DIFF
--- a/anda/terra/obsolete/terra-obsolete.spec
+++ b/anda/terra/obsolete/terra-obsolete.spec
@@ -4,7 +4,7 @@ Version:    %{?fedora:%{fedora}}%{?rhel:%{rhel}}
 # The dist number is the version here, it is intentionally not repeated in the release
 %global dist %nil
 
-Release:    2%?dist
+Release:    3%{?dist}
 Summary:    A package to obsolete retired packages, based on Fedora's equivalent package
 
 License:    LicenseRef-Fedora-Public-Domain
@@ -126,6 +126,9 @@ Packager:   Terra Packaging Team <terra@fyralabs.com>
 
 %obsolete_ticket https://github.com/terrapkg/packages/pull/7098
 %obsolete terra-surface-dtx-daemon v0.3.10~1-5
+
+%obsolete supergfxctl
+%obsolete gnome-shell-extension-gpu-switcher-supergfxctl
 
 %obsolete_ticket https://github.com/terrapkg/packages/pull/7521
 %obsolete x264-bash-completion 0.165-18.20250609gitb35605ac


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat (terra-obsolete): obsolete supergfxctl packages (#12665)](https://github.com/terrapkg/packages/pull/12665)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)