### PR TITLE
[f44] fix: rust-typst (#14060)

### DIFF
--- a/anda/langs/rust/typst/rust-typst.spec
+++ b/anda/langs/rust/typst/rust-typst.spec
@@ -43,7 +43,7 @@ Provides:       %crate-cli = %version-%release
 %_mandir/man1/typst-update.1.gz
 %_mandir/man1/typst-watch.1.gz
 %_mandir/man1/typst.1.gz
-
+%_mandir/man1/typst-eval.1.gz
 
 %pkg_completion -Bfzn %crate
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: rust-typst (#14060)](https://github.com/terrapkg/packages/pull/14060)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)