### PR TITLE
[f43] fix (crystal): bdep asciidoctor, formatting, use %pkg_completion, add new files, dep zlib-ng-devel instead of zlib-devel (#14041)

### DIFF
--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -14,11 +14,24 @@ Source1:       https://dev.alpinelinux.org/archive/crystal/crystal-%{bootstrap_v
 %else
 BuildRequires: crystal
 %endif
-BuildRequires: gcc gcc-c++ make gc-devel llvm-devel
-BuildRequires: pcre2-devel libyaml-devel libffi-devel
-Requires:      gcc pkgconfig gc-devel
-Requires:      pcre2-devel openssl-devel zlib-devel
-Requires:      libyaml-devel libxml2-devel gmp-devel
+BuildRequires: gcc
+BuildRequires: gcc-c++
+BuildRequires: make
+BuildRequires: gc-devel
+BuildRequires: llvm-devel
+BuildRequires: rubygem-asciidoctor
+BuildRequires: pcre2-devel
+BuildRequires: libyaml-devel
+BuildRequires: libffi-devel
+Requires:      gcc
+Requires:      pkgconfig
+Requires:      gc-devel
+Requires:      pcre2-devel
+Requires:      openssl-devel
+Requires:      zlib-ng-devel
+Requires:      libyaml-devel
+Requires:      libxml2-devel
+Requires:      gmp-devel
 Suggests:      shards
 
 %description
@@ -28,6 +41,8 @@ Crystal is a programming language with the following goals:
 - Be able to call C code by writing bindings to it in Crystal
 - Have compile-time evaluation and generation of code, to avoid boilerplate code
 - Compile to efficient native code
+
+%pkg_completion -Bf
 
 %prep
 %setup -q
@@ -50,11 +65,24 @@ export PATH="%{_builddir}/crystal-%{bootstrap_version}-%{_arch}-alpine-linux-mus
 %{_bindir}/crystal
 %{_datadir}/crystal
 %{_datadir}/zsh/site-functions/_crystal
-%{_datadir}/bash-completion/completions/crystal
-%{_datadir}/fish/vendor_completions.d/crystal.fish
 %{_mandir}/man1/crystal.1.gz
+%{_mandir}/man1/crystal-build.1.gz
+%{_mandir}/man1/crystal-docs.1.gz
+%{_mandir}/man1/crystal-env.1.gz
+%{_mandir}/man1/crystal-eval.1.gz
+%{_mandir}/man1/crystal-init.1.gz
+%{_mandir}/man1/crystal-play.1.gz
+%{_mandir}/man1/crystal-run.1.gz
+%{_mandir}/man1/crystal-spec.1.gz
+%{_mandir}/man1/crystal-tool-dependencies.1.gz
+%{_mandir}/man1/crystal-tool-format.1.gz
+%{_mandir}/man1/crystal-tool-macro_code_coverage.1.gz
+%{_mandir}/man1/crystal-tool-unreachable.1.gz
 
 %changelog
+* Thu Jul 16 2026 Owen Zimmerman <owen@fyralabs.com> - 1.21.0-1 
+- Update for 1.21.0, use %%pkg_completions
+
 * Mon Nov 03 2025 Carl Hörberg <carl@84codes.com> -  1.18.2-2
 - Build from source, support multiple architectures.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (crystal): bdep asciidoctor, formatting, use %pkg_completion, add new files, dep zlib-ng-devel instead of zlib-devel (#14041)](https://github.com/terrapkg/packages/pull/14041)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)