### PR TITLE
[f45] feat(opengamepadui): disable manage_all in overlay mode (#14404)

### DIFF
--- a/anda/games/opengamepadui/disable-manage-all.patch
+++ b/anda/games/opengamepadui/disable-manage-all.patch
@@ -1,0 +1,15 @@
+diff --git a/core/ui/card_ui_overlay_mode/card_ui_overlay_mode.gd b/core/ui/card_ui_overlay_mode/card_ui_overlay_mode.gd
+index 08a6fde4..d9055acb 100644
+--- a/core/ui/card_ui_overlay_mode/card_ui_overlay_mode.gd
++++ b/core/ui/card_ui_overlay_mode/card_ui_overlay_mode.gd
+@@ -190,8 +190,8 @@ func _setup_overlay_mode(args: PackedStringArray) -> void:
+ 	_remove_children(remove_list, quick_bar_menu)
+ 	_remove_children(settings_remove_list, settings_menu)
+ 
+-	# Enable InputPlumber management of all supported input devices
+-	input_plumber.manage_all_devices = true
++	# Disable InputPlumber management of all supported input devices
++	input_plumber.manage_all_devices = false
+ 
+ 	# Setup inputplumber to receive guide presses.
+ 	input_plumber.set_intercept_mode(InputPlumberInstance.INTERCEPT_MODE_PASS)

--- a/anda/games/opengamepadui/opengamepadui.spec
+++ b/anda/games/opengamepadui/opengamepadui.spec
@@ -1,6 +1,6 @@
 Name:           opengamepadui
 Version:        0.45.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Open source gamepad-native game launcher and overlay
 
 License:        GPLv3
@@ -9,6 +9,7 @@ Packager:       Cappy Ishihara <cappy@fyralabs.com>
 
 # https://patch-diff.githubusercontent.com/raw/ShadowBlip/OpenGamepadUI/pull/523
 Patch0:         523.patch
+Patch1:         disable-manage-all.patch
 
 BuildRequires:  godot
 BuildRequires:  scons
@@ -57,6 +58,7 @@ git clone %{url} %{build_dir} -b v%{version}
 cd %{build_dir}
 git checkout tags/v%{version}
 %patch 0 -p1
+%patch 1 -p1
 
 %build
 cd %{build_dir}
@@ -81,5 +83,8 @@ cd %{build_dir}
 
 
 %changelog
+* Fri Jul 24 2026 HikariKnight <2557889+HikariKnight@users.noreply.github.com>
+- Add patch to disable manage_all for inputplumber in overlay mode
+
 * Sun Oct 20 2024 Cappy Ishihara <cappy@cappuchino.xyz>
 - Initial Package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat(opengamepadui): disable manage_all in overlay mode (#14404)](https://github.com/terrapkg/packages/pull/14404)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)