### PR TITLE
[f43] fix: scx-scheds-nightly (#13330)

### DIFF
--- a/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
+++ b/anda/system/scx-scheds/nightly/scx-scheds-nightly.spec
@@ -33,6 +33,7 @@ BuildRequires:  rust
 BuildRequires:  systemd
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  zlib-ng-compat
+BuildRequires:  pkgconfig(openssl)
 Requires:       (scx-tools or scx-tools-nightly)
 Suggests:       scx-tools-nightly
 Requires:       elfutils-libelf


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: scx-scheds-nightly (#13330)](https://github.com/terrapkg/packages/pull/13330)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)