### PR TITLE
[f43] fix viciane (#14848)

### DIFF
--- a/anda/system/vicinae/vicinae.spec
+++ b/anda/system/vicinae/vicinae.spec
@@ -1,9 +1,3 @@
-%if 0%{?fedora} > 43
-%global gcc_compat 15
-%global __cc gcc-%{gcc_compat}
-%global __cxx g++-%{gcc_compat}
-%endif
-
 Name:           vicinae
 License:        GPL-3.0-or-later
 Version:        0.24.0
@@ -11,11 +5,11 @@ Release:        1%{?dist}
 URL:            https://docs.vicinae.com
 Source:         https://github.com/vicinaehq/%{name}/archive/refs/tags/v%{version}.tar.gz
 Summary:        A high-performance, native launcher for Linux
-Packager:       Olivia <git@olivia.sh>
+Packager:       Olivia <git@olivia.sh>, Jaiden Riordan <jade@fyralabs.com>
 
 BuildRequires:  cmake
-BuildRequires:  gcc%{?gcc_compat}
-BuildRequires:  gcc%{?gcc_compat}-c++
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
 BuildRequires:  kf6-syntax-highlighting-devel
 BuildRequires:  cmake(absl)
 BuildRequires:  openssl-devel
@@ -38,6 +32,7 @@ BuildRequires:  anda-srpm-macros
 BuildRequires:  ninja-build
 BuildRequires:  qt6-qtbase-devel
 BuildRequires:  qt6-qtbase-private-devel
+BuildRequires:  cmake(Qt6LinguistTools)
 BuildRequires:  xcb-util-keysyms-devel
 BuildRequires:  desktop-file-utils
 
@@ -96,6 +91,9 @@ install -Dm 644 extra/%{name}-url-handler.desktop -t %{buildroot}%{_appsdir}
 %dnl %{_udevrulesdir}/70-vicinae.rules
 
 %changelog
+* Sun Jul 19 2026 Jaiden Riordan <jade@fyralabs.com> - 0.24.0-1
+- Remove GCC compats
+
 * Sun Jul 19 2026 Olivia <git@olivia.sh> - 0.23.2-2
 - Update packager
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix viciane (#14848)](https://github.com/terrapkg/packages/pull/14848)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)