### PR TITLE
[f43] chore (turbowarp-desktop): remove hack (#13435)

### DIFF
--- a/anda/devs/turbowarp/turbowarp.spec
+++ b/anda/devs/turbowarp/turbowarp.spec
@@ -94,7 +94,6 @@ Packager:         junefish <june@fyralabs.com>
 
 %build
 %npm_build -c -B -r fetch,webpack:prod
-echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt
 
 %install
 %electron_install -i %appid -I build/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (turbowarp-desktop): remove hack (#13435)](https://github.com/terrapkg/packages/pull/13435)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)