### PR TITLE
[f43] fix: hf-xet (#14122)

### DIFF
--- a/anda/langs/python/hf-xet/xf-xet.spec
+++ b/anda/langs/python/hf-xet/xf-xet.spec
@@ -7,8 +7,7 @@ Release:		1%{?dist}
 Summary:		xet client tech, used in huggingface_hub
 License:		Apache-2.0
 URL:			https://github.com/huggingface/xet-core
-Source0:		%{url}/releases/download/%{version}/hf_xet-%{version}.tar.gz
-
+Source0:		%{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires:  python3-devel
 BuildRequires:  python3-pip
 BuildRequires:  python3-setuptools
@@ -40,14 +39,18 @@ Summary:        documentation for python3-%{pypi_name}
 documentation for python3-%{pypi_name}.
 
 %prep
-%autosetup -n hf_xet-%{version}
+%autosetup -C
 
 %build
+pushd hf_xet
 %pyproject_wheel
+popd
 
 %install
+pushd hf_xet
 %pyproject_install
 %pyproject_save_files hf_xet
+popd
 
 %files -n python3-%{pypi_name} -f %{pyproject_files}
 %doc *.md


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: hf-xet (#14122)](https://github.com/terrapkg/packages/pull/14122)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)