### PR TITLE
[f44] chore (taidan): pull in nmgui instead of netto (#13486)

### DIFF
--- a/anda/system/taidan/taidan.spec
+++ b/anda/system/taidan/taidan.spec
@@ -1,6 +1,6 @@
 Name:           taidan
 Version:        0.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Out-Of-Box-Experience (OOBE) and Welcome App
 SourceLicense:  GPL-3.0-or-later AND GPL-2.0-or-later
 License:        (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Zlib OR Apache-2.0) AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND GPL-3.0-or-later AND GPL-2.0-or-later
@@ -19,7 +19,7 @@ Requires:       libwebp
 Requires:       webp-pixbuf-loader
 Requires:       xhost
 Requires:       kwin-wayland swaybg
-Requires:       netto network-manager-applet
+Requires:       nmgui network-manager-applet
 Requires:       polkit
 BuildRequires:  anda-srpm-macros mold cargo rust-packaging perl systemd-rpm-macros
 BuildRequires:  pkgconfig(libhelium-1)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (taidan): pull in nmgui instead of netto (#13486)](https://github.com/terrapkg/packages/pull/13486)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)