### PR TITLE
[f42] chore(taisei): add missing dependency, remove deprecated build option (#13662)

### DIFF
--- a/anda/games/taisei/taisei.spec
+++ b/anda/games/taisei/taisei.spec
@@ -21,6 +21,7 @@ BuildRequires:  pkgconfig(libzstd)
 BuildRequires:  python3-zstandard
 BuildRequires:  pkgconfig(gamemode)
 BuildRequires:  pkgconfig(mimalloc)
+BuildRequires:  pkgconfig(libunibreak)
 # shader validation
 BuildRequires:  glslc
 # documentation
@@ -58,7 +59,6 @@ sed -i "/'strip=true'/d" meson.build
 %conf
 %meson \
     -Dallocator=mimalloc \
-    -Dvfs_zip=enabled \
     -Dpackage_data=enabled \
     -Dinstall_relocatable=disabled \
     -Dinstall_freedesktop=enabled \
@@ -78,7 +78,7 @@ sed -i "/'strip=true'/d" meson.build
 %meson_test
 
 %files
-%license COPYING
+%license COPYING.txt
 %{_bindir}/taisei
 %{_appsdir}/org.taisei_project.Taisei.desktop
 %{_appsdir}/org.taisei_project.Taisei.tsr.desktop
@@ -91,7 +91,7 @@ sed -i "/'strip=true'/d" meson.build
 %{_docdir}/taisei
 
 %files data
-%license COPYING
+%license COPYING.txt
 %{_datadir}/taisei
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(taisei): add missing dependency, remove deprecated build option (#13662)](https://github.com/terrapkg/packages/pull/13662)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)