### PR TITLE
[f43] add: linsh (#13097)

### DIFF
--- a/anda/devs/linsh/anda.hcl
+++ b/anda/devs/linsh/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "linsh.spec"
+  }
+}

--- a/anda/devs/linsh/linsh.spec
+++ b/anda/devs/linsh/linsh.spec
@@ -1,0 +1,32 @@
+Name:          linsh
+Version:       0.02
+Release:       1%{?dist}
+Summary:       Linux shell
+License:       GPL-2.0-or-later
+URL:           https://github.com/maxskiier/linsh
+Source0:       %{url}/archive/refs/tags/v%{version}.tar.gz
+Packager:      Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires: make
+BuildRequires: gcc
+
+%description
+%{summary}.
+
+%prep
+%autosetup
+
+%build
+%make_build CC="%__cc %build_cflags %build_ldflags"
+
+%install
+install -Dm755 linsh %{buildroot}%{_bindir}/linsh
+
+%files
+%license LICENSE
+%doc README.txt
+%{_bindir}/linsh
+
+%changelog
+* Mon Jun 15 2026 Owen Zimmerman <owen@fyralabs.com> - 0.02-1
+- Initial package

--- a/anda/devs/linsh/update.rhai
+++ b/anda/devs/linsh/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("maxskiier/linsh"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: linsh (#13097)](https://github.com/terrapkg/packages/pull/13097)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)