### PR TITLE
[el10] fix (gnome-shell-extension-grand-theft-focus): uuid (#12950)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-grand-theft-focus/gnome-shell-extension-grand-theft-focus.spec
@@ -1,9 +1,9 @@
 %global extension   grand-theft-focus
-%global uuid        %{extension}@zalckos
+%global uuid        %{extension}@zalckos.github.com
 
 Name:           gnome-shell-extension-%{extension}
 Version:        10
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        GNOME extension that removes the 'Window is ready' notification and brings the window into focus instead
 License:        AGPL-3.0-only
 URL:            https://github.com/zalckos/GrandTheftFocus


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (gnome-shell-extension-grand-theft-focus): uuid (#12950)](https://github.com/terrapkg/packages/pull/12950)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)