### PR TITLE
[el10] chore: bring proton-core out of extras (#13028)

### DIFF
--- a/anda/langs/python/proton-core/anda.hcl
+++ b/anda/langs/python/proton-core/anda.hcl
@@ -3,7 +3,4 @@ project pkg {
   rpm {
     spec = "proton-core.spec"
   }
-  labels {
-    subrepo = "extras"
-  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: bring proton-core out of extras (#13028)](https://github.com/terrapkg/packages/pull/13028)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)