### PR TITLE
[el10] fix: bup (#13906)

### DIFF
--- a/anda/misc/bup/bup.spec
+++ b/anda/misc/bup/bup.spec
@@ -1,5 +1,5 @@
 Name:			bup
-Version:		0.25.rc2
+Version:		0.33.10
 Release:		1%{?dist}
 Summary:		Efficient backup system based on the git packfile format
 License:		LGPL-2.0-only
@@ -7,7 +7,8 @@ URL:			https://bup.github.io
 Source0:		https://github.com/bup/bup/archive/refs/tags/%version.tar.gz
 Packager:		madonuko <mado@fyralabs.com>
 BuildRequires:  python3-devel
-BuildRequires:	gcc-c++ git-core
+BuildRequires:	gcc-c++
+BuildRequires:	git-core
 BuildRequires:  pandoc
 BuildRequires:	pkgconfig(readline)
 BuildRequires:	pkgconfig(libacl)
@@ -25,8 +26,10 @@ HTML documentations for %name.
 %prep
 %autosetup
 
-%build
+%conf
 ./configure
+
+%build
 %make_build
 
 %install
@@ -76,7 +79,7 @@ HTML documentations for %name.
 
 %files
 %license LICENSE
-%doc README.md DESIGN HACKING 
+%doc README.md DESIGN HACKING
 %_bindir/bup
 %_libdir/bup/
 %_mandir/man1/bup-bloom.1.*
@@ -118,3 +121,7 @@ HTML documentations for %name.
 %_mandir/man1/bup-web.1.*
 %_mandir/man1/bup.1.*
 %_mandir/man5/bup-config.5.*
+
+%changelog
+* Fri Jul 10 2026 Owen Zimmerman <owen@fyralabs.com>
+- Clean up spec

--- a/anda/misc/bup/update.rhai
+++ b/anda/misc/bup/update.rhai
@@ -1,3 +1,1 @@
-let v = gh_tag("bup/bup");
-v.crop(4);
-rpm.version(v);
+rpm.version(gh_tag("bup/bup"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: bup (#13906)](https://github.com/terrapkg/packages/pull/13906)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)