### PR TITLE
[f45] feat: Update to the latest OGC gamescope (#14427)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -2,7 +2,7 @@
 
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
-%global gamescope_commit 9b0214868571b4ae9cae2dab36e22fff4ee33674
+%global gamescope_commit 7282613d1e16be9b3b9446433932c1d91e7abca6
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           terra-gamescope


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update to the latest OGC gamescope (#14427)](https://github.com/terrapkg/packages/pull/14427)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)