### PR TITLE
[f44] chore (ShivaVG): update devel files, clean up cmake (#13553)

### DIFF
--- a/anda/lib/ShivaVG/ShivaVG.spec
+++ b/anda/lib/ShivaVG/ShivaVG.spec
@@ -29,7 +29,6 @@ Requires:       %{name} = %evr
 Requires:       glew-devel
 Requires:       mesa-libGL-devel
 %pkg_devel_files
-%_libdir/cmake/OpenVG/
 
 %package static
 Requires:       %{name} = %evr
@@ -39,8 +38,13 @@ Requires:       %{name} = %evr
 %autosetup -n ShivaVG-%{commit}
 sed '/set(CMAKE_C_FLAGS/d' -i CMakeLists.txt
 
+%conf
+%cmake -DBUILD_EXAMPLES=OFF \
+			 -DDEBUG=ON -DPROJECT_VERSION=%commit \
+			 -DCMAKE_C_FLAGS='%build_cflags' \
+			 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
 %build
-%cmake -DBUILD_EXAMPLES=OFF -DDEBUG=ON -DPROJECT_VERSION=%commit -DCMAKE_C_FLAGS='%build_cflags'
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (ShivaVG): update devel files, clean up cmake (#13553)](https://github.com/terrapkg/packages/pull/13553)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)