### PR TITLE
[el10] chore(xpad-noone): switch to maintained fork (#13405)

### DIFF
--- a/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
+++ b/anda/system/xpad-noone/akmod/xpad-noone-kmod.spec
@@ -1,6 +1,6 @@
-%global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
+%global commit da247eb378287b435fa2963bfaee634bda96caac
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20240109
+%global commitdate 20260627
 %global ver 1.0
 %global modulename xpad-noone
 %global debug_package %{nil}
@@ -10,14 +10,11 @@ This is the original upstream xpad driver from the Linux kernel with support for
 
 Name:          %{modulename}-kmod
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       6%{?dist}
+Release:       7%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
-URL:           https://github.com/medusalix/xpad-noone
+URL:           https://github.com/Jan200101/xpad-noone
 Source0:       %{url}/archive/%{commit}/%{modulename}-%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
-# Fix kmod compilation on kernel 6.18+
-Patch0:        https://github.com/medusalix/xpad-noone/pull/8.patch
-Patch1:        https://github.com/medusalix/xpad-noone/pull/9.patch
 BuildRequires: gcc
 BuildRequires: kmodtool
 BuildRequires: make
@@ -37,7 +34,7 @@ Packager:      Gilver E. <roachy@fyralabs.com>
 
 kmodtool --target %{_target_cpu} --repo terrapkg.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
 
-%autosetup -n %{modulename}-%{commit} -p1
+%autosetup -c %{modulename}-%{commit}
 
 for kernel_version  in %{?kernel_versions} ; do
   cp -a %{modulename}-%{commit} _kmod_build_${kernel_version%%___*}
@@ -57,5 +54,8 @@ done
 %{?akmod_install}
 
 %changelog
+* Sat Jun 27 2026 Jan200101 <sentrycraft123@gmail.com> - 1.0^20260627git.da247eb-7
+- Update package to use updated fork
+
 * Fri Mar 07 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
+++ b/anda/system/xpad-noone/dkms/dkms-xpad-noone.spec
@@ -1,6 +1,6 @@
-%global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
+%global commit da247eb378287b435fa2963bfaee634bda96caac
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20240109
+%global commitdate 20260627
 %global ver 1.0
 %global modulename xpad-noone
 %global _description %{expand:
@@ -8,15 +8,12 @@ This is the original upstream xpad driver from the Linux kernel with support for
 
 Name:          dkms-%{modulename}
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       4%{?dist}
+Release:       5%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
-URL:           https://github.com/medusalix/xpad-noone
+URL:           https://github.com/Jan200101/xpad-noone
 Source0:       %{url}/archive/%{commit}/%{modulename}-%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
 Source1:       no-weak-modules.conf
-# Fix kmod compilation on kernel 6.18+
-Patch0:        https://github.com/medusalix/xpad-noone/pull/8.patch
-Patch1:        https://github.com/medusalix/xpad-noone/pull/9.patch
 Requires:      %{modulename} = %{?epoch:%{epoch}:}%{version}
 Requires:      dkms
 Conflicts:     akmod-%{modulename}
@@ -26,7 +23,7 @@ Packager:      Gilver E. <roachy@fyralabs.com>
 %description %_description
 
 %prep
-%autosetup -n %{modulename}-%{commit} -p1
+%autosetup -n %{modulename}-%{commit}
 
 %build
 
@@ -54,5 +51,8 @@ dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
 %endif
 
 %changelog
+* Sat Jun 27 2026 Jan200101 <sentrycraft123@gmail.com> - 1.0^20260627git.da247eb-5
+- Update package to use updated fork
+
 * Fri Mar 07 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package

--- a/anda/system/xpad-noone/kmod-common/update.rhai
+++ b/anda/system/xpad-noone/kmod-common/update.rhai
@@ -1,8 +1,8 @@
-rpm.global("commit", gh_commit("medusalix/xpad-noone"));
+rpm.global("commit", gh_commit("Jan200101/xpad-noone"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commitdate", date());
-    let html = get(`https://raw.githubusercontent.com/medusalix/xpad-noone/refs/heads/master/dkms.conf`);
+    let html = get(`https://raw.githubusercontent.com/Jan200101/xpad-noone/refs/heads/master/dkms.conf`);
     let v = find("PACKAGE_VERSION=\"([\\d.]+)\"", html, 1);
     rpm.global("ver", v);
 }

--- a/anda/system/xpad-noone/kmod-common/xpad-noone.spec
+++ b/anda/system/xpad-noone/kmod-common/xpad-noone.spec
@@ -1,16 +1,16 @@
-%global commit 6970c40930bedd8b58d0764894e0d5f04813b7c5
+%global commit da247eb378287b435fa2963bfaee634bda96caac
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20240109
+%global commitdate 20260627
 %global ver 1.0
 %global _description %{expand:
 This is the original upstream xpad driver from the Linux kernel with support for XBox One controllers removed. If you are running the xone driver you may have to replace the xpad kernel module with this one to retain the functionality of XBox and XBox 360 controllers.}
 
 Name:          xpad-noone
 Version:       %{ver}^%{commitdate}git.%{shortcommit}
-Release:       3%{?dist}
+Release:       4%{?dist}
 License:       GPL-2.0-or-later
 Summary:       xpad driver with support for XBox One controllers removed
-URL:           https://github.com/medusalix/xpad-noone
+URL:           https://github.com/Jan200101/xpad-noone
 Source0:       %{url}/archive/%{commit}/%{name}-%{commit}.tar.gz#/%{name}-%{shortcommit}.tar.gz
 BuildRequires: sed
 BuildRequires: systemd-rpm-macros
@@ -48,5 +48,8 @@ install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
 %{_modulesloaddir}/%{name}.conf
 
 %changelog
+* Sat Jun 27 2026 Jan200101 <sentrycraft123@gmail.com> - 1.0^20260627git.da247eb-4
+- Update package to use updated fork
+
 * Fri Mar 07 2025 Gilver E. <rockgrub@disroot.org>
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(xpad-noone): switch to maintained fork (#13405)](https://github.com/terrapkg/packages/pull/13405)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)