### PR TITLE
[f43] fix(deno): don't use large (#14436)

### DIFF
--- a/anda/devs/deno/anda.hcl
+++ b/anda/devs/deno/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
 	rpm {
 		spec = "rust-deno.spec"
 	}
-	labels {
-		large = 1
-	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(deno): don't use large (#14436)](https://github.com/terrapkg/packages/pull/14436)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)