### PR TITLE
[f45] build(deps): bump ossf/scorecard-action from 2.4.3 to 2.4.4 (#14580)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [build(deps): bump ossf/scorecard-action from 2.4.3 to 2.4.4 (#14580)](https://github.com/terrapkg/packages/pull/14580)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)