### PR TITLE
[f44] remove the devcontainer common utils (most are included or not useful) (#12805)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,6 @@
   "name": "Terra Devcontainer",
   "image": "ghcr.io/terrapkg/builder:frawhide",
   "runArgs": ["--privileged"],
-  "features": {
-    "ghcr.io/devcontainers/features/common-utils:2": {}
-  },
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [remove the devcontainer common utils (most are included or not useful) (#12805)](https://github.com/terrapkg/packages/pull/12805)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)