### PR TITLE
[f45] feat: Update OGC gamescope to the latest version (#14544)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -2,7 +2,7 @@
 
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
-%global gamescope_commit 7282613d1e16be9b3b9446433932c1d91e7abca6
+%global gamescope_commit 74aace056d9d4300072287b62349458709aba3d2
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           terra-gamescope


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update OGC gamescope to the latest version (#14544)](https://github.com/terrapkg/packages/pull/14544)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)