### PR TITLE
remove the devcontainer common utils (most are included or not useful)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
   "name": "Terra Devcontainer",
   "image": "ghcr.io/terrapkg/builder:frawhide",
   "runArgs": ["--privileged"],
-  "features": {
-    "ghcr.io/devcontainers/features/common-utils:2": {}
-  },
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
fixes conflict issues with zlib and zlib-ng-compat

check out this function upstream for a list of the packages
https://github.com/devcontainers/features/blob/main/src/common-utils/main.sh#L172

should also reduce devcontainer startup time