### PR TITLE
[f43] fix (equibop): missing desktop entry and icons (#14572)

### DIFF
--- a/anda/apps/equibop/equibop.spec
+++ b/anda/apps/equibop/equibop.spec
@@ -2,7 +2,7 @@
 
 Name:           equibop
 Version:        3.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Custom Discord client focused on performance and Linux support
 Packager:       bangetto <bangettoyou2@gmail.com>
 License:        GPL-3.0-only AND %electron_license
@@ -12,6 +12,7 @@ Source0:        https://github.com/Equicord/Equibop/archive/refs/tags/v%{version
 %electronmeta -D
 
 BuildRequires:  bun-bin
+BuildRequires:  desktop-file-utils
 BuildRequires:  jq
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(gio-2.0)
@@ -32,6 +33,14 @@ mv package.json.tmp package.json
 
 %install
 %electron_install
+
+# Install desktop entry and icons under official AppID and symlink short name. Also hint window managers.
+install -Dm644 build/%{appid}.desktop %{buildroot}%{_appsdir}/%{appid}.desktop
+ln -sf %{appid}.desktop %{buildroot}%{_appsdir}/%{name}.desktop
+desktop-file-edit --set-key=StartupWMClass --set-value=equibop %{buildroot}%{_appsdir}/%{appid}.desktop
+install -Dm644 build/icon.svg %{buildroot}%{_scalableiconsdir}/%{appid}.svg
+ln -sf %{appid}.svg %{buildroot}%{_scalableiconsdir}/%{name}.svg
+
 %terra_appstream
 
 %files
@@ -39,8 +48,13 @@ mv package.json.tmp package.json
 %doc README.md
 %{_bindir}/%{name}
 %{_libdir}/%{name}/
+%{_appsdir}/*.desktop
+%{_hicolordir}/*/apps/*
 %{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Tue Jul 28 2026 bangetto <bangettoyou2@gmail.com> - 3.2.2-2
+- Add launcher desktop file and icon paths to %files
+
 * Tue Jul 28 2026 bangetto <bangettoyou2@gmail.com> - 3.2.2-1
 - Initial package release


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (equibop): missing desktop entry and icons (#14572)](https://github.com/terrapkg/packages/pull/14572)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)