### PR TITLE
[f44] fix: quickjs-ng (#14800)

### DIFF
--- a/anda/lib/quickjs-ng/quickjs-ng.spec
+++ b/anda/lib/quickjs-ng/quickjs-ng.spec
@@ -54,6 +54,9 @@ rm %{buildroot}%{_docdir}/quickjs/LICENSE
 %license LICENSE
 %{_bindir}/qjs
 %{_bindir}/qjsc
+%{_mandir}/man1/qjs.1/qjs.man.*
+%{_mandir}/man1/qjsc.1/qjsc.man.*
+
 
 %files examples
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: quickjs-ng (#14800)](https://github.com/terrapkg/packages/pull/14800)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)