### PR TITLE
[f42] chore (bsc): fix license tag (#13689)

### DIFF
--- a/anda/buildsys/bsc/bsc.spec
+++ b/anda/buildsys/bsc/bsc.spec
@@ -4,13 +4,11 @@
 
 Name:           bsc
 Version:        2026.01
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Bluespec Compiler (BSC)
-
-License:        BSD-3-Clause AND BSD-2-Clause AND MIT AND LGPL-2.0-or-later AND AND BSL-1.0
+License:        BSD-3-Clause AND BSD-2-Clause AND MIT AND LGPL-2.0-or-later AND BSL-1.0
 URL:            https://github.com/B-Lang-org/bsc
 Source:         %{url}/archive/refs/tags/%{version}.tar.gz
-
 BuildRequires:  ghc
 BuildRequires:  ghc-regex-compat-devel
 BuildRequires:  ghc-syb-devel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore (bsc): fix license tag (#13689)](https://github.com/terrapkg/packages/pull/13689)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)