### PR TITLE
[f44] fix(ci/bootstrap): update buildsys dir path (#12981)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -37,11 +37,11 @@ jobs:
           dnf5 install -y ./anda-build/rpm/rpms/anda-*.rpm
 
       - name: Install build dependencies
-        run: dnf5 builddep -y anda/terra/{mock-configs,srpm-macros}/*.spec anda/tools/buildsys/{anda,subatomic}/*.spec
+        run: dnf5 builddep -y anda/terra/{mock-configs,srpm-macros}/*.spec anda/buildsys/{anda,subatomic}/*.spec
 
       - name: Install Anda
         run: |
-          rpmbuild -bb anda/tools/buildsys/anda/*.spec --undefine=_disable_source_fetch -D "_sourcedir $(pwd)/anda/tools/buildsys/anda/" -D "_rpmdir $(pwd)/anda-build/rpm/rpms/"
+          rpmbuild -bb anda/buildsys/anda/*.spec --undefine=_disable_source_fetch -D "_sourcedir $(pwd)/anda/buildsys/anda/" -D "_rpmdir $(pwd)/anda-build/rpm/rpms/"
           mv ./anda-build/rpm/rpms/*/anda-*.rpm ./anda-build/rpm/rpms/
           dnf5 install -y ./anda-build/rpm/rpms/anda-*.rpm
 
@@ -61,7 +61,7 @@ jobs:
         run: anda build -D "vendor Terra" -D "__python %{__python3}" -rrpmbuild anda/terra/appstream-helper/pkg
 
       - name: Build Subatomic
-        run: anda build -D "vendor Terra" -rrpmbuild anda/tools/buildsys/subatomic/pkg
+        run: anda build -D "vendor Terra" -rrpmbuild anda/buildsys/subatomic/pkg
       - name: Install Subatomic
         run: dnf5 install -y ./anda-build/rpm/rpms/subatomic-*.rpm
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(ci/bootstrap): update buildsys dir path (#12981)](https://github.com/terrapkg/packages/pull/12981)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)