### PR TITLE
add: fisher

### DIFF
--- a/anda/tools/fisher/anda.hcl
+++ b/anda/tools/fisher/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "fisher.spec"
+	}
+}

--- a/anda/tools/fisher/fisher.spec
+++ b/anda/tools/fisher/fisher.spec
@@ -1,0 +1,35 @@
+Name:           fisher
+Version:        4.4.8
+Release:        1%{?dist}
+Summary:        A plugin manager for the fish shell
+
+License:        MIT
+URL:            https://github.com/jorgebucaran/fisher
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+Packager:       Caio Bruno <cbrunofb@gmail.com>
+
+BuildArch:      noarch
+Requires:       fish curl
+
+%description
+fisher is a plugin manager for the fish shell — install plugins, themes,
+and functions from the command line with a single command.
+
+%prep
+%autosetup -n fisher-%{version}
+
+%build
+
+%install
+install -Dm644 functions/fisher.fish    %{buildroot}%{_datadir}/fish/vendor_functions.d/fisher.fish
+install -Dm644 completions/fisher.fish  %{buildroot}%{_datadir}/fish/vendor_completions.d/fisher.fish
+
+%files
+%license LICENSE.md
+%doc README.md
+%{_datadir}/fish/vendor_functions.d/fisher.fish
+%{_datadir}/fish/vendor_completions.d/fisher.fish
+
+%changelog
+* Thu Jul 30 2026 Caio Bruno <cbrunofb@gmail.com>
+- Initial package

--- a/anda/tools/fisher/fisher.spec
+++ b/anda/tools/fisher/fisher.spec
@@ -28,7 +28,7 @@ install -Dm644 completions/fisher.fish  %{buildroot}%{_datadir}/fish/vendor_comp
 %license LICENSE.md
 %doc README.md
 %{_datadir}/fish/vendor_functions.d/fisher.fish
-%{_datadir}/fish/vendor_completions.d/fisher.fish
+%{fish_completions_dir}/fisher.fish
 
 %changelog
 * Thu Jul 30 2026 Caio Bruno <cbrunofb@gmail.com>

--- a/anda/tools/fisher/update.rhai
+++ b/anda/tools/fisher/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("jorgebucaran/fisher"));


### PR DESCRIPTION
**What software is being packaged here?**

**fisher** — a plugin manager for the fish shell.

- Source: https://github.com/jorgebucaran/fisher
- License: MIT

**Describe the motivation**

Not in Fedora or Terra. Fisher is the de facto plugin manager for fish (~6k★ on GitHub). A native Terra RPM gives fish users a clean `dnf`-installable option.

**Additional context**

- Pure fish shell scripts (`noarch`). Installs `fisher.fish` to `vendor_functions.d` and its completions to `vendor_completions.d` (standard fish vendor paths, auto-sourced by fish). `Requires: fish curl`.
- `update.rhai` bumps via `gh("jorgebucaran/fisher")`.
- Tested: `anda build` → green; installed with `fish` in `fedora:rawhide` — `fish -c "type fisher"` finds the function.

**Checklist**

- [x] This package is maintained OR there is a valid reason to add it (e.g. python dependency)
- [x] I have tested at least the `x86_64` version of the package
- [x] I have read through any relevant [Terra](https://developer.fyralabs.com/terra) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
- [x] I have made sure there are no security issues with this package to the best of my ability
- [x] I have made sure this is not in Fedora (unless adding to the [extras repo](https://developer.fyralabs.com/terra/installing#extras)).