### PR TITLE
add: superfile

### DIFF
--- a/anda/tools/superfile/anda.hcl
+++ b/anda/tools/superfile/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "superfile.spec"
+	}
+}

--- a/anda/tools/superfile/superfile.spec
+++ b/anda/tools/superfile/superfile.spec
@@ -1,0 +1,44 @@
+# https://github.com/yorukot/superfile
+%global goipath         github.com/yorukot/superfile
+Version:                1.6.0
+
+%gometa -f
+
+%global common_description %{expand:
+Pretty fancy and modern terminal file manager.}
+
+%global golicenses      LICENSE
+%global godocs          README.md
+
+Name:           superfile
+Release:        1%{?dist}
+Summary:        Pretty fancy and modern terminal file manager
+
+License:        MIT
+URL:            https://github.com/yorukot/superfile
+Source:         %{gosource}
+Packager:       Caio Bruno <cbrunofb@gmail.com>
+
+%description %{common_description}
+
+%gopkg
+
+%prep
+%goprep -A
+
+%build
+%global gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/bin/spf %{goipath}
+
+%install
+install -m 0755 -vd %{buildroot}%{_bindir}
+install -m 0755 -vp %{gobuilddir}/bin/spf %{buildroot}%{_bindir}/
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/spf
+
+%changelog
+* Thu Jul 30 2026 Caio Bruno <cbrunofb@gmail.com>
+- Initial package

--- a/anda/tools/superfile/update.rhai
+++ b/anda/tools/superfile/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("yorukot/superfile"));


### PR DESCRIPTION
**What software is being packaged here?**

**superfile** — a pretty fancy and modern terminal file manager (TUI).

- Source: https://github.com/yorukot/superfile
- License: MIT

**Describe the motivation**

Not in Fedora or Terra. A popular, modern Go TUI file manager (already on AUR/nix/Homebrew); a native Terra RPM gives Fedora users a clean, `dnf`-updatable package.

**Additional context**

- Built from source via the Go macros (`%gometa -f` + `%gobuild`, `%gomodulesmode GO111MODULE=on`), like `lazygit`. The binary is `spf` (upstream's command name); package name is `superfile`.
- `update.rhai` bumps via `gh("yorukot/superfile")`.
- Tested: `anda build -c terra-rawhide-x86_64 -rrpmbuild` → green; installed in `fedora:rawhide` — `spf --version` → `superfile version v1.6.0`, only glibc/libresolv runtime deps.

Opening as draft to validate against the Terra CI first.

**Checklist**

- [x] This package is maintained OR there is a valid reason to add it (e.g. python dependency)
- [x] I have tested at least the `x86_64` version of the package
- [x] I have read through any relevant [Terra](https://developer.fyralabs.com/terra) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
- [x] I have made sure there are no security issues with this package to the best of my ability
- [x] I have made sure this is not in Fedora (unless adding to the [extras repo](https://developer.fyralabs.com/terra/installing#extras)).
