### PR TITLE
[f43] fix: rpi-utils (#14626)

### DIFF
--- a/anda/tools/rpi-utils/rpi-utils.spec
+++ b/anda/tools/rpi-utils/rpi-utils.spec
@@ -237,11 +237,18 @@ Summary:        A tool to get VideoCore 'assert' or 'msg' logs with optional -f 
 %doc piolib/README.md
 %license LICENCE
 %{_bindir}/apitest
+%{_bindir}/blockingtest
 %{_bindir}/dpi_csync
+%{_bindir}/irqhog
+%{_bindir}/irqtest
+%{_bindir}/irqtest2
 %{_bindir}/piopwm
 %{_bindir}/pioseq
 %{_bindir}/piotest
 %{_bindir}/piows2812
+%{_bindir}/rxsource
+%{_bindir}/txcount
+%{_bindir}/txsink
 %{_bindir}/quadenc
 %{_bindir}/rp1sm
 %{_libdir}/libpio.so.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: rpi-utils (#14626)](https://github.com/terrapkg/packages/pull/14626)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)