### PR TITLE
zed: add missing terra-appstream-helper BuildRequires for %terra_appstream macro

### DIFF
--- a/anda/devs/zed/nightly/zed-nightly.spec
+++ b/anda/devs/zed/nightly/zed-nightly.spec
@@ -40,6 +40,8 @@ BuildRequires:  libedit(x86-64)
 %endif
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
+BuildRequires:  python3-terra-appstream-helper
+BuildRequires:  terra-appstream-helper
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  gettext-envsubst

--- a/anda/devs/zed/preview/zed-preview.spec
+++ b/anda/devs/zed/preview/zed-preview.spec
@@ -35,6 +35,8 @@ BuildRequires:  libedit(x86-64)
 %endif
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
+BuildRequires:  python3-terra-appstream-helper
+BuildRequires:  terra-appstream-helper
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  gettext-envsubst

--- a/anda/devs/zed/stable/zed.spec
+++ b/anda/devs/zed/stable/zed.spec
@@ -35,6 +35,8 @@ BuildRequires:  libedit(x86-64)
 %endif
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
+BuildRequires:  python3-terra-appstream-helper
+BuildRequires:  terra-appstream-helper
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  gettext-envsubst


### PR DESCRIPTION
The zed.spec files are missing the `BuildRequires` for `terra-appstream-helper` and `python3-terra-appstream-helper` which provide the %terra_appstream macro.  Build fails without this at my COPR at https://copr.fedorainfracloud.org/coprs/cjatherton/zed/ .