### PR TITLE
[el10] chore (ansible-collection-onepassword-connect): use ansible_galaxy update function (#14118)

### DIFF
--- a/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/update.rhai
+++ b/anda/tools/ansible-collections/ansible-onepasswordconnect-collection/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("1Password/ansible-onepasswordconnect-collection"));
+rpm.version(ansible_galaxy("onepassword", "connect"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (ansible-collection-onepassword-connect): use ansible_galaxy update function (#14118)](https://github.com/terrapkg/packages/pull/14118)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)