### PR TITLE
[f43] add .DS_Store to gitignore (#12903)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ anda-build/
 **/*.nupkg
 **/*.rpm
 **/*.kate-swp
+**/.DS_Store


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add .DS_Store to gitignore (#12903)](https://github.com/terrapkg/packages/pull/12903)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)