### PR TITLE
[el10] wl-kmod: sync patches with rpmfusion for kernels 7.1+ (#14287)

### DIFF
--- a/anda/system/wl-kmod/wl-kmod-036_kernel_7.1_adaptation_replace_net_device_struct_with_wireless_dev_struct.patch
+++ b/anda/system/wl-kmod/wl-kmod-036_kernel_7.1_adaptation_replace_net_device_struct_with_wireless_dev_struct.patch
@@ -1,0 +1,150 @@
+From 8649648f2066e53e034f24f26fa82fa2717f9269 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Wed, 13 May 2026 15:26:05 +0200
+Subject: [PATCH] wl_cfg80211_hybrid.c: adapt compatibility with kernel >=
+ 7.1.x replace net_device struct with wireless_dev struct - Related to commit
+ "wifi: nl80211/cfg80211: support stations of non-netdev interfaces" (Miri
+ Korenblit, 19 Feb 2026) and to commit "wifi: cfg80211: support key
+ installation on non-netdev wdevs" (Avraham Stern, 7 Jan 2026)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ src/wl/sys/wl_cfg80211_hybrid.c | 56 +++++++++++++++++++++++++++++----
+ 1 file changed, 50 insertions(+), 6 deletions(-)
+
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index 58f1023..e30fed0 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -83,9 +83,14 @@ static s32 wl_cfg80211_leave_ibss(struct wiphy *wiphy, struct net_device *dev);
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0)
+ static s32 wl_cfg80211_get_station(struct wiphy *wiphy,
+            struct net_device *dev, u8 *mac, struct station_info *sinfo);
+-#else
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)
+ static s32 wl_cfg80211_get_station(struct wiphy *wiphy,
+            struct net_device *dev, const u8 *mac, struct station_info *sinfo);
++#else
++// Related to commit "wifi: nl80211/cfg80211: support stations of non-netdev
++// interfaces" (Miri Korenblit, 19 Feb 2026)
++static s32 wl_cfg80211_get_station(struct wiphy *wiphy,
++           struct wireless_dev *wdev, const u8 *mac, struct station_info *sinfo);
+ #endif
+ 
+ static s32 wl_cfg80211_set_power_mgmt(struct wiphy *wiphy,
+@@ -133,7 +138,17 @@ static s32 wl_cfg80211_config_default_key(struct wiphy *wiphy,
+ static s32 wl_cfg80211_config_default_key(struct wiphy *wiphy,
+            struct net_device *dev, u8 key_idx);
+ #endif
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++// Related to commit "wifi: cfg80211: support key installation on non-netdev
++// wdevs" (Avraham Stern, 7 Jan 2026)
++static s32 wl_cfg80211_add_key(struct wiphy *wiphy, struct wireless_dev *wdev,
++           int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr, struct key_params *params);
++static s32 wl_cfg80211_del_key(struct wiphy *wiphy, struct wireless_dev *wdev,
++           int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr);
++static s32 wl_cfg80211_get_key(struct wiphy *wiphy, struct wireless_dev *wdev,
++           int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr,
++           void *cookie, void (*callback) (void *cookie, struct key_params *params));
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+ static s32 wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+            int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr, struct key_params *params);
+ static s32 wl_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+@@ -1309,7 +1324,11 @@ wl_cfg80211_config_default_key(struct wiphy *wiphy,
+ 	return 0;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++static s32
++wl_cfg80211_add_key(struct wiphy *wiphy, struct wireless_dev *wdev,
++                    int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr, struct key_params *params)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+ static s32
+ wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+                     int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr, struct key_params *params)
+@@ -1323,6 +1342,9 @@ wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+                     u8 key_idx, const u8 *mac_addr, struct key_params *params)
+ #endif
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++	struct net_device *dev = wdev->netdev;
++#endif
+ 	struct wl_cfg80211_priv *wl = ndev_to_wl(dev);
+ 	struct wl_wsec_key key;
+ 	s32 secval, secnew = 0;
+@@ -1434,7 +1456,11 @@ wl_cfg80211_add_key(struct wiphy *wiphy, struct net_device *dev,
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++static s32
++wl_cfg80211_del_key(struct wiphy *wiphy, struct wireless_dev *wdev,
++                    int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+ static s32
+ wl_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+                     int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr)
+@@ -1448,6 +1474,9 @@ wl_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+                     u8 key_idx, const u8 *mac_addr)
+ #endif
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++	struct net_device *dev = wdev->netdev;
++#endif
+ 	struct wl_wsec_key key;
+ 	s32 err = 0;
+ 
+@@ -1481,7 +1510,12 @@ wl_cfg80211_del_key(struct wiphy *wiphy, struct net_device *dev,
+ 	return err;
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++static s32
++wl_cfg80211_get_key(struct wiphy *wiphy, struct wireless_dev *wdev,
++                    int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr,
++                    void *cookie, void (*callback) (void *cookie, struct key_params * params))
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+ static s32
+ wl_cfg80211_get_key(struct wiphy *wiphy, struct net_device *dev,
+                     int link_id, u8 key_idx, bool pairwise, const u8 *mac_addr, void *cookie,
+@@ -1498,6 +1532,9 @@ wl_cfg80211_get_key(struct wiphy *wiphy, struct net_device *dev,
+                     void (*callback) (void *cookie, struct key_params * params))
+ #endif
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++	struct net_device *dev = wdev->netdev;
++#endif
+ 	struct key_params params;
+ 	struct wl_wsec_key key;
+ 	struct wl_cfg80211_priv *wl = wiphy_to_wl(wiphy);
+@@ -1557,12 +1594,19 @@ wl_cfg80211_get_key(struct wiphy *wiphy, struct net_device *dev,
+ static s32
+ wl_cfg80211_get_station(struct wiphy *wiphy, struct net_device *dev,
+                         u8 *mac, struct station_info *sinfo)
+-#else
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)
+ static s32
+ wl_cfg80211_get_station(struct wiphy *wiphy, struct net_device *dev,
+                         const u8 *mac, struct station_info *sinfo)
++#else
++static s32
++wl_cfg80211_get_station(struct wiphy *wiphy, struct wireless_dev *wdev,
++                        const u8 *mac, struct station_info *sinfo)
+ #endif
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
++	struct net_device *dev = wdev->netdev;
++#endif
+ 	struct wl_cfg80211_priv *wl = wiphy_to_wl(wiphy);
+ 	scb_val_t scb_val;
+ 	int rssi;
+-- 
+2.54.0
+

--- a/anda/system/wl-kmod/wl-kmod-037_kernel_6.13_remove_flush_scheduled_work.patch
+++ b/anda/system/wl-kmod/wl-kmod-037_kernel_6.13_remove_flush_scheduled_work.patch
@@ -1,0 +1,33 @@
+From cf35ee5c912482a44d22a24a162ca966ab565469 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Wed, 13 May 2026 15:57:21 +0200
+Subject: [PATCH] wl_linux.c: remove flush_scheduled_work - not recommended
+ since kernel 6.13 and warns since kernel 6.17
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ src/wl/sys/wl_linux.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 4512f73..b0cb8b7 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -1502,7 +1502,11 @@ wl_down(wl_info_t *wl)
+ 		int i = 0;
+ 		for (i = 0; (atomic_read(&wl->callbacks) > callbacks) && i < 10000; i++) {
+ 			schedule();
++// Flushing system-wide queue was not recommended since kernel 6.13 and
++// provided warnings since kernel 6.17, so remove flush_scheduled_work call.
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+ 			flush_scheduled_work();
++#endif
+ 		}
+ 	}
+ 	else
+-- 
+2.54.0
+

--- a/anda/system/wl-kmod/wl-kmod.spec
+++ b/anda/system/wl-kmod/wl-kmod.spec
@@ -10,7 +10,7 @@
 
 Name:       wl-kmod
 Version:    6.30.223.271
-Release:    6%{?dist}
+Release:    7%{?dist}
 Summary:    Kernel module for Broadcom wireless devices
 Group:      System Environment/Kernel
 License:    Redistributable, no modification permitted
@@ -52,6 +52,8 @@ Patch30:    wl-kmod-032_add_MODULE_DESCRIPTION_macro.patch
 Patch31:    wl-kmod-033_disable_objtool_add_warning_unmaintained.patch
 Patch32:    wl-kmod-034_kernel_6.15_adaptation_replace_del_timer_with_timer_delete.patch
 Patch33:    wl-kmod-035_kernel_6.17_adaptation_fix_functions_prototypes.patch
+Patch34:    wl-kmod-036_kernel_7.1_adaptation_replace_net_device_struct_with_wireless_dev_struct.patch
+Patch35:    wl-kmod-037_kernel_6.13_remove_flush_scheduled_work.patch
 ExclusiveArch:  i686 x86_64
 BuildRequires:  kmodtool
 BuildRequires:  elfutils-libelf-devel
@@ -111,6 +113,8 @@ pushd %{name}-%{version}-src
 %patch -P 31 -p1 -b .disable_objtool
 %patch -P 32 -p1 -b .kernel_6.15_adaptation
 %patch -P 33 -p1 -b .kernel_6.17_adaptation
+%patch -P 34 -p1 -b .kernel_7.1_adaptation
+%patch -P 35 -p1 -b .flush_scheduled_work
 
 # Manual patching to build for RHEL - inspired by CentOS wl-kmod.spec
 # Actually works for RHEL 6.x and 7.x
@@ -370,6 +374,7 @@ pushd %{name}-%{version}-src
   %if %{kvr} >= 611
    #  Apply to EL 9.7 point release and later
    %{__sed} -i  's/ < KERNEL_VERSION(6, 13, 0)/ < KERNEL_VERSION(5, 14, 0)/g' src/include/linuxver.h
+   %{__sed} -i  's/ < KERNEL_VERSION(6, 13, 0)/ < KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_linux.c
    %{__sed} -i  's/ >= KERNEL_VERSION(6, 14, 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
    %{__sed} -i  's/ >= KERNEL_VERSION(6, 17, 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
   %endif
@@ -392,6 +397,7 @@ pushd %{name}-%{version}-src
   %if %{kvr} >= 55
    #  Apply to EL 10.0 point release and later
    %{__sed} -i  's/ < KERNEL_VERSION(6, 13, 0)/ < KERNEL_VERSION(6, 12, 0)/g' src/include/linuxver.h
+   %{__sed} -i  's/ < KERNEL_VERSION(6, 13, 0)/ < KERNEL_VERSION(6, 12, 0)/g' src/wl/sys/wl_linux.c
   %endif
   %if %{kvr} >= 124
    #  Apply to EL 10.1 point release and later


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [wl-kmod: sync patches with rpmfusion for kernels 7.1+ (#14287)](https://github.com/terrapkg/packages/pull/14287)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)