### PR TITLE
[f43] chore (pyproject-parser): dont provide pyproject-parser (#14106)

### DIFF
--- a/anda/langs/python/pyproject-parser/pyproject-parser.spec
+++ b/anda/langs/python/pyproject-parser/pyproject-parser.spec
@@ -3,7 +3,7 @@
 
 Name:			python-%{pypi_name}
 Version:		0.14.0
-Release:		2%?dist
+Release:		3%?dist
 Summary:		Parser for 'pyproject.toml'
 License:		MIT
 URL:			https://pyproject-parser.readthedocs.io/en/latest/
@@ -21,7 +21,6 @@ Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
 %package -n     python3-%{pypi_name}
 Summary:        %{summary}
-Provides:       pyvcd
 %{?python_provide:%python_provide python3-%{pypi_name}}
 
 %description -n python3-%{pypi_name}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (pyproject-parser): dont provide pyproject-parser (#14106)](https://github.com/terrapkg/packages/pull/14106)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)