### PR TITLE
[el10] add: arudino-serial-monitor (#13886)

### DIFF
--- a/anda/tools/arduino-serial-monitor/anda.hcl
+++ b/anda/tools/arduino-serial-monitor/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "arduino-serial-monitor.spec"
+	}
+}

--- a/anda/tools/arduino-serial-monitor/arduino-serial-monitor.spec
+++ b/anda/tools/arduino-serial-monitor/arduino-serial-monitor.spec
@@ -1,0 +1,38 @@
+%global goipath github.com/arduino/serial-monitor
+Version:        0.15.0
+
+%gometa -f
+
+Name:           arduino-serial-monitor
+Release:        1%{?dist}
+Summary:        Arduino pluggable monitor for serial ports
+License:        GPL-3.0-or-later
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+URL:            %{gourl}
+Source:         %{url}/archive/v%{version}.tar.gz
+BuildRequires:  golang
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%goprep
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/serial-monitor %{goipath}
+
+%install
+install -Dm755 %{gobuilddir}/bin/serial-monitor -t %buildroot%{_bindir}
+
+%files
+%license LICENSE.txt
+%doc README.md
+%{_bindir}/serial-monitor
+
+%changelog
+* Thu Jul 09 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/arduino-serial-monitor/update.rhai
+++ b/anda/tools/arduino-serial-monitor/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/serial-monitor"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: arudino-serial-monitor (#13886)](https://github.com/terrapkg/packages/pull/13886)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)