### PR TITLE
[f45] fix (qtdbusmock): add update script (#14364)

### DIFF
--- a/anda/lib/qtdbusmock/update.rhai
+++ b/anda/lib/qtdbusmock/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gitlab_tag("43385942"))


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix (qtdbusmock): add update script (#14364)](https://github.com/terrapkg/packages/pull/14364)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)