### PR TITLE
[el10] fix: discord-ptb-openasar (#14121)

### DIFF
--- a/anda/apps/discord-ptb-openasar/discord-ptb-openasar.spec
+++ b/anda/apps/discord-ptb-openasar/discord-ptb-openasar.spec
@@ -43,6 +43,7 @@ ln -s %_datadir/discord-ptb-openasar/discord-ptb.desktop %{buildroot}%{_datadir}
 ln -s %_datadir/discord-ptb-openasar/discord.png %{buildroot}%{_datadir}/pixmaps/discord-ptb-openasar.png
 install discord-ptb.desktop %{buildroot}%{_datadir}/applications/discord-ptb-openasar.desktop
 install discord.png %{buildroot}%{_datadir}/pixmaps/discord-ptb-openasar.png
+mkdir -p %{buildroot}%{_datadir}/discord-ptb-openasar/resources
 cp -v %{SOURCE1} %{buildroot}%{_datadir}/discord-ptb-openasar/resources/app.asar
 chmod o+w %{buildroot}%{_datadir}/discord-ptb-openasar/resources -R
 ln -s %_datadir/discord-ptb-openasar/Discord %buildroot%_bindir/discord-ptb-openasar


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: discord-ptb-openasar (#14121)](https://github.com/terrapkg/packages/pull/14121)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)