### PR TITLE
[f42] chore(falcond,falcond-gui): Use gitea() (#12728)

### DIFF
--- a/anda/apps/falcond-gui/update.rhai
+++ b/anda/apps/falcond-gui/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(get("https://git.pika-os.com/api/v1/repos/general-packages/falcond-gui/releases").json_arr()[0].tag_name);
+rpm.version(gitea("git.pika-os.com", "general-packages/falcond-gui"));

--- a/anda/system/falcond/update.rhai
+++ b/anda/system/falcond/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(get("https://git.pika-os.com/api/v1/repos/general-packages/falcond/releases").json_arr()[0].tag_name);
+rpm.version(gitea("git.pika-os.com", "general-packages/falcond"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(falcond,falcond-gui): Use gitea() (#12728)](https://github.com/terrapkg/packages/pull/12728)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)