### PR TITLE
[el10] fix: noctalia (#14358)

### DIFF
--- a/anda/desktops/noctalia/noctalia.spec
+++ b/anda/desktops/noctalia/noctalia.spec
@@ -40,6 +40,8 @@ BuildRequires:  pkgconfig(polkit-gobject-1)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols)
 BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(libsecret-1)
+BuildRequires:  pkgconfig(libsodium)
 
 Provides:       desktop-notification-daemon
 Provides:       PolicyKit-authentication-agent


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: noctalia (#14358)](https://github.com/terrapkg/packages/pull/14358)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)