### PR TITLE
[f44] chore (rpi-utils): use %conf (#13653)

### DIFF
--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -164,8 +164,10 @@ Summary:        A tool to get VideoCore 'assert' or 'msg' logs with optional -f 
 %prep
 %autosetup -p1 -n utils-%{commit}
 
-%build
+%conf
 %cmake -DBUILD_SHARED_LIBS=1
+
+%build
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (rpi-utils): use %conf (#13653)](https://github.com/terrapkg/packages/pull/13653)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)