### PR TITLE
[f42] build(deps): bump actions/attest-build-provenance from 4.1.0 to 4.1.1 (#13602)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -93,7 +93,7 @@ jobs:
             terra${{ matrix.version }}-source anda-build/rpm/srpm/*
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             anda-build/rpm/rpms/*

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Attest build provenance
         if: inputs.publish
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             anda-build/rpm/rpms/*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [build(deps): bump actions/attest-build-provenance from 4.1.0 to 4.1.1 (#13602)](https://github.com/terrapkg/packages/pull/13602)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)