### PR TITLE
[f44] feat: Update to temporary patched branch of OpenGamepadUI (#14456)

### DIFF
--- a/anda/games/opengamepadui/opengamepadui.spec
+++ b/anda/games/opengamepadui/opengamepadui.spec
@@ -7,9 +7,7 @@ License:        GPLv3
 URL:            https://github.com/ShadowBlip/OpenGamepadUI
 Packager:       Cappy Ishihara <cappy@fyralabs.com>
 
-# https://patch-diff.githubusercontent.com/raw/ShadowBlip/OpenGamepadUI/pull/523
-Patch0:         523.patch
-Patch1:         disable-manage-all.patch
+Patch0:         disable-manage-all.patch
 
 BuildRequires:  godot
 BuildRequires:  scons
@@ -56,9 +54,10 @@ remap gamepad input to mouse and keyboard inputs.
 rm -rf %{build_dir}
 git clone %{url} %{build_dir} -b v%{version}
 cd %{build_dir}
-git checkout tags/v%{version}
+#git checkout tags/v%{version}
+# Temporary while some final issues are resolved, same version as above.
+git checkout pastaq/bazzite_crashes
 %patch 0 -p1
-%patch 1 -p1
 
 %build
 cd %{build_dir}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Update to temporary patched branch of OpenGamepadUI (#14456)](https://github.com/terrapkg/packages/pull/14456)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)