### PR TITLE
[el10] fix: MareTF (#13212)

### DIFF
--- a/anda/tools/MareTF/MareTF.spec
+++ b/anda/tools/MareTF/MareTF.spec
@@ -43,12 +43,15 @@ BuildRequires:  vulkan-headers
 %files
 %doc README.md
 %license LICENSE
+%license %{_defaultlicensedir}/maretf/CREDITS
 %{_bindir}/maretf
 %{_bindir}/maretf_gui
+%{_bindir}/maretf_thumbnailer
 %{_appsdir}/maretf.desktop
 %{_hicolordir}/512x512/apps/maretf.png
 %{_defaultlicensedir}/maretf/LICENSE
 %{_datadir}/mime/packages/maretf.xml
+%{_datadir}/thumbnailers/maretf.thumbnailer
 
 %changelog
 * Sun Mar 15 2026 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: MareTF (#13212)](https://github.com/terrapkg/packages/pull/13212)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)