### PR TITLE
[el10] fix (melonDS-nightly): name (#13500)

### DIFF
--- a/anda/games/melonDS/nightly/melonDS-nightly.spec
+++ b/anda/games/melonDS/nightly/melonDS-nightly.spec
@@ -6,9 +6,9 @@
 
 %global ver 1.1
 
-Name:           melonds
+Name:           melonds-nightly
 Version:        %{ver}^%{commit_date}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        DS emulator, sorta
 License:        GPL-3.0-or-later
 URL:            https://melonds.kuribo64.net/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (melonDS-nightly): name (#13500)](https://github.com/terrapkg/packages/pull/13500)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)