### PR TITLE
[f44] chore (muon): use sourcehut update script (#12861)

### DIFF
--- a/anda/buildsys/muon/update.rhai
+++ b/anda/buildsys/muon/update.rhai
@@ -1,4 +1,1 @@
-let versions = get("https://muon.build/releases/").json().keys();
-versions.sort();
-versions.pop();
-rpm.version(versions.pop());
+rpm.version(sourcehut("~lattis/muon"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (muon): use sourcehut update script (#12861)](https://github.com/terrapkg/packages/pull/12861)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)