### PR TITLE
[f42] fix: mangowm (#12756)

### DIFF
--- a/anda/desktops/mangowm/mangowm.spec
+++ b/anda/desktops/mangowm/mangowm.spec
@@ -21,6 +21,7 @@ BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(libinput)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(libpcre2-8)
+BuildRequires:  pkgconfig(libcjson)
 BuildRequires:  scenefx-devel
 
 Conflicts:      mangowc < %{mangowc_ver}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: mangowm (#12756)](https://github.com/terrapkg/packages/pull/12756)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)