### PR TITLE
[f45] add: cosmic folder and cosmic-ext-classic-menu (#14615)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-classic-menu/anda.hcl
+++ b/anda/desktops/cosmic/cosmic-ext-classic-menu/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "cosmic-ext-classic-menu.spec"
+	}
+}

--- a/anda/desktops/cosmic/cosmic-ext-classic-menu/com.championpeak87.cosmic-ext-classic-menu.metainfo.xml
+++ b/anda/desktops/cosmic/cosmic-ext-classic-menu/com.championpeak87.cosmic-ext-classic-menu.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>com.championpeak87.cosmic-ext-classic-menu</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <icon type="local">/usr/share/icons/hicolor/scalable/apps/com.championpeak87.cosmic-ext-classic-menu.svg</icon>
+
+  <name>cosmic-ext-classic-menu</name>
+  <summary>A menu applet for COSMIC Desktop</summary>
+
+  <screenshots>
+    <screenshot type="default"><image>https://github.com/championpeak87/cosmic-ext-classic-menu/blob/master/screenshots/cosmic-ext-classic-menu-applet.png</image></screenshot>
+  </screenshots>
+
+  <description>
+    <p>
+        A menu applet for COSMIC Desktop.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">com.championpeak87.cosmic-ext-classic-menu</launchable>
+
+  <url type="homepage">https://github.com/championpeak87/cosmic-ext-classic-menu</url>
+
+  <keywords>
+    <keyword>Cosmic</keyword>
+  </keywords>
+</component>

--- a/anda/desktops/cosmic/cosmic-ext-classic-menu/cosmic-ext-classic-menu.spec
+++ b/anda/desktops/cosmic/cosmic-ext-classic-menu/cosmic-ext-classic-menu.spec
@@ -1,0 +1,46 @@
+%global appid com.championpeak87.cosmic-ext-classic-menu
+
+Name:           cosmic-ext-classic-menu
+Version:        0.0.14
+Release:        1%{?dist}
+SourceLicense:  GPL-3.0-or-later
+License:        GPL-3.0-or-later (BSD-3-Clause OR MIT OR Apache-2.0) AND Apache-2.0 AND MIT AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND BSD-2-Clause AND Zlib AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND (MIT OR Apache-2.0 OR CC0-1.0) AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND (BSD-3-Clause OR Apache-2.0) AND BSL-1.0 AND ISC AND (MIT OR LGPL-3.0-or-later) AND GPL-3.0-only AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
+Summary:        A menu applet for COSMIC Desktop
+URL:            https://github.com/championpeak87/cosmic-ext-classic-menu
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+Source1:        %{appid}.metainfo.xml
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  just
+Requires:       cosmic-osd
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup
+%cargo_prep_online
+
+%build
+%cargo_build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+just rootdir=%{buildroot} install
+%terra_appstream %{S:1}
+
+%files
+%doc README.md
+%license LICENSE LICENSE.dependencies
+%{_bindir}/%{name}-applet
+%{_bindir}/%{name}-settings
+%{_appsdir}/%{appid}.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_scalableiconsdir}/%{appid}.svg
+%{_datadir}/cosmic/%{appid}/applet-buttons/*
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%changelog
+* Wed Jul 29 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/desktops/cosmic/cosmic-ext-classic-menu/update.rhai
+++ b/anda/desktops/cosmic/cosmic-ext-classic-menu/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("championpeak87/cosmic-ext-classic-menu"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: cosmic folder and cosmic-ext-classic-menu (#14615)](https://github.com/terrapkg/packages/pull/14615)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)