### PR TITLE
[el10] chore: Deprecate f42 (#13970)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
   "repoOwner": "terrapkg",
   "repoName": "packages",
   "resetAuthor": true,
-  "targetBranchChoices": ["frawhide", "f44", "f43", "f42", "el10"],
+  "targetBranchChoices": ["frawhide", "f44", "f43", "el10"],
   "branchLabelMapping": {
     "^sync-(.+)$": "$1"
   }

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -17,7 +17,6 @@ jobs:
           - frawhide
           - f44
           - f43
-          - f42
           - el10
     container:
       image: ghcr.io/terrapkg/builder:frawhide

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -8,7 +8,6 @@ on:
       - frawhide
       - f44
       - f43
-      - f42
       - el10
     paths:
       - comps.xml

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -52,7 +52,6 @@ jobs:
             }
             copy_over f44 || true
             copy_over f43 || true
-            copy_over f42 || true
             copy_over el10 || true
             git push -u origin --all
           fi

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -52,7 +52,6 @@ jobs:
             }
             copy_over f44 || true
             copy_over f43 || true
-            copy_over f42 || true
             copy_over el10 || true
             git push -u origin --all
           fi

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -52,7 +52,6 @@ jobs:
             }
             copy_over f44 || true
             copy_over f43 || true
-            copy_over f42 || true
             copy_over el10 || true
             git push -u origin --all
           fi


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: Deprecate f42 (#13970)](https://github.com/terrapkg/packages/pull/13970)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)