### PR TITLE
[el10] chore: add f45 to CI (#14322)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -29,9 +29,9 @@ body:
       description: Which version of Terra are you using?
       options:
         - frawhide
+        - f45
         - f44
         - f43
-        - f42
         - el10
       default: 1
   - type: textarea

--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         branch:
           - frawhide
+          - f45
           - f44
           - f43
           - el10

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - frawhide
+      - f45
       - f44
       - f43
       - el10

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -50,6 +50,7 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
+            copy_over f45 || true
             copy_over f44 || true
             copy_over f43 || true
             copy_over el10 || true

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -50,6 +50,7 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
+            copy_over f45 || true
             copy_over f44 || true
             copy_over f43 || true
             copy_over el10 || true

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -50,6 +50,7 @@ jobs:
               git add anda
               git commit -S -a -m "$msg"
             }
+            copy_over f45 || true
             copy_over f44 || true
             copy_over f43 || true
             copy_over el10 || true


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: add f45 to CI (#14322)](https://github.com/terrapkg/packages/pull/14322)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)