### PR TITLE
chore: remove update scripts that fetch archive.ubuntu.com

### DIFF
--- a/anda/desktops/compiz9/update.rhai
+++ b/anda/desktops/compiz9/update.rhai
@@ -1,5 +1,0 @@
-let html = get("http://archive.ubuntu.com/ubuntu/pool/universe/c/compiz/?C=N;O=D");
-let v = find("compiz_([\\d.]+)\\+(.+?).tar.xz", html, 1);
-let r = find("compiz_([\\d.]+)\\+(.+?).tar.xz", html, 2);
-rpm.version(v);
-rpm.define("_ubuntu_rel", r);

--- a/anda/desktops/lomiri-unity/unity-greeter/update.rhai
+++ b/anda/desktops/lomiri-unity/unity-greeter/update.rhai
@@ -1,5 +1,0 @@
-let html = get("http://archive.ubuntu.com/ubuntu/pool/universe/u/unity-greeter/?C=N;O=D");
-let v = find("unity-greeter_([\\d.+]+)-0ubuntu(\\d+)", html, 1);
-let rn = find("unity-greeter_([\\d.+]+)-0ubuntu(\\d+)", html, 2);
-rpm.version(v);
-rpm.global("rn", rn);

--- a/anda/desktops/lomiri-unity/unity-session/update.rhai
+++ b/anda/desktops/lomiri-unity/unity-session/update.rhai
@@ -1,5 +1,0 @@
-let html = get("http://archive.ubuntu.com/ubuntu/pool/universe/g/gnome-session/?C=N;O=D");
-let v = find("unity-session_([\\d.]+)-(.+?)_all.deb", html, 1);
-let r = find("unity-session_([\\d.]+)-(.+?)_all.deb", html, 2);
-rpm.version(v);
-rpm.define("_ubuntu_rel", r);

--- a/anda/desktops/lomiri-unity/unity-shell/update.rhai
+++ b/anda/desktops/lomiri-unity/unity-shell/update.rhai
@@ -1,4 +1,0 @@
-let html = get("http://archive.ubuntu.com/ubuntu/pool/universe/u/unity/?C=N;O=D");
-let v = find("unity_([\\d.]+)\\+.+?.tar.xz", html, 1);
-rpm.version(v);
-rpm.define("archive", find("unity_([\\d.]+)\\+.+?.tar.xz", html, 0));

--- a/anda/lib/glewmx/update.rhai
+++ b/anda/lib/glewmx/update.rhai
@@ -1,3 +1,0 @@
-let html = get("http://archive.ubuntu.com/ubuntu/pool/universe/g/glewmx/?C=N;O=D");
-let v = find("glewmx_([\\d.+]+)\\.", html, 1);
-rpm.version(v);


### PR DESCRIPTION
These scripts are slowing down `anda update` to the point that on average it takes 10 minutes to finish.