### PR TITLE
[el10] chore (codium): bump rel (#14245)

### DIFF
--- a/anda/devs/codium/codium.spec
+++ b/anda/devs/codium/codium.spec
@@ -4,7 +4,7 @@ Name:			      codium
 Version:		    1.126.04524
 %electronmeta -D
 %global __requires_exclude %{__requires_exclude}|libcurl.so|libmsalruntime.so
-Release:		    1%{?dist}
+Release:		    2%{?dist}
 Summary:		    Code editing. Redefined.
 License:	      %{electron_license}
 URL:            https://vscodium.com/


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (codium): bump rel (#14245)](https://github.com/terrapkg/packages/pull/14245)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)