### PR TITLE
[f43] feat: Update to the latest gamescope session part 2 (#14846)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,6 +1,6 @@
 %define debug_package %nil
 
-%global commit 85d56e5dea799e46ea31985c044a55135dda84d6
+%global commit 2de366835f64145e027645f76ab33e72132da860
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260801
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update to the latest gamescope session part 2 (#14846)](https://github.com/terrapkg/packages/pull/14846)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)