### PR TITLE
[f44] fix(run0-sudo-shim): provides sudo (#13474)

### DIFF
--- a/anda/langs/rust/run0-sudo-shim/anda.hcl
+++ b/anda/langs/rust/run0-sudo-shim/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "run0-sudo-shim.spec"
   }
+  labels {
+    subrepo = "extras"
+  }
 }

--- a/anda/langs/rust/run0-sudo-shim/run0-sudo-shim.spec
+++ b/anda/langs/rust/run0-sudo-shim/run0-sudo-shim.spec
@@ -1,13 +1,15 @@
 Name:			run0-sudo-shim
 Version:		1.4.2
-Release:		1%{?dist}
+Release:		2%{?dist}
 Summary:		An imitation of sudo, using run0 internally
 SourceLicense:	BSD-3-Clause
 License:		(Apache-2.0 OR MIT) AND BSD-3-Clause AND MIT
 URL:			https://github.com/LordGrimmauld/run0-sudo-shim
 Source0:		%url/archive/refs/tags/%version.tar.gz
+Packager:		madonuko <mado@fyralabs.com>
 BuildRequires:	rpm_macro(cargo_install) rust-packaging
 Conflicts:		sudo
+Provides:		sudo = %evr
 
 %description
 run0-sudo-shim attempts to imitate sudo as close as possible, while actually using run0 in the back.
@@ -33,3 +35,7 @@ ln -s %_bindir/run0-sudo-shim %buildroot%_bindir/sudo
 %license LICENSE.dependencies
 %_bindir/run0-sudo-shim
 %_bindir/sudo
+
+%changelog
+* Sun Jun 28 2026 madonuko <mado@fyralabs.com> - 1.3.1-2
+- add provides sudo


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(run0-sudo-shim): provides sudo (#13474)](https://github.com/terrapkg/packages/pull/13474)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)