### PR TITLE
[f42] feat: Add ryzen-smu kmod/dkms for use with Powerstation/OpengamepadUI (#12867)

### DIFF
--- a/anda/system/ryzen-smu/akmod/anda.hcl
+++ b/anda/system/ryzen-smu/akmod/anda.hcl
@@ -1,0 +1,10 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "ryzen_smu-kmod.spec"
+	}
+	labels {
+		mock = 1
+		nightly = 1
+	}
+}

--- a/anda/system/ryzen-smu/akmod/ryzen_smu-kmod.spec
+++ b/anda/system/ryzen-smu/akmod/ryzen_smu-kmod.spec
@@ -1,0 +1,69 @@
+# The reason why this package is a separate from the main one despite using the same sources
+# is because akmods use the srpm to build the kmod package, and if the kmod package is included
+# in the main package, akmods will reinstall the userspace package every time the kernel is updated.
+
+%if 0%{?fedora}
+%global buildforkernels akmod
+%global debug_package %{nil}
+%endif
+
+%global commit 0bb95d961664c7a0ac180f849fa16fe7da71922d
+%global commitdate 20260425
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global modulename ryzen_smu
+
+Name:           %{modulename}-kmod
+Version:        0.1.7^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen processors
+License:        GPL-2.0-only
+URL:            https://github.com/amkillam/ryzen_smu
+Source0:        %{url}/archive/%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  kmodtool
+
+Requires:       akmods
+Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
+Requires:       %{modulename}-akmod-modules = %{?epoch:%{epoch}:}%{version}
+Requires:       kernel-devel
+Conflicts:      dkms-%{modulename}
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%{expand:%(kmodtool --target %{_target_cpu} --repo terrapkg.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Ryzen SMU is a Linux kernel driver that exposes access to the SMU (System
+Management Unit) for certain AMD Ryzen processors. It allows reading and writing
+SMU mailbox commands and exposes the power metrics (PM) table via sysfs.
+Use at your own risk.
+
+%prep
+# error out if there was something wrong with kmodtool
+%{?kmodtool_check}
+
+# print kmodtool output for debugging purposes:
+kmodtool --target %{_target_cpu} --repo terrapkg.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%setup -q -c -n %{modulename}-%{commit}
+
+for kernel_version  in %{?kernel_versions} ; do
+  cp -a %{modulename}-%{commit} _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version  in %{?kernel_versions} ; do
+  make V=1 %{?_smp_mflags} -C ${kernel_version##*___} M=${PWD}/_kmod_build_${kernel_version%%___*} modules
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+ mkdir -p %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ install -D -m 755 _kmod_build_${kernel_version%%___*}/%{modulename}.ko %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ chmod a+x %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/%{modulename}.ko
+done
+%{?akmod_install}
+
+%changelog
+* Thu Jun 04 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package release

--- a/anda/system/ryzen-smu/akmod/update.rhai
+++ b/anda/system/ryzen-smu/akmod/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("amkillam/ryzen_smu"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+}

--- a/anda/system/ryzen-smu/dkms/anda.hcl
+++ b/anda/system/ryzen-smu/dkms/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "dkms-ryzen_smu.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/system/ryzen-smu/dkms/dkms-ryzen_smu.spec
+++ b/anda/system/ryzen-smu/dkms/dkms-ryzen_smu.spec
@@ -1,0 +1,61 @@
+%global commit 0bb95d961664c7a0ac180f849fa16fe7da71922d
+%global debug_package %{nil}
+%global modulename ryzen_smu
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260425
+
+Name:           dkms-%{modulename}
+Version:        0.1.7^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen processors
+License:        GPL-2.0-only
+URL:            https://github.com/amkillam/ryzen_smu
+Source:         %{url}/archive/%{commit}.tar.gz
+BuildRequires:  sed
+BuildRequires:  systemd-rpm-macros
+Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}
+Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+BuildArch:      x86_64
+Requires:       dkms
+Conflicts:      akmod-%{modulename}
+Provides:       %{modulename}-kmod
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%description
+Ryzen SMU is a Linux kernel driver that exposes access to the SMU (System
+Management Unit) for certain AMD Ryzen processors. It allows reading and writing
+SMU mailbox commands and exposes the power metrics (PM) table via sysfs.
+Use at your own risk.
+
+%package       akmod-modules
+Summary:       Modules for Akmods
+Requires:      akmod-%{name}
+BuildArch:     noarch
+
+%description   akmod-modules
+Akmods modules for the akmod-%{name} package.
+
+%prep
+%autosetup -p1 -n %{modulename}-%{commit}
+/usr/bin/sed -i -e 's/@VERSION@/%{version}/g' -e 's/@CFLGS@//g' dkms.conf
+# Fix bad python3 shebangs
+find . -name '*.py' -exec /usr/bin/sed -i '1s|^#![[:space:]]*/bin/python$|#!/usr/bin/python3|' {} +
+
+%install
+mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}
+cp -fr ./ %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+
+%post
+dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{modulename} -v %{version} -q || :
+dkms install -m %{modulename} -v %{version} -q --force || :
+
+%files
+%{_usrsrc}/%{modulename}-%{version}
+%license LICENSE
+%doc README.md
+
+%changelog
+* Thu Jun 04 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package release

--- a/anda/system/ryzen-smu/dkms/update.rhai
+++ b/anda/system/ryzen-smu/dkms/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("amkillam/ryzen_smu"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+}

--- a/anda/system/ryzen-smu/kmod-common/anda.hcl
+++ b/anda/system/ryzen-smu/kmod-common/anda.hcl
@@ -1,0 +1,9 @@
+project pkg {
+        arches = ["x86_64"]
+	rpm {
+		spec = "ryzen_smu.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/system/ryzen-smu/kmod-common/ryzen_smu.spec
+++ b/anda/system/ryzen-smu/kmod-common/ryzen_smu.spec
@@ -1,0 +1,50 @@
+%global commit 0bb95d961664c7a0ac180f849fa16fe7da71922d
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global commitdate 20260425
+
+Name:           ryzen_smu
+Version:        0.1.7^%{commitdate}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen processors
+License:        GPL-2.0-only
+URL:            https://github.com/amkillam/ryzen_smu
+Source:         %{url}/archive/%{commit}.tar.gz
+BuildRequires:  systemd-rpm-macros
+Requires:       %{name}-kmod = %{?epoch:%{epoch}:}%{version}
+Provides:       %{name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+BuildArch:      noarch
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
+
+%description
+Ryzen SMU is a Linux kernel driver that exposes access to the SMU (System
+Management Unit) for certain AMD Ryzen processors. It allows reading and writing
+SMU mailbox commands and exposes the power metrics (PM) table via sysfs.
+Use at your own risk.
+
+%package       akmod-modules
+Summary:       Modules for Akmods
+Requires:      %{name}-kmod = %{?epoch:%{epoch}:}%{version}
+BuildArch:     noarch
+
+%description   akmod-modules
+Akmods modules for the akmod-%{name} package.
+
+%prep
+%autosetup -p1 -n %{name}-%{commit}
+
+# Autoload the module on boot
+echo %{name} > %{name}.conf
+
+# Akmods modules
+install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
+
+%files
+%license LICENSE
+%doc README.md
+
+%files akmod-modules
+%{_modulesloaddir}/%{name}.conf
+
+%changelog
+* Thu Jun 04 2026 Kyle Gospodnetich <me@kylegospodneti.ch>
+- Initial package release

--- a/anda/system/ryzen-smu/kmod-common/update.rhai
+++ b/anda/system/ryzen-smu/kmod-common/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("amkillam/ryzen_smu"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commitdate", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [feat: Add ryzen-smu kmod/dkms for use with Powerstation/OpengamepadUI (#12867)](https://github.com/terrapkg/packages/pull/12867)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)