### PR TITLE
[f44] chore (nirius): add update script (#13049)

### DIFF
--- a/anda/desktops/niri/nirius/update.rhai
+++ b/anda/desktops/niri/nirius/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(sourcehut("~tsdh/nirius"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (nirius): add update script (#13049)](https://github.com/terrapkg/packages/pull/13049)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)