### PR TITLE
[f44] fix: rust-mise (#14295)

### DIFF
--- a/anda/buildsys/mise/rust-mise.spec
+++ b/anda/buildsys/mise/rust-mise.spec
@@ -18,7 +18,7 @@ Source3:        https://raw.githubusercontent.com/jdx/mise/main/completions/mise
 Source4:        https://raw.githubusercontent.com/jdx/mise/main/completions/_mise
 Packager:       madonuko <mado@fyralabs.com>
 
-BuildRequires:  anda-srpm-macros mold cargo-rpm-macros >= 24
+BuildRequires:  anda-srpm-macros cmake mold cargo-rpm-macros >= 24
 BuildRequires:  pkgconfig(openssl)
 
 %global _description %{expand:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: rust-mise (#14295)](https://github.com/terrapkg/packages/pull/14295)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)