### PR TITLE
[f43] add: ggc (#14491)

### DIFF
--- a/anda/misc/ggc/anda.hcl
+++ b/anda/misc/ggc/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "ggc.spec"
+	}
+}

--- a/anda/misc/ggc/ggc.spec
+++ b/anda/misc/ggc/ggc.spec
@@ -1,0 +1,48 @@
+%global goipath github.com/bmf-san/ggc/v8
+Version:        8.7.2
+
+%gometa -f
+
+Name:           ggc
+Release:        1%{?dist}
+Summary:        A modern Git CLI tool with both traditional command-line and interactive incremental-search UI
+
+License:        MIT
+URL:            https://github.com/bmf-san/ggc
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+Requires:       glibc
+
+%description
+%{summary}.
+
+%gopkg
+
+%pkg_completion -bfz
+
+%prep
+%autosetup
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/cmd/ %{goipath}
+
+%install
+install -Dm755 %{gobuilddir}/cmd/ggc    %{buildroot}%{_bindir}/ggc
+install -Dm644 cmd/completions/ggc.bash %{buildroot}%{bash_completions_dir}/ggc.bash
+install -Dm644 cmd/completions/ggc.fish %{buildroot}%{fish_completions_dir}/ggc.fish
+install -Dm644 cmd/completions/ggc.zsh  %{buildroot}%{zsh_completions_dir}/_ggc
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md
+%{_bindir}/ggc
+
+%changelog
+* Sun Jul 26 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/misc/ggc/update.rhai
+++ b/anda/misc/ggc/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("bmf-san/ggc"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: ggc (#14491)](https://github.com/terrapkg/packages/pull/14491)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)