### PR TITLE
[f45] add: cosmic-calculator (#14735)

### DIFF
--- a/anda/desktops/cosmic/cosmic-calculator/anda.hcl
+++ b/anda/desktops/cosmic/cosmic-calculator/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "cosmic-calculator.spec"
+	}
+}

--- a/anda/desktops/cosmic/cosmic-calculator/cosmic-calculator.spec
+++ b/anda/desktops/cosmic/cosmic-calculator/cosmic-calculator.spec
@@ -1,0 +1,43 @@
+%global appid dev.edfloreshz.Calculator
+
+Name:           cosmic-calculator
+Version:        0.2.1
+Release:        1%{?dist}
+SourceLicense:  GPL-3.0-only
+License:        (BSD-3-Clause OR MIT OR Apache-2.0) AND Apache-2.0 AND MIT AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND BSD-2-Clause AND Zlib AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND GPL-3.0 AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND (MIT OR Apache-2.0 OR CC0-1.0) AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND (BSD-3-Clause OR Apache-2.0) AND BSL-1.0 AND ISC AND (MIT OR LGPL-3.0-or-later) AND GPL-3.0-only AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
+Summary:        Calculator for the COSMIC desktop
+URL:            https://github.com/cosmic-utils/calculator
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  pkgconfig(xkbcommon)
+Requires:       cosmic-osd
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -C
+%cargo_prep_online
+
+%build
+%cargo_build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+install -Dm0755 target/rpm/cosmic-ext-calculator                %{buildroot}%{_bindir}/cosmic-ext-calculator
+install -Dm0644 res/app.desktop                                 %{buildroot}%{_appsdir}/%{appid}.desktop
+install -Dm0644 res/metainfo.xml                                %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
+install -Dm0644 res/icons/hicolor/scalable/apps/%{appid}.svg    %{buildroot}%{_scalableiconsdir}/%{appid}.svg
+
+%files
+%doc README.md
+%license LICENSE LICENSE.dependencies
+%{_bindir}/cosmic-ext-calculator
+%{_appsdir}/%{appid}.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_scalableiconsdir}/%{appid}.svg
+
+%changelog
+* Thu Jul 30 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/desktops/cosmic/cosmic-calculator/update.rhai
+++ b/anda/desktops/cosmic/cosmic-calculator/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("cosmic-utils/calculator"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: cosmic-calculator (#14735)](https://github.com/terrapkg/packages/pull/14735)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)