### PR TITLE
[f43] fix(edit): cd into crates folder (#12693)

### DIFF
--- a/anda/devs/edit/edit.spec
+++ b/anda/devs/edit/edit.spec
@@ -37,7 +37,9 @@ Packager:      Gilver E. <roachy@fyralabs.com>
 
 %install
 %crate_install_bin
-%{cargo_license_online} > LICENSE.dependencies
+pushd crates/edit
+%{cargo_license_online} > ../../LICENSE.dependencies
+popd
 install -Dm644 assets/edit.svg %{buildroot}%{_iconsdir}/hicolor/scalable/apps/%{appid}.svg
 
 sed -i "s|^Icon=edit$|Icon=%{appid}|g" assets/%{appid}.desktop


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(edit): cd into crates folder (#12693)](https://github.com/terrapkg/packages/pull/12693)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)