### PR TITLE
[f44] fix (gnome-shell-extension-battery_time): uuid (#12951)

### DIFF
--- a/anda/desktops/gnome/gnome-shell-extension-battery_time/gnome-shell-extension-battery_time.spec
+++ b/anda/desktops/gnome/gnome-shell-extension-battery_time/gnome-shell-extension-battery_time.spec
@@ -3,11 +3,11 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global extension   battery_time
-%global uuid        %{extension}@pomoke
+%global uuid        %{extension}@typeof.pw
 
 Name:           gnome-shell-extension-%{extension}
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Battery remaining time extension for GNOME Shell
 License:        GPL-2.0-only
 URL:            https://github.com/pomoke/battery_time


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (gnome-shell-extension-battery_time): uuid (#12951)](https://github.com/terrapkg/packages/pull/12951)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)