### PR TITLE
[f45] fix: Add yet more selinux rules for steamos-manager-powerstation (#14369)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -4,7 +4,7 @@
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          4%{?dist}
+Release:          5%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager

--- a/anda/games/steamos-manager-powerstation/steamos_manager.te
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.te
@@ -1,4 +1,4 @@
-policy_module(steamos_manager, 1.0.2)
+policy_module(steamos_manager, 1.0.3)
 
 ########################################
 # Init
@@ -188,6 +188,15 @@ optional_policy(`
 	systemd_manage_all_unit_files(steamos_manager_t)
 ')
 
+# Wi-Fi power-management
+optional_policy(`
+     gen_require(`
+             type NetworkManager_etc_t;
+     ')
+     allow steamos_manager_t NetworkManager_etc_t:dir { search read open getattr add_name remove_name write create };
+     allow steamos_manager_t NetworkManager_etc_t:file { getattr open read create write unlink rename };
+')
+
 ########################################
 # User state and runtime files
 ########################################
@@ -242,6 +251,9 @@ optional_policy(`
 # Unix domain sockets for DBus
 allow steamos_manager_t self:unix_stream_socket { create connect read write getattr shutdown };
 allow steamos_manager_t self:unix_dgram_socket { create connect read write getattr sendto };
+
+# Wi-Fi power management 
+allow steamos_manager_t self:netlink_generic_socket { create bind write read getattr setopt getopt };
 
 # Speech-dispatcher and dconf-service connections
 corenet_tcp_connect_all_ports(steamos_manager_t)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: Add yet more selinux rules for steamos-manager-powerstation (#14369)](https://github.com/terrapkg/packages/pull/14369)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)