### PR TITLE
[f42] add: python-nmcli (#13475)

### DIFF
--- a/anda/langs/python/nmcli/anda.hcl
+++ b/anda/langs/python/nmcli/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "python-nmcli.spec"
+  }
+}

--- a/anda/langs/python/nmcli/python-nmcli.spec
+++ b/anda/langs/python/nmcli/python-nmcli.spec
@@ -1,0 +1,51 @@
+Name:           python-nmcli
+Version:        1.8.0
+Release:        1%?dist
+Summary:        A python wrapper library for the network-manager cli client
+
+License:        MIT
+URL:            https://github.com/ushiboy/nmcli
+Source:         %{pypi_source nmcli}
+Packager:       madonuko <mado@fyralabs.com>
+
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+
+
+%global _description %{expand:
+nmcli is a python wrapper library for the network-manager cli client.}
+
+%description %_description
+
+%package -n     python3-nmcli
+Summary:        %{summary}
+
+%description -n python3-nmcli %_description
+
+
+%prep
+%autosetup -p1 -n nmcli-%{version}
+
+%build
+%pyproject_wheel
+
+
+%install
+%pyproject_install
+%pyproject_save_files nmcli
+
+
+%check
+%pyproject_check_import
+
+
+%files -n python3-nmcli -f %{pyproject_files}
+%doc README.md
+%license LICENSE.txt
+
+
+%changelog
+* Sun Jun 28 2026 madonuko <mado@fyralabs.com> - 1.8.0-1
+- Initial package

--- a/anda/langs/python/nmcli/update.rhai
+++ b/anda/langs/python/nmcli/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(pypi("nmcli"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [add: python-nmcli (#13475)](https://github.com/terrapkg/packages/pull/13475)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)