### PR TITLE
[el10] add panda to the scripts (#12751)

### DIFF
--- a/anda/terra/terra-scripts/terra-scripts.spec
+++ b/anda/terra/terra-scripts/terra-scripts.spec
@@ -1,5 +1,5 @@
 Name:           terra-scripts
-Version:        0.1.4
+Version:        0.2.0
 Release:        1%{?dist}
 Summary:        Helpful scripts for contributing to Terra
 License:        GPL-3.0-or-later
@@ -8,6 +8,7 @@ Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 Requires:       bash
 BuildArch:      noarch
 Packager:       Its-J <jonah@fyralabs.com>
+Recommends:     podman
 
 %description
 %{summary}.
@@ -20,6 +21,7 @@ install -Dm 755 format-license.sh %{buildroot}%{_bindir}/format-license
 install -Dm 755 ldd-dnf.sh %{buildroot}%{_bindir}/ldd-dnf
 install -Dm 755 changelog.sh %{buildroot}%{_bindir}/changelog
 install -Dm 755 getcommit.sh %{buildroot}%{_bindir}/getcommit
+install -Dm 755 panda.sh %{buildroot}%{_bindir}/panda
 
 %files
 %doc README.md
@@ -28,8 +30,11 @@ install -Dm 755 getcommit.sh %{buildroot}%{_bindir}/getcommit
 %{_bindir}/ldd-dnf
 %{_bindir}/changelog
 %{_bindir}/getcommit
+%{_bindir}/panda
 
 %changelog
+* Fri May 29 2026 Jaiden Riordan <jade@fyralabs.com>
+- Add panda.sh
 * Sun May 24 2026 Its-J <jonah@fyralabs.com>
 - Add getcommit.sh
 * Sat May 23 2026 Its-J <jonah@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add panda to the scripts (#12751)](https://github.com/terrapkg/packages/pull/12751)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)