### PR TITLE
[f44] chore(continuwuity-nightly,continuwuity) use forgejo update functions (#13770)

### DIFF
--- a/anda/misc/continuwuity/nightly/update.rhai
+++ b/anda/misc/continuwuity/nightly/update.rhai
@@ -1,6 +1,6 @@
 rpm.global("ver", get("https://forgejo.ellis.link/api/v1/repos/continuwuation/continuwuity/releases?pre-release=true").json.tag_name);
-rpm.global("commit", get("https://forgejo.ellis.link/api/v1/repos/continuwuation/continuwuity/commits?limit=1").json_arr()[0].sha);
+rpm.global("commit", forgejo_commit("forgejo.ellis.link", "continuwuation/continuwuity"));
 if rpm.changed() {
-    rpm.release();
-    rpm.global("commit_date", date());
+  rpm.release();
+  rpm.global("commit_date", date());
 }

--- a/anda/misc/continuwuity/stable/update.rhai
+++ b/anda/misc/continuwuity/stable/update.rhai
@@ -1,3 +1,1 @@
-let req = new_req("https://forgejo.ellis.link/api/v1/repos/continuwuation/continuwuity/releases/latest");
-let ver = req.get().json().name;
-rpm.version(ver);
+rpm.version(forgejo("forgejo.ellis.link", "continuwuation/continuwuity"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(continuwuity-nightly,continuwuity) use forgejo update functions (#13770)](https://github.com/terrapkg/packages/pull/13770)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)