### PR TITLE
[f45] fix (pixi): add LICENSE.dependencies and update License: tag (#10690)

### DIFF
--- a/anda/system/pixi/anda.hcl
+++ b/anda/system/pixi/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "pixi.spec"
   }
+	labels {
+		large = 1
+	}
 }

--- a/anda/system/pixi/pixi.spec
+++ b/anda/system/pixi/pixi.spec
@@ -1,8 +1,9 @@
 Name:           pixi
 Version:        0.73.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A cross-platform, multi-language package manager
-License:        BSD-3-Clause
+License:        BSD-3-Clause AND bzip2-1.0.6 AND MPL-2.0 AND Unicode-3.0 AND (Zlib OR Apache-2.0 OR MIT) AND Zlib AND (Unlicense OR MIT) AND (MIT OR Zlib OR Apache-2.0) AND (MIT OR LGPL-3.0-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR BSD-1-Clause) AND CDLA-Permissive-2.0 AND (LGPL-3.0-or-later OR MPL-2.0) AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND (ISC AND (Apache-2.0 OR ISC)) AND ISC AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0) AND BSL-1.0 AND (Apache-2.0 OR MIT) AND BSD-2-Clause AND (MIT OR Apache-2.0) AND Unicode-3.0 AND 0BSD AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND MIT AND (Apache-2.0 OR BSD-2-Clause) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR GPL-2.0-only) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT OR Zlib) AND (Apache-2.0 WITH LLVM-exception) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT)
+
 URL:            https://pixi.sh
 Source:         https://github.com/prefix-dev/pixi/archive/refs/tags/v%{version}.tar.gz
 Packager:       Olivia <git@olivia.sh>
@@ -11,7 +12,7 @@ BuildRequires:  anda-srpm-macros
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  mold
 
-%pkg_completion -Befz
+%pkg_completion -BefNz
 
 %description
 pixi is a cross-platform, multi-language package manager and workflow tool
@@ -25,24 +26,28 @@ but for any language.
 
 %build
 %cargo_build
-for shell in bash elvish fish zsh; do
+for shell in bash elvish fish nushell zsh; do
     target/rpm/%{name} completion --shell $shell > completions.$shell
 done
-%dnl %cargo_license_online > LICENSE.dependencies
+%{cargo_license_online} > LICENSE.dependencies
 
 %install
 install -Dm 755 target/rpm/%{name} %{buildroot}%{_bindir}/%{name}
 install -Dm 644 completions.bash %{buildroot}%{bash_completions_dir}/%{name}
 install -Dm 644 completions.elvish %{buildroot}%{elvish_completions_dir}/%{name}.elv
 install -Dm 644 completions.fish %{buildroot}%{fish_completions_dir}/%{name}.fish
+install -Dm 644 completions.nushell %{buildroot}%{nushell_completions_dir}/%{name}.nu
 install -Dm 644 completions.zsh %{buildroot}%{zsh_completions_dir}/_%{name}
 
 %files
 %doc README.md CHANGELOG.md
-%license LICENSE
+%license LICENSE LICENSE.dependencies
 %{_bindir}/%{name}
 
 %changelog
+* Thu Jul 23 2026 Owen Zimmerman <owen@fyralabs.com> - 0.66.0-1
+- Add dependency licenses, add nushell completions
+
 * Sun Jul 19 2026 Olivia <git@olivia.sh> - 0.73.0-2
 - Update packager
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix (pixi): add LICENSE.dependencies and update License: tag (#10690)](https://github.com/terrapkg/packages/pull/10690)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)