### PR TITLE
[f43] feat (chawan): split into nightly and stable packages, switch to sourcehut sources (#14468)

### DIFF
--- a/anda/misc/chawan/nightly/anda.hcl
+++ b/anda/misc/chawan/nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "chawan-nightly.spec"
+  }
+ 	labels {
+		nightly = 1
+	}
+}

--- a/anda/misc/chawan/nightly/chawan-nightly.spec
+++ b/anda/misc/chawan/nightly/chawan-nightly.spec
@@ -4,12 +4,12 @@
 
 %define debug_package %nil
 
-Name:           chawan
+Name:           chawan-nightly
 Version:        0~%{commit_date}git.%{shortcommit}
 Release:        1%{?dist}
 Summary:        TUI web (and (S)FTP, Gopher, Gemini, ...) browser with CSS, inline image and JavaScript support
-URL:            https://github.com/kachick/chawan
-Source0:        %url/archive/%commit/chawan-%commit.tar.gz
+URL:            https://git.sr.ht/~bptato/chawan
+Source0:        %{url}/archive/%{commit}.tar.gz
 License:        Unlicense
 BuildRequires: nim
 BuildRequires: gcc
@@ -18,6 +18,7 @@ BuildRequires: openssl-devel
 BuildRequires: brotli-devel
 BuildRequires: pkgconf-pkg-config
 BuildRequires: make
+Conflicts:     chawan
 Packager: apolunar <ijholm@tuta.io>
 
 %description
@@ -29,7 +30,7 @@ which can nevertheless display many websites in a manner similar to major graphi
 It can also be used as a terminal pager.
 
 %prep
-%autosetup -n chawan-%commit
+%autosetup -n chawan-%{commit}
 
 %build
 %make_build
@@ -44,10 +45,10 @@ It can also be used as a terminal pager.
 %{_mandir}/man1/cha.1.*
 %{_mandir}/man1/mancha.1.*
 %{_mandir}/man5/cha-config.5.*
-%{_mandir}/man5/cha-localcgi.5.*
 %{_mandir}/man5/cha-mailcap.5.*
 %{_mandir}/man5/cha-mime.types.5.*
 %{_mandir}/man5/cha-urimethodmap.5.*
+%{_mandir}/man5/cha-cgi.5.*
 %{_mandir}/man7/cha-api.7.*
 %{_mandir}/man7/cha-css.7.*
 %{_mandir}/man7/cha-image.7.*
@@ -58,5 +59,8 @@ It can also be used as a terminal pager.
 %doc README.md
 
 %changelog
+* Sun Jul 26 2026 Owen Zimmerman <owen@fyralabs.com>
+- Split into nightly and stable
+
 * Fri Mar 20 2026 apolunar <ijholm@tuta.io>
 - Initial commit

--- a/anda/misc/chawan/nightly/update.rhai
+++ b/anda/misc/chawan/nightly/update.rhai
@@ -1,4 +1,4 @@
-rpm.global("commit", gh_commit("kachick/chawan"));
+rpm.global("commit", sourcehut_commit("~bptato/chawan"));
 if rpm.changed() {
   rpm.release();
   rpm.global("commit_date", date());

--- a/anda/misc/chawan/stable/anda.hcl
+++ b/anda/misc/chawan/stable/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
   rpm {
     spec = "chawan.spec"
   }
- 	labels {
-		nightly = 1
-	}
 }

--- a/anda/misc/chawan/stable/chawan.spec
+++ b/anda/misc/chawan/stable/chawan.spec
@@ -1,0 +1,63 @@
+%define debug_package %nil
+
+Name:           chawan-nightly
+Version:        0.4.4
+Release:        1%{?dist}
+Epoch:          1
+Summary:        TUI web (and (S)FTP, Gopher, Gemini, ...) browser with CSS, inline image and JavaScript support
+URL:            https://git.sr.ht/~bptato/chawan
+Source0:        %{url}/archive/v%{version}.tar.gz
+License:        Unlicense
+BuildRequires: nim
+BuildRequires: gcc
+BuildRequires: libssh2-devel
+BuildRequires: openssl-devel
+BuildRequires: brotli-devel
+BuildRequires: pkgconf-pkg-config
+BuildRequires: make
+Conflicts:     chawan-nightly
+Packager: apolunar <ijholm@tuta.io>
+
+%description
+TUI web (and (S)FTP, Gopher, Gemini, ...) browser with CSS, inline image and JavaScript support.
+
+It uses its own small browser engine developed from scratch,
+which can nevertheless display many websites in a manner similar to major graphical browsers.
+
+It can also be used as a terminal pager.
+
+%prep
+%autosetup -C
+
+%build
+%make_build
+
+%install
+%make_install PREFIX=/usr
+
+%files
+%{_bindir}/cha
+%{_bindir}/mancha
+%{_libexecdir}/chawan/
+%{_mandir}/man1/cha.1.*
+%{_mandir}/man1/mancha.1.*
+%{_mandir}/man5/cha-config.5.*
+%{_mandir}/man5/cha-mailcap.5.*
+%{_mandir}/man5/cha-mime.types.5.*
+%{_mandir}/man5/cha-urimethodmap.5.*
+%{_mandir}/man5/cha-cgi.5.gz
+%{_mandir}/man7/cha-api.7.*
+%{_mandir}/man7/cha-css.7.*
+%{_mandir}/man7/cha-image.7.*
+%{_mandir}/man7/cha-protocols.7.*
+%{_mandir}/man7/cha-terminal.7.*
+%{_mandir}/man7/cha-troubleshooting.7.*
+%license UNLICENSE
+%doc README.md
+
+%changelog
+* Sun Jul 26 2026 Owen Zimmerman <owen@fyralabs.com>
+- Split into nightly and stable
+
+* Fri Mar 20 2026 apolunar <ijholm@tuta.io>
+- Initial commit

--- a/anda/misc/chawan/stable/update.rhai
+++ b/anda/misc/chawan/stable/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(sourcehut("~bptato/chawan"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat (chawan): split into nightly and stable packages, switch to sourcehut sources (#14468)](https://github.com/terrapkg/packages/pull/14468)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)