### PR TITLE
[f44] add: desktop-plus (#14789)

### DIFF
--- a/anda/apps/desktop-plus-bin/anda.hcl
+++ b/anda/apps/desktop-plus-bin/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "desktop-plus-bin.spec"
+	}
+}

--- a/anda/apps/desktop-plus-bin/desktop-plus-bin.spec
+++ b/anda/apps/desktop-plus-bin/desktop-plus-bin.spec
@@ -1,0 +1,65 @@
+%undefine __brp_mangle_shebangs
+%global __strip /bin/true
+%global _build_id_links none
+
+%ifarch x86_64
+%global rpmarch x86_64
+%elifarch aarch64
+%global rpmarch arm64
+%endif
+
+Name:           desktop-plus-bin
+%global appname desktop-plus
+%global appid   org.desktop-plus.DesktopPlus
+Version:        3.6.4.1
+%electronmeta -D
+%global __requires_exclude %{?__requires_exclude:%{__requires_exclude}|}CURL_GNUTLS
+Release:        1%{?dist}
+Summary:        A GitHub Desktop fork with advanced functionality and improvements
+License:        MIT AND %{electron_license}
+URL:            https://desktop-plus.org
+Source0:        https://github.com/desktop-plus/desktop-plus/releases/download/v%{version}/DesktopPlus-v%{version}-linux-%{rpmarch}.rpm
+Source1:        %{appid}.metainfo.xml
+Packager:       Caio Bruno <cbrunofb@gmail.com>
+
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  anda-srpm-macros
+BuildRequires:  cpio
+BuildRequires:  terra-appstream-helper
+Recommends:     (gnome-keyring or kf6-kwallet)
+
+%description
+Desktop Plus is a community fork of GitHub Desktop with additional features:
+commit search, multi-account support (GitHub, Bitbucket, GitLab, Codeberg),
+commit graph, multiple stashes per branch, and more.
+
+%prep
+%autosetup -Tc
+rpm2cpio %{SOURCE0} | cpio -idm
+
+%build
+
+%install
+cp -pr usr %{buildroot}/
+rm -f %{buildroot}%{_prefix}/lib/%{appname}/chrome-sandbox
+find %{buildroot}%{_prefix}/lib/%{appname} -type f -executable -exec \
+  sed -i 's/libcurl-gnutls\.so\.4/libcurl.so.4\x00\x00\x00\x00\x00\x00\x00/g' {} \;
+chmod 0755 %{buildroot}%{_prefix}/lib/%{appname}/resources/app/static/desktop-plus-cli
+ln -sf %{_prefix}/lib/%{appname}/resources/app/static/desktop-plus-cli %{buildroot}%{_bindir}/desktop-plus-cli
+rm -f %{buildroot}%{_datadir}/doc/%{appname}/copyright
+cp -p usr/lib/%{appname}/LICENSE .
+%terra_appstream -o %{SOURCE1}
+
+%files
+%license LICENSE
+%{_bindir}/%{appname}
+%{_bindir}/desktop-plus-cli
+%{_prefix}/lib/%{appname}/
+%{_appsdir}/%{appname}.desktop
+%{_hicolordir}/*/apps/gh-desktop-plus.png
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%changelog
+* Thu Jul 30 2026 Caio Bruno <cbrunofb@gmail.com>
+- Initial package

--- a/anda/apps/desktop-plus-bin/org.desktop-plus.DesktopPlus.metainfo.xml
+++ b/anda/apps/desktop-plus-bin/org.desktop-plus.DesktopPlus.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>org.desktop-plus.DesktopPlus</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Desktop Plus</name>
+  <summary>A GitHub Desktop fork with advanced functionality and improvements</summary>
+
+  <description>
+    <p>
+      Desktop Plus is a community fork of GitHub Desktop with additional features
+      including commit search, multi-account support (GitHub, Bitbucket, GitLab,
+      Codeberg), commit graph visualization, and multiple stashes per branch.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">desktop-plus.desktop</launchable>
+  <url type="homepage">https://desktop-plus.org</url>
+
+  <releases>
+    <release version="3.6.4.1" date="2026-07-28" />
+  </releases>
+</component>

--- a/anda/apps/desktop-plus-bin/update.rhai
+++ b/anda/apps/desktop-plus-bin/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("desktop-plus/desktop-plus"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: desktop-plus (#14789)](https://github.com/terrapkg/packages/pull/14789)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)