### PR TITLE
add: cliamp

### DIFF
--- a/anda/multimedia/cliamp/anda.hcl
+++ b/anda/multimedia/cliamp/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "cliamp.spec"
+	}
+}

--- a/anda/multimedia/cliamp/cliamp.spec
+++ b/anda/multimedia/cliamp/cliamp.spec
@@ -1,0 +1,48 @@
+%define debug_package %{nil}
+
+Name:           cliamp
+Version:        1.62.0
+Release:        1%{?dist}
+Summary:        A retro terminal music player inspired by Winamp
+
+License:        MIT
+URL:            https://cliamp.stream
+Source0:        https://github.com/bjarneo/cliamp/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Caio Bruno <cbrunofb@gmail.com>
+
+BuildRequires:  golang gcc alsa-lib-devel libvorbis-devel flac-devel desktop-file-utils
+Recommends:     ffmpeg yt-dlp pipewire-alsa
+
+%description
+cliamp is a retro terminal (TUI) music player inspired by Winamp that plays
+local files, HTTP streams, podcasts, and content from YouTube, SoundCloud,
+Spotify, Navidrome, Plex, Jellyfin and more, with a spectrum visualizer,
+parametric EQ, and a Lua plugin system.
+
+%prep
+%autosetup -n cliamp-%{version}
+sed -i 's/^Name=cliamp$/Name=Cliamp/' cliamp.desktop
+
+%build
+export CGO_ENABLED=1
+go build -trimpath -buildmode=pie -ldflags "-s -w -X main.version=%{version}" -o cliamp .
+
+%install
+install -Dpm755 cliamp        %{buildroot}%{_bindir}/cliamp
+install -Dpm644 cliamp.desktop %{buildroot}%{_appsdir}/cliamp.desktop
+install -Dpm644 Cliamp.png     %{buildroot}%{_hicolordir}/512x512/apps/cliamp.png
+
+%check
+desktop-file-validate %{buildroot}%{_appsdir}/cliamp.desktop
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/cliamp
+%{_appsdir}/cliamp.desktop
+%{_hicolordir}/512x512/apps/cliamp.png
+
+%changelog
+* Fri Jul 31 2026 Caio Bruno <cbrunofb@gmail.com> - 1.62.0-1
+- Initial package

--- a/anda/multimedia/cliamp/update.rhai
+++ b/anda/multimedia/cliamp/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("bjarneo/cliamp"));


### PR DESCRIPTION
**What software is being packaged here?**
[**cliamp**](https://cliamp.stream) — a retro terminal (TUI) music player inspired by Winamp, written in Go (Bubbletea).
Source: https://github.com/bjarneo/cliamp (MIT).

**Describe the motivation**
- Terminal music player for local files, HTTP streams, podcasts, and YouTube / YouTube Music / SoundCloud / Spotify / Navidrome / Plex / Jellyfin / radio.
- Ships a spectrum visualizer, 10-band parametric EQ, MPRIS integration, and a Lua plugin system.
- No comparable TUI music player exists in Terra today; upstream is otherwise only on AUR/Homebrew.

**Additional context**
- **Source build (Go)**, not prebuilt — idiomatic for Terra and avoids the prebuilt-binary strip caveat. Manual `go build` with `-X main.version=%{version}` instead of `%gometa`/`%gobuild`, since this is an end-user app and no `-devel` subpackage is wanted.
- **Runtime deps**: the C codec/audio libs (`libFLAC`, `libasound`, `libvorbis`, `libogg`) are auto-Required from the binary's ELF `NEEDED` entries. `ffmpeg`, `yt-dlp`, `pipewire-alsa` are `Recommends` — upstream documents them as *optional* runtime deps (local MP3/FLAC/Vorbis playback works without them).
- **No shell completions**: cliamp exposes no `completion` subcommand (verified by running the built binary — urfave/cli v3 treats it as a track path), so none are packaged.
- Ships the upstream `cliamp.desktop` (`Terminal=true`) + the 512×512 `Cliamp.png` icon; `Name=Cliamp`.
- No AppStream metainfo for now (upstream ships none); can be added later.
- Verified: x86_64 build OK, `rpmlint` clean (0 errors/badness), installs and runs in a `fedora:rawhide` distrobox (`cliamp version 1.62.0`); not present in Fedora.

**YouTube Music works once the user supplies an OAuth client (source-build note)**
- cliamp's built-in YouTube Music fallback OAuth pool is **injected in upstream's release build only** — it's an empty `var []oauthCreds` in `external/ytmusic/fallback.go`, populated in their CI, **absent from the public source/tarball**.
- So in this package the **YouTube Music provider is hidden by default** until the user configures their own key — **but it works fully once they do** (playlists, Liked Music, playback, the lot).
- **One-time, free setup:** create a Google Cloud OAuth *Desktop app* client at https://console.cloud.google.com/ (enable YouTube Data API v3), then `cliamp setup` (YouTube Music → custom) or add to `config.toml`:
  ```toml
  [ytmusic]
  client_id = "..."
  client_secret = "..."
  ```
- **Not redistributable:** the upstream fallback is the maintainer's private, quota-rotated set of Google Cloud projects — not appropriate for a distro to extract/embed.
- **Scope:** only YouTube Music is affected. **Spotify works out of the box** (built-in `client_id` is a `const` in source). Navidrome/Plex/Jellyfin/NetEase/Qobuz need user config by nature (personal servers/accounts). Plan to file an upstream request to publish the YTM fallback in-source (like Spotify), which would remove this for all distro/source builds.

**Checklist**
- [x] This package is maintained OR there is a valid reason to add it (e.g. python dependency)
- [x] I have tested at least the `x86_64` version of the package
- [x] I have read through any relevant [Terra](https://developer.fyralabs.com/terra) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
- [x] I have made sure there are no security issues with this package to the best of my ability
- [x] I have made sure this is not in Fedora (unless adding to the [extras repo](https://developer.fyralabs.com/terra/installing#extras)).
