### PR TITLE
[f45] feat: Update gamescope to the latest OGC release (#14847)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -2,7 +2,7 @@
 
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
-%global gamescope_commit 74aace056d9d4300072287b62349458709aba3d2
+%global gamescope_commit 5a103fa622a2c7789624e5d455ae5d29f963131f
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           terra-gamescope


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update gamescope to the latest OGC release (#14847)](https://github.com/terrapkg/packages/pull/14847)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)