### PR TITLE
[f43] chore(cglm): remove redundant devel files (#13615)

### DIFF
--- a/anda/lib/cglm/cglm.spec
+++ b/anda/lib/cglm/cglm.spec
@@ -39,9 +39,6 @@ Requires:       %{name} = %{version}
 %{_libdir}/libcglm.so.%{version}
 %{_libdir}/libcglm.so.0
 
-%files devel
-%{_libdir}/cmake/cglm/
-
 %changelog
 * Mon Jun 29 2026 Jan200101 <sentrycraft123@gmail.com>
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore(cglm): remove redundant devel files (#13615)](https://github.com/terrapkg/packages/pull/13615)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)