### PR TITLE
[f42] chore (lily): use %conf (#12703)

### DIFF
--- a/anda/langs/lily/lily.spec
+++ b/anda/langs/lily/lily.spec
@@ -22,8 +22,10 @@ Requires:      %{name}
 %prep
 %autosetup -n %{name}-%{version}
 
-%build
+%conf
 %cmake
+
+%build
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (lily): use %conf (#12703)](https://github.com/terrapkg/packages/pull/12703)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)