### PR TITLE
add: localsend-bin

### DIFF
--- a/anda/apps/localsend-bin/anda.hcl
+++ b/anda/apps/localsend-bin/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "localsend-bin.spec"
+    }
+}

--- a/anda/apps/localsend-bin/localsend-bin.spec
+++ b/anda/apps/localsend-bin/localsend-bin.spec
@@ -1,0 +1,114 @@
+# Prebuilt upstream bundle, there are no sources to extract debuginfo from.
+%define debug_package %nil
+
+%ifarch x86_64
+%global a x86-64
+%elifarch aarch64
+%global a arm-64
+%endif
+
+%global appid               org.localsend.localsend_app
+%global name_pretty         LocalSend
+%global appstream_component desktop-application
+%global developer           Tien Do Nam
+# The Flutter bundle links its plugins with an $ORIGIN/lib rpath, so the whole
+# tree has to stay together next to the executable.
+%global bundledir           %{_libdir}/localsend
+
+# The bundled Flutter engine and plugins are private to this package. Without
+# this they would export sonames as generic as libapp.so into the global
+# namespace, colliding with any other Flutter application packaged this way,
+# and depend on themselves. Requires are filtered by soname rather than by path
+# so that genuine external dependencies of those same libraries -- GTK, epoxy,
+# libayatana-appindicator -- are still picked up.
+%global __provides_exclude_from ^%{bundledir}/lib/.*$
+%global __requires_exclude ^(libapp|librhttp|libflutter_linux_gtk|lib.*_plugin)\\.so.*$
+
+Name:           localsend-bin
+Version:        1.17.0
+Release:        1%{?dist}
+Summary:        An open source cross-platform alternative to AirDrop
+URL:            https://localsend.org
+Source0:        https://github.com/localsend/localsend/releases/download/v%{version}/LocalSend-%{version}-linux-%{a}.tar.gz
+Source1:        localsend.desktop
+# The release tarball ships no licence text.
+Source2:        https://raw.githubusercontent.com/localsend/localsend/v%{version}/LICENSE
+
+# app/linux/packaging/rpm/make_config.yaml claims MIT, but the LICENSE file in
+# the repository is Apache-2.0. Going with the actual licence text.
+License:        Apache-2.0
+
+# Upstream publishes Linux bundles for these two only.
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  desktop-file-utils
+BuildRequires:  patchelf
+BuildRequires:  anda-srpm-macros
+BuildRequires:  terra-appstream-helper
+
+Requires:       libayatana-appindicator-gtk3
+Requires:       xdg-user-dirs
+
+Provides:       localsend = %{version}-%{release}
+
+Packager:       NichSchlagen <tim-rosenhagen@web.de>
+
+%description
+LocalSend lets you share files and messages with nearby devices over your local
+network, without an internet connection and without a third-party server. It
+speaks a common protocol across Linux, Windows, macOS, Android and iOS.
+
+This package repackages the official upstream build. LocalSend %{version} pins
+wechat_assets_picker and yaru to versions that predate Flutter's Material theme
+migration, so it cannot currently be built from source against the Flutter in
+Terra.
+
+%prep
+# The tarball has no top level directory of its own.
+%autosetup -c -n localsend-%{version}
+cp -p %{SOURCE2} LICENSE
+
+%install
+install -dm755 %{buildroot}%{bundledir}
+cp -a data lib localsend_app %{buildroot}%{bundledir}/
+
+# Upstream's CI leaks its own build directory into the plugin RUNPATHs
+# ("/home/runner/work/localsend/...", plus a Debian multiarch path). rpm's
+# check-rpaths rejects that, rightly. The plugins only need libflutter_linux_gtk
+# .so, which sits beside them and already carries $ORIGIN itself.
+for so in %{buildroot}%{bundledir}/lib/*.so; do
+    case "$(patchelf --print-rpath "$so")" in
+        ''|'$ORIGIN') ;;
+        *) patchelf --set-rpath '$ORIGIN' "$so" ;;
+    esac
+done
+
+install -dm755 %{buildroot}%{_bindir}
+ln -s %{bundledir}/localsend_app %{buildroot}%{_bindir}/localsend
+
+%desktop_file_install %{SOURCE1}
+
+for px in 32 128 256 512; do
+    install -Dpm644 data/flutter_assets/assets/img/logo-${px}.png \
+        %{buildroot}%{_hicolordir}/${px}x${px}/apps/%{appid}.png
+done
+
+%terra_appstream
+
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/localsend.desktop
+
+%files
+%license LICENSE
+%{_bindir}/localsend
+%{bundledir}
+%{_appsdir}/localsend.desktop
+%{_hicolordir}/32x32/apps/%{appid}.png
+%{_hicolordir}/128x128/apps/%{appid}.png
+%{_hicolordir}/256x256/apps/%{appid}.png
+%{_hicolordir}/512x512/apps/%{appid}.png
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%changelog
+* Sun Jul 26 2026 NichSchlagen <tim-rosenhagen@web.de>
+- Initial package

--- a/anda/apps/localsend-bin/localsend.desktop
+++ b/anda/apps/localsend-bin/localsend.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=LocalSend
+GenericName=File transfer
+Comment=Share files easily with LocalSend
+Exec=localsend
+Icon=org.localsend.localsend_app
+Terminal=false
+Categories=Network;FileTransfer;Utility;
+Keywords=Sharing;LAN;Files;
+StartupNotify=true
+StartupWMClass=org.localsend.localsend_app

--- a/anda/apps/localsend-bin/update.rhai
+++ b/anda/apps/localsend-bin/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("localsend/localsend"));


### PR DESCRIPTION
[LocalSend](https://localsend.org) shares files and messages with nearby devices over the local network — no internet connection, no third-party server. It is one of the more commonly requested applications with no RPM anywhere: upstream ships deb, AppImage, tar.gz and Flathub only.

Packaged at v1.17.0, Apache-2.0.

## Why `-bin` and not a source build

I tried the source build first and could not get it to work against Terra's Flutter 3.44.8. Recording the details here so the next person does not repeat it.

Three problems were solvable:

- `path` and `intl` are pinned exactly, while `flutter_localizations` from a current SDK pins its own versions. Resolved by deferring to the SDK through `dependency_overrides`. Upstream already marks both constraints "allow newer versions, so it can compile with newer Flutter versions".
- `build_runner` is pinned to 2.4.13, whose `analyzer` range cannot coexist with the `flutter_test` of a current SDK. This turned out to be moot: all generated sources (54 `*.g.dart`, 21 `*.mapper.dart`, `strings.g.dart`) are committed upstream, so the codegen step and the whole `dev_dependencies` block can go.

The one that is not solvable from a spec file is Flutter's Material theme migration (`XTheme` → `XThemeData`). `yaru` 5.3.2, `wechat_assets_picker` 9.5.0 and `wechat_picker_library` 1.0.5 all predate it, and the Dart compile fails inside those packages — 88 errors, 6 distinct kinds, 4 files. Bumping `yaru` would be harmless (LocalSend uses it in one file, only `YaruTheme`), but `wechat_assets_picker` appears in nine files with `AssetEntity` in core model types and around fifty localisation delegates. Bumping it across a major version would break LocalSend's own code.

That is upstream's move to make, not a packager's. I intend to file it with them; if it lands, this package should be replaced by a source build. `Provides: localsend` is there so that swap costs users nothing.

## Notes for review

**Upstream leaks its CI build path into the binaries.** Twelve of the fifteen bundled plugin libraries carry

```
RUNPATH  /home/runner/work/localsend/localsend/app/linux/flutter/ephemeral:/usr/lib/x86_64-linux-gnu
```

which `check-rpaths` rejects, correctly. Rather than silencing it with `QA_RPATHS`, the spec rewrites those to `$ORIGIN` with patchelf — the plugins only need `libflutter_linux_gtk.so`, which sits beside them and already carries `$ORIGIN` itself. `libapp.so`, `librhttp.so` and `libflutter_linux_gtk.so` are left alone. This affects upstream's own deb and AppImage too and will go into the same report.

**Bundled libraries are filtered out of the dependency metadata.** Without it the package would export sonames as generic as `libapp.so()(64bit)` — the name every Flutter application uses — and depend on itself. Provides are filtered by path, Requires by soname, so that genuine external dependencies of those same libraries (GTK, epoxy, libayatana-appindicator, dbusmenu, harfbuzz) survive.

**`%{_libdir}/localsend`** keeps the bundle together because the executable resolves its plugins through an `$ORIGIN/lib` rpath.

**Licence.** `app/linux/packaging/rpm/make_config.yaml` says MIT, the repository's `LICENSE` is Apache-2.0. I went with the actual licence text and noted the discrepancy in the spec. The release tarball ships no licence at all, so it is pulled from the tag as a separate source.

## Verification

Built with `anda build -c terra-rawhide-x86_64`, then installed on a clean `fedora:rawhide`: dependency resolution succeeds and no ELF object in the bundle has an unresolved library. The desktop file passes `%check`.

The GUI starts and file transfer works.

aarch64 is untested — upstream publishes an `arm-64` bundle and the spec selects it, but I have only built x86_64.