### PR TITLE
fix(signal): don't use --use-tray-icon

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -3,7 +3,7 @@
 Name:			signal-desktop
 %electronmeta -aD
 Version:		8.17.0
-Release:		1%{?dist}
+Release:		2%{?dist}
 Summary:		A private messenger for Windows, macOS, and Linux
 URL:			https://signal.org
 Source0:		https://github.com/signalapp/Signal-Desktop/archive/refs/tags/v%{version}.tar.gz

--- a/anda/apps/signal-desktop/signal.desktop
+++ b/anda/apps/signal-desktop/signal.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Signal
-Exec=signal-desktop --use-tray-icon %U
+Exec=signal-desktop %U
 Terminal=false
 Type=Application
 Icon=signal


### PR DESCRIPTION
Turns out this prevents the start minimized to tray option from working

Resolves #13779