### PR TITLE
[f42] fix: use %terra_crates_source (#13207)

### DIFF
--- a/anda/buildsys/mise/rust-mise.spec
+++ b/anda/buildsys/mise/rust-mise.spec
@@ -11,7 +11,7 @@ Summary:        Front-end to your dev env
 
 License:        MIT
 URL:            https://crates.io/crates/mise
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Source1:        https://raw.githubusercontent.com/jdx/mise/refs/tags/v%version/man/man1/mise.1
 Source2:        https://raw.githubusercontent.com/jdx/mise/refs/tags/v%version/completions/mise.bash
 Source3:        https://raw.githubusercontent.com/jdx/mise/refs/tags/v%version/completions/mise.fish

--- a/anda/desktops/waylands/matugen/rust-matugen.spec
+++ b/anda/desktops/waylands/matugen/rust-matugen.spec
@@ -8,7 +8,7 @@ Summary:        Material you color generation tool with templates
 
 License:        GPL-2.0-or-later
 URL:            https://crates.io/crates/matugen
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Source1:        https://raw.githubusercontent.com/InioX/matugen/refs/tags/v%version/README.md
 Source2:        https://raw.githubusercontent.com/InioX/matugen/refs/tags/v%version/CHANGELOG.md
 Source3:        https://raw.githubusercontent.com/InioX/matugen/refs/tags/v%version/LICENSE

--- a/anda/desktops/waylands/niri-taskbar/rust-niri-taskbar.spec
+++ b/anda/desktops/waylands/niri-taskbar/rust-niri-taskbar.spec
@@ -11,7 +11,7 @@ Summary:        Niri taskbar module for Waybar
 
 License:        MIT
 URL:            https://crates.io/crates/niri-taskbar
-Source:         %{crates_source %{crate} %{crate_version}}
+Source:         https://static.crates.io/crates/%{crate}/%{crate}-%{crate_version}.crate
 # Automatically generated patch to strip dependencies and normalize metadata
 Patch:          niri-taskbar-fix-metadata-auto.diff
 

--- a/anda/devs/atac/atac.spec
+++ b/anda/devs/atac/atac.spec
@@ -12,7 +12,7 @@ Summary:        Arguably a Terminal API Client
 
 License:        MIT
 URL:            https://crates.io/crates/atac
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 Packager:       xiaoshihou <xiaoshihou@tutamail.com>
 BuildRequires:  anda-srpm-macros cargo-rpm-macros mold

--- a/anda/devs/create-tauri-app/create-tauri-app.spec
+++ b/anda/devs/create-tauri-app/create-tauri-app.spec
@@ -6,7 +6,7 @@ Release:        1%{?dist}
 Summary:        Rapidly scaffold out a new tauri app project
 License:        Apache-2.0 OR MIT
 URL:            https://crates.io/crates/create-tauri-app
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  mold

--- a/anda/devs/deno/rust-deno.spec
+++ b/anda/devs/deno/rust-deno.spec
@@ -12,7 +12,7 @@ Summary:        Deno executable
 
 License:        MIT
 URL:            https://crates.io/crates/deno
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Source1:        https://raw.githubusercontent.com/denoland/deno/refs/tags/v%version/LICENSE.md
 Source2:        gcc-wrapper.sh
 Source3:        land.deno.deno.metainfo.xml

--- a/anda/devs/git-biance/git-biance.spec
+++ b/anda/devs/git-biance/git-biance.spec
@@ -7,7 +7,7 @@ Summary:        Visualize code contributions in a GitHub-style graph.
 
 License:        GPL-3.0
 URL:            https://crates.io/crates/git-biance
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 Packager:       xiaoshihou <xiaoshihou@tutamail.com>
 BuildRequires:  anda-srpm-macros cargo-rpm-macros mold

--- a/anda/devs/lowfi/rust-lowfi.spec
+++ b/anda/devs/lowfi/rust-lowfi.spec
@@ -8,7 +8,7 @@ Summary:        Extremely simple lofi player
 
 License:        MIT
 URL:            https://crates.io/crates/lowfi
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 Packager:       sadlerm <lerm@chromebooks.lol>
 

--- a/anda/devs/neovide/neovide.spec
+++ b/anda/devs/neovide/neovide.spec
@@ -8,7 +8,7 @@ Summary:        No Nonsense Neovim Client in Rust
 
 License:        MIT
 URL:            https://crates.io/crates/neovide
-Source0:        %{crates_source}
+Source0:        %{terra_crates_source}
 Source1:        %{raw_forgeurl}/%{version}/assets/%{crate}-16x16.png
 Source2:        %{raw_forgeurl}/%{version}/assets/%{crate}-32x32.png
 Source3:        %{raw_forgeurl}/%{version}/assets/%{crate}-48x48.png

--- a/anda/games/2048-rs/rust-game-2048.spec
+++ b/anda/games/2048-rs/rust-game-2048.spec
@@ -10,7 +10,7 @@ Summary:        Cli implementation of the popular 2048 game writen in rust
 
 License:        MIT
 URL:            https://crates.io/crates/game-2048
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  anda-srpm-macros rust-packaging >= 21
 

--- a/anda/games/chess-tui/rust-chess-tui.spec
+++ b/anda/games/chess-tui/rust-chess-tui.spec
@@ -10,7 +10,7 @@ Summary:        Rusty chess game in your terminal 🦀
 
 License:        MIT
 URL:            https://crates.io/crates/chess-tui
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  pkgconfig(openssl)

--- a/anda/games/typeracer/rust-typeracer.spec
+++ b/anda/games/typeracer/rust-typeracer.spec
@@ -12,7 +12,7 @@ Summary:        Terminal typing game
 
 License:        GPL-3.0
 URL:            https://crates.io/crates/typeracer
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  perl openssl-devel anda-srpm-macros rust-packaging >= 21 mold
 

--- a/anda/games/umu-wrapper/rust-umu-wrapper.spec
+++ b/anda/games/umu-wrapper/rust-umu-wrapper.spec
@@ -10,7 +10,7 @@ Summary:        Simplified wrapper for UMU-Launcher
 
 License:        MIT
 URL:            https://crates.io/crates/umu-wrapper
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  mold anda-srpm-macros rust-packaging >= 21
 

--- a/anda/langs/rust/bacon/rust-bacon.spec
+++ b/anda/langs/rust/bacon/rust-bacon.spec
@@ -12,7 +12,7 @@ Packager:       metcya <metcya@gmail.com>
 
 License:        AGPL-3.0
 URL:            https://crates.io/crates/bacon
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  anda-srpm-macros 
 BuildRequires:  mold

--- a/anda/langs/rust/bandwhich/rust-bandwhich.spec
+++ b/anda/langs/rust/bandwhich/rust-bandwhich.spec
@@ -11,7 +11,7 @@ Summary:        Display current network utilization by process, connection and r
 
 License:        MIT
 URL:            https://crates.io/crates/bandwhich
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 # Automatically generated patch to strip dependencies and normalize metadata
 Patch:          bandwhich-fix-metadata-auto.diff
 

--- a/anda/langs/rust/bottom/rust-bottom.spec
+++ b/anda/langs/rust/bottom/rust-bottom.spec
@@ -11,7 +11,7 @@ Summary:        Customizable cross-platform graphical process/system monitor for
 
 License:        MIT
 URL:            https://crates.io/crates/bottom
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 # Automatically generated patch to strip dependencies and normalize metadata
 Patch:          bottom-fix-metadata-auto.diff
 

--- a/anda/langs/rust/dysk/rust-dysk.spec
+++ b/anda/langs/rust/dysk/rust-dysk.spec
@@ -10,7 +10,7 @@ Summary:        Give information on mounted filesystems
 
 License:        MIT
 URL:            https://crates.io/crates/dysk
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Packager:       madonuko <mado@fyralabs.com>
 
 BuildRequires:  cargo-rpm-macros >= 24

--- a/anda/langs/rust/eza/rust-eza.spec
+++ b/anda/langs/rust/eza/rust-eza.spec
@@ -10,7 +10,7 @@ Summary:        Modern replacement for ls
 
 License:        EUPL-1.2
 URL:            https://crates.io/crates/eza
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 # Automatically generated patch to strip dependencies and normalize metadata
 Patch:          eza-fix-metadata-auto.diff
 

--- a/anda/langs/rust/felix/rust-felix.spec
+++ b/anda/langs/rust/felix/rust-felix.spec
@@ -9,7 +9,7 @@ Summary:        Tui file manager with vim-like key mapping
 
 License:        MIT
 URL:            https://crates.io/crates/felix
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  anda-srpm-macros rust-packaging >= 21 mold
 

--- a/anda/langs/rust/gitoxide/rust-gitoxide.spec
+++ b/anda/langs/rust/gitoxide/rust-gitoxide.spec
@@ -11,7 +11,7 @@ Summary:        Command-line application for interacting with git repositories
 
 License:        MIT OR Apache-2.0
 URL:            https://crates.io/crates/gitoxide
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  openssl-devel-engine cmake anda-srpm-macros rust-packaging >= 21 mold
 

--- a/anda/langs/rust/gping/rust-gping.spec
+++ b/anda/langs/rust/gping/rust-gping.spec
@@ -12,7 +12,7 @@ Summary:        Ping, but with a graph
 
 License:        MIT
 URL:            https://crates.io/crates/gping
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Source1:        https://github.com/orf/gping/blob/gping-v%version/LICENSE
 
 BuildRequires:  anda-srpm-macros rust-packaging >= 21 mold

--- a/anda/langs/rust/jellyfin-rpc/rust-jellyfin-rpc-cli.spec
+++ b/anda/langs/rust/jellyfin-rpc/rust-jellyfin-rpc-cli.spec
@@ -11,7 +11,7 @@ Summary:        Displays the content you're currently watching on Discord!
 
 License:        GPL-3.0-or-later
 URL:            https://crates.io/crates/jellyfin-rpc-cli
-Source0:        %{crates_source}
+Source0:        %{terra_crates_source}
 Source1:        https://raw.githubusercontent.com/Radiicall/jellyfin-rpc/%version/LICENSE
 Packager:       madonuko <mado@fyralabs.com>
 

--- a/anda/langs/rust/joshuto/rust-joshuto.spec
+++ b/anda/langs/rust/joshuto/rust-joshuto.spec
@@ -11,7 +11,7 @@ Summary:        Terminal file manager inspired by ranger
 
 License:        LGPL-3.0
 URL:            https://crates.io/crates/joshuto
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  anda-srpm-macros rust-packaging >= 21
 

--- a/anda/langs/rust/koji/rust-koji.spec
+++ b/anda/langs/rust/koji/rust-koji.spec
@@ -11,7 +11,7 @@ Summary:        Interactive CLI for creating conventional commits
 
 License:        MIT
 URL:            https://crates.io/crates/koji
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  cargo-rpm-macros >= 24 anda-srpm-macros
 BuildRequires:  openssl-devel

--- a/anda/langs/rust/kondo-ui/rust-kondo-ui.spec
+++ b/anda/langs/rust/kondo-ui/rust-kondo-ui.spec
@@ -8,7 +8,7 @@ Summary:        Filesystem cleaning tool that recursively searches directories f
 
 License:        MIT
 URL:            https://crates.io/crates/kondo-ui
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  pkgconfig(glib-2.0) pkgconfig(cairo) pkgconfig(cairo-gobject) pkgconfig(gdk-pixbuf-2.0) >= 2.30 pkgconfig(pango) >= 1.36 pkgconfig(atk) >= 2.14
 BuildRequires:  pkgconfig(gdk-3.0) >= 3.22

--- a/anda/langs/rust/ouch/rust-ouch.spec
+++ b/anda/langs/rust/ouch/rust-ouch.spec
@@ -11,7 +11,7 @@ Summary:        Command-line utility for easily compressing and decompressing fi
 
 License:        MIT
 URL:            https://crates.io/crates/ouch
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 # Automatically generated patch to strip dependencies and normalize metadata
 %dnl Patch:          ouch-fix-metadata-auto.diff
 

--- a/anda/langs/rust/starship/rust-starship.spec
+++ b/anda/langs/rust/starship/rust-starship.spec
@@ -10,7 +10,7 @@ Summary:        Minimal, blazing-fast, and infinitely customizable prompt for an
 
 License:        ISC
 URL:            https://crates.io/crates/starship
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros

--- a/anda/langs/rust/tectonic/rust-tectonic.spec
+++ b/anda/langs/rust/tectonic/rust-tectonic.spec
@@ -10,7 +10,7 @@ Summary:        Modernized, complete, embeddable TeX/LaTeX engine
 
 License:        MIT
 URL:            https://crates.io/crates/tectonic
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  pkgconfig(fontconfig) g++ libicu-devel freetype-devel openssl-devel graphite2-devel anda-srpm-macros rust-packaging >= 21
 

--- a/anda/langs/rust/television/rust-television.spec
+++ b/anda/langs/rust/television/rust-television.spec
@@ -11,7 +11,7 @@ Summary:        Very fast, portable and hackable fuzzy finder for the terminal
 
 License:        MIT
 URL:            https://crates.io/crates/television
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 # Automatically generated patch to strip dependencies and normalize metadata
 Patch:          television-fix-metadata-auto.diff
 

--- a/anda/langs/rust/typstyle/rust-typstyle.spec
+++ b/anda/langs/rust/typstyle/rust-typstyle.spec
@@ -10,7 +10,7 @@ Summary:        CLI for Typstyle
 
 License:        Apache-2.0
 URL:            https://crates.io/crates/typstyle
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Source1:        https://raw.githubusercontent.com/typstyle-rs/typstyle/v%{version}/LICENSE
 Packager:       metcya <metcya@gmail.com>
 

--- a/anda/langs/rust/usage/rust-usage-cli.spec
+++ b/anda/langs/rust/usage/rust-usage-cli.spec
@@ -10,7 +10,7 @@ Summary:        CLI for working with usage-based CLIs
 
 License:        MIT
 URL:            https://crates.io/crates/usage-cli
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Source1:        https://raw.githubusercontent.com/jdx/usage/refs/tags/v%version/LICENSE
 Packager:       madonuko <mado@fyralabs.com>
 

--- a/anda/langs/rust/wild/rust-wild-linker.spec
+++ b/anda/langs/rust/wild/rust-wild-linker.spec
@@ -10,7 +10,7 @@ Summary:        Very fast linker for Linux
 
 License:        MIT OR Apache-2.0
 URL:            https://crates.io/crates/wild-linker
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Source1:        https://github.com/davidlattimore/wild/archive/refs/tags/%version.tar.gz
 
 BuildRequires:  cargo-rpm-macros >= 24

--- a/anda/langs/rust/xdvdfs/rust-xdvdfs-cli.spec
+++ b/anda/langs/rust/xdvdfs/rust-xdvdfs-cli.spec
@@ -10,7 +10,7 @@ Summary:        Tool for interacting with XISO/XDVDFS images
 
 License:        MIT
 URL:            https://crates.io/crates/xdvdfs-cli
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 Source1:		https://raw.githubusercontent.com/antangelo/xdvdfs/v%version/LICENSE
 Packager:		madonuko <mado@fyralabs.com>
 

--- a/anda/langs/rust/xplr/rust-xplr.spec
+++ b/anda/langs/rust/xplr/rust-xplr.spec
@@ -10,7 +10,7 @@ Summary:        Hackable, minimal, fast TUI file explorer
 
 License:        MIT
 URL:            https://crates.io/crates/xplr
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  mold

--- a/anda/langs/rust/youki/rust-youki.spec
+++ b/anda/langs/rust/youki/rust-youki.spec
@@ -10,7 +10,7 @@ Summary:        Container runtime written in Rust
 
 License:        None
 URL:            https://crates.io/crates/youki
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  anda-srpm-macros cargo-rpm-macros >= 24
 BuildRequires:  pkg-config

--- a/anda/langs/rust/zellij/rust-zellij.spec
+++ b/anda/langs/rust/zellij/rust-zellij.spec
@@ -11,7 +11,7 @@ Summary:        Terminal workspace with batteries included
 
 License:        MIT
 URL:            https://crates.io/crates/zellij
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 ExclusiveArch:  %{rust_arches}
 

--- a/anda/langs/rust/zoi/rust-zoi-rs.spec
+++ b/anda/langs/rust/zoi/rust-zoi-rs.spec
@@ -10,7 +10,7 @@ Summary:        Universal Package Manager & Environment Setup Tool
 SourceLicense:  Apache-2.0
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND BSL-1.0 AND CDLA-Permissive-2.0 AND ISC AND LGPL-2.0-or-later AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND MPL-2.0+ AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib
 URL:            https://crates.io/crates/zoi-rs
-Source:         %{crates_source %{crate} %{crate_version}}
+Source:         https://static.crates.io/crates/%{crate}/%{crate}-%{crate_version}.crate
 BuildRequires:  cargo
 BuildRequires:  gcc-c++
 BuildRequires:  rpm_macro(cargo_install)

--- a/anda/misc/pokeget/pokeget.spec
+++ b/anda/misc/pokeget/pokeget.spec
@@ -10,7 +10,7 @@ SourceLicense: MIT
 License:       (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND MIT AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 Summary:       A better Rust version of pokeget.
 URL:           https://crates.io/crates/%{crate}
-Source0:       %{crates_source}
+Source0:       %{terra_crates_source}
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo-rpm-macros
 BuildRequires: mold

--- a/anda/terra/sccache/terra-sccache.spec
+++ b/anda/terra/sccache/terra-sccache.spec
@@ -14,7 +14,7 @@ Summary:       Remote caching enabled builds of sccache
 SourceLicense: Apache-2.0 AND (Apache-2.0 OR MIT)
 License:       ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (MIT OR Apache-2.0) AND Unicode-DFS-2016) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CDLA-Permissive-2.0 AND ISC AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
 URL:           https://crates.io/crates/sccache
-Source0:       %{crates_source}
+Source0:       %{terra_crates_source}
 BuildRequires: anda-srpm-macros
 BuildRequires: cargo
 BuildRequires: cargo-rpm-macros

--- a/anda/tools/kanata/rust-kanata.spec
+++ b/anda/tools/kanata/rust-kanata.spec
@@ -10,7 +10,7 @@ Summary:        Multi-layer keyboard customization
 
 License:        LGPL-3.0-only
 URL:            https://crates.io/crates/kanata
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 # Automatically generated patch to strip dependencies and normalize metadata
 Patch:          kanata-fix-metadata-auto.diff
 Packager:       madonuko <mado@fyralabs.com>

--- a/anda/tools/sheldon/sheldon.spec
+++ b/anda/tools/sheldon/sheldon.spec
@@ -10,7 +10,7 @@ Summary:        Fast, configurable, shell plugin manager
 
 License:        MIT OR Apache-2.0
 URL:            https://sheldon.cli.rs
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros

--- a/anda/tools/tauri/tauri.spec
+++ b/anda/tools/tauri/tauri.spec
@@ -7,7 +7,7 @@ Release:        1%{?dist}
 Summary:        Command line interface for building Tauri apps
 License:        Apache-2.0 OR MIT
 URL:            https://crates.io/crates/create-tauri-app
-Source:         %{crates_source}
+Source:         %{terra_crates_source}
 BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  mold

--- a/anda/tools/typos/typos.spec
+++ b/anda/tools/typos/typos.spec
@@ -8,7 +8,7 @@ Summary:        Source Code Spelling Correction
 
 License:        MIT OR Apache-2.0
 URL:            https://crates.io/crates/typos-cli
-Source0:        %{crates_source}
+Source0:        %{terra_crates_source}
 Source1:        https://raw.githubusercontent.com/crate-ci/%{name}/refs/tags/v%{version}/LICENSE-MIT
 Source2:        https://raw.githubusercontent.com/crate-ci/%{name}/refs/tags/v%{version}/LICENSE-APACHE
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: use %terra_crates_source (#13207)](https://github.com/terrapkg/packages/pull/13207)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)