### PR TITLE
[el10] fix: mangowm (#12930)

### DIFF
--- a/anda/desktops/mangowm/mangowm.spec
+++ b/anda/desktops/mangowm/mangowm.spec
@@ -55,6 +55,7 @@ dwl — crafted for speed, flexibility, and a customizable desktop experience.
 %{_sysconfdir}/mango/config.conf
 %{_datadir}/wayland-sessions/mango.desktop
 %{_datadir}/xdg-desktop-portal/mango-portals.conf
+%{_mandir}/man1/mmsg.1.*
 
 %changelog
 * Wed Mar 04 2026 metcya <metcya@gmail.com> - 0.12.5-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: mangowm (#12930)](https://github.com/terrapkg/packages/pull/12930)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)