### PR TITLE
fix: t3code

### DIFF
--- a/anda/devs/t3code/t3code.spec
+++ b/anda/devs/t3code/t3code.spec
@@ -10,6 +10,7 @@ URL:            https://github.com/pingdotgg/t3code
 Source0:        https://github.com/pingdotgg/t3code/archive/refs/tags/v%{version}.tar.gz
 
 BuildRequires:  anda-srpm-macros
+BuildRequires:  cargo
 BuildRequires:  ImageMagick
 BuildRequires:  pnpm
 
@@ -26,6 +27,9 @@ Cursor, and OpenCode.
 
 %prep
 %autosetup -n %{name}-%{version}
+for manifest in apps/server/package.json apps/desktop/package.json apps/web/package.json packages/contracts/package.json; do
+  node -e 'const fs = require("fs"); const [file, version] = process.argv.slice(1); const pkg = JSON.parse(fs.readFileSync(file, "utf8")); pkg.version = version; fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");' "$manifest" %{version}
+done
 
 %build
 export T3CODE_DESKTOP_VERSION=%{version}


### PR DESCRIPTION
- adds cargo as a build dep due to new additions to t3code
- patches in the correct version number, otherwise it causes warnings in app about being outdated, upstream does this after release and not before release for some reason