### PR TITLE
[f44] chore(heroic): build on arm64 (#14023)

### DIFF
--- a/anda/games/heroic-games-launcher/anda.hcl
+++ b/anda/games/heroic-games-launcher/anda.hcl
@@ -1,5 +1,5 @@
 project pkg {
-        arches = ["x86_64"]
+        // arches = ["x86_64"]
     rpm {
         spec = "heroic-games-launcher.spec"
     }

--- a/anda/games/heroic-games-launcher/heroic-games-launcher.spec
+++ b/anda/games/heroic-games-launcher/heroic-games-launcher.spec
@@ -15,6 +15,7 @@ License:       GPL-3.0-only AND MIT AND BSD-3-Clause
 URL:           https://heroicgameslauncher.com
 BuildRequires: anda-srpm-macros
 BuildRequires: pnpm
+BuildRequires: openjpeg-tools
 Requires:      alsa-lib
 Requires:      gtk3
 Requires:      hicolor-icon-theme


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(heroic): build on arm64 (#14023)](https://github.com/terrapkg/packages/pull/14023)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)