### PR TITLE
[el10] fix(rpcs3): check if ver is empty (#14577)

### DIFF
--- a/anda/games/rpcs3/rpcs3.spec
+++ b/anda/games/rpcs3/rpcs3.spec
@@ -10,12 +10,12 @@
 %global build_cflags %(echo "%{__build_flags_lang_c}" | sed 's|-Wp,-D_GLIBCXX_ASSERTIONS ||g') %{?_distro_extra_cflags}
 %global build_cxxflags %(echo "%{__build_flags_lang_cxx}" | sed 's|-Wp,-D_GLIBCXX_ASSERTIONS ||g') %{?_distro_extra_cflags}
 %global commit cf9133abedd619efb16715f38a0efe1f92fb92b6
-%global ver 
+%global ver 0.0.41-19652
 
-
-
-
-0.0.41-19652
+Name:           rpcs3
+Version:        %(echo %{ver} | sed 's/-/^/g')
+Release:        1%{?dist}
+Summary:        PlayStation 3 emulator and debugger
 License:        GPL-2.0-only
 URL:            https://github.com/RPCS3/rpcs3
 Source0:        %{url}/archive/%{commit}/%{name}-%{commit}.tar.gz

--- a/anda/games/rpcs3/update.rhai
+++ b/anda/games/rpcs3/update.rhai
@@ -1,9 +1,12 @@
 let release = get("https://api.github.com/repos/RPCS3/rpcs3-binaries-linux/releases/latest").json();
-rpm.global("ver", release.name);
+release.name.trim();
+if !release.name.is_empty() {
+  rpm.global("ver", release.name);
+}
 
-if rpm.changed () {
-     let c = release.tag_name;
-     c.crop(6);
-     rpm.global("commit", c);
-     rpm.release();
+if rpm.changed() {
+  let c = release.tag_name;
+  c.crop(6);
+  rpm.global("commit", c);
+  rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(rpcs3): check if ver is empty (#14577)](https://github.com/terrapkg/packages/pull/14577)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)