### PR TITLE
[f42] fix: quickjs-ng (#12855)

### DIFF
--- a/anda/lib/quickjs-ng/quickjs-ng.spec
+++ b/anda/lib/quickjs-ng/quickjs-ng.spec
@@ -33,7 +33,7 @@ Requires:   %{name}-libs%{_isa} = %evr
 %pkg_devel_files
 
 %files devel
-%{_libdir}/cmake/quickjs/*.cmake
+%{_libdir}/cmake/qjs/*.cmake
 
 
 %package examples


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: quickjs-ng (#12855)](https://github.com/terrapkg/packages/pull/12855)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)