### PR TITLE
[el10] fix (continuwuity): use large runners (#14126)

### DIFF
--- a/anda/misc/continuwuity/nightly/anda.hcl
+++ b/anda/misc/continuwuity/nightly/anda.hcl
@@ -4,5 +4,6 @@ project pkg {
   }
   labels {
     nightly = 1
+    large = 1
   }
 }

--- a/anda/misc/continuwuity/stable/anda.hcl
+++ b/anda/misc/continuwuity/stable/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "continuwuity.spec"
   }
+  labels {
+    large =1
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (continuwuity): use large runners (#14126)](https://github.com/terrapkg/packages/pull/14126)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)