### PR TITLE
fix(continuwuity-nightly): more reliably get latest tag of any type

### DIFF
--- a/anda/misc/continuwuity/nightly/update.rhai
+++ b/anda/misc/continuwuity/nightly/update.rhai
@@ -1,4 +1,4 @@
-rpm.global("ver", get("https://forgejo.ellis.link/api/v1/repos/continuwuation/continuwuity/releases?pre-release=true").json_arr()[0].tag_name);
+rpm.global("ver", forgejo_tag("forgejo.ellis.link", "continuwuation/continuwuity"));
 rpm.global("commit", forgejo_commit("forgejo.ellis.link", "continuwuation/continuwuity"));
 if rpm.changed() {
   rpm.release();


### PR DESCRIPTION
What it says on the tin. For some reason, the `?pre-release=true` query param in `/api/v1/repos/{owner}/{repo}/releases` makes the results *exclusively* pre-releases, rather than simply additively including them in output.

Tested locally with `anda update anda/misc/continuwuity/nightly/pkg --filters nightly=1`.