### PR TITLE
[f42] fix: arduino-app-lab (#13625)

### DIFF
--- a/anda/tools/arduino-app-lab-bin/arduino-app-lab-bin.spec
+++ b/anda/tools/arduino-app-lab-bin/arduino-app-lab-bin.spec
@@ -1,16 +1,16 @@
 %global appid cc.arduino.AppLab
 
 Name:           arduino-app-lab-bin
-Version:        0.5.0
+Version:        0.8.0
 Release:        1%?dist
 Summary:        A powerful visual environment for managing the Arduino UNO Q
 
 Provides:       arduino-app-lab
 URL:            https://www.arduino.cc/en/software
-License:        GPL-3.0
+License:        GPL-3.0-or-later
 
 Source0:        https://downloads.arduino.cc/AppLab/Stable/ArduinoAppLab_%{version}_Linux_x86-64.tar.gz
-Source1:        https://downloads.arduino.cc/AppLab/Stable/source-app-lab-%{version}.zip
+Source1:        https://github.com/arduino/arduino-app-lab/archive/refs/tags/al-%{version}.zip
 Source2:        cc.arduino.AppLab.desktop
 Source3:        cc.arduino.AppLab.metainfo.xml
 
@@ -29,20 +29,19 @@ Packager:       Jaiden Riordan <jade@fyralabs.com>
 
 %prep
 tar -xvf %{_sourcedir}/ArduinoAppLab_%{version}_Linux_x86-64.tar.gz
-unzip %{_sourcedir}/source-app-lab-%{version}.zip
+unzip %{_sourcedir}/al-%{version}.zip
 
 %install
 install -dm755 %{buildroot}%{_bindir}
 install -p -m755 ArduinoAppLab_%{version}_Linux_x86-64/arduino-app-lab %{buildroot}%{_bindir}/%{name}
 
 install -dm755 %{buildroot}%{_scalableiconsdir}/
-install -p -m644 source-app-lab/ui-packages/images/assets/round-arduino-logo.svg %{buildroot}%{_scalableiconsdir}/cc.arduino.AppLab.svg
+install -p -m644 arduino-app-lab-al-%{version}/ui-packages/images/assets/round-arduino-logo.svg %{buildroot}%{_scalableiconsdir}/cc.arduino.AppLab.svg
 
 install -dm755 %{buildroot}%{_appsdir}/
 install -p -m644 %{SOURCE2} %{buildroot}%{_appsdir}/%{appid}.desktop
 
-cp source-app-lab/LICENSE -t .
-cp source-app-lab/dependency_licenses -t .
+cp arduino-app-lab-al-%{version}/LICENSE -t .
 
 %terra_appstream -o %{SOURCE3}
 
@@ -51,13 +50,14 @@ desktop-file-validate %{buildroot}%{_appsdir}/%{appid}.desktop
 
 %files
 %license LICENSE
-%license dependency_licenses
 %{_bindir}/%{name}
 %{_scalableiconsdir}/%{appid}.svg
 %{_appsdir}/%{appid}.desktop
 %{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Wed Jul 1 2026 Jaiden Riordan <jade@fyralabs.com>
+- Source changes
 * Thu Dec 25 2025 Owen Zimmerman <owen@fyralabs.com>
 - Add %check, update macros
 * Thu Dec 4 2025 Jaiden Riordan <jade@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: arduino-app-lab (#13625)](https://github.com/terrapkg/packages/pull/13625)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)