### PR TITLE
[f43] fix: mise (#14011)

### DIFF
--- a/anda/buildsys/mise/rust-mise.spec
+++ b/anda/buildsys/mise/rust-mise.spec
@@ -87,6 +87,7 @@ Zsh command line completion support for %{crate}.
 %cargo_prep_online
 
 %build
+export LDFLAGS="$LDFLAGS -fPIE"
 %{cargo_license_summary_online}
 %{cargo_license_online} > LICENSE.dependencies
 %{cargo_build} --locked


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: mise (#14011)](https://github.com/terrapkg/packages/pull/14011)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)