### PR TITLE
[el10] add 1Password and 1Password CLI (#13171)

### DIFF
--- a/anda/apps/1password-cli/1password-cli.spec
+++ b/anda/apps/1password-cli/1password-cli.spec
@@ -1,0 +1,49 @@
+%global debug_package %{nil}
+
+%ifarch x86_64
+%global op_arch amd64
+%elifarch aarch64
+%global op_arch arm64
+%endif
+
+Name:           1password-cli
+Version:        2.34.1
+Release:        1%{?dist}
+Summary:        1Password command-line tool
+
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+License:        LicenseRef-1Password-Proprietary
+URL:            https://developer.1password.com/docs/cli/
+Source0:        https://cache.agilebits.com/dist/1P/op2/pkg/v%{version}/op_linux_%{op_arch}_v%{version}.zip
+Source1:        1password-cli.sysusers
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  unzip
+Recommends:     1password
+Recommends:     polkit
+
+%description
+1Password CLI brings 1Password to your terminal.
+
+%prep
+%autosetup -c
+
+%build
+
+%install
+install -Dm0755 op %{buildroot}%{_bindir}/op
+chmod 2755 %{buildroot}%{_bindir}/op
+install -Dm0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/%{name}.conf
+
+%pre
+%sysusers_create_package %{name} %{SOURCE1}
+
+%files
+%attr(2755,root,onepassword-cli) %{_bindir}/op
+%{_sysusersdir}/%{name}.conf
+
+%changelog
+* Fri Jun 19 2026 Cappy Ishihara <cappy@cappuchino.xyz>
+- Initial Package

--- a/anda/apps/1password-cli/1password-cli.sysusers
+++ b/anda/apps/1password-cli/1password-cli.sysusers
@@ -1,0 +1,1 @@
+g onepassword-cli -

--- a/anda/apps/1password-cli/anda.hcl
+++ b/anda/apps/1password-cli/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64", "aarch64"]
+	rpm {
+		spec = "1password-cli.spec"
+	}
+}

--- a/anda/apps/1password-cli/update.rhai
+++ b/anda/apps/1password-cli/update.rhai
@@ -1,0 +1,37 @@
+let html = get("https://app-updates.agilebits.com/product_history/CLI2");
+let versions = [];
+
+for matches in find_all(`op_linux_amd64_v([\d]+\.[\d]+\.[\d]+)\.zip`, html) {
+    versions += matches[1];
+}
+
+versions.dedup();
+
+let latest = "";
+let latest_major = 0;
+let latest_minor = 0;
+let latest_patch = 0;
+
+for version in versions {
+    let parts = version.split(".");
+    let major = parts[0].parse_int();
+    let minor = parts[1].parse_int();
+    let patch = parts[2].parse_int();
+
+    if latest == "" ||
+        major > latest_major ||
+        major == latest_major && minor > latest_minor ||
+        major == latest_major && minor == latest_minor && patch > latest_patch {
+        latest = version;
+        latest_major = major;
+        latest_minor = minor;
+        latest_patch = patch;
+    }
+}
+
+if latest == "" {
+    print("E: no 1Password CLI version found");
+    terminate();
+}
+
+rpm.version(latest);

