### PR TITLE
[f43] fix: helium-browser-bin: conflict helium-bin (#13393)

### DIFF
--- a/anda/apps/helium-browser-bin/helium-browser-bin.spec
+++ b/anda/apps/helium-browser-bin/helium-browser-bin.spec
@@ -12,7 +12,7 @@
 
 Name:           helium-browser-bin
 Version:        0.13.6.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Private, fast, and honest web browser based on Chromium
 
 URL:            https://helium.computer
@@ -31,6 +31,7 @@ BuildRequires:  desktop-file-utils
 Requires:       xdg-utils
 Requires:       liberation-fonts
 
+Conflicts:      helium-bin
 Packager:       Nadia P <nyadiia@pm.me>, Jaiden Riordan <jade@fyralabs.com>
 
 %description
@@ -116,6 +117,9 @@ chmod 755 %{buildroot}%{_bindir}/%{name}
 %{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Fri Jun 26 2026 Jaiden Riordan <jade@fyralabs.com>
+- Conflict helium-bin to avoid messing with people who use upstream's COPR
+
 * Sun Feb 15 2026 Jaiden Rirordan <jade@fyralabs.com>
 - Use downstream desktop file and recombobulate
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: helium-browser-bin: conflict helium-bin (#13393)](https://github.com/terrapkg/packages/pull/13393)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)