### PR TITLE
chore(ci/update): disable cron

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,8 +2,8 @@ name: Update
 permissions:
   contents: read
 on:
-  schedule:
-    - cron: "*/10 * * * *"
+  #schedule:
+  #  - cron: "*/10 * * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I have a cron job on stack triggering the workflow every 10min, the cron inside the workflow is no longer needed now
