### PR TITLE
[f43] fix: Add yet more missing SELinux rules for steamos-manager (#14050)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -4,7 +4,7 @@
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          3%{?dist}
+Release:          4%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager

--- a/anda/games/steamos-manager-powerstation/steamos_manager.te
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.te
@@ -1,4 +1,4 @@
-policy_module(steamos_manager, 1.0.1)
+policy_module(steamos_manager, 1.0.2)
 
 ########################################
 # Init
@@ -67,6 +67,11 @@ optional_policy(`
 dev_read_sysfs(steamos_manager_t)
 dev_rw_sysfs(steamos_manager_t)
 
+gen_require(`
+     type sysfs_t;
+')
+allow steamos_manager_t sysfs_t:dir write;
+
 ########################################
 # Procfs access
 ########################################
@@ -129,7 +134,7 @@ optional_policy(`
 	gen_require(`
 		type usb_device_t;
 	')
-	allow steamos_manager_t usb_device_t:chr_file { getattr watch watch_reads };
+	allow steamos_manager_t usb_device_t:chr_file { read getattr watch watch_reads };
 ')
 
 # /dev/input/event* — inputplumber


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: Add yet more missing SELinux rules for steamos-manager (#14050)](https://github.com/terrapkg/packages/pull/14050)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)