### PR TITLE
[f44] fix(x264): Fix i686 builds and update versioning scheme (#12784)

### DIFF
--- a/anda/multimedia/x264/anda.hcl
+++ b/anda/multimedia/x264/anda.hcl
@@ -7,5 +7,6 @@ project pkg {
     labels { 
         mock = 1
         subrepo = "multimedia"
+        nightly = 1
     }
 }

--- a/anda/multimedia/x264/update.rhai
+++ b/anda/multimedia/x264/update.rhai
@@ -1,0 +1,10 @@
+let domain = `code.videolan.org`;
+let c = gitlab_commit(domain, "536", "master");
+
+rpm.global("commit", c);
+
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+  rpm.global("api_version", find(`#define X264_BUILD ([\d]+)`, get(`https://${domain}/videolan/x264/-/raw/${c}/x264.h`), 1));
+}

--- a/anda/multimedia/x264/x264.spec
+++ b/anda/multimedia/x264/x264.spec
@@ -3,11 +3,15 @@
 %global api_version 165
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
+%ifarch %{ix86}
+%global _pkg_extra_ldflags "-Wl,-z,notext"
+%endif
+
 %bcond_with bootstrap
 
 Name:           x264
-Version:        0.%{api_version}
-Release:        38%{?shortcommit:.%{commit_date}git%{shortcommit}}%{?dist}
+Version:        0^%{commit_date}git%{shortcommit}
+Release:        1%{?dist}
 Epoch:          1
 Summary:        H264/AVC video streams encoder
 License:        GPL-2.0-or-later
@@ -22,8 +26,8 @@ BuildRequires:  pkgconfig(libavformat)
 BuildRequires:  pkgconfig(libavutil)
 BuildRequires:  pkgconfig(libswscale)
 %endif
-
 Requires:       bash-completion
+Packager:       Terra Packaging Team <terra@fyralabs.com>
 
 %description
 %{name} is a free software library and application for encoding video streams into
@@ -40,12 +44,14 @@ libraries.
 
 %package devel
 Summary:        Development files for the x264 library
-Requires:       %{name}-libs%{?_isa} = %{?epoch}:%{version}-%{release}
+Requires:       %{name}-libs%{?_isa} = %{evr}
 Requires:       pkgconfig
 
 %description devel
 The %{name}-devel package contains libraries and header files for developing
 applications that use %{name}.
+
+%pkg_completion -B
 
 
 %prep
@@ -69,8 +75,9 @@ applications that use %{name}.
 %ldconfig_scriptlets libs
 
 %files
+%license COPYING
+%doc AUTHORS
 %{_bindir}/%{name}
-%{_datadir}/bash-completion/completions/%{name}
 
 %files libs
 %license COPYING
@@ -85,4 +92,6 @@ applications that use %{name}.
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
-%autochangelog
+* Mon Jun 1 2026 Gilver E. <roachy@fyralabs.com> - 0^20250910git0480cb0-1
+- Fix i686 builds
+- Update versioning scheme to modern Fedora snapshot guidelines


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(x264): Fix i686 builds and update versioning scheme (#12784)](https://github.com/terrapkg/packages/pull/12784)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)