### PR TITLE
add: ventoy

### DIFF
--- a/anda/tools/ventoy/anda.hcl
+++ b/anda/tools/ventoy/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "ventoy.spec"
+	}
+}

--- a/anda/tools/ventoy/sanitize.patch
+++ b/anda/tools/ventoy/sanitize.patch
@@ -1,0 +1,81 @@
+Author: DuckSoft <realducksoft@gmail.com>
+
+I just cannot stand such a dirty package. 
+Let me do some optimisations.
+
+If you are interested to improve this patch, welcome to mail me.
+
+diff -Npur a/tool/ventoy_lib.sh b/tool/ventoy_lib.sh
+--- a/tool/ventoy_lib.sh	2026-04-05 09:27:04.000000000 -0600
++++ b/tool/ventoy_lib.sh	2026-04-06 10:03:00.691008472 -0600
+@@ -51,31 +51,6 @@ vtoy_gen_uuid() {
+ }
+ 
+ check_tool_work_ok() {
+-    
+-    if echo 1 | hexdump > /dev/null; then
+-        vtdebug "hexdump test ok ..."
+-    else
+-        vtdebug "hexdump test fail ..."
+-        ventoy_false
+-        return
+-    fi
+-   
+-    if mkexfatfs -V > /dev/null; then        
+-        vtdebug "mkexfatfs test ok ..."
+-    else
+-        vtdebug "mkexfatfs test fail ..."
+-        ventoy_false
+-        return
+-    fi
+-    
+-    if vtoycli fat -T; then
+-        vtdebug "vtoycli fat test ok ..."
+-    else
+-        vtdebug "vtoycli fat test fail ..."
+-        ventoy_false
+-        return
+-    fi
+-    
+     vtdebug "tool check success ..."
+     ventoy_true
+ }
+diff -Npur a/VentoyPlugson.sh b/VentoyPlugson.sh
+--- a/VentoyPlugson.sh	2026-04-05 09:27:04.000000000 -0600
++++ b/VentoyPlugson.sh	2026-04-06 10:03:00.692415370 -0600
+@@ -34,8 +34,6 @@ if echo $machine | grep -E -q 'aarch64|a
+     TOOLDIR=aarch64
+ elif echo $machine | grep -E -q 'x86_64|amd64'; then
+     TOOLDIR=x86_64
+-elif echo $machine | grep -E -q 'mips64'; then
+-    TOOLDIR=mips64el
+ elif echo $machine | grep -E -q 'i[3-6]86'; then
+     TOOLDIR=i386
+ else
+diff -Npur a/VentoyWeb.sh b/VentoyWeb.sh
+--- a/VentoyWeb.sh	2026-04-05 09:27:04.000000000 -0600
++++ b/VentoyWeb.sh	2026-04-06 10:03:00.692673550 -0600
+@@ -15,12 +15,6 @@ print_err() {
+     echo ""
+ }
+ 
+-uid=$(id -u)
+-if [ $uid -ne 0 ]; then
+-    print_err "Please use sudo or run the script as root."
+-    exit 1
+-fi
+-
+ OLDDIR=$(pwd)
+ 
+ if uname -m | grep -E -q 'aarch64|arm64'; then
+@@ -85,8 +79,8 @@ if ps -ef | grep "V2DServer.*$HOST.*$POR
+     exit 1
+ fi
+ 
+-LOGFILE=log.txt
+-#delete the log.txt if it's more than 8MB
++LOGFILE=/var/log/ventoy.log
++#delete the ventoy.log if it's more than 8MB
+ if [ -f $LOGFILE ]; then
+     logsize=$(stat -c '%s' $LOGFILE)
+     if [ $logsize -gt 8388608 ]; then

--- a/anda/tools/ventoy/update.rhai
+++ b/anda/tools/ventoy/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("ventoy/Ventoy"));

--- a/anda/tools/ventoy/ventoy
+++ b/anda/tools/ventoy/ventoy
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /opt/ventoy || exit 1
+exec ./Ventoy2Disk.sh "$@"

--- a/anda/tools/ventoy/ventoy-extend-persistent
+++ b/anda/tools/ventoy/ventoy-extend-persistent
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /opt/ventoy/ExtendPersistentImg.sh "$@"

--- a/anda/tools/ventoy/ventoy-persistent
+++ b/anda/tools/ventoy/ventoy-persistent
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /opt/ventoy/CreatePersistentImg.sh "$@"

--- a/anda/tools/ventoy/ventoy.desktop
+++ b/anda/tools/ventoy/ventoy.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Icon=ventoy
+Name=Ventoy
+Exec=ventoygui
+Terminal=false
+Hidden=false
+Categories=Utility
+Comment=Ventoy2Disk GUI
+StartupWMClass=Ventoy2Disk.gtk3

