### PR TITLE
[f44] fix: LCEVdec (#13133)

### DIFF
--- a/anda/multimedia/LCEVCdec/LCEVCdec.spec
+++ b/anda/multimedia/LCEVCdec/LCEVCdec.spec
@@ -123,42 +123,33 @@ python3 src/func_tests/run_tests.py
 %doc README.md
 %{_libdir}/liblcevc_dec_api.so.4
 %{_libdir}/liblcevc_dec_api.so.%{version}
-%{_libdir}/liblcevc_dec_legacy.so.1
 %{_libdir}/liblcevc_dec_pipeline_cpu.so.1
-%{_libdir}/liblcevc_dec_pipeline_legacy.so.1
 
 %files devel
 %{_includedir}/LCEVC
 %{_libdir}/liblcevc_dec_api.so
-%{_libdir}/liblcevc_dec_legacy.so
 %{_libdir}/liblcevc_dec_pipeline_cpu.so
-%{_libdir}/liblcevc_dec_pipeline_legacy.so
+%{_libdir}/pkgconfig/lcevc_dec.pc
+%{_libdir}/pkgconfig/lcevc_dec_extract.pc
+%{_libdir}/pkgconfig/lcevc_dec_utility.pc
+
 # Static:
 %{_libdir}/liblcevc_dec_api_utility.a
-%{_libdir}/liblcevc_dec_common.a
-%{_libdir}/liblcevc_dec_enhancement.a
 %{_libdir}/liblcevc_dec_extract.a
-%{_libdir}/liblcevc_dec_pipeline.a
-%{_libdir}/liblcevc_dec_pixel_processing.a
-%{_libdir}/liblcevc_dec_sequencer.a
 %{_libdir}/liblcevc_dec_unit_test_utilities.a
 %{_libdir}/liblcevc_dec_utility.a
-%{_libdir}/pkgconfig/lcevc_dec.pc
 
 %files samples
 %{_bindir}/lcevc_dec_common_test_unit
 %{_bindir}/lcevc_dec_enhancement_sample
 %{_bindir}/lcevc_dec_enhancement_test_unit
-%{_bindir}/lcevc_dec_legacy_test_unit
 %{_bindir}/lcevc_dec_pipeline_cpu_test_unit
-%{_bindir}/lcevc_dec_pipeline_legacy_test_unit
 %{_bindir}/lcevc_dec_pipeline_test_unit
 %{_bindir}/lcevc_dec_pixel_processing_test_unit
 %{_bindir}/lcevc_dec_sample
 %{_bindir}/lcevc_dec_test_harness
 %{_bindir}/lcevc_dec_test_unit
 %{_bindir}/lcevc_dec_utility_test_unit
-%{_bindir}/lcevc_sequencer_test_unit
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: LCEVdec (#13133)](https://github.com/terrapkg/packages/pull/13133)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)