### PR TITLE
[f43] fix(codium): Yeet bundled x86_64 deps (#14237)

### DIFF
--- a/anda/devs/codium/codium.spec
+++ b/anda/devs/codium/codium.spec
@@ -66,6 +66,14 @@ EOF
 %build
 
 %install
+%ifnarch %{x86_64}
+find . -name "x64" -type d -prune -exec rm -rf "{}" ";"
+%endif
+
+%ifnarch %{arm64}
+find . -name "arm64" -type d -prune -exec rm -rf "{}" ";"
+%endif
+
 cd stuff
 mkdir -p %{buildroot}%{_datadir}/doc/%{name}/ %{buildroot}%{_datadir}/licenses/%{name}
 install -Dm644 %{SOURCE1} %{buildroot}%{_docdir}/%{name}/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(codium): Yeet bundled x86_64 deps (#14237)](https://github.com/terrapkg/packages/pull/14237)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)