### PR TITLE
[f42] fix(adobe-source-han-*): include only the static otc fonts in main pkg (#13668)

### DIFF
--- a/anda/fonts/adobe-source-han-sans/adobe-source-han-sans-fonts.spec
+++ b/anda/fonts/adobe-source-han-sans/adobe-source-han-sans-fonts.spec
@@ -3,7 +3,7 @@
 
 Name:           adobe-source-han-sans-fonts
 Version:        %(echo %ver | sed -E 's/R$//')
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Source Han Sans | 思源黑体 | 思源黑體 | 思源黑體 香港 | 源ノ角ゴシック | 본고딕
 License:        OFL-1.1
 URL:            https://github.com/adobe-fonts/source-han-sans
@@ -20,7 +20,13 @@ This package ships the Static OTC versions.
 
 %files
 %license LICENSE.txt
-%_datadir/fonts/%name/
+%_datadir/fonts/%name/SourceHanSans-Bold.ttc
+%_datadir/fonts/%name/SourceHanSans-ExtraLight.ttc
+%_datadir/fonts/%name/SourceHanSans-Heavy.ttc
+%_datadir/fonts/%name/SourceHanSans-Light.ttc
+%_datadir/fonts/%name/SourceHanSans-Medium.ttc
+%_datadir/fonts/%name/SourceHanSans-Normal.ttc
+%_datadir/fonts/%name/SourceHanSans-Regular.ttc
 
 
 %dnl DO NOT CHANGE THIS TO `%global`, I REPEAT, DO NOT USE `%global`, OTHERWISE MACROS LIKE `%{-h}` DO NOT EXPAND.

--- a/anda/fonts/adobe-source-han-serif/adobe-source-han-serif-fonts.spec
+++ b/anda/fonts/adobe-source-han-serif/adobe-source-han-serif-fonts.spec
@@ -3,7 +3,7 @@
 
 Name:           adobe-source-han-serif-fonts
 Version:        %(echo %ver | sed -E 's/R$//')
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Source Han Serif | 思源宋体 | 思源宋體 | 思源宋體 香港 | 源ノ明朝 | 본명조
 License:        OFL-1.1
 URL:            https://github.com/adobe-fonts/source-han-serif
@@ -20,7 +20,13 @@ This package ships the Static OTC versions.
 
 %files
 %license LICENSE.txt
-%_datadir/fonts/%name/
+%_datadir/fonts/%name/SourceHanSerif-Bold.ttc
+%_datadir/fonts/%name/SourceHanSerif-ExtraLight.ttc
+%_datadir/fonts/%name/SourceHanSerif-Heavy.ttc
+%_datadir/fonts/%name/SourceHanSerif-Light.ttc
+%_datadir/fonts/%name/SourceHanSerif-Medium.ttc
+%_datadir/fonts/%name/SourceHanSerif-Regular.ttc
+%_datadir/fonts/%name/SourceHanSerif-SemiBold.ttc
 
 
 %dnl DO NOT CHANGE THIS TO `%global`, I REPEAT, DO NOT USE `%global`, OTHERWISE MACROS LIKE `%{-h}` DO NOT EXPAND.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(adobe-source-han-*): include only the static otc fonts in main pkg (#13668)](https://github.com/terrapkg/packages/pull/13668)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)