### PR TITLE
[el10] fix: logitech-rs50-linux-driver dkms (#14357)

### DIFF
--- a/anda/system/logitech-rs50-linux-driver/dkms/dkms-logitech-rs50-linux-driver.spec
+++ b/anda/system/logitech-rs50-linux-driver/dkms/dkms-logitech-rs50-linux-driver.spec
@@ -36,7 +36,7 @@ BuildArch:     noarch
 Akmods modules for the akmod-%{name} package.
 
 %prep
-%autosetup -p1 -n %{modulename}-%{commit}
+%autosetup -p1 -n logitech-trueforce-linux-driver-%{commit}
 pushd mainline
 mkdir build
 cp %{SOURCE1} ./dkms.conf
@@ -44,20 +44,20 @@ sed -i -e 's/__VERSION_STRING/%{version}/g' dkms.conf
 popd
 
 %install
-mkdir -p %{buildroot}%{_usrsrc}/%{modulename}-%{version}
-cp -fr ./mainline/* %{buildroot}%{_usrsrc}/%{modulename}-%{version}/
+mkdir -p %{buildroot}%{_usrsrc}/logitech-trueforce-linux-driver-%{version}
+cp -fr ./mainline/* %{buildroot}%{_usrsrc}/logitech-trueforce-linux-driver-%{version}/
 
 %post
-dkms add -m %{modulename} -v %{version} -q --rpm_safe_upgrade || :
+dkms add -m logitech-trueforce-linux-driver -v %{version} -q --rpm_safe_upgrade || :
 # Rebuild and make available for the currently running kernel:
-dkms build -m %{modulename} -v %{version} -q || :
-dkms install -m %{modulename} -v %{version} -q --force || :
+dkms build -m logitech-trueforce-linux-driver -v %{version} -q || :
+dkms install -m logitech-trueforce-linux-driver -v %{version} -q --force || :
 
 %preun
-dkms remove -m %{modulename} -v %{version} -q --all --rpm_safe_upgrade || :
+dkms remove -m logitech-trueforce-linux-driver -v %{version} -q --all --rpm_safe_upgrade || :
 
 %files
-%{_usrsrc}/%{modulename}-%{version}
+%{_usrsrc}/logitech-trueforce-linux-driver-%{version}
 
 %changelog
 * Sun May 03 2026 Luan V. <luanv.oliveira@outlook.com> - 1.0^20260502git.7296717-2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: logitech-rs50-linux-driver dkms (#14357)](https://github.com/terrapkg/packages/pull/14357)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)