### PR TITLE
[f43] chore (Vicinae): use proper license identifier (#12774)

### DIFF
--- a/anda/system/vicinae/vicinae.spec
+++ b/anda/system/vicinae/vicinae.spec
@@ -5,9 +5,9 @@
 %endif
 
 Name:           vicinae
+License:        GPL-3.0-or-later
 Version:        0.21.5
-Release:        1%{?dist}
-License:        GPL-3.0
+Release:        2%{?dist}
 URL:            https://docs.vicinae.com
 Source:         https://github.com/vicinaehq/%{name}/archive/refs/tags/v%{version}.tar.gz
 Summary:        A high-performance, native launcher for Linux


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (Vicinae): use proper license identifier (#12774)](https://github.com/terrapkg/packages/pull/12774)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)