### PR TITLE
[el10] fix: opencc (#13994)

### DIFF
--- a/anda/langs/python/opencc/opencc.spec
+++ b/anda/langs/python/opencc/opencc.spec
@@ -41,6 +41,7 @@ Summary:        %{summary}
 %files -n python3-%{pypi_name} -f %{pyproject_files}
 %doc README.md AUTHORS
 %license LICENSE
+%{_bindir}/opencc
 
 %changelog
 * Sun Mar 29 2026 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: opencc (#13994)](https://github.com/terrapkg/packages/pull/13994)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)