### PR TITLE
[f44] fix: qtdbusmock (#14365)

### DIFF
--- a/anda/lib/qtdbusmock/qtdbusmock.spec
+++ b/anda/lib/qtdbusmock/qtdbusmock.spec
@@ -4,9 +4,9 @@
 
 Name:       qtdbusmock
 Version:    0.9.0
-Release:    %autorelease
+Release:    1%{?dist}
 Summary:    Library for mocking DBus interactions using Qt
-License:    LGPL-3.0
+License:    LGPL-3.0-or-later
 URL:        https://gitlab.com/ubports/development/core/libqtdbusmock
 Source0:    %{url}/-/archive/%commit/libqtdbusmock-%commit.tar.gz
 
@@ -33,8 +33,10 @@ developing applications that use %{name}.
 %prep
 %autosetup -n libqtdbusmock-%commit
 
+%conf
+%cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
 %build
-%cmake
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: qtdbusmock (#14365)](https://github.com/terrapkg/packages/pull/14365)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)