### PR TITLE
[frawhide] fix(fluxer): Exclude libcap (#13990)

### DIFF
--- a/anda/apps/fluxer/anda.hcl
+++ b/anda/apps/fluxer/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "fluxer.spec"
   }
+  labels {
+    large = 1
+  }
 }

--- a/anda/apps/fluxer/fluxer.spec
+++ b/anda/apps/fluxer/fluxer.spec
@@ -2,12 +2,12 @@
 
 Name:           fluxer
 Version:        2026.710.164008
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Fluxer is a free and open source instant messaging and VoIP platform built for friends, groups, and communities
 URL:            https://fluxer.app
 
 %electronmeta -D
-%global __provides_exclude %{__provides_exclude}|libcbor\.so.*|libcrypto\.so.*|libfido2\.so.*|libudev\.so.*|libz\.so.*
+%global __provides_exclude %{__provides_exclude}|libcbor\.so.*|libcrypto\.so.*|libfido2\.so.*|libudev\.so.*|libz\.so.*|libcap\.so.*
 
 License:        AGPL-3.0-or-later AND %electron_license
 Source0:        https://github.com/fluxerapp/fluxer/archive/refs/tags/%version.tar.gz
@@ -19,9 +19,10 @@ BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  clang-devel
 BuildRequires:  pipewire-devel
+Provides:       bundled(libcap)
 Provides:       bundled(libcbor)
 Provides:       bundled(libfido2)
-Provides:       bundled(libudev1)
+Provides:       bundled(libudev)
 Provides:       bundled(openssl)
 Provides:       bundled(zlib)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `f43` to `frawhide`:
 - [fix(fluxer): Exclude libcap (#13990)](https://github.com/terrapkg/packages/pull/13990)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)