### PR TITLE
[el10] chore (amaranth): remove ghosted files (#12704)

### DIFF
--- a/anda/langs/amaranth/amaranth.spec
+++ b/anda/langs/amaranth/amaranth.spec
@@ -5,7 +5,7 @@
 
 Name:			python-%{pypi_name}
 Version:		0.5.8
-Release:		2%?dist
+Release:		3%?dist
 Summary:		A modern hardware definition language and toolchain based on Python
 License:		BSD-2-Clause
 URL:			https://github.com/amaranth-lang/amaranth
@@ -54,8 +54,6 @@ export PDM_BUILD_SCM_VERSION=%{version}
 %doc README.md CONTRIBUTING.txt
 %license LICENSE.txt
 %{_bindir}/amaranth-rpc
-%ghost %python3_sitelib/__pycache__/*.cpython-*.pyc
-%ghost %python3_sitelib/%{name}/subcommands/__pycache__/*.cpython-*.pyc
 
 %changelog
 * Sun Sep 28 2025 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (amaranth): remove ghosted files (#12704)](https://github.com/terrapkg/packages/pull/12704)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)