### PR TITLE
add: desktop-plus

### DIFF
--- a/anda/apps/desktop-plus/anda.hcl
+++ b/anda/apps/desktop-plus/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "desktop-plus.spec"
+	}
+}

--- a/anda/apps/desktop-plus/desktop-plus.spec
+++ b/anda/apps/desktop-plus/desktop-plus.spec
@@ -1,0 +1,55 @@
+%undefine __brp_mangle_shebangs
+%define debug_package %{nil}
+%global __strip /bin/true
+%global _build_id_links none
+
+%ifarch x86_64
+%global rpmarch x86_64
+%elifarch aarch64
+%global rpmarch arm64
+%endif
+
+Name:           desktop-plus
+Version:        3.6.4.1
+%electronmeta
+Release:        1%{?dist}
+Summary:        A GitHub Desktop fork with advanced functionality and improvements
+License:        MIT
+URL:            https://desktop-plus.org
+Source0:        https://github.com/desktop-plus/desktop-plus/releases/download/v%{version}/DesktopPlus-v%{version}-linux-%{rpmarch}.rpm
+Packager:       Caio Bruno <cbrunofb@gmail.com>
+
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  cpio
+Recommends:     (gnome-keyring or kf6-kwallet or kf5-wallet)
+
+%description
+Desktop Plus is a community fork of GitHub Desktop with additional features:
+commit search, multi-account support (GitHub, Bitbucket, GitLab, Codeberg),
+commit graph, multiple stashes per branch, and more.
+
+%prep
+%autosetup -Tc
+rpm2cpio %{SOURCE0} | cpio -idm
+chmod -R a+rX,u+w,go-w .
+
+%build
+
+%install
+cp -pr usr %{buildroot}/
+rm -f %{buildroot}%{_datadir}/doc/%{name}/copyright
+cp -p usr/lib/%{name}/LICENSE .
+
+%files
+%license LICENSE
+%{_bindir}/%{name}
+%{_prefix}/lib/%{name}/
+%exclude %{_prefix}/lib/%{name}/chrome-sandbox
+%attr(4755, root, root) %{_prefix}/lib/%{name}/chrome-sandbox
+%{_appsdir}/%{name}.desktop
+%{_hicolordir}/*/apps/gh-desktop-plus.png
+
+%changelog
+* Thu Jul 30 2026 Caio Bruno <cbrunofb@gmail.com>
+- Initial package

--- a/anda/apps/desktop-plus/update.rhai
+++ b/anda/apps/desktop-plus/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("desktop-plus/desktop-plus"));


### PR DESCRIPTION
**What software is being packaged here?**

**Desktop Plus** — a community fork of GitHub Desktop with advanced functionality (MIT, Electron).

- Source: https://github.com/desktop-plus/desktop-plus
- Website: https://desktop-plus.org
- License: MIT

**Describe the motivation**

Not in Fedora or Terra. The official GitHub Desktop has no Linux builds; Desktop Plus is the actively-maintained fork that ships Linux RPM/DEB/AppImage releases (~594★). Features include commit search, multi-account (GitHub/Bitbucket/GitLab/Codeberg), commit graph, and multiple stashes per branch.

**Additional context**

Repackages the upstream **Linux RPM release** (`DesktopPlus-v<ver>-linux-<arch>.rpm`), the same approach `cursor` takes with its upstream package. A source build was investigated but is impractical here: provider sign-in needs OAuth client secrets (×4) that are GitHub Actions secrets and not in the repo, and the upstream pipeline uses electron-packager + electron-installer-redhat rather than stock electron-builder. The prebuilt RPM embeds those credentials, so repackaging it (as AUR `desktop-plus-bin` does) is the pragmatic choice.

Since `rpm2cpio` extraction discards the upstream RPM's `postinstall` scriptlet, the things it handled are reproduced at build time:

- **libcurl-gnutls → libcurl.so.4**: the bundled git/copilot ELFs link `libcurl-gnutls.so.4` (the Debian split), which Fedora doesn't ship. The SONAME is rewritten in `%install` (the same `sed` the upstream scriptlet runs), and the residual `CURL_GNUTLS_3` versioned-symbol require is filtered via `__requires_exclude` — it's unsatisfiable in RPM metadata but only a harmless runtime warning, since the symbol still binds to Fedora's libcurl.
- **No setuid chrome-sandbox**: dropped for security (a setuid-root helper from a third-party prebuilt binary is a local-privilege-escalation surface). Fedora enables unprivileged user namespaces by default, so Electron's namespace sandbox stays fully active with no setuid binary — matching Terra's own `electron` package. Verified the app launches sandboxed as a non-root user.
- `desktop-plus-cli` symlink recreated (upstream built it in the lost scriptlet).
- `Recommends: (gnome-keyring or kf6-kwallet)` for the Secret Service the app uses via `libsecret` (auto-required); KF5 dropped as EOL on rawhide.
- `ExclusiveArch: x86_64 aarch64`; `update.rhai` via `gh("desktop-plus/desktop-plus")`.

Tested: `anda build -c terra-rawhide-x86_64` → green; aarch64 built and install-tested locally too. Both install cleanly in `fedora:rawhide` and the app launches.

**Checklist**

- [x] This package is maintained OR there is a valid reason to add it (e.g. python dependency)
- [x] I have tested at least the `x86_64` version of the package
- [x] I have read through any relevant [Terra](https://developer.fyralabs.com/terra) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
- [x] I have made sure there are no security issues with this package to the best of my ability
- [x] I have made sure this is not in Fedora (unless adding to the [extras repo](https://developer.fyralabs.com/terra/installing#extras)).
