### PR TITLE
[f43] fix(gstreamer1-plugin-libav): remove `AUTHORS` & `NEWS` (#13189)

### DIFF
--- a/anda/multimedia/gstreamer1/gstreamer1-plugin-libav/gstreamer1-plugin-libav.spec
+++ b/anda/multimedia/gstreamer1/gstreamer1-plugin-libav/gstreamer1-plugin-libav.spec
@@ -48,7 +48,7 @@ find %{buildroot} -name "*.la" -delete
 
 %files
 %license COPYING
-%doc AUTHORS NEWS README.md
+%doc README.md
 %{_libdir}/gstreamer-1.0/libgstlibav.so
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(gstreamer1-plugin-libav): remove `AUTHORS` & `NEWS` (#13189)](https://github.com/terrapkg/packages/pull/13189)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)