### PR TITLE
[f43] feat: Update OGC steamos-manager to the latest build (#12717)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,10 +1,10 @@
-%global commit 7b4d0f49351a60d1f93d48f081b4c0e35e10fa6d
+%global commit 37d1cb6f98e02b76221190b10af3c6e1c6b7534d
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260325
+%global commitdate 20260528
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          4%{?dist}
+Release:          1%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager

--- a/anda/games/steamos-manager-powerstation/steamos_manager.te
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.te
@@ -84,6 +84,7 @@ gen_require(`
 	type tracefs_t;
 ')
 allow steamos_manager_t tracefs_t:dir search;
+allow steamos_manager_t tracefs_t:dir write;
 
 ########################################
 # Cgroup access


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update OGC steamos-manager to the latest build (#12717)](https://github.com/terrapkg/packages/pull/12717)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)