### PR TITLE
fix(chromium-ectool): Fix compile warning (#14061)

### DIFF
--- a/anda/tools/chromium-ectool/cbi-util-compile.patch
+++ b/anda/tools/chromium-ectool/cbi-util-compile.patch
@@ -1,0 +1,20 @@
+--- a/util/cbi-util.c	2026-07-17 08:21:42.672670295 -0700
++++ b/util/cbi-util.c	2026-07-17 08:22:07.533924407 -0700
+@@ -229,7 +229,7 @@
+ {
+ 	uint64_t val;
+ 	char *e;
+-	char *ch;
++	const char *ch;
+ 
+ 	val = strtoull(arg, &e, 0);
+ 	if (val > UINT32_MAX || !*arg || (e && *e && *e != ':')) {
+@@ -264,7 +264,7 @@
+ {
+ 	uint64_t val;
+ 	char *e;
+-	char *ch;
++	const char *ch;
+ 
+ 	val = strtoul(arg, &e, 0);
+ 	/* strtoul sets an errno for invalid input. If the value read is out of

--- a/anda/tools/chromium-ectool/chromium-ectool.spec
+++ b/anda/tools/chromium-ectool/chromium-ectool.spec
@@ -7,8 +7,10 @@ License:        BSD-3-Clause
 URL:            https://chromium.googlesource.com/chromiumos/platform/ec/
 
 Version:        %shortcommit
-Release:        2%{?dist}
+Release:        3%{?dist}
 Source0:        https://github.com/coreboot/chrome-ec/archive/refs/heads/release-R100-14526.B-main.tar.gz
+# fix warning in util/cbi-util.c
+Patch0:         cbi-util-compile.patch
 Conflicts:      ectool
 
 BuildRequires:  make gcc libftdi-devel libusb1-devel hostname
@@ -17,7 +19,7 @@ BuildRequires:  make gcc libftdi-devel libusb1-devel hostname
 A tool to query and send commands to ChromiumOS EC from userspace.
 
 %prep
-%autosetup -n chrome-ec-release-R100-14526.B-main
+%autosetup -n chrome-ec-release-R100-14526.B-main -p1
 
 %build
 BOARD=host %make_build utils-host


### PR DESCRIPTION
Added patch to fix compile warning that caused build failures on F44 (#14061)