### PR TITLE
[f43] fix(gcm-core): try dotnet 10 (#14072)

### DIFF
--- a/anda/tools/gcm-core/gcm-core.spec
+++ b/anda/tools/gcm-core/gcm-core.spec
@@ -20,11 +20,11 @@ Source0:        %{forgesource}
 Provides:       %{long_name} = %{version}-%{release}
 Provides:       %{long_name}-core = %{version}-%{release}
 
-BuildRequires:  dotnet-sdk-8.0
+BuildRequires:  dotnet-sdk-10.0
 # Require DPKG, so that we can use the `dpkg-architecture` command. which makes the build script happy.
 # TODO: Better solution: Patch out the debian-specific packaging code.
 BuildRequires:  dpkg-dev
-Requires:       dotnet-runtime-8.0
+Requires:       dotnet-runtime-10.0
 
 
 %description


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(gcm-core): try dotnet 10 (#14072)](https://github.com/terrapkg/packages/pull/14072)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)