### PR TITLE
[f43] test (bdf2sfd): use declarative build (#13262)

### DIFF
--- a/anda/tools/bdf2sfd/bdf2sfd.spec
+++ b/anda/tools/bdf2sfd/bdf2sfd.spec
@@ -6,22 +6,13 @@ License:		BSD-2-Clause
 URL:			https://github.com/fcambus/bdf2sfd
 Source0:		%url/archive/refs/tags/%version.tar.gz
 BuildRequires:	cmake gcc
+BuildSystem:  cmake
 
 %description
 bdf2sfd is a BDF to SFD converter, allowing to vectorize bitmap fonts.
 
 It works by converting each pixel of a glyph to a polygon, which produces
 large and unoptimized SFD files that should be post-processed using FontForge.
-
-%prep
-%autosetup
-
-%build
-%cmake
-%cmake_build
-
-%install
-%cmake_install
 
 %files
 %doc README.md ChangeLog AUTHORS THANKS


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [test (bdf2sfd): use declarative build (#13262)](https://github.com/terrapkg/packages/pull/13262)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)