### PR TITLE
[f42] add: noctalia-greeter (#13019)

### DIFF
--- a/anda/desktops/noctalia-greeter/anda.hcl
+++ b/anda/desktops/noctalia-greeter/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "noctalia-greeter.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/desktops/noctalia-greeter/noctalia-greeter.spec
+++ b/anda/desktops/noctalia-greeter/noctalia-greeter.spec
@@ -1,0 +1,72 @@
+%global ver 1.0.0
+
+%global commit          db60c06b5f6ff5da4d5f1126eff312b2a41ef614
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global commitdate      20260609
+
+Name:   	noctalia-greeter
+Version:	%{ver}^%{commitdate}git.%{shortcommit}
+Release:	1%{?dist}
+Summary:	A minimal login greeter for greetd that matches the look and feel of Noctalia Shell.
+
+License:    shortcommit
+URL:        https://github.com/noctalia-dev/noctalia-greeter
+Source0:    https://github.com/noctalia-dev/noctalia-greeter/archive/%{commit}/noctalia-greeter-%{commit}.tar.gz
+
+BuildRequires:  cage
+BuildRequires:  dbus
+BuildRequires:  gcc-c++
+BuildRequires:  greetd
+BuildRequires:  just
+BuildRequires:  meson
+BuildRequires:  pkgconfig(cairo)
+BuildRequires:  pkgconfig(egl)
+BuildRequires:  pkgconfig(fontconfig)
+BuildRequires:  pkgconfig(freetype2)
+BuildRequires:  pkgconfig(glesv2)
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(librsvg-2.0)
+BuildRequires:  pkgconfig(libwebp)
+BuildRequires:  pkgconfig(pango)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-protocols)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  polkit
+BuildRequires:  wlr-randr
+
+Requires:       cage
+Requires:       dbus
+Requires:       greetd
+
+Packager:       Cypress Reed <cypress@fyralabs.com>
+
+%description
+Noctalia Greeter is the screen you see before your desktop session starts.
+It lets you pick a user, enter your password, choose a Wayland session, and pick a color scheme - with the same visual language as Noctalia Shell.
+
+%prep
+%autosetup -n noctalia-greeter-%{commit}
+
+%conf
+export LDFLAGS="%{__global_ldflags} -Wl,-z,notext"
+%meson
+
+%build
+%meson_build
+
+%install
+%meson_install
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}
+%{_bindir}/%{name}-apply-appearance
+%{_bindir}/%{name}-print-greetd-config
+%{_bindir}/%{name}-session
+%{_datadir}/%{name}/*
+%{_datadir}/polkit-1/actions/org.noctalia.greeter.apply-appearance.policy
+
+%changelog
+* Tue Jun 09 2026 Cypress Reed <cypress@fyralabs.com>
+- Port to terra from Fedora COPR lionheartp/Hyprland

--- a/anda/desktops/noctalia-greeter/update.rhai
+++ b/anda/desktops/noctalia-greeter/update.rhai
@@ -1,0 +1,6 @@
+rpm.global("commit", get("https://api.github.com/repos/noctalia-dev/noctalia-greeter/commits/main").json().sha);
+if rpm.changed() {
+        rpm.global("ver", gh("noctalia-dev/noctalia-greeter"));
+        rpm.global("commit_date", date());
+        rpm.release();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: noctalia-greeter (#13019)](https://github.com/terrapkg/packages/pull/13019)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)