### PR TITLE
add: opendeck

### DIFF
--- a/anda/apps/opendeck/anda.hcl
+++ b/anda/apps/opendeck/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "opendeck.spec"
+    }
+}

--- a/anda/apps/opendeck/opendeck.desktop
+++ b/anda/apps/opendeck/opendeck.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=OpenDeck
+Comment=Use stream controllers
+Exec=opendeck
+Icon=opendeck
+Terminal=false
+Categories=Utility;
+StartupWMClass=opendeck
+MimeType=x-scheme-handler/opendeck;x-scheme-handler/openaction;x-scheme-handler/streamdeck;

--- a/anda/apps/opendeck/opendeck.spec
+++ b/anda/apps/opendeck/opendeck.spec
@@ -1,0 +1,108 @@
+%undefine __brp_mangle_shebangs
+
+%global appid               opendeck
+%global name_pretty         OpenDeck
+%global appstream_component desktop-application
+%global developer           Aman Khanna
+# Tauri resolves its resource directory relative to the binary, i.e. /usr/bin/../lib/opendeck.
+# This is /usr/lib even on 64-bit, so %%_libdir must not be used here.
+%global opendeck_libdir     %{_prefix}/lib/%{name}
+
+Name:           opendeck
+Version:        2.13.1
+Release:        1%{?dist}
+Summary:        Use stream controllers
+URL:            https://github.com/nekename/OpenDeck
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+Source1:        opendeck.desktop
+
+SourceLicense:  GPL-3.0-or-later
+License:        GPL-3.0-or-later AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 AND MIT) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND BSD-3-Clause AND (BSD-3-Clause AND MIT) AND (BSD-3-Clause OR Apache-2.0) AND (BSD-3-Clause OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND CDLA-Permissive-2.0 AND ISC AND (ISC AND (Apache-2.0 OR ISC)) AND (ISC AND (Apache-2.0 OR ISC) AND OpenSSL) AND MIT AND (MIT OR Apache-2.0) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
+
+BuildRequires:  %{tauri_buildrequires}
+# The frontend and the bundled starter pack plugin are built with Deno.
+BuildRequires:  deno
+# reqwest pulls in native-tls -> openssl-sys, which refuses to build against
+# OpenSSL 4.0. openssl3-devel provides openssl-devel and conflicts with >= 4.0,
+# so it replaces the default. Drop this once openssl-sys supports OpenSSL 4.
+BuildRequires:  openssl3-devel
+BuildRequires:  anda-srpm-macros
+BuildRequires:  terra-appstream-helper
+# Detected from src-tauri/Cargo.lock
+BuildRequires:  glib2-devel
+BuildRequires:  gtk3-devel
+BuildRequires:  javascriptcoregtk4.1-devel
+BuildRequires:  libsoup3-devel
+# hidapi (hidraw backend) needs libudev, the Tauri process needs libdbus
+BuildRequires:  systemd-devel
+BuildRequires:  dbus-devel
+# font-loader -> servo-fontconfig-sys, active-win-pos-rs/enigo -> X11 and Wayland
+BuildRequires:  fontconfig-devel
+BuildRequires:  freetype-devel
+BuildRequires:  expat-devel
+BuildRequires:  libX11-devel
+BuildRequires:  libxcb-devel
+BuildRequires:  libxkbcommon-devel
+BuildRequires:  wayland-devel
+# aws-lc-sys and libgit2-sys build native code
+BuildRequires:  cmake
+BuildRequires:  clang
+BuildRequires:  perl
+BuildRequires:  zlib-devel
+
+# Optional plugin runtimes, see the upstream README
+Recommends:     nodejs
+Suggests:       wine
+
+Packager:       NichSchlagen <tim-rosenhagen@web.de>
+
+%description
+OpenDeck is a desktop application for using stream controller devices like the
+Elgato Stream Deck. OpenDeck supports plugins made for the original Stream Deck
+SDK, allowing many plugins made for the Elgato software ecosystem to be used.
+
+%prep
+%autosetup -n OpenDeck-%{version}
+%tauri_prep
+
+%build
+%deno_build
+%{tauri_cargo_license_summary}
+%{tauri_cargo_license} > LICENSE.dependencies
+
+%install
+install -Dpm755 src-tauri/target/rpm/%{name}   %{buildroot}%{_bindir}/%{name}
+%desktop_file_install                          %{SOURCE1}
+install -Dpm644 src-tauri/icons/icon.png       %{buildroot}%{_hicolordir}/512x512/apps/%{name}.png
+install -Dpm644 src-tauri/bundle/40-streamdeck.rules \
+                                               %{buildroot}%{_udevrulesdir}/40-streamdeck.rules
+install -Dpm644 src-tauri/bundle/%{name}.metainfo.xml \
+                                               %{buildroot}%{_metainfodir}/%{name}.metainfo.xml
+
+# The starter pack plugin is built by src-tauri/build.rs and would normally be
+# copied in by the Tauri bundler, which we do not run.
+mkdir -p %{buildroot}%{opendeck_libdir}
+cp -a src-tauri/target/plugins %{buildroot}%{opendeck_libdir}/plugins
+# `cargo install` bookkeeping, not needed at runtime
+find %{buildroot}%{opendeck_libdir} \( -name '.crates.toml' -o -name '.crates2.json' \) -delete
+
+%terra_appstream
+
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/%{name}.desktop
+
+%files
+%license LICENSE.md
+%license LICENSE.dependencies
+%doc README.md
+%{_bindir}/%{name}
+%{_appsdir}/%{name}.desktop
+%{_hicolordir}/512x512/apps/%{name}.png
+%{_metainfodir}/%{name}.metainfo.xml
+%{_udevrulesdir}/40-streamdeck.rules
+%dir %{opendeck_libdir}
+%{opendeck_libdir}/plugins
+
+%changelog
+* Sat Jul 25 2026 NichSchlagen <tim-rosenhagen@web.de>
+- Initial package

--- a/anda/apps/opendeck/update.rhai
+++ b/anda/apps/opendeck/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("nekename/OpenDeck"));


