### PR TITLE
[f44] add: melonDS (#13455)

### DIFF
--- a/anda/games/melonDS/anda.hcl
+++ b/anda/games/melonDS/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "melonDS.spec"
+    }
+}

--- a/anda/games/melonDS/melonDS.spec
+++ b/anda/games/melonDS/melonDS.spec
@@ -1,0 +1,44 @@
+%define debug_package %{nil}
+
+Name:           melonds
+Version:        1.1
+Release:        1%{?dist}
+Summary:        DS emulator, sorta
+License:        GPL-3.0-or-later
+URL:            https://melonds.kuribo64.net/
+Source0:        https://github.com/melonDS-emu/melonDS/archive/refs/tags/%{version}.tar.gz
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+BuildRequires:  cmake
+BuildRequires:  extra-cmake-modules
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  cmake(Qt6)
+BuildRequires:  qt6-qtmultimedia-devel
+BuildRequires:  qt6-qtsvg-devel
+BuildRequires:  pkgconfig(sdl2)
+BuildRequires:  pkgconfig(libarchive)
+BuildRequires:  pkgconfig(libzstd)
+BuildRequires:  pkgconfig(faad2)
+BuildRequires:  pkgconfig(libenet)
+BuildSystem:    cmake
+
+Provides:       melonDS
+
+%description
+%{summary}.
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/melonDS
+%{_appsdir}/net.kuribo64.melonDS.desktop
+%{_hicolordir}/128x128/apps/net.kuribo64.melonDS.png
+%{_hicolordir}/16x16/apps/net.kuribo64.melonDS.png
+%{_hicolordir}/256x256/apps/net.kuribo64.melonDS.png
+%{_hicolordir}/32x32/apps/net.kuribo64.melonDS.png
+%{_hicolordir}/48x48/apps/net.kuribo64.melonDS.png
+%{_hicolordir}/64x64/apps/net.kuribo64.melonDS.png
+
+%changelog
+* Sat Jun 27 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/games/melonDS/update.rhai
+++ b/anda/games/melonDS/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("melonDS-emu/melonDS"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: melonDS (#13455)](https://github.com/terrapkg/packages/pull/13455)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)