### PR TITLE
chore(fdk-aac): Track Bodhi

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -4,8 +4,8 @@ project pkg {
     spec = "fdk-aac.spec"
   }
   labels {
-        mock=1
+        mock = 1
         subrepo = "multimedia"
-        weekly = 1
+        updbranch = 1
     }
 }

--- a/anda/lib/fdk-aac/update.rhai
+++ b/anda/lib/fdk-aac/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh_tag("mstorsjo/fdk-aac"));
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::bodhi("fdk-aac-free", bump::as_bodhi_ver(labels.branch)));


### PR DESCRIPTION
Related to changes made in #12766.

Basically, since FFmpeg can't build with these builds but can dlopen with them we need to make sure they are on the same versions as Fedora's stripped down packages.