### PR TITLE
[el10] fix: budgie-extras (#12673)

### DIFF
--- a/anda/desktops/budgie/budgie-extras/budgie-extras.spec
+++ b/anda/desktops/budgie/budgie-extras/budgie-extras.spec
@@ -14,7 +14,7 @@ BuildRequires:  meson
 BuildRequires:  vala
 BuildRequires:  intltool
 
-BuildRequires:  pkgconfig(budgie-1.0)
+BuildRequires:  pkgconfig(budgie-3.0)
 BuildRequires:  pkgconfig(gee-0.8)
 BuildRequires:  pkgconfig(gnome-settings-daemon)
 BuildRequires:  pkgconfig(json-glib-1.0)
@@ -25,6 +25,9 @@ BuildRequires:  pkgconfig(libnma)
 BuildRequires:  pkgconfig(libnotify)
 BuildRequires:  pkgconfig(libsoup-2.4)
 BuildRequires:  pkgconfig(libwnck-3.0)
+BuildRequires:  pkgconfig(libpeas-2)
+BuildRequires:  pkgconfig(libxfce4windowing-0)
+BuildRequires:  pkgconfig(gtk-layer-shell-0)
 
 BuildRequires:  pkgconfig(appstream)
 BuildRequires:  pkgconfig(granite)
@@ -129,13 +132,6 @@ Summary:        Shows the time in a Fuzzy Way
 %description -n	budgie-applet-fuzzyclock
 %{summary}
 
-%package -n	budgie-applet-hotcorners
-Requires:       budgie-extras-common
-Summary:        Applet providing hotcorners capabilities for the Budgie Desktop
-%description -n	budgie-applet-hotcorners
-The hotcorners applet allow user defined commands to be executed
-when the mouse cursor is pushed into a corner of the main desktop.
-
 %package -n	budgie-applet-kangaroo
 Requires:       budgie-extras-common
 Summary:        Applet to allow quick file-browsing
@@ -143,15 +139,6 @@ Summary:        Applet to allow quick file-browsing
 The kangaroo applet allows for quick & easy browsing, across
 (possibly) many directory layers, without having to do a single mouse
 click.
-
-%package -n	budgie-applet-keyboard-autoswitch
-Requires:       budgie-extras-common
-Summary:        Applet adding the ability to set a different keyboard layout per application
-%description -n	budgie-applet-keyboard-autoswitch
-The Keyboard Auto Switcher applet provides the user the ability to set
-a different keyboard layout per application. Exceptions to the default
-layout can be set by simply choosing a different layout using the
-Keyboard Layout applet.
 
 %package -n	budgie-applet-network-manager
 Requires:       budgie-extras-common
@@ -181,12 +168,11 @@ Summary:        Applet displays files recently accessed for the Budgie Desktop
 The recentlyused applet displays the users files that have been opened
 or created within a configurable period of time.
 
-%package -n	budgie-applet-rotation-lock
+%package -n	budgie-applet-screencast
 Requires:       budgie-extras-common
-Summary:        Applet to lock or unlock the screen rotation
-%description -n	budgie-applet-rotation-lock
-The Rotation Lock applet provides the user an easy way to lock or
-unlock the screen rotation.
+Summary:        Applet wrapper around wf-recorder
+%description -n	budgie-applet-screencast
+Applet wrapper around wf-recorder. Allows recording of whole screen displays or areas.
 
 %package -n	budgie-applet-showtime
 Requires:       budgie-extras-common
@@ -227,31 +213,6 @@ Summary:        Applet to display the weather and forecast
 The weathershow applet displays daily and three hourly weather
 forecasts on both the desktop and a Popover.
 
-%package -n	budgie-applet-window-shuffler
-Requires:       budgie-extras-common
-Requires:       budgie-extras-daemon
-Summary:        Budgie Window Shuffler
-%description -n	budgie-applet-window-shuffler
-%{summary}
-
-%package -n	budgie-applet-workspace-stopwatch
-Requires:       budgie-extras-common
-Summary:        An applet to keep track of usage per workspace
-%description -n	budgie-applet-workspace-stopwatch
-Workspace Timer Applet is an applet to keep track of usage per workspace, e.g.
-to find out how much minutes/hours were actually spent on a job. Workspaces can
-be freely named, custom names and all data are rmembered, also after
-logout/restart, until the RESET button is pressed. The log file is updated
-onworkspace switch/clicking the icon for popup or else every 30 seconds. Time
-during suspend is automatically retracted from a workspace' time.
-
-%package -n	budgie-applet-wpreviews
-Requires:       budgie-extras-common
-Requires:       budgie-extras-daemon
-Summary:	Applet providing window previews capabilities for the Budgie Desktop
-%description -n	budgie-applet-wpreviews
-The Previews applet shows an overview of windows in an expose like way.
-
 %package -n	budgie-applet-wswitcher
 Requires:       budgie-extras-common
 Requires:       budgie-extras-daemon
@@ -266,8 +227,14 @@ workspaces.
 %prep
 %autosetup -p1
 
+find . -name "meson.build" -exec sed -i "s/dependency('budgie-1.0')/dependency('budgie-3.0')/g" {} +
+find . -name "meson.build" -exec sed -i "s/dependency('libpeas-1.0')/dependency('libpeas-2')/g" {} +
+find . -name "meson.build" -exec sed -i "s/dependency('libpeas-gtk-1.0')/dependency('libpeas-2')/g" {} +
+
+%conf
+%meson -Dfor-wayland=true
+
 %build
-%meson
 %meson_build
 
 %install
@@ -282,7 +249,6 @@ rm -f %{buildroot}%{_bindir}/quickchar
 
 %{__ln_s} -fv %{_bindir}/quickchar %{_libdir}/quickchar/quickchar
 
-
 %files
 
 %files common
@@ -294,103 +260,91 @@ rm -f %{buildroot}%{_bindir}/quickchar
 %{_bindir}/budgie-extras-daemon
 %{_libdir}/budgie-extras-daemon/invoke.py
 %{_datadir}/budgie-desktop/layouts/*.layout
-%{_datadir}/budgie-extras-daemon
 %{_mandir}/man1/budgie-extras-daemon.1.gz
 
 %files -n budgie-applet-app-launcher
 %{_datadir}/pixmaps/budgie-app-launcher*.svg
 %{_libdir}/budgie-desktop/plugins/budgie-app-launcher
+%{_metainfodir}/org.ubuntubudgie.applauncher.metainfo.xml
 
 %files -n budgie-applet-applications-menu
 %{_libdir}/budgie-desktop/plugins/applications-menu
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
-#%%{_datadir}/glib-2.0/schemas/io.elementary.desktop.wingpanel.applications-menu.gschema.xml
 
 %files -n budgie-applet-brightness-controller
 %{_libdir}/budgie-desktop/plugins/budgie-brightness-controller
 %{_datadir}/pixmaps/budgie-brightness-controller-1-symbolic.svg
+%{_metainfodir}/org.ubuntubudgie.brightnesscontroller.metainfo.xml
 
 %files -n budgie-applet-clockworks
 %{_libdir}/budgie-desktop/plugins/budgie-clockworks
 %{_datadir}/glib-2.0/schemas/*budgie-clockworks*.xml
 %{_datadir}/pixmaps/budgie-clockworks*.svg
+%{_metainfodir}/org.ubuntubudgie.clockworks.metainfo.xml
 
 %files -n budgie-applet-countdown
 %{_libdir}/budgie-desktop/plugins/budgie-countdown
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-countdown.gschema.xml
 %{_datadir}/pixmaps/budgie-countdown-symbolic.svg
 %{_datadir}/pixmaps/cr_*.png
+%{_metainfodir}/org.ubuntubudgie.countdown.metainfo.xml
 
 %files -n budgie-applet-dropby
 %{_libdir}/budgie-desktop/plugins/budgie-dropby
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-dropby.gschema.xml
 %{_datadir}/pixmaps/budgie-dropby*.svg
+%{_metainfodir}/org.ubuntubudgie.dropby.metainfo.xml
 
 %files -n budgie-applet-fuzzyclock
 %{_libdir}/budgie-desktop/plugins/budgie-fuzzyclock
-
-%files -n budgie-applet-hotcorners
-%{_libdir}/budgie-desktop/plugins/budgie-hotcorners
-%config %{_sysconfdir}/xdg/autostart/org.ubuntubudgie.budgie-extras.HotCorners-autostart.desktop
-%{_datadir}/glib-2.0/schemas/org.ubuntubudgie.budgie-extras.HotCorners.gschema.xml
-%{_datadir}/applications/org.ubuntubudgie.budgie-extras.HotCorners.desktop
-%{_datadir}/budgie-hotcorners
-/usr/libexec/budgie-hotcorners/
-
-%{_datadir}/pixmaps/budgie-hotcorners-symbolic.svg
-%{_datadir}/pixmaps/budgie-hotcgui-*.svg
-%{_datadir}/icons/hicolor/scalable/apps/org.ubuntubudgie.budgie-extras.hotcorners.svg
+%{_metainfodir}/org.ubuntubudgie.fuzzyclock.metainfo.xml
 
 %files -n budgie-applet-kangaroo
 %{_libdir}/budgie-desktop/plugins/budgie-kangaroo
 %{_datadir}/pixmaps/budgie-foldertrack-symbolic.svg
-
-%files -n budgie-applet-keyboard-autoswitch
-%{_libdir}/budgie-desktop/plugins/budgie-keyboard-autoswitch
-%{_datadir}/pixmaps/budgie-keyboard-autoswitch-symbolic.svg
+%{_metainfodir}/org.ubuntubudgie.kangaroo.metainfo.xml
 
 %files -n budgie-applet-network-manager
 %{_libdir}/budgie-desktop/plugins/budgie-network-manager
 
 %files -n budgie-applet-quickchar
-%config %{_sysconfdir}/xdg/autostart/quickchar-autostart.desktop
 %ghost %{_bindir}/quickchar
-%{_libdir}/quickchar
-%{_datadir}/applications/org.ubuntubudgie.quickchar.desktop
-%{_datadir}/glib-2.0/schemas/org.ubuntubudgie.quickchar.gschema.xml
-%{_datadir}/quickchar/chardata
-%{_datadir}/icons/hicolor/scalable/apps/org.ubuntubudgie.quickchar.svg
-%{_mandir}/man1/quickchar.1.gz
-%{_datadir}/metainfo/org.ubuntubudgie.quickchar.metainfo.xml
 
 %files -n budgie-applet-quicknote
 %{_libdir}/budgie-desktop/plugins/budgie-quicknote
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.quicknote.gschema.xml
 %{_datadir}/pixmaps/budgie-quicknote-symbolic.svg
+%{_metainfodir}/org.ubuntubudgie.quicknote.metainfo.xml
 
 %files -n budgie-applet-recentlyused
 %{_libdir}/budgie-desktop/plugins/budgie-recentlyused
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-recentlyused.gschema.xml
+%{_metainfodir}/org.ubuntubudgie.recentlyused.metainfo.xml
 
-%files -n budgie-applet-rotation-lock
-%{_libdir}/budgie-desktop/plugins/budgie-rotation-lock
-%{_datadir}/pixmaps/budgie-rotation-*.svg
+%files -n budgie-applet-screencast
+%{_libdir}/budgie-desktop/plugins/budgie-screencast/BudgieScreencast.plugin
+%{_libdir}/budgie-desktop/plugins/budgie-screencast/libbudgie-screencast.so
+%{_datadir}/glib-2.0/schemas/org.ubuntubudgie.budgie-screencast.gschema.xml
+%{_datadir}/pixmaps/budgie-screencast-symbolic.svg
 
 %files -n budgie-applet-showtime
-%{_libdir}/budgie-desktop/plugins/budgie-showtime
-%{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-showtime.gschema.xml
+%{_libdir}/budgie-desktop/raven-plugins/org.ubuntubudgie.raven.widget.budgie-showtime/*
 %{_datadir}/pixmaps/showtimenew-symbolic.svg
+%{_metainfodir}/org.ubuntubudgie.showtime.metainfo.xml
 
 %files -n budgie-applet-takeabreak
 %{_libdir}/budgie-desktop/plugins/budgie-takeabreak
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.takeabreak.gschema.xml
+%{_datadir}/glib-2.0/schemas/org.ubuntubudgie.raven.widget.budgie-showtime.gschema.xml
 %{_datadir}/pixmaps/takeabreak*.svg
+%{_metainfodir}/org.ubuntubudgie.takeabreak.metainfo.xml
 
 %files -n budgie-applet-visualspace
 %config %{_sysconfdir}/xdg/autostart/visualspace-autostart.desktop
 %{_libdir}/budgie-desktop/plugins/budgie-visualspace
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-visualspace.gschema.xml
 %{_datadir}/pixmaps/visualspace-symbolic.svg
+%{_metainfodir}/org.ubuntubudgie.visualspace.metainfo.xml
 
 %files -n budgie-applet-wallstreet
 %config %{_sysconfdir}/xdg/autostart/wallstreet-autostart.desktop
@@ -406,42 +360,18 @@ rm -f %{buildroot}%{_bindir}/quickchar
 %{_datadir}/budgie-desktop/budgie-weathershow/weather_icons/*
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.weathershow.gschema.xml
 %{_datadir}/pixmaps/budgie-wticon-symbolic.svg
-
-%files -n budgie-applet-window-shuffler
-%config %{_sysconfdir}/xdg/autostart/layoutspopup-autostart.desktop
-%config %{_sysconfdir}/xdg/autostart/dragsnap-autostart.desktop
-%config %{_sysconfdir}/xdg/autostart/shuffler*.desktop
-%{_libdir}/budgie-window-shuffler
-%{_datadir}/applications/org.ubuntubudgie.shufflercontrol.desktop
-%{_datadir}/icons/hicolor/scalable/apps/org.ubuntubudgie.shuffler-control.svg
-%{_datadir}/glib-2.0/schemas/org.ubuntubudgie.windowshuffler.gschema.xml
-%{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-shufflerapplet.gschema.xml
-%{_datadir}/pixmaps/shuffler-*.svg
-%{_datadir}/pixmaps/shufflerapplet-*.svg
-%{_datadir}/pixmaps/dragsnapimg*.svg
-%{_libdir}/budgie-desktop/plugins/budgie-window-shuffler/ShufflerAPplet.plugin
-%{_libdir}/budgie-desktop/plugins/budgie-window-shuffler/libshufflerapplet.so
-%{_datadir}/metainfo/org.ubuntubudgie.shufflercontrol.metainfo.xml
-
-%files -n budgie-applet-workspace-stopwatch
-%{_libdir}/budgie-desktop/plugins/budgie-workspace-stopwatch
-%{_datadir}/pixmaps/budgie-wstopwatch-symbolic.svg
-
-%files -n budgie-applet-wpreviews
-%config %{_sysconfdir}/xdg/autostart/previews-*.desktop
-%{_libdir}/budgie-previews
-%{_datadir}/applications/org.ubuntubudgie.previewscontrols.desktop
-%{_datadir}/metainfo/org.ubuntubudgie.previewscontrols.metainfo.xml
-%{_datadir}/glib-2.0/schemas/org.ubuntubudgie.budgie-wpreviews.gschema.xml
-%{_datadir}/pixmaps/budgie_wpreviews_*.png
-%{_datadir}/icons/hicolor/scalable/apps/org.ubuntubudgie.budgiewpreviews.svg
+%{_metainfodir}/org.ubuntubudgie.weathershow.metainfo.xml
 
 %files -n budgie-applet-wswitcher
-%{_libdir}/budgie-desktop/plugins/budgie-wswitcher
+%{_libdir}/budgie-desktop/raven-plugins/org.ubuntubudgie.raven.widget.budgie-wswitcher/*
 %{_datadir}/glib-2.0/schemas/org.ubuntubudgie.plugins.budgie-wswitcher.gschema.xml
 %{_datadir}/pixmaps/budgie-wsw-symbolic.svg
+%{_metainfodir}/org.ubuntubudgie.wswitcher.metainfo.xml
 
 %changelog
+* Tue Jun 02 2026 Owen Zimmerman <owen@fyralabs.com> - 2.2.3-1
+- Update for 2.2.3
+
 * Thu Jun 09 2022 Cappy Ishihara <cappy@cappuchino.xyz> - 1.4.0-1
 - Updated to 1.4.0
 - Added requirements for Workspace Overview


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: budgie-extras (#12673)](https://github.com/terrapkg/packages/pull/12673)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)