### PR TITLE
chore: bring proton-core out of extras

### DIFF
--- a/anda/langs/python/proton-core/anda.hcl
+++ b/anda/langs/python/proton-core/anda.hcl
@@ -3,7 +3,4 @@ project pkg {
   rpm {
     spec = "proton-core.spec"
   }
-  labels {
-    subrepo = "extras"
-  }
 }


### PR DESCRIPTION
Fedora has a very old version of this package, and I am proposing an exception to our extras policy as all the packages that require this one require this version, and it has become a UX nightmare to have a proton VPN dep in terra-extras for users on Nobara/Fedora and Fedora->Ultramarine conversions.