### PR TITLE
[f43] feat: switch backport runners to self-hosted (#14082)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     name: Backport/sync PR
-    runs-on: ubuntu-22.04
+    runs-on: arc-runner-set
     if: github.event.pull_request.merged
     steps:
       - name: Install SSH signing key


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: switch backport runners to self-hosted (#14082)](https://github.com/terrapkg/packages/pull/14082)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)