### PR TITLE
[f43] fix: logitech-rs50-linux-driver (#14104)

### DIFF
--- a/anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec
+++ b/anda/system/logitech-rs50-linux-driver/kmod-common/logitech-rs50-linux-driver.spec
@@ -33,7 +33,7 @@ BuildArch:     noarch
 Akmods modules for the akmod-%{name} package.
 
 %prep
-%autosetup -p1 -n %{name}-%{commit}
+%autosetup -p1 -n logitech-trueforce-linux-driver-%{commit}
 
 echo hid-logitech-hidpp > %{name}.conf
 mv sdk/README.md README-SDK.md
@@ -50,8 +50,9 @@ ln -sr %_sharedstatedir/%{name} %{buildroot}%{_datadir}/%{name}/sdk
 install -Dm755 tools/install-tf-shim.sh %{buildroot}%{_datadir}/%{name}/tools/
 install -Dm755 %{SOURCE2} %{buildroot}%{_bindir}/logi-rs50-proton-setup
 
-install -Dm644 udev/70-logitech-rs50.rules -t %{buildroot}%{_udevrulesdir}/
-install -D -m644 userspace/libtrueforce/udev/99-logitech-rs50-trueforce.rules %{buildroot}%{_udevrulesdir}/70-logitech-rs50-trueforce.rules
+install -Dm644 udev/70-logitech-trueforce.rules -t %{buildroot}%{_udevrulesdir}/
+install -Dm644 udev/71-logi-ffb-uhid.rules -t %{buildroot}%{_udevrulesdir}/
+install -D -m644 userspace/libtrueforce/udev/99-logitech-trueforce.rules %{buildroot}%{_udevrulesdir}/70-logitech-rs50-trueforce.rules
 
 # Akmods modules
 install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
@@ -65,9 +66,10 @@ fi
 
 
 %files
-%doc README.terra.md README.md README-SDK.md CHANGELOG.md rs-wheel-hub-button-layout.png docs/*
+%doc README.terra.md README.md README-SDK.md CHANGELOG.md docs/*
 %{_datadir}/metainfo/com.github.rs50.metainfo.xml
-%{_udevrulesdir}/70-logitech-rs50.rules
+%{_udevrulesdir}/70-logitech-trueforce.rules
+%{_udevrulesdir}/71-logi-ffb-uhid.rules
 %{_udevrulesdir}/70-logitech-rs50-trueforce.rules
 %{_datadir}/%{name}/tools/*
 %{_bindir}/logi-rs50-proton-setup


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: logitech-rs50-linux-driver (#14104)](https://github.com/terrapkg/packages/pull/14104)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)