### PR TITLE
[el10] chore (senpai): fix update script (#12862)

### DIFF
--- a/anda/misc/senpai/update.rhai
+++ b/anda/misc/senpai/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("delthas/senpai"));
+rpm.version(gh_tag("delthas/senpai"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (senpai): fix update script (#12862)](https://github.com/terrapkg/packages/pull/12862)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)