### PR TITLE
[f43] add: arduinoOTA (#13885)

### DIFF
--- a/anda/tools/arduinoota/anda.hcl
+++ b/anda/tools/arduinoota/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "arduinoota.spec"
+	}
+}

--- a/anda/tools/arduinoota/arduinoota.spec
+++ b/anda/tools/arduinoota/arduinoota.spec
@@ -1,0 +1,39 @@
+%global goipath github.com/arduino/arduinoOTA
+Version:        1.4.1
+
+%gometa -f
+
+Name:           arduinoota
+Release:        1%{?dist}
+Summary:        Tool for uploading programs to Arduino boards over a network
+License:        GPL-3.0-or-later
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+URL:            %{gourl}
+Source:         %{url}/archive/%{version}.tar.gz
+BuildRequires:  golang
+Provides:       arduinoOTA
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%goprep
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/arduinoOTA %{goipath}
+
+%install
+install -Dm755 %{gobuilddir}/bin/arduinoOTA -t %buildroot%{_bindir}
+
+%files
+%license LICENSE.txt
+%doc README.md
+%{_bindir}/arduinoOTA
+
+%changelog
+* Thu Jul 09 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/arduinoota/update.rhai
+++ b/anda/tools/arduinoota/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("arduino/arduinoOTA"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: arduinoOTA (#13885)](https://github.com/terrapkg/packages/pull/13885)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)