### PR TITLE
[f44] add desktop file and icon (#13307)

### DIFF
--- a/anda/desktops/noctalia-git/noctalia-git.spec
+++ b/anda/desktops/noctalia-git/noctalia-git.spec
@@ -18,6 +18,7 @@ Source0:	https://github.com/noctalia-dev/noctalia/archive/%{commit}/noctalia-%{c
 BuildRequires:  meson
 BuildRequires:  gcc-c++
 BuildRequires:  git
+BuildRequires:  desktop-file-utils
 BuildRequires:  pipewire-devel
 BuildRequires:  sdbus-cpp-devel
 BuildRequires:  pkgconfig(cairo)
@@ -77,13 +78,21 @@ find third_party -type f \( -name "LICENSE*" -o -name "COPYING*" -o -name "NOTIC
     install -p -m 0644 "$file" "$dest_dir/"
 done
 
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/dev.noctalia.Noctalia.desktop
+
 %files
 %doc README.md
 %license LICENSE
 %{_licensedir}/%{name}/third_party/
 %{_bindir}/noctalia
 %{_datadir}/noctalia/
+%{_appsdir}/dev.noctalia.Noctalia.desktop
+%{_scalableiconsdir}/noctalia.svg
 
 %changelog
+* Wed Jun 24 2026 Cypress Reed <cypress@fyralabs.com>
+- Add desktop file and icon
+
 * Fri Jun 05 2026 Cypress Reed <cypress@fyralabs.com>
 - Port to terra from Fedora COPR lionheartp/Hyprland

--- a/anda/desktops/noctalia-git/noctalia-git.spec
+++ b/anda/desktops/noctalia-git/noctalia-git.spec
@@ -2,9 +2,9 @@
 
 %global ver 5.0.0
 
-%global commit          6b0e16179645e15693efd94f51109d22b199418c
+%global commit          a5eeef13338167fb85ecf8ea7c2fabb4c5536010
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
-%global commitdate      20260608
+%global commitdate      20260623
 
 Name:   	noctalia-git
 Version:	%{ver}^%{commitdate}git.%{shortcommit}

--- a/anda/desktops/noctalia-git/update.rhai
+++ b/anda/desktops/noctalia-git/update.rhai
@@ -1,4 +1,4 @@
-rpm.global("commit", get("https://api.github.com/repos/noctalia-dev/noctalia/commits/main").json().sha);
+rpm.global("commit", gh_commit("noctalia-dev/noctalia"));
 if rpm.changed() {
         // rpm.global("ver", gh("noctalia-dev/noctalia"));
         rpm.global("commitdate", date());


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add desktop file and icon (#13307)](https://github.com/terrapkg/packages/pull/13307)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)