### PR TITLE
[f43] fix (pyvcd): use pypi_source (#14107)

### DIFF
--- a/anda/langs/python/pyvcd/pyvcd.spec
+++ b/anda/langs/python/pyvcd/pyvcd.spec
@@ -7,7 +7,7 @@ Release:		2%?dist
 Summary:		Python package for writing Value Change Dump (VCD) files
 License:		MIT
 URL:			https://github.com/SanDisk-Open-Source/pyvcd
-Source0:		%url/releases/download/%version/pyvcd-%{version}.tar.gz
+Source0:		%{pypi_source}
 BuildArch:      noarch
 
 BuildRequires:  python3-build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (pyvcd): use pypi_source (#14107)](https://github.com/terrapkg/packages/pull/14107)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)