### PR TITLE
[f43] add: wego (#14490)

### DIFF
--- a/anda/misc/wego/anda.hcl
+++ b/anda/misc/wego/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "wego.spec"
+    }
+}

--- a/anda/misc/wego/update.rhai
+++ b/anda/misc/wego/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("schachmat/wego"));

--- a/anda/misc/wego/wego.spec
+++ b/anda/misc/wego/wego.spec
@@ -1,0 +1,43 @@
+%global goipath github.com/schachmat/wego
+Version:        2.4
+
+%gometa -f
+
+Name:           wego
+Release:        1%{?dist}
+Summary:        weather app for the terminal
+
+License:        ISC
+URL:            https://github.com/schachmat/wego
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+Requires:       glibc
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%autosetup
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/wego %{goipath}/
+
+%install
+install -Dm755 %{gobuilddir}/wego %{buildroot}%{_bindir}/wego
+
+%files
+%license LICENSE
+%doc README.md CONTRIBUTING.md
+%{_bindir}/wego
+
+%changelog
+* Sun Jul 26 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: wego (#14490)](https://github.com/terrapkg/packages/pull/14490)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)