### PR TITLE
[f43] chore(ci/update): disable cron (#13635)

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,8 +2,8 @@ name: Update
 permissions:
   contents: read
 on:
-  schedule:
-    - cron: "*/10 * * * *"
+  #schedule:
+  #  - cron: "*/10 * * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore(ci/update): disable cron (#13635)](https://github.com/terrapkg/packages/pull/13635)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)