### PR TITLE
[f44] chore(zig-master): replace removed flags with env vars (#13741)

### DIFF
--- a/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
+++ b/anda/langs/zig/bootstrap/zig-master-bootstrap.spec
@@ -25,11 +25,9 @@
     \
     -Dtarget=native \
     -Dcpu=baseline \
-    --zig-lib-dir lib \
     --build-id=sha1 \
     \
     --cache-dir "%{zig_cache_dir}" \
-    --global-cache-dir "%{zig_cache_dir}" \
     \
     -Dversion-string="%(v=%{ver}; echo ${v:0:6})" \
     -Dstatic-llvm=false \
@@ -149,6 +147,13 @@ export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
     -DZIG_VERSION:STRING="%(v=%{ver}; echo ${v:0:6})"
 
 %build
+# Zig generates a large C file for bootstrapping which does not
+# behave well with ccache so explicitly disable it.
+export CCACHE_DISABLE=1
+
+export ZIG_GLOBAL_CACHE_DIR="%{zig_cache_dir}"
+export ZIG_LIB_DIR="lib"
+
 %if %{with bootstrap}
 %cmake_build --target stage3
 %else
@@ -169,7 +174,6 @@ attempt=1
 while
   ./zig-out/bin/zig build docs \
     --verbose \
-    --global-cache-dir "%{zig_cache_dir}" \
     -Dversion-string="%(v=%{ver}; echo ${v:0:6})"
   [[ $? != 0 ]]
 do
@@ -186,6 +190,9 @@ done
 %endif
 
 %install
+export ZIG_GLOBAL_CACHE_DIR="%{zig_cache_dir}"
+export ZIG_LIB_DIR="lib"
+
 %if %{with bootstrap}
 %cmake_install
 %else

--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -85,11 +85,9 @@ Packager:       Gilver E. <roachy@fyralabs.com>
     \
     -Dtarget=native \
     -Dcpu=baseline \
-    --zig-lib-dir lib \
     --build-id=sha1 \
     \
     --cache-dir "%{zig_cache_dir}" \
-    --global-cache-dir "%{zig_cache_dir}" \
     \
     -Dversion-string="%(v=%{version_no_tilde}; echo ${v:0:6})" \
     -Dstatic-llvm=false \
@@ -162,6 +160,13 @@ export LLVM_DIR=%{_libdir}/llvm%{?llvm_compat}/%{_lib}/cmake
 
 
 %build
+# Zig generates a large C file for bootstrapping which does not
+# behave well with ccache so explicitly disable it.
+export CCACHE_DISABLE=1
+
+export ZIG_GLOBAL_CACHE_DIR="%{zig_cache_dir}"
+export ZIG_LIB_DIR="lib"
+
 %if %{with bootstrap}
 %cmake_build --target stage3
 %else
@@ -182,7 +187,6 @@ attempt=1
 while
   ./zig-out/bin/zig build docs \
     --verbose \
-    --global-cache-dir "%{zig_cache_dir}" \
     -Dversion-string="%(v=%{version_no_tilde}; echo ${v:0:6})"
   [[ $? != 0 ]]
 do
@@ -199,6 +203,9 @@ done
 %endif
 
 %install
+export ZIG_GLOBAL_CACHE_DIR="%{zig_cache_dir}"
+export ZIG_LIB_DIR="lib"
+
 %if %{with bootstrap}
 %cmake_install
 %else


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(zig-master): replace removed flags with env vars (#13741)](https://github.com/terrapkg/packages/pull/13741)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)