### PR TITLE
[f43] fix: cardwire (#12931)

### DIFF
--- a/anda/system/cardwire/cardwire.spec
+++ b/anda/system/cardwire/cardwire.spec
@@ -7,6 +7,7 @@ Source0:        https://github.com/OpenGamingCollective/cardwire/archive/refs/ta
 License:	GPL-3.0-or-later AND (Apache-2.0 OR MIT) AND BSD-3-Clause AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND ISC AND MIT (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND Zlib
 BuildRequires:  cargo-rpm-macros
 BuildRequires:	systemd-rpm-macros
+BuildRequires:  systemd-devel
 BuildRequires:	libbpf-devel
 BuildRequires:	clang-devel
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: cardwire (#12931)](https://github.com/terrapkg/packages/pull/12931)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)