### PR TITLE
[f43] fix: bluefin (#14302)

### DIFF
--- a/anda/langs/haskell/ghc-bluefin/ghc-bluefin.spec
+++ b/anda/langs/haskell/ghc-bluefin/ghc-bluefin.spec
@@ -69,7 +69,7 @@ This package provides the Haskell %{pkg_name} profiling library.
 # Begin cabal-rpm setup:
 %setup -q -n %{pkgver}
 # End cabal-rpm setup
-
+sed -i 's/.*bluefin-internal >= 0.1.* && < 0.9.*/    bluefin-internal >= 0.1/' %{pkg_name}.cabal
 
 %build
 # Begin cabal-rpm build:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: bluefin (#14302)](https://github.com/terrapkg/packages/pull/14302)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)