### PR TITLE
[el10] add: cachyos-ananicy-rules (#14632)

### DIFF
--- a/anda/misc/cachyos-ananicy-rules/anda.hcl
+++ b/anda/misc/cachyos-ananicy-rules/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+      arches = ["x86_64"]
+	rpm {
+		spec = "cachyos-ananicy-rules.spec"
+	}
+}

--- a/anda/misc/cachyos-ananicy-rules/cachyos-ananicy-rules.spec
+++ b/anda/misc/cachyos-ananicy-rules/cachyos-ananicy-rules.spec
@@ -1,0 +1,34 @@
+Name:           cachyos-ananicy-rules
+Version:        1.1.47
+Release:        1%{?dist}
+Summary:        List of rules used to assign specific nice values to specific processes
+
+License:        GPL-3.0-or-later
+URL:            https://github.com/CachyOS/ananicy-rules
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+Requires:       ananicy-cpp
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+BuildArch:      noarch
+
+%description
+%{summary}.
+
+%prep
+%autosetup -C
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_sysconfdir}/ananicy.d
+cp 00-default %{buildroot}%{_sysconfdir}/ananicy.d/ -r
+cp 00-cgroups.cgroups %{buildroot}%{_sysconfdir}/ananicy.d/ -r
+cp 00-types.types %{buildroot}%{_sysconfdir}/ananicy.d/ -r
+cp ananicy.conf %{buildroot}%{_sysconfdir}/ananicy.d/ -r
+
+%files
+%defattr(-,root,root,-)
+%{_sysconfdir}/ananicy.d/*
+
+%changelog
+* Thu Jul 30 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/misc/cachyos-ananicy-rules/update.rhai
+++ b/anda/misc/cachyos-ananicy-rules/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("CachyOS/ananicy-rules"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: cachyos-ananicy-rules (#14632)](https://github.com/terrapkg/packages/pull/14632)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)