### PR TITLE
[el10] fix: kotlin-native (#14128)

### DIFF
--- a/anda/langs/kotlin/kotlin-native/kotlin-native.spec
+++ b/anda/langs/kotlin/kotlin-native/kotlin-native.spec
@@ -38,7 +38,7 @@ sed -i "s|\(KONAN_HOME *= *\).*|\1%{_datadir}/%{name}|" bin/*
 rm -rf %{buildroot} && mkdir -p %{buildroot}%{_bindir}/ && cd kotlin-native-prebuilt-linux-x86_64-%{version}
 install -m 0755 bin/cinterop %{buildroot}%{_bindir}/
 install -m 0755 bin/generate-platform %{buildroot}%{_bindir}/
-install -m 0755 bin/jsinterop %{buildroot}%{_bindir}/
+%dnl install -m 0755 bin/jsinterop %{buildroot}%{_bindir}/
 install -m 0755 bin/klib %{buildroot}%{_bindir}/
 install -m 0755 bin/konanc %{buildroot}%{_bindir}/
 install -m 0755 bin/konan-lldb %{buildroot}%{_bindir}/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: kotlin-native (#14128)](https://github.com/terrapkg/packages/pull/14128)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)