### PR TITLE
[f43] build(deps): bump github/codeql-action from 4.35.5 to 4.36.0 (#12687)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [build(deps): bump github/codeql-action from 4.35.5 to 4.36.0 (#12687)](https://github.com/terrapkg/packages/pull/12687)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)