### PR TITLE
[el10] chore(xavs): Update spec (#7243)

### DIFF
--- a/anda/lib/xavs/xavs.spec
+++ b/anda/lib/xavs/xavs.spec
@@ -1,8 +1,13 @@
+%global commit r55
+%global date 20110821
+
+%global _pkg_extra_cflags "-Wno-int-conversion -Wno-declaration-missing-parameter-type"
+
 Name:           xavs
-Version:        0.1.55
-Release:        1%{?dist}
+Version:        0.1.55^%{date}svn%{commit}
+Release:        2%{?dist}
 Summary:        AVS1 (First-generation AVS Standards) library
-License:        GPLv2
+License:        GPL-2.0-only
 URL:            https://xavs.sourceforge.net/
 Patch0:         %{name}-cflags.patch
 BuildRequires:  autoconf
@@ -10,7 +15,7 @@ BuildRequires:  automake
 BuildRequires:  gcc
 BuildRequires:  libtool
 BuildRequires:  subversion
-#BuildRequires:  yasm
+%dnl BuildRequires:  yasm
 
 %description
 AVS is a complete standard system including system, video, audio, and digital
@@ -35,7 +40,7 @@ The %{name}-devel package contains libraries and header files for
 developing applications that use %{name}.
 
 %prep
-svn co https://svn.code.sf.net/p/xavs/code/trunk %{name}
+svn co -r %{commit} https://svn.code.sf.net/p/xavs/code/trunk %{name}
 %setup -T -D -n %{name}
 %autopatch -p1
 
@@ -43,8 +48,7 @@ svn co https://svn.code.sf.net/p/xavs/code/trunk %{name}
 %configure \
     --disable-asm \
     --enable-pic \
-    --enable-shared \
-    --extra-cflags="-Wno-int-conversion -Wno-declaration-missing-parameter-type"
+    --enable-shared
 
 %build
 %make_build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(xavs): Update spec (#7243)](https://github.com/terrapkg/packages/pull/7243)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)