### PR TITLE
[f44] fix: Grant wider permissions to steamos-manager for sysfs_t (#14398)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -4,7 +4,7 @@
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          5%{?dist}
+Release:          6%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager

--- a/anda/games/steamos-manager-powerstation/steamos_manager.te
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.te
@@ -1,4 +1,4 @@
-policy_module(steamos_manager, 1.0.3)
+policy_module(steamos_manager, 1.0.4)
 
 ########################################
 # Init
@@ -70,7 +70,7 @@ dev_rw_sysfs(steamos_manager_t)
 gen_require(`
      type sysfs_t;
 ')
-allow steamos_manager_t sysfs_t:dir write;
+allow steamos_manager_t sysfs_t:dir { write add_name remove_name };
 
 ########################################
 # Procfs access


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: Grant wider permissions to steamos-manager for sysfs_t (#14398)](https://github.com/terrapkg/packages/pull/14398)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)