### PR TITLE
[f45] feat: Update to the latest gamescope session (#14827)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,8 +1,8 @@
 %define debug_package %nil
 
-%global commit b5c2d0d3ebcefa7450d9d4336dd5802aa96d8513
+%global commit 85d56e5dea799e46ea31985c044a55135dda84d6
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260202
+%global commit_date 20260801
 
 Name:           gamescope-session
 Version:        0~%{commit_date}git.%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update to the latest gamescope session (#14827)](https://github.com/terrapkg/packages/pull/14827)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)