### PR TITLE
[el10] add: ansible-collection-onepassword-connect and ansible-collections/ folder (#13063)

### DIFF
--- a/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/anda.hcl
+++ b/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+	rpm {
+		spec = "ansible-onepasswordconnect-collection.spec"
+	}
+}

--- a/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/ansible-onepasswordconnect-collection.spec
+++ b/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/ansible-onepasswordconnect-collection.spec
@@ -1,0 +1,52 @@
+%if %{defined fedora}
+%bcond_without tests
+%else
+%bcond_with tests
+%endif
+
+Name:           ansible-collection-onepassword-connect
+Version:        2.4.0
+Release:        1%{?dist}
+Summary:        Contains modules that interact with your 1Password Connect deployment
+License:        GPL-3.0-or-later
+URL:            %{ansible_collection_url onepassword connect}
+Source0:        https://github.com/1Password/ansible-onepasswordconnect-collection/archive/refs/tags/v%{version}.tar.gz
+Patch0:         doc-files.patch
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  ansible-packaging
+%if %{with tests}
+BuildRequires:  ansible-packaging-tests
+%endif
+
+BuildArch:      noarch
+
+%description
+The 1Password Connect collection contains modules that interact
+with your 1Password Connect deployment. The modules communicate
+with the 1Password Connect API to support Vault Item
+create/read/update/delete operations.
+
+%prep
+%autosetup -n ansible-onepasswordconnect-collection-%{version} -p1
+# https://docs.fedoraproject.org/en-US/packaging-guidelines/Ansible_collections/#_shebangs
+find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{}' +
+
+%build
+%ansible_collection_build
+
+%install
+%ansible_collection_install
+
+%if %{with tests}
+%check
+%ansible_test_unit
+%endif
+
+%files -f %{ansible_collection_filelist}
+%license LICENSE.md
+%doc CHANGELOG.md README.md USAGEGUIDE.md CHANGELOG.rst
+
+%changelog
+* Sun Jun 14 2026 Owen Zimmerman <owen@fyralabs.com> - 2.4.0-1
+- Initial commit

--- a/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/doc-files.patch
+++ b/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/doc-files.patch
@@ -1,0 +1,10 @@
+diff --git a/galaxy.yml b/galaxy.yml
+index f068ebc..6ef0f71 100644
+--- a/galaxy.yml
++++ b/galaxy.yml
+@@ -31,4 +31,4 @@ issues: https://github.com/1Password/ansible-onepasswordconnect-collection/issue
+ 
+ # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
+ # artifact.
+-build_ignore: [scripts, .venv, venv, .*, tests]
++build_ignore: [.md, .rst, scripts, .venv, venv, .*, tests]

--- a/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/update.rhai
+++ b/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("1Password/ansible-onepasswordconnect-collection"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: ansible-collection-onepassword-connect and ansible-collections/ folder (#13063)](https://github.com/terrapkg/packages/pull/13063)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)