### PR TITLE
[f44] switch update runners to custom (#14086)

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,7 @@ jobs:
   autoupdate:
     permissions:
       contents: write
-    runs-on: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     container:
       image: ghcr.io/terrapkg/builder:f44
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [switch update runners to custom (#14086)](https://github.com/terrapkg/packages/pull/14086)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)