### PR TITLE
[f43] Revert "feat(ci): Put Scorecard update on arc-runner-set (#14274)" (#14278)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: arc-runner-set
+    runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [Revert "feat(ci): Put Scorecard update on arc-runner-set (#14274)" (#14278)](https://github.com/terrapkg/packages/pull/14278)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)