### PR TITLE
[f43] fix: discord-canary-openasar (#14120)

### DIFF
--- a/anda/apps/discord-canary-openasar/discord-canary-openasar.spec
+++ b/anda/apps/discord-canary-openasar/discord-canary-openasar.spec
@@ -41,6 +41,7 @@ mkdir -p %{buildroot}%{_datadir}/applications/
 mkdir -p %{buildroot}%{_datadir}/pixmaps
 ln -s %_datadir/discord-canary-openasar/discord-canary.desktop %{buildroot}%{_datadir}/applications/discord-canary-openasar.desktop
 ln -s %_datadir/discord-canary-openasar/discord.png %{buildroot}%{_datadir}/pixmaps/discord-canary-openasar.png
+mkdir -p %{buildroot}%{_datadir}/discord-canary-openasar/resources
 cp -v %{SOURCE1} %{buildroot}%{_datadir}/discord-canary-openasar/resources/app.asar
 chmod o+w %{buildroot}%{_datadir}/discord-canary-openasar/resources -R
 ln -s %_datadir/discord-canary-openasar/DiscordCanary %buildroot%_bindir/discord-canary-openasar


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: discord-canary-openasar (#14120)](https://github.com/terrapkg/packages/pull/14120)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)