### PR TITLE
[el10] add: astra (#13404)

### DIFF
--- a/anda/apps/astra/anda.hcl
+++ b/anda/apps/astra/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "astra.spec"
+  }
+}

--- a/anda/apps/astra/astra.spec
+++ b/anda/apps/astra/astra.spec
@@ -1,0 +1,40 @@
+%global appid dev.astramusic.astra
+%global ver 0.6.1-beta
+
+Name:           astra
+%electronmeta -D
+Version:        %(echo %ver | sed 's/-/~/')
+Release:        1%?dist
+Summary:        A desktop music player for people who still have a music library
+License:        GPL-3.0-only AND %electron_license
+URL:            https://astramusic.dev
+Source0:        https://github.com/Boof2015/astra/archive/refs/tags/v%ver.tar.gz
+BuildRequires:  nodejs-npm nodejs-packaging
+
+%description
+Audiophile music player with gapless playback, parametric EQ, AutoEQ import, and real-time DSP visualizers.
+
+%prep
+%autosetup -n %name-%ver
+
+%build
+%npm_build -BV -M production
+%__nodejs ./scripts/build/writeAppBuildMetadata.cjs
+
+%install
+%electron_install -I -D
+
+%terra_appstream
+
+%files
+%license LICENSE
+%doc README.md
+%_bindir/%name
+%_libdir/%name
+%_appsdir/%name.desktop
+%_metainfodir/%appid.metainfo.xml
+%_hicolordir/*/apps/%name.png
+
+%changelog
+* Sat Jun 28 2026 madonuko <madonuko@outlook.com> - 0.6.1~beta
+- Initial package.

--- a/anda/apps/astra/update.rhai
+++ b/anda/apps/astra/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Boof2015/astra"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: astra (#13404)](https://github.com/terrapkg/packages/pull/13404)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)