### PR TITLE
[f42] chore(continuwuity-nightly): json is a function, use it like one (#13796)

### DIFF
--- a/anda/misc/continuwuity/nightly/update.rhai
+++ b/anda/misc/continuwuity/nightly/update.rhai
@@ -1,4 +1,4 @@
-rpm.global("ver", get("https://forgejo.ellis.link/api/v1/repos/continuwuation/continuwuity/releases?pre-release=true").json.tag_name);
+rpm.global("ver", get("https://forgejo.ellis.link/api/v1/repos/continuwuation/continuwuity/releases?pre-release=true").json().tag_name);
 rpm.global("commit", forgejo_commit("forgejo.ellis.link", "continuwuation/continuwuity"));
 if rpm.changed() {
   rpm.release();


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [chore(continuwuity-nightly): json is a function, use it like one (#13796)](https://github.com/terrapkg/packages/pull/13796)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)