### PR TITLE
[f42] fix: inputplumber (#12722)

### DIFF
--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -52,6 +52,7 @@ keyboards) and translate their input to a variety of virtual device formats.
 %_datadir/dbus-1/system.d/org.shadowblip.InputPlumber.conf
 %_datadir/inputplumber/
 %{_udevrulesdir}/99-inputplumber-device-setup.rules
+%{_udevrulesdir}/50-8bitdo-u2-controller.rules
 %{_datadir}/polkit-1/actions/org.shadowblip.InputPlumber.policy
 %{_datadir}/polkit-1/rules.d/org.shadowblip.InputPlumber.rules
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: inputplumber (#12722)](https://github.com/terrapkg/packages/pull/12722)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)