### PR TITLE
[el10] fix: noctalia-greeter (#14269)

### DIFF
--- a/anda/desktops/noctalia-greeter/noctalia-greeter.spec
+++ b/anda/desktops/noctalia-greeter/noctalia-greeter.spec
@@ -30,6 +30,9 @@ BuildRequires:  pkgconfig(pango)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols)
 BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(tomlplusplus)
+BuildRequires:  pkgconfig(nlohmann_json)
+BuildRequires:  stb-devel
 BuildRequires:  polkit
 BuildRequires:  wlroots-devel >= 0.20
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: noctalia-greeter (#14269)](https://github.com/terrapkg/packages/pull/14269)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)