### PR TITLE
[f43] fix(v2ray-nightly): versioning (#13045)

### DIFF
--- a/anda/langs/go/v2ray/nightly/v2ray-nightly.spec
+++ b/anda/langs/go/v2ray/nightly/v2ray-nightly.spec
@@ -4,7 +4,7 @@
 %global commit_date 20260611
 
 %global goipath         github.com/v2fly/v2ray-core
-Version:                %{ver}^%{commit_date}git.%{shortcommit}
+Version:                %(echo %ver | sed -E 's/^v//')^%{commit_date}git.%{shortcommit}
 
 %global golicenses      LICENSE
 %global godocs          README.md SECURITY.md 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(v2ray-nightly): versioning (#13045)](https://github.com/terrapkg/packages/pull/13045)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)