### PR TITLE
[f43] fix (kotlin-native): license (#14167)

### DIFF
--- a/anda/langs/kotlin/kotlin-native/kotlin-native.spec
+++ b/anda/langs/kotlin/kotlin-native/kotlin-native.spec
@@ -2,11 +2,11 @@
 
 Name:           kotlin-native
 Version:        2.4.10
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        LLVM backend for the Kotlin compiler
 ExclusiveArch:  x86_64
 
-License:        ASL 2.0
+License:        Apache-2.0
 URL:            https://kotlinlang.org/docs/reference/native-overview.html
 Source0:        https://github.com/JetBrains/kotlin/releases/download/v%version/kotlin-native-prebuilt-linux-x86_64-%version.tar.gz
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (kotlin-native): license (#14167)](https://github.com/terrapkg/packages/pull/14167)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)