### PR TITLE
[f45] fix: legcord (#14462)

### DIFF
--- a/anda/apps/legcord/stable/Legcord.desktop
+++ b/anda/apps/legcord/stable/Legcord.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Legcord
+Exec=/usr/lib64/legcord/Legcord %U
+Terminal=false
+Type=Application
+Icon=legcord
+StartupWMClass=legcord
+Comment=Legcord is a custom client designed to enhance your Discord experience while keeping everything lightweight.
+MimeType=x-scheme-handler/discord;
+Categories=Network;
+X-Desktop-File-Install-Version=0.28

--- a/anda/apps/legcord/stable/legcord.spec
+++ b/anda/apps/legcord/stable/legcord.spec
@@ -9,6 +9,7 @@ Release:        1%{?dist}
 License:        OSL-3.0 AND %{electron_license}
 Summary:        Custom lightweight Discord client designed to enhance your experience
 URL:            https://github.com/Legcord/Legcord
+Source0:        Legcord.desktop
 Group:          Applications/Internet
 Packager:       madonuko <mado@fyralabs.com>
 Requires:       xdg-utils
@@ -28,10 +29,11 @@ while keeping everything lightweight.
 %pnpm_build -r build
 
 %install
-%electron_install -i legcord -l -I dist/.icon-set/icon_16.png -I dist/.icon-set/icon_32.png -I dist/.icon-set/icon_48x48.png -I dist/.icon-set/icon_64.png -I dist/.icon-set/icon_128.png -I dist/.icon-set/icon_256.png -I dist/.icon-set/icon_512.png -I dist/.icon-set/icon_1024.png
+%electron_install -i legcord -l -I dist/.icon-set/
+%desktop_file_install %{S:0}
 
-dist/Legcord-*.AppImage --appimage-extract '*.desktop'
-%desktop_file_install -k Exec,Icon -v "%{_libdir}/legcord/Legcord",legcord -u %U -f squashfs-root/Legcord.desktop
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/Legcord.desktop
 
 %files
 %doc README.md
@@ -40,15 +42,18 @@ dist/Legcord-*.AppImage --appimage-extract '*.desktop'
 %{_datadir}/applications/Legcord.desktop
 %{_libdir}/legcord/
 %{_iconsdir}/hicolor/16x16/apps/legcord.png
+%{_iconsdir}/hicolor/24x24/apps/legcord.png
 %{_iconsdir}/hicolor/32x32/apps/legcord.png
 %{_iconsdir}/hicolor/48x48/apps/legcord.png
 %{_iconsdir}/hicolor/64x64/apps/legcord.png
 %{_iconsdir}/hicolor/128x128/apps/legcord.png
 %{_iconsdir}/hicolor/256x256/apps/legcord.png
 %{_iconsdir}/hicolor/512x512/apps/legcord.png
-%{_iconsdir}/hicolor/1024x1024/apps/legcord.png
 
 %changelog
+* Thu Jul 30 2026 Owen-sz <owen@fyralabs.com> - 1.3.0-1
+- Vendor our own .desktop file
+
 * Mon May 18 2026 june-fish <june@fyralabs.com> - 1.2.4-1
 - Use electron macros
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: legcord (#14462)](https://github.com/terrapkg/packages/pull/14462)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)