### PR TITLE
[f42] fix(mangowm): Build requires pkgconfig(pangocairo) (#13876)

### DIFF
--- a/anda/desktops/mangowm/mangowm.spec
+++ b/anda/desktops/mangowm/mangowm.spec
@@ -22,6 +22,7 @@ BuildRequires:  pkgconfig(libinput)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(libpcre2-8)
 BuildRequires:  pkgconfig(libcjson)
+BuildRequires:  pkgconfig(pangocairo)
 BuildRequires:  scenefx-devel
 
 Conflicts:      mangowc < %{mangowc_ver}
@@ -45,11 +46,6 @@ dwl — crafted for speed, flexibility, and a customizable desktop experience.
 %files
 %doc README.md
 %license LICENSE
-%license LICENSE.wlroots
-%license LICENSE.tinywl 
-%license LICENSE.sway 
-%license LICENSE.dwm 
-%license LICENSE.dwl 
 %{_bindir}/mango
 %{_bindir}/mmsg
 %{_sysconfdir}/mango/config.conf


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f42`:
 - [fix(mangowm): Build requires pkgconfig(pangocairo) (#13876)](https://github.com/terrapkg/packages/pull/13876)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)