### PR TITLE
[f45] chore (qt5-qtdbustest): bump, clean up spec, add update script (#14367)

### DIFF
--- a/anda/lib/qt5-qtdbustest/qt5-qtdbustest.spec
+++ b/anda/lib/qt5-qtdbustest/qt5-qtdbustest.spec
@@ -1,14 +1,10 @@
-%global forgeurl https://gitlab.com/ubports/development/core/libqtdbustest
-%global commit 58990d63f2327d285d6ead430d03b02558257291
-%forgemeta
-
 Name:       qt5-qtdbustest
-Version:    0.3.0
-Release:    %autorelease
+Version:    0.4.1
+Release:    1%{?dist}
 Summary:    Library for testing DBus interactions using Qt5
-License:    LGPL-3.0
+License:    LGPL-3.0-or-later
 URL:        https://gitlab.com/ubports/development/core/libqtdbustest
-Source0:    %url/-/archive/%commit/libqtdbustest-%commit.tar.gz
+Source0:    %{url}/-/archive/%{version}/libqtdbustest-%{version}.tar.gz?ref_type=tags
 
 BuildRequires: cmake
 BuildRequires: cmake-extras
@@ -24,18 +20,15 @@ A simple library for testing Qt based DBus services and clients.
 This package contains the shared libraries.
 
 %package devel
-Summary: Development files for %{name}
-Requires: %{name}%{?_isa} = %{version}-%{release}
-
-%description devel
-%{name}-devel package contains libraries and header files for
-developing applications that use %{name}.
+%pkg_devel_files
 
 %prep
-%autosetup -n libqtdbustest-%commit
+%autosetup -n libqtdbustest-%{version}
+
+%conf
+%cmake
 
 %build
-%cmake
 %cmake_build
 
 %install
@@ -46,17 +39,9 @@ developing applications that use %{name}.
 %license COPYING
 %{_bindir}/qdbus-simple-test-runner
 %{_libdir}/libqtdbustest.so.*
-%dir %{_libexecdir}/libqtdbustest
 %{_libexecdir}/libqtdbustest/watchdog
-%dir %{_datadir}/libqtdbustest
 %{_datadir}/libqtdbustest/*.conf
 
-%files devel
-%dir %{_includedir}/libqtdbustest-1
-%dir %{_includedir}/libqtdbustest-1/libqtdbustest
-%{_includedir}/libqtdbustest-1/libqtdbustest/*.h
-%{_libdir}/libqtdbustest.so
-%{_libdir}/pkgconfig/libqtdbustest-1.pc
-
 %changelog
-%autochangelog
+* Thu Jul 23 2026 Owen Zimmerman <owen@fyralabs.com> - 0.4.1-1
+- Bump, modernize spec, get rid of commit tracking and forgemeta

--- a/anda/lib/qt5-qtdbustest/update.rhai
+++ b/anda/lib/qt5-qtdbustest/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gitlab_tag("43353750"))


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (qt5-qtdbustest): bump, clean up spec, add update script (#14367)](https://github.com/terrapkg/packages/pull/14367)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)