### PR TITLE
[f43] feat(ci): Switch update jobs to arc-runner-set (#14089)

### DIFF
--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -10,7 +10,7 @@ jobs:
   autoupdate:
     permissions:
       contents: write
-    runs-on: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     strategy:
       matrix:
         branch:

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   update-comps:
-    runs-on: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     container:
       image: ghcr.io/terrapkg/builder:f43
     steps:

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -10,7 +10,7 @@ jobs:
   autoupdate:
     permissions:
       contents: write
-    runs-on: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     container:
       image: ghcr.io/terrapkg/builder:f43
       options: --cap-add=SYS_ADMIN --privileged

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -10,7 +10,7 @@ jobs:
   autoupdate:
     permissions:
       contents: write
-    runs-on: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     container:
       image: ghcr.io/terrapkg/builder:f43
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat(ci): Switch update jobs to arc-runner-set (#14089)](https://github.com/terrapkg/packages/pull/14089)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)