### PR TITLE
[f42] build(deps): bump github/codeql-action from 4.36.1 to 4.36.2 (#13023)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [build(deps): bump github/codeql-action from 4.36.1 to 4.36.2 (#13023)](https://github.com/terrapkg/packages/pull/13023)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)