### PR TITLE
[f43] add: cosmic-ext-flux (#14617)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-flux/anda.hcl
+++ b/anda/desktops/cosmic/cosmic-ext-flux/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "cosmic-ext-flux.spec"
+	}
+}

--- a/anda/desktops/cosmic/cosmic-ext-flux/cosmic-ext-flux.spec
+++ b/anda/desktops/cosmic/cosmic-ext-flux/cosmic-ext-flux.spec
@@ -1,0 +1,67 @@
+%global appid io.github.franz_net.CosmicExtAppletFlux
+
+Name:           cosmic-ext-flux
+Version:        3.1.1
+Release:        1%{?dist}
+SourceLicense:  GPL-3.0-only
+License:        (BSD-3-Clause OR MIT OR Apache-2.0) AND Apache-2.0 AND MIT AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND BSD-2-Clause AND Zlib AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND (MIT OR Apache-2.0 OR CC0-1.0) AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND (BSD-3-Clause OR Apache-2.0) AND BSL-1.0 AND ISC AND (MIT OR LGPL-3.0-or-later) AND GPL-3.0-only AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
+
+Summary:        Animated desktop wallpapers for COSMIC — play any video or GIF as your background
+URL:            https://www.franz-e.net/cosmic-ext-flux/
+Source0:        https://github.com/franz-net/cosmic-ext-flux/archive/refs/tags/v%{version}.tar.gz
+Source1:        %{appid}.metainfo.xml
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  wayland-devel
+BuildRequires:  gstreamer1-plugins-base-devel
+BuildRequires:  pkgconfig(xkbcommon)
+Requires:       cosmic-osd
+Requires:       gstreamer1-plugins-base
+Requires:       gstreamer1-plugins-good
+Requires:       gstreamer1-plugins-bad
+Requires:       hicolor-icon-theme
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup
+%cargo_prep_online
+
+%build
+%cargo_build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+install -Dm755 target/rpm/cosmic-ext-flux-daemon %{buildroot}%{_bindir}/cosmic-ext-flux-daemon
+install -Dm755 target/rpm/cosmic-ext-applet-flux %{buildroot}%{_bindir}/cosmic-ext-applet-flux
+install -Dm644 applet/resources/app.desktop %{buildroot}%{_appsdir}/%{appid}.desktop
+install -Dm644 applet/resources/icon.svg %{buildroot}%{_scalableiconsdir}/%{appid}.svg
+install -Dm644 applet/resources/icon-stopped.svg %{buildroot}%{_scalableiconsdir}/%{appid}-stopped.svg
+install -Dm644 data/cosmic-ext-flux-daemon.service %{buildroot}%{_userunitdir}/cosmic-ext-flux-daemon.service
+
+%terra_appstream -o %{S:1}
+
+%post
+%systemd_user_post cosmic-ext-flux-daemon.service
+
+%preun
+%systemd_user_preun cosmic-ext-flux-daemon.service
+
+%postun
+%systemd_user_postun_with_restart cosmic-ext-flux-daemon.service
+
+%files
+%doc README.md
+%license LICENSE LICENSE.dependencies
+%{_bindir}/cosmic-ext-flux-daemon
+%{_bindir}/cosmic-ext-applet-flux
+%{_appsdir}/%{appid}.desktop
+%{_scalableiconsdir}/%{appid}.svg
+%{_scalableiconsdir}/%{appid}-stopped.svg
+%{_userunitdir}/cosmic-ext-flux-daemon.service
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%changelog
+* Wed Jul 29 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/desktops/cosmic/cosmic-ext-flux/io.github.franz_net.CosmicExtAppletFlux.metainfo.xml
+++ b/anda/desktops/cosmic/cosmic-ext-flux/io.github.franz_net.CosmicExtAppletFlux.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>io.github.franz_net.CosmicExtAppletFlux</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <icon type="local">/usr/share/icons/hicolor/scalable/apps/io.github.franz_net.CosmicExtAppletFlux.svg</icon>
+
+  <name>cosmic-ext-flux</name>
+  <summary>Animated desktop wallpapers for COSMIC — play any video or GIF as your background</summary>
+
+  <screenshots>
+    <screenshot type="default"><image>https://github.com/franz-net/cosmic-ext-flux/blob/main/assets/screenshot.png</image></screenshot>
+  </screenshots>
+
+  <description>
+    <p>
+        Animated desktop wallpapers for COSMIC — play any video or GIF as your background.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">io.github.franz_net.CosmicExtAppletFlux.desktop</launchable>
+
+  <url type="homepage">https://www.franz-e.net/cosmic-ext-flux/</url>
+
+  <keywords>
+    <keyword>Cosmic</keyword>
+  </keywords>
+</component>

--- a/anda/desktops/cosmic/cosmic-ext-flux/update.rhai
+++ b/anda/desktops/cosmic/cosmic-ext-flux/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("franz-net/cosmic-ext-flux"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: cosmic-ext-flux (#14617)](https://github.com/terrapkg/packages/pull/14617)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)