### PR TITLE
[el10] fix: jellyfin-apiclient-python (#13785)

### DIFF
--- a/anda/langs/python/jellyfin-apiclient-python/jellyfin-apiclient-python.spec
+++ b/anda/langs/python/jellyfin-apiclient-python/jellyfin-apiclient-python.spec
@@ -7,7 +7,7 @@ Release:		1%{?dist}
 Summary:		Python API Client for Jellyfin
 License:		GPL-3.0-or-later
 URL:			https://github.com/jellyfin/jellyfin-apiclient-python
-Source0:		%url/archive/refs/tags/v%version.tar.gz
+Source0:		%{pypi_source jellyfin_apiclient_python}
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
@@ -29,7 +29,7 @@ Provides:       jellyfin-apiclient
 %_desc
 
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -C
 
 %build
 %pyproject_wheel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: jellyfin-apiclient-python (#13785)](https://github.com/terrapkg/packages/pull/13785)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)