### PR TITLE
[f44] chore(cglm): use modern macros (#13526)

### DIFF
--- a/anda/lib/cglm/cglm.spec
+++ b/anda/lib/cglm/cglm.spec
@@ -1,6 +1,6 @@
 Name:           cglm
 Version:        0.9.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Highly Optimized Graphics Math (glm) for C
 Packager:       Jan200101 <sentrycraft123@gmail.com>
 
@@ -8,8 +8,8 @@ License:        MIT
 URL:            https://github.com/recp/cglm
 Source0:        %{url}/archive/v%{version}.tar.gz#/cglm-%{version}.tar.gz
 
-BuildRequires: gcc
-BuildRequires: cmake
+BuildRequires:  gcc
+BuildRequires:  cmake
 
 %description
 Highly optimized 2D|3D math library, also known as OpenGL Mathematics
@@ -19,17 +19,16 @@ quick to write. It is community friendly, feel free to bring any
 issues, bugs you faced.
 
 %package devel
-Summary:        Development package for %{name}
 Requires:       %{name} = %{version}
-
-%description devel
-Development package for %{name}.
+%pkg_devel_files
 
 %prep
 %autosetup
 
-%build
+%conf
 %cmake
+
+%build
 %cmake_build
 
 %install
@@ -38,13 +37,10 @@ Development package for %{name}.
 %files
 %license LICENSE
 %{_libdir}/libcglm.so.%{version}
+%{_libdir}/libcglm.so.0
 
 %files devel
-%{_libdir}/libcglm.so
-%{_libdir}/libcglm.so.0
-%{_includedir}/cglm/
 %{_libdir}/cmake/cglm/
-%{_libdir}/pkgconfig/cglm.pc
 
 %changelog
 * Mon Jun 29 2026 Jan200101 <sentrycraft123@gmail.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(cglm): use modern macros (#13526)](https://github.com/terrapkg/packages/pull/13526)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)