### PR TITLE
fix(bazzite-updater): Update spec

### DIFF
--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -3,7 +3,7 @@
 Name:           bazzite-updater
 Version:        0.8.0
 Release:        1%{?dist}
-Summary:        Update your Bazzite system
+Summary:        Update your system
 
 License:        GPL-2.0-or-later AND BSD-3-Clause AND CC0-1.0
 URL:            https://github.com/rfrench3/bazzite-updater
@@ -33,20 +33,22 @@ BuildRequires:  cmake(KF6I18n)
 BuildRequires:  cmake(KF6IconThemes)
 BuildRequires:  cmake(KF6KirigamiAddons)
 
+
 Requires:       kf6-kirigami%{?_isa}
 Requires:       kf6-kirigami-addons%{?_isa}
 Requires:       kf6-qqc2-desktop-style%{?_isa}
-Requires:       which%{?_isa}
 Requires:       qt6-controllable%{?_isa}
-Requires:       uupd%{?_isa}
 Requires:       hicolor-icon-theme
+Requires:       systemd%{?_isa} >= 258
 
 Provides:       bazzite-updater = %{evr}
 
 %description
-This is a convenient, easy-to-use interface for updating your Bazzite system.
+This is a convenient, easy-to-use interface for updating a Linux system.
+By default, it is configured for Bazzite.
 - Simple and powerful
 - Full support for all input types (keyboard/mouse, controller, touchscreen)
+- Configurable update and update-rollback commands
 
 %prep
 %autosetup
@@ -71,7 +73,11 @@ desktop-file-validate %{buildroot}%{_kf6_datadir}/applications/%{appid}.desktop
 %{_appsdir}/%{appid}.desktop
 %{_metainfodir}/%{appid}.*.xml
 %{_scalableiconsdir}/%{appid}.svg
+/usr/etc/bazzite-updater
 
 %changelog
+* Sat Jul 04 2026 Robert French - 0.8.0
+- Added config file support
+
 * Thu Feb 05 2026 Robert French
 - Initial rpm build of Bazzite Updater

--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -72,6 +72,7 @@ desktop-file-validate %{buildroot}%{_kf6_datadir}/applications/%{appid}.desktop
 %{_appsdir}/%{appid}.desktop
 %{_metainfodir}/%{appid}.*.xml
 %{_scalableiconsdir}/%{appid}.svg
+%config %{_prefix}/etc/bazzite-updater/config.ini
 %{_prefix}/etc/bazzite-updater
 
 %changelog

--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -72,7 +72,7 @@ desktop-file-validate %{buildroot}%{_kf6_datadir}/applications/%{appid}.desktop
 %{_appsdir}/%{appid}.desktop
 %{_metainfodir}/%{appid}.*.xml
 %{_scalableiconsdir}/%{appid}.svg
-/usr/etc/bazzite-updater
+%{_prefix}/etc/bazzite-updater
 
 %changelog
 * Sat Jul 04 2026 Robert French - 0.8.0

--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -33,7 +33,6 @@ BuildRequires:  cmake(KF6I18n)
 BuildRequires:  cmake(KF6IconThemes)
 BuildRequires:  cmake(KF6KirigamiAddons)
 
-
 Requires:       kf6-kirigami%{?_isa}
 Requires:       kf6-kirigami-addons%{?_isa}
 Requires:       kf6-qqc2-desktop-style%{?_isa}


### PR DESCRIPTION
The latest update utilizes config files (defaults are stored in `/usr/etc/bazzite-updater`) and has some updated dependencies.

It builds without any issues when I use the pet container, but the Github action automated builder in my fork of this repository is repeatedly failing on the "Upload packages to subatomic" step with the issue "upload failed with: io: read/write on closed pipe". I am unsure if that is expected/an issue.