### PR TITLE
[f42] chore (picotool): modernize spec (#13554)

### DIFF
--- a/anda/tools/picotool/picotool.spec
+++ b/anda/tools/picotool/picotool.spec
@@ -4,7 +4,7 @@
 
 Name:           picotool
 Version:        %sanitized_ver
-Release:        3%?dist
+Release:        4%{?dist}
 Summary:        Tool to inspect RP2040 binaries
 License:        BSD-3-Clause
 URL:            https://github.com/raspberrypi/picotool
@@ -17,11 +17,16 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %description
 Picotool is a tool for inspecting RP2040 binaries, and interacting with RP2040 devices when they are in BOOTSEL mode.
 
+%package devel
+%pkg_devel_files
+
 %prep
 %autosetup -a 1 -n %name-%ver
 
-%build
+%conf
 %cmake -DPICO_SDK_PATH="../pico-sdk-%sdk_version"
+
+%build
 %cmake_build
 
 %install
@@ -33,9 +38,8 @@ mv %buildroot{%_prefix/lib,%_libdir}
 %doc README.md
 %license LICENSE.TXT
 %_bindir/picotool
-%_libdir/cmake/picotool/*
 %_datadir/picotool/*
 
 %changelog
-* Mon Nov 18 2024 Owen-sz <owen@fyralabs.com>
+* Mon Nov 18 2024 Owen Zimmerman <owen@fyralabs.com>
 - Package Raspberry Pi Picotools


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (picotool): modernize spec (#13554)](https://github.com/terrapkg/packages/pull/13554)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)