### PR TITLE
[f42] fix: update scripts and spec files (#13636)

### DIFF
--- a/anda/apps/astra/update.rhai
+++ b/anda/apps/astra/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("Boof2015/astra"));
+rpm.global("ver", gh("Boof2015/astra"));

--- a/anda/desktops/hyprland/hyprlock/anda.hcl
+++ b/anda/desktops/hyprland/hyprlock/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "hyprlock.spec"
 	}
+	labels {
+		updbranch = 1
+	}
 }

--- a/anda/fonts/adobe-source-han-serif/update.rhai
+++ b/anda/fonts/adobe-source-han-serif/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("adobe-fonts/source-han-serif"));
+rpm.global("ver", gh("adobe-fonts/source-han-serif"));

--- a/anda/lib/breakpad/update.rhai
+++ b/anda/lib/breakpad/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("google/breakpad"));
+rpm.version(gh_tag("google/breakpad"));

--- a/anda/lib/mesa/update.rhai
+++ b/anda/lib/mesa/update.rhai
@@ -1,2 +1,2 @@
 let v = find(`mesa-([\d.]+).tar.xz`, get("https://archive.mesa3d.org/?C=D;O=D"), 1);
-rpm.version(v);
+rpm.global("ver", v);

--- a/anda/lib/terra-glfw/anda.hcl
+++ b/anda/lib/terra-glfw/anda.hcl
@@ -5,5 +5,6 @@ project pkg {
   }
   labels {
     mock = 1
+    updbranch = 1
   }
 }

--- a/anda/misc/bup/update.rhai
+++ b/anda/misc/bup/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("bup/bup"));
+rpm.version(gh_tag("bup/bup"));

--- a/anda/misc/miraclecast/update.rhai
+++ b/anda/misc/miraclecast/update.rhai
@@ -1,4 +1,4 @@
-rpm.global("ver", gh("albfan/miraclecast"));
+rpm.global("ver", gh_tag("albfan/miraclecast"));
 
 rpm.global("commit", gh_commit("albfan/miraclecast"));
 if rpm.changed() {

--- a/anda/multimedia/openutau/update.rhai
+++ b/anda/multimedia/openutau/update.rhai
@@ -1,5 +1,5 @@
 let v = gh("stakira/OpenUtau");
-let url = `OpenUtau-linux-x64.tar.gz`
+let url = `OpenUtau-linux-x64.tar.gz`;
 
 if get(`https://github.com/stakira/OpenUtau/releases/expanded_assets/${v}`).contains(url) {
   rpm.global("ver", v);

--- a/anda/system/croskbd/update.rhai
+++ b/anda/system/croskbd/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("WeirdTreeThing/croskbd"));
+rpm.version(gh_tag("WeirdTreeThing/croskbd"));

--- a/anda/tools/virtualsmartcard/virtualsmartcard.spec
+++ b/anda/tools/virtualsmartcard/virtualsmartcard.spec
@@ -1,5 +1,5 @@
 Name:           virtualsmartcard
-Version:        0.10 
+Version:        0.10
 Release:        2%?dist
 Summary:        Smart card emulator and driver for networked smart card reader/emulator
 URL:            https://frankmorgner.github.io/vsmartcard/index.html


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix: update scripts and spec files (#13636)](https://github.com/terrapkg/packages/pull/13636)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)