### PR TITLE
[f43] fix: logitech-rs50-linux-driver akmod (#14334)

### DIFF
--- a/anda/system/logitech-rs50-linux-driver/akmod/logitech-rs50-linux-driver-kmod.spec
+++ b/anda/system/logitech-rs50-linux-driver/akmod/logitech-rs50-linux-driver-kmod.spec
@@ -45,12 +45,12 @@ Note: This driver replaces the in-kernel hid-logitech-hidpp module and continues
 # print kmodtool output for debugging purposes:
 kmodtool --target %{_target_cpu} --repo terrapkg.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
 
-%setup -q -c -n %{modulename}-%{commit}
+%setup -q -c -n logitech-trueforce-linux-driver-%{commit}
 
-mv %{modulename}-%{commit}/mainline/* %{modulename}-%{commit}/
+mv logitech-trueforce-linux-driver-%{commit}/mainline/* logitech-trueforce-linux-driver-%{commit}/
 
 for kernel_version  in %{?kernel_versions} ; do
-  cp -a %{modulename}-%{commit} _kmod_build_${kernel_version%%___*}
+  cp -a logitech-trueforce-linux-driver-%{commit} _kmod_build_${kernel_version%%___*}
 done
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: logitech-rs50-linux-driver akmod (#14334)](https://github.com/terrapkg/packages/pull/14334)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)