--- a/anda/tools/ventoy/ventoy.spec
+++ b/anda/tools/ventoy/ventoy.spec
@@ -1,0 +1,105 @@
+%define debug_package %{nil}
+%global __strip /bin/true
+
+Name:           ventoy
+Version:        1.1.17
+Release:        1%{?dist}
+Summary:        A new bootable USB solution for ISO/WIM/IMG/VHD(x)/EFI files
+
+License:        GPL-3.0-or-later
+URL:            https://www.ventoy.net
+Source0:        https://github.com/ventoy/Ventoy/releases/download/v%{version}/%{name}-%{version}-linux.tar.gz
+Source1:        %{name}.desktop
+Source2:        %{name}
+Source3:        %{name}gui
+Source4:        %{name}web
+Source5:        %{name}plugson
+Source6:        %{name}-persistent
+Source7:        %{name}-extend-persistent
+Source8:        https://raw.githubusercontent.com/ventoy/Ventoy/v%{version}/COPYING
+Patch0:         sanitize.patch
+Packager:       Caio Bruno <cbrunofb@gmail.com>
+
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  xz
+Requires:       bash dosfstools util-linux which xz
+Recommends:     e2fsprogs gtk3 polkit
+Recommends:     ntfs-3g parted xfsprogs
+
+%description
+Ventoy is an open source tool to create bootable USB drive for ISO/WIM/IMG/VHD(x)/EFI files. With Ventoy you don't need to format the disk over and over, just copy the image files to the USB drive and boot them.
+
+%prep
+%autosetup -n ventoy-%{version} -p1
+cp %{SOURCE8} COPYING
+
+# Decompress bundled tool binaries
+pushd tool/%{_arch}
+for f in *.xz; do
+  xzcat "$f" > "${f%.xz}"
+  chmod +x "${f%.xz}"
+done
+rm -f *.xz
+popd
+
+# Log location
+sed -i 's|log\.txt|/var/log/ventoy.log|g' WebUI/static/js/languages.js tool/languages.json
+sed -i 's|\./log\.txt|/var/log/ventoy.log|g' Ventoy2Disk.sh tool/ventoy_lib.sh tool/VentoyWorker.sh
+
+# Use bash for non-POSIX scripts
+sed -i 's|bin/sh|usr/bin/env bash|g' Ventoy2Disk.sh VentoyVlnk.sh tool/create_ventoy_iso_part_dm.sh tool/ventoy_lib.sh tool/VentoyWorker.sh
+
+# Drop bundled tools we replace with system ones
+rm -f tool/%{_arch}/{xzcat,hexdump}
+
+%build
+# Prebuilt binaries, nothing to compile.
+
+%install
+DEST=%{buildroot}/opt/ventoy
+install -d -m0755 "$DEST"/{boot,ventoy,tool/%{_arch}}
+
+install -Dm0644 -t "$DEST"/boot/          boot/*
+install -Dm0644 -t "$DEST"/ventoy/         ventoy/*
+install -Dm0644 -t "$DEST"/tool/           tool/*.{cer,glade,json,sh,xz}
+install -Dm0755 -t "$DEST"/tool/%{_arch}/  tool/%{_arch}/*
+install -Dm0755 -t "$DEST"/                *.sh
+cp -a plugin WebUI "$DEST"/
+
+install -Dm0755 VentoyGUI.%{_arch} "$DEST"/
+install -Dm0644 WebUI/static/img/VentoyLogo.png %{buildroot}%{_datadir}/pixmaps/%{name}.png
+install -Dm0644 %{SOURCE1} %{buildroot}%{_appsdir}/%{name}.desktop
+
+install -Dm0755 %{SOURCE2} %{buildroot}%{_bindir}/%{name}
+install -Dm0755 %{SOURCE3} %{buildroot}%{_bindir}/%{name}gui
+install -Dm0755 %{SOURCE4} %{buildroot}%{_bindir}/%{name}web
+install -Dm0755 %{SOURCE5} %{buildroot}%{_bindir}/%{name}plugson
+install -Dm0755 %{SOURCE6} %{buildroot}%{_bindir}/%{name}-persistent
+install -Dm0755 %{SOURCE7} %{buildroot}%{_bindir}/%{name}-extend-persistent
+
+# Use system xzcat/hexdump instead of the bundled ones
+ln -s %{_bindir}/xzcat   "$DEST"/tool/%{_arch}/xzcat
+ln -s %{_bindir}/hexdump "$DEST"/tool/%{_arch}/hexdump
+
+# Drop the gtk2 variant on x86_64 (we ship gtk3/qt5)
+%ifarch x86_64
+rm -f "$DEST"/tool/%{_arch}/Ventoy2Disk.gtk2
+%endif
+
+%files
+%license COPYING
+%doc README
+%{_bindir}/%{name}
+%{_bindir}/%{name}gui
+%{_bindir}/%{name}web
+%{_bindir}/%{name}plugson
+%{_bindir}/%{name}-persistent
+%{_bindir}/%{name}-extend-persistent
+/opt/ventoy/
+%{_appsdir}/%{name}.desktop
+%{_datadir}/pixmaps/%{name}.png
+
+%changelog
+* Thu Jul 30 2026 Caio Bruno <cbrunofb@gmail.com>
+- Initial package

--- a/anda/tools/ventoy/ventoygui
+++ b/anda/tools/ventoy/ventoygui
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd /opt/ventoy || exit 1
+
+if [ "$(uname -m)" = "x86_64" ]; then
+  ./VentoyGUI.x86_64 "$@"
+elif [ "$(uname -m)" = "aarch64" ]; then
+  ./VentoyGUI.aarch64 "$@"
+fi

--- a/anda/tools/ventoy/ventoyplugson
+++ b/anda/tools/ventoy/ventoyplugson
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /opt/ventoy || exit 1
+exec ./VentoyPlugson.sh "$@"

--- a/anda/tools/ventoy/ventoyweb
+++ b/anda/tools/ventoy/ventoyweb
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /opt/ventoy || exit 1
+exec ./VentoyWeb.sh "$@"


### PR DESCRIPTION
**What software is being packaged here?**

**ventoy** — an open source tool to create bootable USB drives for ISO/WIM/IMG/VHD(x)/EFI files.

- Source: https://github.com/ventoy/Ventoy
- Website: https://www.ventoy.net
- License: GPL-3.0-or-later

**Describe the motivation**

Closes #3790. 

Ventoy is extremely popular (~78k★) and is **not available as an RPM** in Fedora or Terra. This gives Fedora users a clean, `dnf`-installable package with the GUI (`ventoygui` + `.desktop`, so it shows in the application menu and opens with a click, no terminal).

**Additional context**

- **Repackages the upstream prebuilt Linux release** (`ventoy-<ver>-linux.tar.gz`). Building from source is impractical: Ventoy bundles and compiles GRUB2 + EDK2 (UEFI) + IPXE using vendored cross-toolchains (Linaro/bootlin/mips/musl) in a CentOS 7.8 env — upstream itself builds it via Docker. Every distro (CachyOS, AUR) uses the prebuilt release; this mirrors the CachyOS `ventoy-bin` packaging.
- Pattern follows CachyOS: install to `/opt/ventoy/` (hardcoded in upstream scripts), wrappers in `%{_bindir}` (`ventoy`, `ventoygui`, `ventoyweb`, `ventoyplugson`, `ventoy-persistent`, `ventoy-extend-persistent`), `.desktop` + icon, system `xzcat`/`hexdump` symlinked in, bundled tool `.xz` binaries decompressed at build time, log path → `/var/log/ventoy.log`, shebangs → bash, and a `sanitize.patch` (the version-drifted `Ventoy2Disk.sh` hunk was dropped — its logic is self-consistent and covered by the build-time decompress).
- The `.desktop` launches `ventoygui` as the current user; VentoyGUI escalates to root internally via **polkit** (system password prompt) — `polkit` is in `Recommends`. No `sudo` in the `.desktop`.
- `ExclusiveArch: x86_64 aarch64`; `__strip /bin/true` + `debug_package %nil` (prebuilt binaries); `update.rhai` via `gh("ventoy/Ventoy")`.
- Tested: `anda build -c terra-rawhide-x86_64` → green; installed in `fedora:rawhide` — wrappers, `VentoyGUI.<arch>`, `boot.img`, `.desktop` and icon all land correctly.

**Checklist**

- [x] This package is maintained OR there is a valid reason to add it (e.g. python dependency)
- [x] I have tested at least the `x86_64` version of the package
- [x] I have read through any relevant [Terra](https://developer.fyralabs.com/terra) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
- [x] I have made sure there are no security issues with this package to the best of my ability
- [x] I have made sure this is not in Fedora (unless adding to the [extras repo](https://developer.fyralabs.com/terra/installing#extras)).

## Distrobox test (with clean Fedora image)
<img width="760" height="1164" alt="image" src="https://github.com/user-attachments/assets/4c97bbf1-4271-40f4-9206-cf35291f4406" />
