### PR TITLE
[f44] chore (libaudec): add update script (#13050)

### DIFF
--- a/anda/lib/audec/update.rhai
+++ b/anda/lib/audec/update.rhai
@@ -1,0 +1,1 @@
+print(sourcehut("~alextee/libaudec"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (libaudec): add update script (#13050)](https://github.com/terrapkg/packages/pull/13050)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)