### PR TITLE
[f44] chore (libaudec)): fix update script (#14027)

### DIFF
--- a/anda/lib/audec/update.rhai
+++ b/anda/lib/audec/update.rhai
@@ -1,1 +1,1 @@
-print(sourcehut("~alextee/libaudec"));
+rpm.version(sourcehut("~alextee/libaudec"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (libaudec)): fix update script (#14027)](https://github.com/terrapkg/packages/pull/14027)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)