### PR TITLE
[f43] fix: Use patch until opengamepadui is fixed upstream (#13506)

### DIFF
--- a/anda/games/opengamepadui/523.patch
+++ b/anda/games/opengamepadui/523.patch
@@ -1,0 +1,24 @@
+From a3a4839724f9cf7be546fa441ba12afc95da2743 Mon Sep 17 00:00:00 2001
+From: Svitkona <svitkona5@gmail.com>
+Date: Fri, 19 Jun 2026 16:22:34 -0400
+Subject: [PATCH] fix: use path.get_base_dir() instead of manual split + join
+
+---
+ core/systems/input/input_plumber_profile.gd | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/core/systems/input/input_plumber_profile.gd b/core/systems/input/input_plumber_profile.gd
+index 7ac5eb37..bdb0adee 100644
+--- a/core/systems/input/input_plumber_profile.gd
++++ b/core/systems/input/input_plumber_profile.gd
+@@ -159,9 +159,7 @@ static func get_target_device(target_device_str: String) -> TargetDevice:
+ func save(path: String) -> Error:
+ 	if path.begins_with("user://") or path.begins_with("res://"):
+ 		path = ProjectSettings.globalize_path(path)
+-	var path_parts := Array(path.split("/", false))
+-	path_parts.pop_back()
+-	var base_path := "/".join(path_parts)
++	var base_path := path.get_base_dir()
+ 	
+ 	if DirAccess.make_dir_recursive_absolute(base_path) != OK:
+ 		print("Failed to mkdir")

--- a/anda/games/opengamepadui/opengamepadui.spec
+++ b/anda/games/opengamepadui/opengamepadui.spec
@@ -1,11 +1,14 @@
 Name:           opengamepadui
 Version:        0.45.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Open source gamepad-native game launcher and overlay
 
 License:        GPLv3
 URL:            https://github.com/ShadowBlip/OpenGamepadUI
 Packager:       Cappy Ishihara <cappy@fyralabs.com>
+
+# https://patch-diff.githubusercontent.com/raw/ShadowBlip/OpenGamepadUI/pull/523
+Patch0:         523.patch
 
 BuildRequires:  godot
 BuildRequires:  scons
@@ -33,6 +36,7 @@ BuildRequires:  pkgconfig(xau)
 BuildRequires:  pkgconfig(xtst)
 BuildRequires:  pkgconfig(xdmcp)
 BuildRequires:  systemd-rpm-macros
+BuildRequires:  patch
 
 Requires:       godot-runner
 Recommends:     inputplumber
@@ -52,6 +56,7 @@ rm -rf %{build_dir}
 git clone %{url} %{build_dir} -b v%{version}
 cd %{build_dir}
 git checkout tags/v%{version}
+%patch 0 -p1
 
 %build
 cd %{build_dir}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: Use patch until opengamepadui is fixed upstream (#13506)](https://github.com/terrapkg/packages/pull/13506)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)