### PR TITLE
[f43] [backport] fix(plasma6-applet-appgrid): sync deps with upstream (#13095) (#13134)

### DIFF
--- a/anda/desktops/kde/plasma6-applet-appgrid/plasma6-applet-appgrid.spec
+++ b/anda/desktops/kde/plasma6-applet-appgrid/plasma6-applet-appgrid.spec
@@ -1,7 +1,7 @@
 Name:           plasma6-applet-appgrid
-Version:        1.8.5
+Version:        1.9.1
 Release:        2%{?dist}
-Summary:        A modern fullscreen application launcher for KDE Plasma
+Summary:        A modern application launcher for KDE Plasma
 # Main code: GPL-2.0-or-later
 # dev.xarbit.appgrid.metainfo.xml: CC0-1.0
 License:        GPL-2.0-or-later AND CC0-1.0
@@ -17,23 +17,27 @@ BuildRequires:  kf6-rpm-macros
 BuildRequires:  cmake(Qt6Quick)
 BuildRequires:  cmake(Qt6Gui)
 BuildRequires:  cmake(Qt6DBus)
+BuildRequires:  cmake(KF6Config)
 BuildRequires:  cmake(KF6Service)
 BuildRequires:  cmake(KF6I18n)
 BuildRequires:  cmake(KF6CoreAddons)
 BuildRequires:  cmake(KF6KIO)
 BuildRequires:  cmake(KF6WindowSystem)
-BuildRequires:  cmake(KF6Package)
 BuildRequires:  cmake(KF6Runner)
+BuildRequires:  cmake(KF6IconThemes)
+BuildRequires:  cmake(KF6GlobalAccel)
+BuildRequires:  cmake(KF6Svg)
 BuildRequires:  cmake(Plasma)
 BuildRequires:  cmake(PlasmaQuick)
 BuildRequires:  cmake(LayerShellQt)
-BuildRequires:  cmake(KF6IconThemes)
 BuildRequires:  cmake(PlasmaActivities)
-BuildRequires:  cmake(LibKWorkspace)
+BuildRequires:  cmake(PlasmaActivitiesStats)
+BuildRequires:  cmake(AppStreamQt)
 
 Requires:       plasma-workspace
 Requires:       plasma-desktop
 Requires:       kf6-kiconthemes
+Requires:       kf6-ksvg
 
 %description
 A modern application launcher for KDE Plasma. It offers unified
@@ -41,7 +45,7 @@ search, favorites, categories, and both a panel and a centered popup
 presentation.
 
 %prep
-%autosetup -n plasma6-applet-appgrid-%{version}
+%autosetup -n %{name}-%{version}
 
 %conf
 %cmake -DAPPGRID_VERSION_OVERRIDE=%{version}
@@ -51,19 +55,20 @@ presentation.
 
 %install
 %cmake_install
-%find_lang dev.xarbit.appgrid --with-kde
+%find_lang dev.xarbit.appgrid
 
 %files -f dev.xarbit.appgrid.lang
 %license LICENSE
 %doc README.md
-%{_libdir}/qt6/plugins/plasma/applets/dev.xarbit.appgrid.so
-%{_libdir}/qt6/plugins/plasma/applets/dev.xarbit.appgrid.panel.so
-%{_datadir}/plasma/plasmoids/dev.xarbit.appgrid/
-%{_datadir}/plasma/plasmoids/dev.xarbit.appgrid.panel/
+%{_qt6_plugindir}/plasma/applets/dev.xarbit.appgrid.so
+%{_qt6_plugindir}/plasma/applets/dev.xarbit.appgrid.panel.so
 %{_metainfodir}/dev.xarbit.appgrid.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/dev.xarbit.appgrid.svg
 
 %changelog
+* Mon Jun 15 2026 hilltty <49129010+hilltty@users.noreply.github.com> - 1.9.1-2
+- Sync with upstream
+
 * Fri May 29 2026 hilltty <49129010+hilltty@users.noreply.github.com> - 1.8.5-1
 - pass version to cmake, update description
 
@@ -76,5 +81,5 @@ presentation.
 * Sat Apr 25 2026 hilltty <49129010+hilltty@users.noreply.github.com> - 1.7.8-1
 - Update to 1.7.8
 
-* Thu Apr 24 2026 hilltty <49129010+hilltty@users.noreply.github.com> - 1.2.1-1
+* Fri Apr 24 2026 hilltty <49129010+hilltty@users.noreply.github.com> - 1.2.1-1
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `f44` to `f43`:
 - [[backport] fix(plasma6-applet-appgrid): sync deps with upstream (#13095) (#13134)](https://github.com/terrapkg/packages/pull/13134)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)