### PR TITLE
[el10] fix (coreboot-utils): file permissions (#13352)

### DIFF
--- a/anda/tools/coreboot-utils/coreboot-utils.spec
+++ b/anda/tools/coreboot-utils/coreboot-utils.spec
@@ -1,6 +1,6 @@
 Name:           coreboot-utils
 Version:        26.06
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Various coreboot utilities
 URL:            https://doc.coreboot.org
 License:        BSD-3-Clause AND Apache-2.0 AND CC-BY-SA-3.0 AND GPL-2.0-only AND GPL-3.0-or-later AND ISC AND BSD-2-Clause-Patent AND BSD-4-Clause-UC AND CC-PDDC AND GPL-2.0-or-later AND HPND-sell-varient AND LGPL-2.1-or-later AND BSD-2-Clause AND CC-BY-4.0 AND GPL-3.0-only AND HPND AND X11 AND MIT
@@ -567,7 +567,7 @@ popd
 popd
 
 %install
-install -Dm 777 util/abuild/abuild %{buildroot}%{_bindir}/abuild
+install -Dm 755 util/abuild/abuild %{buildroot}%{_bindir}/abuild
 
 install -Dm 755 util/amdfwtool/amdfwtool %{buildroot}%{_bindir}/amdfwtool
 install -Dm 755 util/amdfwtool/amdfwread %{buildroot}%{_bindir}/amdfwread
@@ -582,7 +582,7 @@ install -Dm 755 util/apcb/apcb_edit.py %{buildroot}%{_bindir}/apcb_edit.py
 install -Dm 755 util/apcb/apcb_v3a_edit.py %{buildroot}%{_bindir}/apcb_v3a_edit.py
 install -Dm 755 util/apcb/apcb_v3_edit.py %{buildroot}%{_bindir}/apcb_v3_edit.py
 
-install -Dm 777 util/archive/archive %{buildroot}%{_bindir}/archive
+install -Dm 755 util/archive/archive %{buildroot}%{_bindir}/archive
 
 install -Dm 755 %{_builddir}/autoport %{buildroot}%{_bindir}/autoport
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (coreboot-utils): file permissions (#13352)](https://github.com/terrapkg/packages/pull/13352)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)