### PR TITLE
add: ytm-player

### DIFF
--- a/anda/apps/ytm-player/anda.hcl
+++ b/anda/apps/ytm-player/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "python-ytm-player.spec"
+	}
+}

--- a/anda/apps/ytm-player/python-ytm-player.spec
+++ b/anda/apps/ytm-player/python-ytm-player.spec
@@ -9,7 +9,7 @@ BuildArch:		noarch
 
 License:		MIT
 URL:			https://github.com/peternaame-boop/ytm-player
-Source0:		https://github.com/peternaame-boop/ytm-player/releases/download/v%{version}/ytm_player-%{version}.tar.gz
+Source0:		%{pypi_source}
 
 Packager:		Caio Bruno <cbrunofb@gmail.com>
 
@@ -24,8 +24,8 @@ BuildRequires:	python3-hatchling
 %package -n		python3-%{pypi_name}
 Summary:		%{summary}
 Requires:		libmpv.so.2
-Provides:		ytm-player = %{version}-%{release}
-Provides:		ytm = %{version}-%{release}
+Provides:		ytm-player = %{evr}
+Provides:		ytm = %{evr}
 %{?python_provide:%python_provide python3-%{pypi_name}}
 
 %description -n	python3-%{pypi_name}
@@ -41,7 +41,6 @@ sed -i 's/python-mpv/mpv/' pyproject.toml
 %install
 %pyproject_install
 %pyproject_save_files %{pypi_name}
-chmod 0644 README.md
 
 %files -n		python3-%{pypi_name} -f %{pyproject_files}
 %doc README.md

--- a/anda/apps/ytm-player/python-ytm-player.spec
+++ b/anda/apps/ytm-player/python-ytm-player.spec
@@ -1,0 +1,53 @@
+%global pypi_name ytm_player
+%global _desc Terminal (TUI) YouTube Music client built with Textual.
+
+Name:			python-%{pypi_name}
+Version:		2.0.0
+Release:		1%{?dist}
+Summary:		Terminal YouTube Music player with synced lyrics
+BuildArch:		noarch
+
+License:		MIT
+URL:			https://github.com/peternaame-boop/ytm-player
+Source0:		https://github.com/peternaame-boop/ytm-player/releases/download/v%{version}/ytm_player-%{version}.tar.gz
+
+Packager:		Caio Bruno <cbrunofb@gmail.com>
+
+BuildRequires:	python3-devel
+BuildRequires:	python3-pip
+BuildRequires:	python3-wheel
+BuildRequires:	python3-hatchling
+
+%description
+%_desc
+
+%package -n		python3-%{pypi_name}
+Summary:		%{summary}
+Requires:		libmpv.so.2
+Provides:		ytm-player = %{version}-%{release}
+Provides:		ytm = %{version}-%{release}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+%description -n	python3-%{pypi_name}
+%_desc
+
+%prep
+%autosetup -n ytm_player-%{version}
+sed -i 's/python-mpv/mpv/' pyproject.toml
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+%pyproject_save_files %{pypi_name}
+chmod 0644 README.md
+
+%files -n		python3-%{pypi_name} -f %{pyproject_files}
+%doc README.md
+%license LICENSE
+%{_bindir}/ytm
+
+%changelog
+* Fri Jul 31 2026 Caio Bruno <cbrunofb@gmail.com> - 2.0.0-1
+- Initial package

--- a/anda/apps/ytm-player/update.rhai
+++ b/anda/apps/ytm-player/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("peternaame-boop/ytm-player"));
+rpm.version(pypi("ytm-player"));

--- a/anda/apps/ytm-player/update.rhai
+++ b/anda/apps/ytm-player/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("peternaame-boop/ytm-player"));


### PR DESCRIPTION
**What software is being packaged here?**
[**ytm-player**](https://github.com/peternaame-boop/ytm-player) — a terminal (TUI) YouTube Music client built with Textual (vim keybindings, synced lyrics, mpv audio backend, queue/playlist management, MPRIS/media-key integration).
Source: https://github.com/peternaame-boop/ytm-player (MIT).

**Describe the motivation**
- Terminal YouTube Music player with a polished TUI (Textual), synced lyrics, and MPRIS support.
- Authentication works from a source build with **no bundled secret** — it uses `ytmusicapi` via browser cookies / OAuth / manual headers (free-tier; no client-id/secret compiled in).
- No comparable working TUI YouTube Music player in Terra today.

**Additional context**
- **Source build (Python, hatchling), `noarch`.** Ships the `ytm` entry point; no desktop file/icon (TUI app). Optional extras `thefuzz`/`anyascii` (Spotify-import transliteration) are not in Fedora — the core player works without them.
- **Two dependency workarounds** (rationale in the commit message):
  - `sed python-mpv -> mpv` in `pyproject.toml`: Terra's `python-mpv` provides `python3dist(mpv)`, not the PyPI-canonical `python-mpv`, so the auto-generated Requires wouldn't resolve; normalizing the declared dep makes them match.
  - `Requires: libmpv.so.2`: `python-mpv` loads libmpv via ctypes at runtime, but the `python3-mpv` subpackage carries no runtime libmpv dependency (its `Requires: mpv-devel` is on the source package). Depending on the `libmpv.so.2` SONAME pulls **only `mpv-libs`** (the shared library) — the full `mpv` player is **not** installed.
- Depends on `python3-mpv`, which is already in `frawhide` (recently added — may still be propagating to the published Terra rawhide repo).
- Verified: builds clean; `rpmlint` 0 errors / 0 badness; installs and runs in a `fedora:rawhide` distrobox (`ytm --version`, `ytm doctor` → `libmpv: OK`); not present in Fedora.

**Checklist**
- [x] This package is maintained OR there is a valid reason to add it (e.g. python dependency)
- [x] I have tested at least the `x86_64` version of the package
- [x] I have read through any relevant [Terra](https://developer.fyralabs.com/terra) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
- [x] I have made sure there are no security issues with this package to the best of my ability
- [x] I have made sure this is not in Fedora (unless adding to the [extras repo](https://developer.fyralabs.com/terra/installing#extras)).

## Distrobox test
<img width="2307" height="1342" alt="image" src="https://github.com/user-attachments/assets/b3dc0780-0d38-4d8c-8e84-9296bd0074ee" />