--- a/anda/apps/1password/1password.spec
+++ b/anda/apps/1password/1password.spec
@@ -1,0 +1,105 @@
+%global debug_package %{nil}
+%global policy_owners unix-group:wheel
+%global appdir %{_datadir}/1password
+
+%ifarch x86_64
+%global tararch x64
+%elifarch aarch64
+%global tararch arm64
+%endif
+
+Name:           1password
+Version:        8.12.24
+Release:        1%{?dist}
+Summary:        Password manager and secure wallet
+
+Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+License:        LicenseRef-1Password-Proprietary
+URL:            https://1password.com
+Source0:        https://downloads.1password.com/linux/tar/stable/%{_arch}/%{name}-%{version}.%{tararch}.tar.gz
+Source1:        https://downloads.1password.com/linux/tar/stable/%{_arch}/%{name}-%{version}.%{tararch}.tar.gz.sig
+Source2:        1password.sysusers
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  desktop-file-utils
+BuildRequires:  systemd-rpm-macros
+Requires:       desktop-file-utils
+Requires:       gtk3
+Requires:       hicolor-icon-theme
+Requires:       nss
+Requires:       polkit
+Requires:       xdg-utils
+
+%description
+%{summary}
+
+%prep
+%autosetup -n %{name}-%{version}.%{tararch}
+
+
+%build
+
+%install
+# Install icons
+install -Dm0644 resources/icons/hicolor/32x32/apps/1password.png -t %{buildroot}%{_datadir}/icons/hicolor/32x32/apps/
+install -Dm0644 resources/icons/hicolor/64x64/apps/1password.png -t %{buildroot}%{_datadir}/icons/hicolor/64x64/apps/
+install -Dm0644 resources/icons/hicolor/256x256/apps/1password.png -t %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/
+install -Dm0644 resources/icons/hicolor/512x512/apps/1password.png -t %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/
+
+sed 's|${POLICY_OWNERS}|%{policy_owners}|g' \
+  com.1password.1Password.policy.tpl > com.1password.1Password.policy
+install -Dm0644 com.1password.1Password.policy -t %{buildroot}%{_datadir}/polkit-1/actions/
+install -Dm0644 resources/custom_allowed_browsers -t %{buildroot}%{_sysconfdir}/1password/
+install -Dm0644 resources/custom_allowed_browsers -t %{buildroot}%{_datadir}/doc/1password/examples/
+sed -i 's|^Exec=/opt/1Password/1password|Exec=%{_bindir}/1password|' resources/1password.desktop
+desktop-file-install --dir=%{buildroot}%{_datadir}/applications resources/1password.desktop
+install -Dm0644 %{SOURCE2} %{buildroot}%{_sysusersdir}/%{name}.conf
+
+# Install application payload under /usr for immutable-system compatibility.
+mkdir -p %{buildroot}%{appdir}
+cp -a . %{buildroot}%{appdir}/
+rm -f %{buildroot}%{appdir}/com.1password.1Password.policy \
+  %{buildroot}%{appdir}/com.1password.1Password.policy.tpl \
+  %{buildroot}%{appdir}/after-install.sh \
+  %{buildroot}%{appdir}/after-remove.sh \
+  %{buildroot}%{appdir}/install.sh \
+  %{buildroot}%{appdir}/install_biometrics_policy.sh
+
+mkdir -p %{buildroot}%{_bindir}
+ln -sr %{buildroot}%{appdir}/%{name} %{buildroot}%{_bindir}/%{name}
+chmod 4755 %{buildroot}%{appdir}/chrome-sandbox
+chmod 2755 %{buildroot}%{appdir}/1Password-BrowserSupport
+if [ -f %{buildroot}%{appdir}/onepassword-mcp ]; then
+  chmod 2755 %{buildroot}%{appdir}/onepassword-mcp
+fi
+find %{buildroot}%{appdir} -type f \
+  ! -name chrome-sandbox \
+  ! -name 1Password-BrowserSupport \
+  ! -name onepassword-mcp \
+  -printf '/%%P\n' | sed "s|^/|%{appdir}/|" > app.files
+
+%pre
+%sysusers_create_package %{name} %{SOURCE2}
+
+%files -f app.files
+%{_bindir}/%{name}
+%dir %{appdir}
+%attr(4755,root,root) %{appdir}/chrome-sandbox
+%attr(2755,root,onepassword) %{appdir}/1Password-BrowserSupport
+%attr(2755,root,onepassword-mcp) %{appdir}/onepassword-mcp
+%{_datadir}/icons/hicolor/32x32/apps/1password.png
+%{_datadir}/icons/hicolor/64x64/apps/1password.png
+%{_datadir}/icons/hicolor/256x256/apps/1password.png
+%{_datadir}/icons/hicolor/512x512/apps/1password.png
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/polkit-1/actions/com.1password.1Password.policy
+%{_sysusersdir}/%{name}.conf
+%config(noreplace) %{_sysconfdir}/1password/custom_allowed_browsers
+%{_datadir}/doc/1password/
+
+
+
+%changelog
+* Fri Jun 19 2026 Cappy Ishihara <cappy@cappuchino.xyz>
+- Initial Package

--- a/anda/apps/1password/1password.sysusers
+++ b/anda/apps/1password/1password.sysusers
@@ -1,0 +1,2 @@
+g onepassword -
+g onepassword-mcp -

--- a/anda/apps/1password/anda.hcl
+++ b/anda/apps/1password/anda.hcl
@@ -1,0 +1,7 @@
+project pkg {
+	arches = ["x86_64", "aarch64"]
+	rpm {
+		spec = "1password.spec"
+	}
+
+}

--- a/anda/apps/1password/update.rhai
+++ b/anda/apps/1password/update.rhai
@@ -1,0 +1,36 @@
+let xml = get("https://releases.1password.com/linux/stable/index.xml");
+
+let latest = "";
+let latest_major = 0;
+let latest_minor = 0;
+let latest_patch = 0;
+
+for title in find_all(`<title>[^<]*</title>`, xml) {
+    let matches = find_all(`[\d]+\.[\d]+\.[\d]+`, title[0]);
+    if matches.len() == 0 {
+        continue;
+    }
+
+    let version = matches[0][0];
+    let parts = version.split(".");
+    let major = parts[0].parse_int();
+    let minor = parts[1].parse_int();
+    let patch = parts[2].parse_int();
+
+    if latest == "" ||
+        major > latest_major ||
+        major == latest_major && minor > latest_minor ||
+        major == latest_major && minor == latest_minor && patch > latest_patch {
+        latest = version;
+        latest_major = major;
+        latest_minor = minor;
+        latest_patch = patch;
+    }
+}
+
+if latest == "" {
+    print("E: no 1Password version found");
+    terminate();
+}
+
+rpm.version(latest);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add 1Password and 1Password CLI (#13171)](https://github.com/terrapkg/packages/pull/13171)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)