### PR TITLE
[f44] fix(brush-shell): update script (#13707)

### DIFF
--- a/anda/system/brush-shell/brush-shell.spec
+++ b/anda/system/brush-shell/brush-shell.spec
@@ -1,5 +1,7 @@
+%global ver brush-shell-v0.4.0
+
 Name:           brush-shell
-Version:        brush.shell.v0.4.0
+Version:        %(echo %ver | sed 's/brush-shell-v//')
 Release:        1%{?dist}
 Summary:        bash/POSIX-compatible shell implemented in Rust
 URL:            https://github.com/reubeno/brush

--- a/anda/system/brush-shell/update.rhai
+++ b/anda/system/brush-shell/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("reubeno/brush"));
+rpm.global("ver", gh("reubeno/brush"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(brush-shell): update script (#13707)](https://github.com/terrapkg/packages/pull/13707)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)