### PR TITLE
[el10] chore(fdk-aac): Track Bodhi (#12767)

### DIFF
--- a/anda/lib/fdk-aac/anda.hcl
+++ b/anda/lib/fdk-aac/anda.hcl
@@ -4,8 +4,8 @@ project pkg {
     spec = "fdk-aac.spec"
   }
   labels {
-        mock=1
+        mock = 1
         subrepo = "multimedia"
-        weekly = 1
+        updbranch = 1
     }
 }

--- a/anda/lib/fdk-aac/update.rhai
+++ b/anda/lib/fdk-aac/update.rhai
@@ -1,1 +1,3 @@
-rpm.version(gh_tag("mstorsjo/fdk-aac"));
+import "andax/bump_extras.rhai" as bump;
+
+rpm.version(bump::bodhi("fdk-aac-free", bump::as_bodhi_ver(labels.branch)));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(fdk-aac): Track Bodhi (#12767)](https://github.com/terrapkg/packages/pull/12767)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)