### PR TITLE
[f44] fix(rpcc): bdep wayland-protocols (#14219)

### DIFF
--- a/anda/apps/rpcc/rpcc.spec
+++ b/anda/apps/rpcc/rpcc.spec
@@ -17,6 +17,7 @@ BuildRequires:  gtk3-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  intltool
 BuildRequires:  gcc
+BuildRequires:  pkgconfig(wayland-protocols)
 
 Requires:       libxml2
 Requires:       gtk3


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(rpcc): bdep wayland-protocols (#14219)](https://github.com/terrapkg/packages/pull/14219)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)