### PR TITLE
[el10] fix: signal-desktop (#14124)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -75,6 +75,7 @@ echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt
 %install
 mv ./packages/mute-state-change/LICENSE ./packages/mute-state-change/LICENSE.mute-state-change
 mv ./packages/windows-ucv/LICENSE ./packages/mute-state-change/LICENSE.windows-ucv
+mv ./packages/types/LICENSE ./packages/mute-state-change/LICENSE.types
 %electron_install -i signal -l -I build/icons/png
 
 %desktop_file_install %{SOURCE1}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: signal-desktop (#14124)](https://github.com/terrapkg/packages/pull/14124)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)