### PR TITLE
[el10] chore(noctalia-git): add wireplumber requirement and use system md4c (#13620)

### DIFF
--- a/anda/desktops/noctalia-git/noctalia-git.spec
+++ b/anda/desktops/noctalia-git/noctalia-git.spec
@@ -2,13 +2,13 @@
 
 %global ver 5.0.0
 
-%global commit          5f636c6cbed0ee6858fa6b83a9981a455c6d4d2c
+%global commit          d8d9f8a836dc07ad856c07e5e87896c9cb508b53
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global commitdate      20260701
 
 Name:   	noctalia-git
 Version:	%{ver}^%{commitdate}git.%{shortcommit}
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	A lightweight Wayland shell and bar built directly on Wayland + OpenGL ES, with no Qt or GTK dependency
 
 License:	MIT
@@ -22,6 +22,8 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  pipewire-devel
 BuildRequires:  sdbus-cpp-devel
 BuildRequires:  tomlplusplus-devel
+BuildRequires:  md4c-devel
+BuildRequires:  wireplumber-devel
 BuildRequires:  pkgconfig(cairo)
 BuildRequires:  pkgconfig(egl)
 BuildRequires:  pkgconfig(freetype2)
@@ -65,9 +67,10 @@ sed -i "s/'unknown'/'%{shortcommit}'/g" meson.build
 
 # Remove bundled libs that we have system copies of
 rm -r third_party/tomlplusplus
+rm -r third_party/md4c
 
 %conf
-%meson -Dsystem_tomlplusplus=true
+%meson -Dsystem_tomlplusplus=true -Dsystem_md4c=true
 
 %build
 %meson_build
@@ -96,6 +99,10 @@ done
 %{_scalableiconsdir}/noctalia.svg
 
 %changelog
+* Wed Jul 01 2026 Cypress Reed <cypress@fyralabs.com>
+- Add md4c as a system library
+- Add wireplumber build requirement
+
 * Tue Jun 30 2026 Cypress Reed <cypress@fyralabs.com>
 - Add tomlplusplus as a sytem library
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(noctalia-git): add wireplumber requirement and use system md4c (#13620)](https://github.com/terrapkg/packages/pull/13620)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)