### PR TITLE
[f42] chore: rename noctalia-shell to noctalia-legacy (#12992)

### DIFF
--- a/anda/desktops/noctalia-legacy/anda.hcl
+++ b/anda/desktops/noctalia-legacy/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "noctalia-legacy.spec"
+  }
+}

--- a/anda/desktops/noctalia-legacy/noctalia-legacy.spec
+++ b/anda/desktops/noctalia-legacy/noctalia-legacy.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
-Name:           noctalia-shell
+Name:           noctalia-legacy
 Version:		4.7.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
-URL:            https://github.com/noctalia-dev/noctalia-shell
-Source0:        https://github.com/noctalia-dev/noctalia-shell/releases/download/v%{version}/noctalia-v%{version}.tar.gz
+URL:            https://github.com/noctalia-dev/noctalia
+Source0:        https://github.com/noctalia-dev/noctalia/releases/download/v%{version}/noctalia-v%{version}.tar.gz
 
 Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts
@@ -22,6 +22,8 @@ Recommends:	    matugen
 Recommends:	    power-profiles-daemon
 Recommends:	    wlsunset
 Recommends:    	gpu-screen-recorder
+
+Obsoletes:      noctalia-shell <= 4.7.7-1
 
 Packager:       Cypress Reed <cypress@fyralabs.com>
 
@@ -41,6 +43,10 @@ cp -r ./* %{buildroot}/etc/xdg/quickshell/noctalia-shell/
 %doc README.md
 %license LICENSE
 %{_sysconfdir}/xdg/quickshell/noctalia-shell/
+
+%post
+echo "noctalia-shell has been renamed to noctalia"
+echo "noctalia v5 is coming soon! keep an eye out as this legacy package will become obsolete"
 
 %changelog
 * Thu Jun 04 2026 Cypress Reed <cypress@fyralabs.com>

--- a/anda/desktops/noctalia-legacy/update.rhai
+++ b/anda/desktops/noctalia-legacy/update.rhai
@@ -1,0 +1,6 @@
+let v = gh("noctalia-dev/noctalia");
+v.crop(1);
+
+if v < "5" {
+  rpm.version(v);
+}

--- a/anda/desktops/noctalia-shell/anda.hcl
+++ b/anda/desktops/noctalia-shell/anda.hcl
@@ -1,5 +1,0 @@
-project pkg {
-  rpm {
-    spec = "noctalia-shell.spec"
-  }
-}

--- a/anda/desktops/noctalia-shell/update.rhai
+++ b/anda/desktops/noctalia-shell/update.rhai
@@ -1,6 +1,0 @@
-let v = gh("noctalia-dev/noctalia-shell");
-v.crop(1);
-
-if v < "5" {
-  rpm.version(v);
-}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore: rename noctalia-shell to noctalia-legacy (#12992)](https://github.com/terrapkg/packages/pull/12992)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)