### PR TITLE
[el10] fix: rust-gitoxide (#13328)

### DIFF
--- a/anda/langs/rust/gitoxide/rust-gitoxide.spec
+++ b/anda/langs/rust/gitoxide/rust-gitoxide.spec
@@ -13,7 +13,7 @@ License:        MIT OR Apache-2.0
 URL:            https://crates.io/crates/gitoxide
 Source:         %{terra_crates_source}
 
-BuildRequires:  openssl-devel-engine cmake anda-srpm-macros rust-packaging >= 21 mold
+BuildRequires:  openssl-devel cmake anda-srpm-macros rust-packaging >= 21 mold
 
 %global _description %{expand:
 A command-line application for interacting with git repositories.}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: rust-gitoxide (#13328)](https://github.com/terrapkg/packages/pull/13328)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)