### PR TITLE
[f44] fix(signal-desktop): fix license name conflicts (#13072)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -74,6 +74,7 @@ popd
 echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt
 
 %install
+mv ./packages/mute-state-change/LICENSE ./packages/mute-state-change/LICENSE.mute-state-change
 %electron_install -i signal -l -I build/icons/png
 
 %desktop_file_install %{SOURCE1}
@@ -83,13 +84,15 @@ install -Dm644 $OUTDIR/resources/$policy %{buildroot}%{_datadir}/polkit-1/rules.
 rm $OUTDIR/resources/$policy
 done
 
+mv LICENSE LICENSE.signal-desktop
+
 %terra_appstream -o %{SOURCE2}
 
 %check
 %desktop_file_validate %{buildroot}%{_appsdir}/signal.desktop
 
 %files
-%license LICENSE
+%license LICENSE.signal-desktop
 %doc README.md CONTRIBUTING.md ACKNOWLEDGMENTS.md
 %license bundled_licenses/*
 %{_bindir}/signal-desktop
@@ -101,6 +104,9 @@ done
 %{_metainfodir}/org.signal.Signal.metainfo.xml
 
 %changelog
+* Sun Jun 14 2026 june-fish <git@june.fish>
+- Fix license name conflicts
+
 * Mon Dec 22 2025 Owen Zimmerman <owen@fyralabs.com>
 - Use more electron macros, correct build failures
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(signal-desktop): fix license name conflicts (#13072)](https://github.com/terrapkg/packages/pull/13072)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)