### PR TITLE
[f42] chore (qdl): update for 2.7 (#12990)

### DIFF
--- a/anda/tools/qdl/qdl.spec
+++ b/anda/tools/qdl/qdl.spec
@@ -5,11 +5,13 @@ Summary:        This tool communicates with USB devices of id 05c6:9008 to uploa
 URL:            https://github.com/linux-msm/qdl
 Source0:        %url/archive/refs/tags/v%version.tar.gz
 License:        BSD-3-Clause
-BuildRequires:  make
+BuildRequires:  meson
 BuildRequires:  gcc
 BuildRequires:  help2man
 BuildRequires:  pkgconfig(libxml-2.0)
 BuildRequires:  pkgconfig(libusb-1.0)
+BuildRequires:  pkgconfig(libzip)
+BuildRequires:  pkgconfig(cmocka)
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
@@ -19,31 +21,30 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %prep
 %autosetup -n qdl-%{version}
 
+%conf
+%meson
+
 %build
-%make_build
-make manpages
+%meson_build
 
 %install
-install -Dm755 qdl %{buildroot}%{_bindir}/qdl
-install -Dm755 qdl %{buildroot}%{_bindir}/qdl-ramdump
-install -Dm755 qdl %{buildroot}%{_bindir}/ks
-mkdir -p %{buildroot}%{_mandir}/man1
-install -Dm644 qdl.1 %{buildroot}%{_mandir}/man1/qdl.1
-install -Dm644 qdl-ramdump.1 %{buildroot}%{_mandir}/man1/qdl-ramdump.1
-install -Dm644 ks.1 %{buildroot}%{_mandir}/man1/ks.1
+%meson_install
 
 %files
 %{_bindir}/qdl
 %{_bindir}/qdl-ramdump
-%{_bindir}/ks
+%{_bindir}/qdl-ks
 %{_mandir}/man1/qdl.1.*
 %{_mandir}/man1/qdl-ramdump.1.*
-%{_mandir}/man1/ks.1.*
+%{_mandir}/man1/qdl-ks.1.*
 
 %license LICENSE
 %doc README.md
 
 %changelog
+* Mon Jun 08 2026 Owen Zimmerman <owen@fyralabs.com> - 2.7-1
+- Update spec for 2.7
+
 * Mon Feb 02 2026 Owen Zimmerman <owen@fyralabs.com>
 - Switch to tagged versions
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (qdl): update for 2.7 (#12990)](https://github.com/terrapkg/packages/pull/12990)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)