### PR TITLE
[f43] add: glyph (#14484)

### DIFF
--- a/anda/desktops/chasm/glyph/anda.hcl
+++ b/anda/desktops/chasm/glyph/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    arches = ["x86_64"]
+  rpm {
+    spec = "glyph.spec"
+  }
+}

--- a/anda/desktops/chasm/glyph/glyph.spec
+++ b/anda/desktops/chasm/glyph/glyph.spec
@@ -1,0 +1,35 @@
+%global _hardened_ldflags %nil
+
+Name:           glyph
+Release:        1%{?dist}
+Version:        0.5.0
+Summary:        Pure assembly TrueType font rasterizer
+License:        Unlicense
+URL:            https://github.com/isene/glyph
+Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires:  nasm gcc
+BuildRequires:  make
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+ExclusiveArch:  x86_64
+
+%description
+Pure assembly TrueType font rasterizer. x86_64 Linux, no libc.
+Handles composite glyphs, UTF-8, OpenType variable fonts. Part of CHasm.
+
+%prep
+%autosetup -C
+
+%build
+%make_build NASM="nasm -g" LD="gcc -nostdlib -fuse-ld=mold -Wl,-z,muldefs %build_ldflags"
+
+%install
+install -Dm755 glyph %{buildroot}%{_bindir}/glyph
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}
+
+%changelog
+* Sun Jul 26 2026 Owen Zimmerman <owen@fyralabs.com> - 0.5.0-1
+- Initial commit

--- a/anda/desktops/chasm/glyph/update.rhai
+++ b/anda/desktops/chasm/glyph/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("isene/glyph"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: glyph (#14484)](https://github.com/terrapkg/packages/pull/14484)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)