### PR TITLE
[f44] chore (quickjs-ng): update devel files (#13555)

### DIFF
--- a/anda/lib/quickjs-ng/quickjs-ng.spec
+++ b/anda/lib/quickjs-ng/quickjs-ng.spec
@@ -32,10 +32,6 @@ intent of reigniting its development.
 Requires:   %{name}-libs%{_isa} = %evr
 %pkg_devel_files
 
-%files devel
-%{_libdir}/cmake/qjs/*.cmake
-
-
 %package examples
 Summary:    Example files for %{name}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (quickjs-ng): update devel files (#13555)](https://github.com/terrapkg/packages/pull/13555)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)