### PR DESCRIPTION
[OpenDeck](https://github.com/nekename/OpenDeck) is a desktop application for using stream controller devices like the Elgato Stream Deck. It supports plugins written against the original Stream Deck SDK and the OpenAction API.

Packaged at v2.13.1, GPL-3.0-or-later.

## Build

Verified with `anda build -c terra-rawhide-x86_64 anda/apps/opendeck/pkg` in `ghcr.io/terrapkg/builder:frawhide` — builds clean in ~9 minutes.

The frontend is built with **Deno**, not npm (`beforeBuildCommand` is `deno task build`), so this uses `%deno_build` rather than `%npm_build`. As far as I can tell this is the first spec in the repo to use that macro; it worked without any coaxing.

## Notes for review

**`openssl3-devel`.** Rawhide has moved to OpenSSL 4.0, and `openssl-sys` 0.9.111 refuses to build against it:

```
This crate is only compatible with OpenSSL (version 1.0.2 through 1.1.1, or 3),
or LibreSSL 3.5 through 4.2.x, but a different version of OpenSSL was found.
```

Only `reqwest` pulls it in, via `native-tls`. `openssl3-devel` provides `openssl-devel = 3.5.7` and conflicts with `>= 1:4.0`, so a plain `BuildRequires` is enough to displace the 4.0 one that `%tauri_buildrequires` would otherwise pick. The resulting package depends on `libssl.so.3` from `openssl3-libs`.

That compat package is marked `deprecated()`, so this is explicitly a stopgap and the spec says so. The alternative is patching `reqwest` onto `rustls-tls` — rustls is already in the dependency tree, so it would likely just work and would drop the openssl dependency entirely. I went with the compat lib because it leaves upstream's TLS stack alone, but I'm happy to switch if you'd prefer not to depend on a deprecated package.

**Resources in `/usr/lib`, not `%{_libdir}`.** Tauri resolves its resource directory relative to the binary, i.e. `/usr/bin/../lib/opendeck`, so the bundled starter pack plugin has to go to `/usr/lib/opendeck/plugins` even on 64-bit. Upstream's own RPM does the same.

**Plugins are installed by hand.** `src-tauri/build.rs` builds the starter pack into `src-tauri/target/plugins/`, and normally the Tauri bundler copies it into place — but `%tauri_common_opts` passes `--no-bundle`, so the spec copies it itself. I drop the `.crates.toml` / `.crates2.json` bookkeeping files that `cargo install` leaves behind; upstream's RPM ships them.

**Desktop file is ours.** Upstream only has a Tauri template with `{{placeholder}}`s that gets filled in during bundling, so the spec carries a real one as `Source1`. Compared to what upstream's bundler generates, I set `Categories=Utility;` instead of `Office;` (generated from their `"category": "Productivity"`, which seems wrong for this), and added `StartupWMClass` plus the `MimeType` scheme handlers that the deep-link plugin needs.

**udev rules** go to `%{_udevrulesdir}` rather than upstream's `/etc/udev/rules.d`, matching `8bitdo-udev-rules` and `wooting-udev-rules`.

The resulting file list matches upstream's RPM, and `%check` validates the desktop file.