### PR TITLE
[f45] chore (opengamepadui): bump release (#14467)

### DIFF
--- a/anda/games/opengamepadui/opengamepadui.spec
+++ b/anda/games/opengamepadui/opengamepadui.spec
@@ -1,6 +1,6 @@
 Name:           opengamepadui
 Version:        0.46.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Open source gamepad-native game launcher and overlay
 
 License:        GPLv3


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (opengamepadui): bump release (#14467)](https://github.com/terrapkg/packages/pull/14467)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)