### PR TITLE
[f44] chore (fisher): use %fish_functions_dir (#14826)

### DIFF
--- a/anda/tools/fisher/fisher.spec
+++ b/anda/tools/fisher/fisher.spec
@@ -27,7 +27,7 @@ install -Dm644 completions/fisher.fish  %{buildroot}%{_datadir}/fish/vendor_comp
 %files
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fish/vendor_functions.d/fisher.fish
+%{fish_functions_dir}/fisher.fish
 %{fish_completions_dir}/fisher.fish
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (fisher): use %fish_functions_dir (#14826)](https://github.com/terrapkg/packages/pull/14826)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)