### PR TITLE
[f43] fix(legcord-nightly): requires nodejs 26, remove hacks (#13070)

### DIFF
--- a/anda/apps/legcord/nightly/anda.hcl
+++ b/anda/apps/legcord/nightly/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
 	}
 	labels {
 		nightly = 1
+		mock = 1
 	}
 }

--- a/anda/apps/legcord/nightly/legcord-nightly.spec
+++ b/anda/apps/legcord/nightly/legcord-nightly.spec
@@ -1,13 +1,12 @@
 %global commit 0a022f149000bdaed644c2609e19aa7b8badf825
 %global commit_date 20260626
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global debug_package %nil
 # terrible evil no good very bad hack
 # fix one day
 %global __requires_exclude_from (.*)lib(.*)so(.*)
 
 Name:           legcord-nightly
-%electronmeta -D
+%electronmeta -aD
 Version:        %commit_date.%shortcommit
 Release:        1%{?dist}
 License:        OSL-3.0 AND %{electron_license}
@@ -18,7 +17,7 @@ Packager:       Owen <owen@fyralabs.com>
 Requires:       xdg-utils
 Obsoletes:      armcord < 3.3.2-1
 Conflicts:      legcord
-BuildRequires:  anda-srpm-macros pnpm nodejs-npm git-core gcc gcc-c++ make desktop-file-utils zlib-ng-compat-devel
+BuildRequires:  anda-srpm-macros pnpm nodejs-npm git-core gcc gcc-c++ make desktop-file-utils zlib-ng-compat-devel nvm
 
 %description
 Legcord is a custom client designed to enhance your Discord experience
@@ -26,9 +25,9 @@ while keeping everything lightweight.
 
 %prep
 %git_clone %{url}.git %{commit}
+%vendor_nodejs -v 26
 
 %build
-echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt
 %pnpm_build -r build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(legcord-nightly): requires nodejs 26, remove hacks (#13070)](https://github.com/terrapkg/packages/pull/13070)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)