### PR TITLE
[el10] chore (legcord): remove hacks (#13433)

### DIFF
--- a/anda/apps/legcord/stable/legcord.spec
+++ b/anda/apps/legcord/stable/legcord.spec
@@ -1,5 +1,3 @@
-%global debug_package %nil
-
 # terrible evil no good very bad hack
 # fix one day
 %global __requires_exclude_from (.*)lib(.*)so(.*)
@@ -27,7 +25,6 @@ while keeping everything lightweight.
 %git_clone %url v%version
 
 %build
-echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt
 %pnpm_build -r build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (legcord): remove hacks (#13433)](https://github.com/terrapkg/packages/pull/13433)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)