### PR TITLE
[f44] fix: scx-scheds (#13652)

### DIFF
--- a/anda/system/scx-scheds/stable/scx-scheds.spec
+++ b/anda/system/scx-scheds/stable/scx-scheds.spec
@@ -29,6 +29,7 @@ BuildRequires:  rust
 BuildRequires:  systemd
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  zlib-ng-compat
+BuildRequires:  pkgconfig(openssl)
 Requires:       (scx-tools or scx-tools-nightly)
 Suggests:       scx-tools
 Requires:       elfutils-libelf


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: scx-scheds (#13652)](https://github.com/terrapkg/packages/pull/13652)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)