### PR TITLE
[f43] fix: continuwuity (#13536)

### DIFF
--- a/anda/misc/continuwuity/continuwuity.spec
+++ b/anda/misc/continuwuity/continuwuity.spec
@@ -1,6 +1,6 @@
 Name:           continuwuity
 Version:        0.5.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A Matrix homeserver written in Rust.
 License:        (MIT OR Apache-2.0 OR BSD-3-Clause) AND ((MIT OR Apache-2.0) AND NCSA) AND Unlicense AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND CDLA-Permissive-2.0 AND BSD-2-Clause AND Zlib AND MIT AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND BlueOak-1.0.0 AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (CC0-1.0 OR Apache-2.0) AND Apache-2.0 AND ISC AND (BSD-3-Clause OR Apache-2.0) AND BSD-3-Clause AND MIT AND ISC AND ((MIT OR Apache-2.0) AND Apache-2.0) AND 0BSD AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
 
@@ -18,7 +18,7 @@ BuildRequires:  rust-srpm-macros
 Requires:       liburing
 Requires:       glibc
 Requires:       libstdc++
-Packager:       Julian Anderson <julian.anderson6207@gmail.com>
+Packager:       Julian Anderson <julian@julian45.net>
 
 %global _description %{expand:
 A Matrix homeserver written in Rust, the official continuation of the conduwuit homeserver.}
@@ -72,5 +72,5 @@ install -Dpm0600 conduwuit-example.toml %{buildroot}%{_sysconfdir}/conduwuit/con
 %systemd_postun_with_restart conduwuit.service
 
 %changelog
-* Sun Jun 28 2026 julian45 <julian.anderson6207@gmail.com>
+* Sun Jun 28 2026 julian45 <julian@julian45.net>
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: continuwuity (#13536)](https://github.com/terrapkg/packages/pull/13536)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)