### PR TITLE
[f44] fix(tauon): include extra files (#14217)

### DIFF
--- a/anda/apps/tauon/tauon.spec
+++ b/anda/apps/tauon/tauon.spec
@@ -58,7 +58,8 @@ install -Dm755 extra/tauonmb.sh %{buildroot}/opt/tauon/tauonmb.sh
 %doc README.md CHANGELOG.md CONTRIBUTING.md
 %license LICENSE
 %{_bindir}/tauonmb
-%{python3_sitearch}/phazor.cpython-314-*-linux-gnu.so
+%{python3_sitearch}/phazor.cpython-*-linux-gnu.so
+%dnl %{python3_sitearch}/phazor-pw.cpython-*-linux-gnu.so
 %{_appsdir}/tauonmb.desktop
 %{_scalableiconsdir}/tauonmb-symbolic.svg
 %{_scalableiconsdir}/tauonmb.svg


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(tauon): include extra files (#14217)](https://github.com/terrapkg/packages/pull/14217)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)