### PR TITLE
[f45] chore (arctis-sound-manager): add provides: field (#14805)

### DIFF
--- a/anda/apps/Arctis-Sound-Manager/Arctis-Sound-Manager.spec
+++ b/anda/apps/Arctis-Sound-Manager/Arctis-Sound-Manager.spec
@@ -5,7 +5,7 @@
 
 Name:			python-%{pypi_name}
 Version:		1.2.19
-Release:		2%{?dist}
+Release:		3%{?dist}
 Summary:		GUI for SteelSeries Arctis headsets
 License:		GPL-3.0-or-later
 # GitHub pages URL 404s
@@ -60,6 +60,7 @@ Provides:       Arctis-Sound-Manager
 
 %package -n     python3-%{pypi_name}
 Summary:        %{summary}
+Provides:       arctis-sound-manager = %{evr}
 %{?python_provide:%python_provide python3-%{pypi_name}}
 
 %description -n python3-%{pypi_name}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (arctis-sound-manager): add provides: field (#14805)](https://github.com/terrapkg/packages/pull/14805)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)