### PR TITLE
[f44] fix: goofcord-nightly (#14102)

### DIFF
--- a/anda/apps/goofcord/nightly/goofcord-nightly.spec
+++ b/anda/apps/goofcord/nightly/goofcord-nightly.spec
@@ -47,13 +47,13 @@ install -Dm644 assetsDev/%{appid}.metainfo.xml -t %{buildroot}%{_metainfodir}
 %{_libdir}/%{base_name}/
 %{_metainfodir}/%{appid}.metainfo.xml
 %{_hicolordir}/16x16/apps/%{base_name}.png
+%{_hicolordir}/24x24/apps/%{base_name}.png
 %{_hicolordir}/32x32/apps/%{base_name}.png
 %{_hicolordir}/48x48/apps/%{base_name}.png
 %{_hicolordir}/64x64/apps/%{base_name}.png
 %{_hicolordir}/128x128/apps/%{base_name}.png
 %{_hicolordir}/256x256/apps/%{base_name}.png
 %{_hicolordir}/512x512/apps/%{base_name}.png
-%{_hicolordir}/1024x1024/apps/%{base_name}.png
 
 %changelog
 * Sat Jun 28 2025 Gilver E. <rockgrub@disroot.org> - 1.10.1^20250615.git.3f5eda1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: goofcord-nightly (#14102)](https://github.com/terrapkg/packages/pull/14102)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)