### PR TITLE
[el10] fix: astra (#13905)

### DIFF
--- a/anda/apps/astra/astra.spec
+++ b/anda/apps/astra/astra.spec
@@ -15,7 +15,7 @@ BuildRequires:  nodejs-npm nodejs-packaging
 Audiophile music player with gapless playback, parametric EQ, AutoEQ import, and real-time DSP visualizers.
 
 %prep
-%autosetup -n %name-%ver
+%autosetup -n %name-%(echo %ver | sed 's/^v//')
 
 %build
 %npm_build -BV -M production


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: astra (#13905)](https://github.com/terrapkg/packages/pull/13905)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)