### PR TITLE
[f42] fix(noctalia-git): fix typo in update.rhai so commitdate gets properly bumped (#13251)

### DIFF
--- a/anda/desktops/noctalia-git/update.rhai
+++ b/anda/desktops/noctalia-git/update.rhai
@@ -1,6 +1,6 @@
 rpm.global("commit", get("https://api.github.com/repos/noctalia-dev/noctalia/commits/main").json().sha);
 if rpm.changed() {
         // rpm.global("ver", gh("noctalia-dev/noctalia"));
-        rpm.global("commit_date", date());
+        rpm.global("commitdate", date());
         rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(noctalia-git): fix typo in update.rhai so commitdate gets properly bumped (#13251)](https://github.com/terrapkg/packages/pull/13251)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)