### PR TITLE
[f43] feat: Update to the latest steamos-manager-powerstation (#14736)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit 1a6e985c88e213bf789432ec23e7bbbf870107b1
+%global commit e01df05e47f4b45f55a90e8c8bf3b08e65300b9e
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260727
+%global commitdate 20260730
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update to the latest steamos-manager-powerstation (#14736)](https://github.com/terrapkg/packages/pull/14736)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)