### PR TITLE
[f43] fix: asusctl update.rhai (#14594)

### DIFF
--- a/anda/system/asusctl/update.rhai
+++ b/anda/system/asusctl/update.rhai
@@ -1,2 +1,2 @@
-rpm.version(gh_tag("OpenGamingCollective/asusctl"));
+rpm.version(gh("OpenGamingCollective/asusctl"));
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: asusctl update.rhai (#14594)](https://github.com/terrapkg/packages/pull/14594)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)