### PR TITLE
[f42] docs: update links for CONTRIBUTING.md (#13845)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 First of all, thanks for being interested in contributing to Terra! If you have any questions about contributing, please [join our chats](https://wiki.ultramarine-linux.org/en/community/community/).
 
-- [Contribution Guide](https://developer.fyralabs.com/terra/contributing)
-- [FAQ](https://developer.fyralabs.com/terra/faq)
-- [Policy](https://developer.fyralabs.com/terra/policy)
+- [Contribution Guide](https://docs.terrapkg.com/contributing/getting-started/)
+- [FAQ](https://docs.terrapkg.com/reference/faq/)
+- [Policy](https://docs.terrapkg.com/contributing/policies/)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [docs: update links for CONTRIBUTING.md (#13845)](https://github.com/terrapkg/packages/pull/13845)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)