### PR TITLE
[f45] feat: Update steamos-manager-powerstation to the latest version (#14553)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,10 +1,10 @@
-%global commit 37d1cb6f98e02b76221190b10af3c6e1c6b7534d
+%global commit 1a6e985c88e213bf789432ec23e7bbbf870107b1
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260528
+%global commitdate 20260727
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          6%{?dist}
+Release:          1%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update steamos-manager-powerstation to the latest version (#14553)](https://github.com/terrapkg/packages/pull/14553)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)