### PR TITLE
[f44] fix: goofcord (#13941)

### DIFF
--- a/anda/apps/goofcord/stable/goofcord.spec
+++ b/anda/apps/goofcord/stable/goofcord.spec
@@ -43,13 +43,13 @@ install -Dm644 assetsDev/%{appid}.metainfo.xml -t %{buildroot}%{_metainfodir}
 %{_libdir}/%{name}/
 %{_metainfodir}/%{appid}.metainfo.xml
 %{_hicolordir}/16x16/apps/%{name}.png
+%{_hicolordir}/24x24/apps/%{name}.png
 %{_hicolordir}/32x32/apps/%{name}.png
 %{_hicolordir}/48x48/apps/%{name}.png
 %{_hicolordir}/64x64/apps/%{name}.png
 %{_hicolordir}/128x128/apps/%{name}.png
 %{_hicolordir}/256x256/apps/%{name}.png
 %{_hicolordir}/512x512/apps/%{name}.png
-%{_hicolordir}/1024x1024/apps/%{name}.png
 
 %changelog
 * Sat Jun 28 2025 Gilver E. <rockgrub@disroot.org> - 1.10.1-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: goofcord (#13941)](https://github.com/terrapkg/packages/pull/13941)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)