### PR TITLE
[f42] chore (senpai): use sourcehut update script (#13048)

### DIFF
--- a/anda/misc/senpai/update.rhai
+++ b/anda/misc/senpai/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh_tag("delthas/senpai"));
+rpm.version(sourcehut("~delthas/senpai"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (senpai): use sourcehut update script (#13048)](https://github.com/terrapkg/packages/pull/13048)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)