### PR TITLE
[el10] fix(continuwuity-nightly): more reliably get latest tag of any type (#14010)

### DIFF
--- a/anda/misc/continuwuity/nightly/update.rhai
+++ b/anda/misc/continuwuity/nightly/update.rhai
@@ -1,4 +1,4 @@
-rpm.global("ver", get("https://forgejo.ellis.link/api/v1/repos/continuwuation/continuwuity/releases?pre-release=true").json_arr()[0].tag_name);
+rpm.global("ver", forgejo_tag("forgejo.ellis.link", "continuwuation/continuwuity"));
 rpm.global("commit", forgejo_commit("forgejo.ellis.link", "continuwuation/continuwuity"));
 if rpm.changed() {
   rpm.release();


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(continuwuity-nightly): more reliably get latest tag of any type (#14010)](https://github.com/terrapkg/packages/pull/14010)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)