### PR TITLE
[f44] fix: rust-deno (#12702)

### DIFF
--- a/anda/devs/deno/rust-deno.spec
+++ b/anda/devs/deno/rust-deno.spec
@@ -5,6 +5,9 @@
 %global appstream_component runtime
 %global crate deno
 
+%global debug_level 1
+%undefine _debugsource_packages
+
 Name:           rust-deno
 Version:        2.9.0
 Release:        1%{?dist}
@@ -17,12 +20,12 @@ Source1:        https://raw.githubusercontent.com/denoland/deno/refs/tags/v%vers
 Source2:        gcc-wrapper.sh
 Source3:        land.deno.deno.metainfo.xml
 # Automatically generated patch to strip dependencies and normalize metadata
-Patch:          deno-fix-metadata-auto.diff
+%dnl Patch:          deno-fix-metadata-auto.diff
 
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
 BuildRequires:  protobuf-compiler
-BuildRequires:  llvm17-devel
+BuildRequires:  llvm19-devel
 BuildRequires:  python3
 BuildRequires:  cmake
 BuildRequires:  gcc
@@ -80,3 +83,5 @@ pushd %{buildroot}%{_bindir}
 ./deno x --install-alias
 popd
 %terra_appstream -o %{SOURCE3}
+
+rm -rf target # save space


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: rust-deno (#12702)](https://github.com/terrapkg/packages/pull/12702)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)