### PR TITLE
[f44] fix: args-hxx, use %conf (#14012)

### DIFF
--- a/anda/lib/args-hxx/args-hxx.spec
+++ b/anda/lib/args-hxx/args-hxx.spec
@@ -25,10 +25,12 @@ Summary:	Documentations for args-hxx
 %prep
 %autosetup -n args-%version
 
-%build
+%conf
 %cmake
+
+%build
 %cmake_build
-make doc/man
+%__make doc/man
 
 %install
 %cmake_install
@@ -36,15 +38,11 @@ make installman DESTDIR=%buildroot%_prefix
 
 %files
 %_includedir/args.hxx
-/usr/lib/cmake/args/args-config-version.cmake
-/usr/lib/cmake/args/args-config.cmake
-%_libdir/pkgconfig/args.pc
+%{_datadir}/cmake/args/args-*.cmake
+%{_datadir}/pkgconfig/args.pc
 
 %files doc
 %_mandir/man3/args*
-%_mandir/man3/DoublesReader.3.gz
-%_mandir/man3/StringAssignable.3.gz
-%_mandir/man3/ToLowerReader.3.gz
 %_mandir/man3/conanfile_ArgsConan.3.gz
 %_mandir/man3/md_CONTRIBUTING.3.gz
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: args-hxx, use %conf (#14012)](https://github.com/terrapkg/packages/pull/14012)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)