### PR TITLE
[f44] fix(ghc-bluefin-internal): bdeps (#14218)

### DIFF
--- a/anda/langs/haskell/ghc-bluefin-internal/ghc-bluefin-internal.spec
+++ b/anda/langs/haskell/ghc-bluefin-internal/ghc-bluefin-internal.spec
@@ -27,6 +27,8 @@ BuildRequires:  ghc-monad-control-devel
 BuildRequires:  ghc-transformers-devel
 BuildRequires:  ghc-transformers-base-devel
 BuildRequires:  ghc-unliftio-core-devel
+BuildRequires:  ghc-primitive-devel
+BuildRequires:  ghc-vault-devel
 %if %{with ghc_prof}
 BuildRequires:  ghc-async-prof
 BuildRequires:  ghc-base-prof
@@ -34,6 +36,8 @@ BuildRequires:  ghc-monad-control-prof
 BuildRequires:  ghc-transformers-prof
 BuildRequires:  ghc-transformers-base-prof
 BuildRequires:  ghc-unliftio-core-prof
+BuildRequires:  ghc-vault-prof
+BuildRequires:  ghc-primitive-prof
 %endif
 # End cabal-rpm deps
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(ghc-bluefin-internal): bdeps (#14218)](https://github.com/terrapkg/packages/pull/14218)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)