### PR TITLE
[f44] chore (vala-language-server-nightly): use proper license identifier (#13256)

### DIFF
--- a/anda/langs/vala/vala-language-server-nightly/vala-language-server-nightly.spec
+++ b/anda/langs/vala/vala-language-server-nightly/vala-language-server-nightly.spec
@@ -14,7 +14,7 @@ Release:		1%{?dist}
 # The entire source is LGPLv2+, except plugins/gnome-builder/vala_langserv.py, which is GPLv3+.
 # It is not installed when the "plugins" meson option is set to false.
 # Since GNOME Builder 41, the VLS the plugin has been included.
-License:		LGPL-2.0+
+License:		LGPL-2.0-or-later
 
 URL:			https://github.com/vala-lang/vala-language-server
 Source0:		https://github.com/vala-lang/vala-language-server/archive/%{commit}/%{real_name}-%{shortcommit}.tar.gz


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (vala-language-server-nightly): use proper license identifier (#13256)](https://github.com/terrapkg/packages/pull/13256)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)