### PR TITLE
[el10] fix: noctalia-git (#14530)

### DIFF
--- a/anda/desktops/noctalia-git/noctalia-git.spec
+++ b/anda/desktops/noctalia-git/noctalia-git.spec
@@ -46,6 +46,7 @@ BuildRequires:  pkgconfig(wayland-protocols)
 BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(libsecret-1)
 BuildRequires:  pkgconfig(libsodium)
+BuildRequires:  pkgconfig(libjxl)
 
 Provides:       desktop-notification-daemon
 Provides:       PolicyKit-authentication-agent


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: noctalia-git (#14530)](https://github.com/terrapkg/packages/pull/14530)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)