### PR TITLE
[el10] fix: move configs from /usr/etc to /etc, use %config(noreplace) (#14265)

### DIFF
--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -72,8 +72,8 @@ desktop-file-validate %{buildroot}%{_kf6_datadir}/applications/%{appid}.desktop
 %{_appsdir}/%{appid}.desktop
 %{_metainfodir}/%{appid}.*.xml
 %{_scalableiconsdir}/%{appid}.svg
-%config %{_prefix}/etc/bazzite-updater/config.ini
-%{_prefix}/etc/bazzite-updater
+%config(noreplace) %{_sysconfdir}/%{name}/config.ini
+%{_sysconfdir}/%{name}
 
 %changelog
 * Sat Jul 04 2026 Robert French - 0.8.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: move configs from /usr/etc to /etc, use %config(noreplace) (#14265)](https://github.com/terrapkg/packages/pull/14265)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)