### PR TITLE
[f44] fix(astra): add native visualizers (#14220)

### DIFF
--- a/anda/apps/astra/astra.spec
+++ b/anda/apps/astra/astra.spec
@@ -9,7 +9,9 @@ Summary:        A desktop music player for people who still have a music library
 License:        GPL-3.0-only AND %electron_license
 URL:            https://astramusic.dev
 Source0:        https://github.com/Boof2015/astra/archive/refs/tags/%ver.tar.gz
+Packager:       madonuko <mado@fyralabs.com>
 BuildRequires:  nodejs-npm nodejs-packaging
+BuildRequires:  alsa-lib-devel
 
 %description
 Audiophile music player with gapless playback, parametric EQ, AutoEQ import, and real-time DSP visualizers.
@@ -18,7 +20,7 @@ Audiophile music player with gapless playback, parametric EQ, AutoEQ import, and
 %autosetup -n %name-%(echo %ver | sed 's/^v//')
 
 %build
-%npm_build -BV -M production
+%npm_build -BV -M production -r rebuild:native
 %__nodejs ./scripts/build/writeAppBuildMetadata.cjs
 
 %install
@@ -36,5 +38,5 @@ Audiophile music player with gapless playback, parametric EQ, AutoEQ import, and
 %_hicolordir/*/apps/%name.png
 
 %changelog
-* Sat Jun 28 2026 madonuko <madonuko@outlook.com> - 0.6.1~beta
+* Sun Jun 28 2026 madonuko <madonuko@outlook.com> - 0.6.1~beta
 - Initial package.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(astra): add native visualizers (#14220)](https://github.com/terrapkg/packages/pull/14220)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)