### PR TITLE
fix(Arctis-Sound-Manager): declare runtime dependencies

### DIFF
--- a/anda/apps/Arctis-Sound-Manager/Arctis-Sound-Manager.spec
+++ b/anda/apps/Arctis-Sound-Manager/Arctis-Sound-Manager.spec
@@ -5,7 +5,7 @@
 
 Name:			python-%{pypi_name}
 Version:		1.2.19
-Release:		1%{?dist}
+Release:		2%{?dist}
 Summary:		GUI for SteelSeries Arctis headsets
 License:		GPL-3.0-or-later
 # GitHub pages URL 404s
@@ -21,6 +21,33 @@ BuildRequires:  python3-uv-build
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  python3-ruamel-yaml
 BuildRequires:  desktop-file-utils
+
+# ── Runtime dependencies ─────────────────────────────────────────────────────
+# Kept in sync with the upstream spec at
+# https://github.com/loteran/Arctis-Sound-Manager/blob/main/arctis-sound-manager.spec
+# The Python bindings are omitted on purpose: they are declared in
+# pyproject.toml, so RPM generates them automatically. Everything below is
+# reached through the filesystem or dlopen, where nothing can infer it.
+#
+# Audio stack the daemon drives directly.
+Requires:       pipewire
+Requires:       pipewire-pulseaudio
+Requires:       wireplumber
+Requires:       libusb1
+Requires:       pulseaudio-libs
+# The `pactl` CLI (used at GUI startup and for EQ/Sonar routing) ships in
+# pulseaudio-utils, NOT in pipewire-pulseaudio or pulseaudio-libs. Without it
+# a clean install crashes on launch with FileNotFoundError: 'pactl'.
+# https://github.com/loteran/Arctis-Sound-Manager/issues/117
+Requires:       pulseaudio-utils
+# Fedora ships the Steve Harris SWH LADSPA pack as `ladspa-swh-plugins`.
+# Required by the HeSuVi 7.1 virtual surround graph (`plate_1423` reverb);
+# Spatial Audio loads nothing and stays silent without it.
+# https://github.com/loteran/Arctis-Sound-Manager/issues/23
+Requires:       ladspa-swh-plugins
+# Used by asm-setup to fetch the HRIR file on first run; without it Spatial
+# Audio has no impulse response to convolve with.
+Requires:       curl
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
 
@@ -124,5 +151,10 @@ install -Dm644 debian/asm-first-run.desktop \
 %{_datadir}/python-arctis-sound-manager/dinit/arctis-gui
 
 %changelog
+* Fri Jul 31 2026 loteran <https://github.com/loteran> - 1.2.19-2
+- Declare the runtime dependencies RPM cannot infer: the audio stack the daemon
+  drives, pulseaudio-utils for pactl (issue #117), ladspa-swh-plugins for the
+  virtual surround graph (issue #23), and curl for the first-run HRIR download
+
 * Mon Jun 15 2026 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit


### PR DESCRIPTION
Hi — I'm the upstream author of Arctis Sound Manager. Thank you for packaging it for Terra; I only discovered it existed this week, through users.

The package currently declares **no `Requires:` at all**, so it installs without the audio stack and Python bindings it needs at runtime. On a system where those are already present everything works, which is presumably why it went unnoticed — but elsewhere users get failures that look like application bugs and aren't.

Two of these are behind reported upstream issues:

| dependency | what breaks without it |
|---|---|
| `pulseaudio-utils` | provides `pactl`, used at GUI startup and for EQ/Sonar routing. A clean install crashes on launch with `FileNotFoundError: 'pactl'` — [#117](https://github.com/loteran/Arctis-Sound-Manager/issues/117) |
| `ladspa-swh-plugins` | provides the reverb plugin the HeSuVi 7.1 virtual surround graph loads. Spatial Audio stays silent — [#23](https://github.com/loteran/Arctis-Sound-Manager/issues/23) |

The Python bindings (`pyside6`, `pyusb`, `pyudev`, `pulsectl`, `dbus-next`, `ruamel-yaml`, `pillow`, `babel`) are imported at runtime rather than declared as build metadata, so they aren't picked up automatically either.

This list matches [the spec I maintain alongside the source](https://github.com/loteran/Arctis-Sound-Manager/blob/main/arctis-sound-manager.spec), where each entry carries the reason it's there.

Nothing else is touched — no version bump, no changes to `%install`, `%files` or the packager field.

---

Two things beyond this PR, if you're open to them:

**I'd be glad to help keep this in sync.** The project releases often (several times a week at the moment) and I'd rather Terra users get a package that works than have them file bugs against code that isn't the problem. Happy to send PRs when packaging-relevant things change, or to be pinged.

**A heads-up on `update.rhai`:** it tracks PyPI, and PyPI publication happens in the same workflow as the GitHub release, so the two can be briefly out of step. `Source0` already points at the GitHub tag, so tracking GitHub releases directly would be marginally more reliable — entirely your call.

Thanks again for the packaging work.
