### PR TITLE
[f44] add noctalia v5 (#12452)

### DIFF
--- a/anda/desktops/noctalia/anda.hcl
+++ b/anda/desktops/noctalia/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "noctalia.spec"
+  }
+}

--- a/anda/desktops/noctalia/noctalia.spec
+++ b/anda/desktops/noctalia/noctalia.spec
@@ -1,19 +1,15 @@
 %global debug_package   %{nil}
 
-%global ver 5.0.0
+%global ver 5.0.0-beta.3
 
-%global commit          5c7e2fba2338125339c6556b5cfb0ca5864ea448
-%global shortcommit     %(c=%{commit}; echo ${c:0:7})
-%global commitdate      20260711
-
-Name:   	noctalia-git
-Version:	%{ver}^%{commitdate}git.%{shortcommit}
-Release:	2%{?dist}
+Name:   	noctalia
+Version:	5.0.0~beta.3
+Release:	1%{?dist}
 Summary:	A lightweight Wayland shell and bar built directly on Wayland + OpenGL ES, with no Qt or GTK dependency
 
 License:	MIT
 URL:		https://github.com/noctalia-dev/noctalia
-Source0:	https://github.com/noctalia-dev/noctalia/archive/%{commit}/noctalia-%{commit}.tar.gz
+Source0:	https://github.com/noctalia-dev/noctalia/releases/download/v%{ver}/noctalia-v%{ver}.tar.gz
 
 BuildRequires:  meson
 BuildRequires:  gcc-c++
@@ -52,7 +48,7 @@ Requires:       hicolor-icon-theme
 Requires:       dejavu-sans-fonts
 Requires:       libwebp
 
-Conflicts:      noctalia
+Conflicts:      noctalia-git
 
 Recommends:     ddcutil
 Recommends:     gpu-screen-recorder
@@ -64,10 +60,7 @@ Packager:       Cypress Reed <cypress@fyralabs.com>
 A lightweight Wayland shell and bar built directly on Wayland + OpenGL ES, with no Qt or GTK dependency.
 
 %prep
-%autosetup -n noctalia-%{commit}
-
-# Manually insert commit hash
-sed -i "s/'unknown'/'%{shortcommit}'/g" meson.build
+%autosetup -n noctalia-release
 
 %conf
 %meson
@@ -100,7 +93,7 @@ done
 
 %changelog
 * Thu Jul 16 2026 Cypress Reed <cypress@fyralabs.com>
-- Add conflicts with noctalia
+- Create noctalia package based on noctalia-git
 
 * Thu Jul 09 2026 Cypress Reed <cypress@fyralabs.com>
 - Noctalia requires system libraries now, so remove the meson options

--- a/anda/desktops/noctalia/update.rhai
+++ b/anda/desktops/noctalia/update.rhai
@@ -1,0 +1,8 @@
+let v = gh("noctalia-dev/noctalia");
+v.crop(1);
+
+if v >= "5" {
+  rpm.global("ver", v);
+  v.replace("-", "~");
+  rpm.version(v);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add noctalia v5 (#12452)](https://github.com/terrapkg/packages/pull/12452)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)