### PR TITLE
[f44] chore (fx2): bump and switch to new upstream (#13410)

### DIFF
--- a/anda/langs/python/fx2/fx2.spec
+++ b/anda/langs/python/fx2/fx2.spec
@@ -6,8 +6,8 @@ Version:		0.16
 Release:		1%{?dist}
 Summary:		Chip support package for Cypress EZ-USB FX2 series microcontrollers
 License:		0BSD
-URL:			https://github.com/whitequark/libfx2
-Source0:		%url/archive/refs/tags/v%version.tar.gz
+URL:			https://glasgowembedded.codeberg.page/libfx2/
+Source0:		https://codeberg.org/GlasgowEmbedded/libfx2/archive/v%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
@@ -34,7 +34,7 @@ Provides:       python3-libfx2
 %_desc
 
 %prep
-%autosetup -n libfx2-%{version}
+%autosetup -n libfx2
 
 %build
 export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (fx2): bump and switch to new upstream (#13410)](https://github.com/terrapkg/packages/pull/13410)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)