### PR TITLE
[el10] chore (Vicinae): Requires: layer-shell-qt (#13236)

### DIFF
--- a/anda/system/vicinae/vicinae.spec
+++ b/anda/system/vicinae/vicinae.spec
@@ -7,7 +7,7 @@
 Name:           vicinae
 License:        GPL-3.0-or-later
 Version:        0.22.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 URL:            https://docs.vicinae.com
 Source:         https://github.com/vicinaehq/%{name}/archive/refs/tags/v%{version}.tar.gz
 Summary:        A high-performance, native launcher for Linux
@@ -42,6 +42,7 @@ BuildRequires:  xcb-util-keysyms-devel
 BuildRequires:  desktop-file-utils
 
 Requires:       nodejs-npm
+Requires:       layer-shell-qt
 
 %description
 Vicinae (pronounced "vih-SIN-ay") is a high-performance, native launcher for


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (Vicinae): Requires: layer-shell-qt (#13236)](https://github.com/terrapkg/packages/pull/13236)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)