### PR TITLE
[f44] chore (gnome-shell-extension-grand-theft-focus) use gnome-extensions update script (#12924)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/update.rhai
+++ b/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("zalckos/GrandTheftFocus"));
+rpm.version(gnome_extensions("grand-theft-focus@zalckos.github.com"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (gnome-shell-extension-grand-theft-focus) use gnome-extensions update script (#12924)](https://github.com/terrapkg/packages/pull/12924)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)