### PR TITLE
[el10] add: bolt-screen-locker (#14487)

### DIFF
--- a/anda/desktops/chasm/bolt-screen-locker/0001-fix-install-permissions.patch
+++ b/anda/desktops/chasm/bolt-screen-locker/0001-fix-install-permissions.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 5c6f213..035f484 100644
+--- a/Makefile
++++ b/Makefile
+@@ -52,7 +52,7 @@ img/logo.rgba: $(LOGO_SRC)
+ install: bolt bolt-auth
+ 	install -d $(DESTDIR)$(BINDIR)
+ 	install -m 0755 bolt $(DESTDIR)$(BINDIR)/bolt
+-	install -m 4755 -o root -g root bolt-auth $(DESTDIR)$(BINDIR)/bolt-auth
++	install -m 0755 bolt-auth $(DESTDIR)$(BINDIR)/bolt-auth
+ 	@echo
+ 	@echo "  bolt installed. The auth helper is suid root (mode 4755):"
+ 	@ls -la $(DESTDIR)$(BINDIR)/bolt-auth

--- a/anda/desktops/chasm/bolt-screen-locker/anda.hcl
+++ b/anda/desktops/chasm/bolt-screen-locker/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "bolt-screen-locker.spec"
+  }
+}

--- a/anda/desktops/chasm/bolt-screen-locker/bolt-screen-locker.spec
+++ b/anda/desktops/chasm/bolt-screen-locker/bolt-screen-locker.spec
@@ -1,0 +1,36 @@
+%global _hardened_ldflags %nil
+
+Name:           bolt-screen-locker
+Release:        1%{?dist}
+Version:        0.2.0
+Summary:        Pure-asm screen locker for the CHasm desktop suite
+License:        Unlicense
+URL:            https://github.com/isene/bolt
+Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
+Patch:          0001-fix-install-permissions.patch
+BuildRequires:  nasm
+BuildRequires:  gcc
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+ExclusiveArch:  x86_64
+
+%description
+Pure-asm screen locker for the CHasm desktop suite (x86_64 NASM, no libc).
+
+%prep
+%autosetup -C
+
+%build
+%make_build NASM="nasm -g" LD="%{__cc} -nostdlib -fuse-ld=mold -Wl,-z,muldefs %build_ldflags" CFLAGS="%build_cflags"
+
+%install
+%make_install PREFIX=%{_prefix}
+
+%files
+%doc README.md
+%license UNLICENSE
+%{_bindir}/bolt
+%attr(4755, root, root) %{_bindir}/bolt-auth
+
+%changelog
+* Sun Jul 26 2026 Owen Zimmerman <owen@fyralabs.com> - 0.2.0-1
+- Initial commit

--- a/anda/desktops/chasm/bolt-screen-locker/update.rhai
+++ b/anda/desktops/chasm/bolt-screen-locker/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("isene/bolt"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: bolt-screen-locker (#14487)](https://github.com/terrapkg/packages/pull/14487)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)