### PR TITLE
[el10] fix(cuda): Fix dependencies for architecture (#13959)

### DIFF
--- a/anda/devs/cuda/cuda/cuda.spec
+++ b/anda/devs/cuda/cuda/cuda.spec
@@ -3,7 +3,7 @@
 
 Name:           cuda
 Version:        13.3.73
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        NVIDIA Compute Unified Device Architecture Toolkit
 Epoch:          1
 License:        CUDA Toolkit
@@ -31,7 +31,7 @@ graphics processing unit (GPU).
 Summary:        Compute Unified Device Architecture command-line tools
 Requires:       %{name} = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:       %{name}-cupti%{?_isa}
-Requires:       %{name}-devel%{?_isa}
+Requires:       %{name}-devel
 Requires:       %{name}-gdb%{?_isa}
 Requires:       %{name}-memcheck%{?_isa}
 Requires:       %{name}-nvdisasm%{?_isa}
@@ -79,27 +79,27 @@ Metapackage that installs all runtime NVIDIA CUDA libraries.
 Summary:        Development files for %{name}
 Requires:       %{name}%{_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
 Requires:       %{name}-libs%{_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
-Requires:       %{name}-cccl-devel%{?_isa}
-Requires:       %{name}-cudart-devel%{?_isa}
-Requires:       %{name}-cupti-devel%{?_isa}
+Requires:       %{name}-cccl-devel
+Requires:       %{name}-cudart-devel
+Requires:       %{name}-cupti-devel
 Requires:       %{name}-nvcc%{?_isa}
 Requires:       %{name}-nvprune%{?_isa}
-Requires:       %{name}-nvml-devel%{?_isa}
-Requires:       %{name}-nvrtc-devel%{?_isa}
-Requires:       %{name}-nvtx-devel%{?_isa}
+Requires:       %{name}-nvml-devel
+Requires:       %{name}-nvrtc-devel
+Requires:       %{name}-nvtx-devel
 Requires:       %{name}-cuobjdump%{?_isa}
-Requires:       %{name}-cuxxfilt-devel%{?_isa}
-Requires:       %{name}-profiler-devel%{?_isa}
-Requires:       %{name}-sandbox-devel%{?_isa}
-Requires:       libcublas-devel%{?_isa}
-Requires:       libcufft-devel%{?_isa}
-Requires:       libcufile-devel%{?_isa}
-Requires:       libcurand-devel%{?_isa}
-Requires:       libcusolver-devel%{?_isa}
-Requires:       libcusparse-devel%{?_isa}
-Requires:       libnpp-devel%{?_isa}
-Requires:       libnvjitlink-devel%{?_isa}
-Requires:       libnvjpeg-devel%{?_isa}
+Requires:       %{name}-cuxxfilt-devel
+Requires:       %{name}-profiler-devel
+Requires:       %{name}-sandbox-devel
+Requires:       libcublas-devel
+Requires:       libcufft-devel
+Requires:       libcufile-devel
+Requires:       libcurand-devel
+Requires:       libcusolver-devel
+Requires:       libcusparse-devel
+Requires:       libnpp-devel
+Requires:       libnvjitlink-devel
+Requires:       libnvjpeg-devel
 Conflicts:      %{name}-headers-%{major_package_version} < %{?epoch:%{epoch}:}%{version}
 Conflicts:      %{name}-libraries-dev-%{major_package_version} < %{?epoch:%{epoch}:}%{version}
 Conflicts:      %{name}-misc-headers-%{major_package_version} < %{?epoch:%{epoch}:}%{version}
@@ -144,5 +144,7 @@ sed -i \
 %{_libdir}/pkgconfig/cuda.pc
 
 %changelog
+* Fri Jul 10 2026 Gilver E. <roachy@fyralabs.com> - 1:13.3.73-3
+- Fix architecture dependent dependencies
 * Wed Jul 8 2026 Gilver E. <roachy@fyralabs.com> - 1:13.3.73-2
 - Mass update CUDA components


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(cuda): Fix dependencies for architecture (#13959)](https://github.com/terrapkg/packages/pull/13959)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)