### PR TITLE
[f44] chore (cardwire): add new cardwire gui package, some updates (#14833)

### DIFF
--- a/anda/system/cardwire/cardwire.spec
+++ b/anda/system/cardwire/cardwire.spec
@@ -1,10 +1,14 @@
+%global appid com.github.opengamingcollective.cardwire
+
 Name:           cardwire
 Version:        0.11.1
 Release:        1%{?dist}
 Summary:        A GPU Manager for linux that uses eBPF LSM hooks to block GPUs
 URL:            https://opengamingcollective.github.io/cardwire/
 Source0:        https://github.com/OpenGamingCollective/cardwire/archive/refs/tags/v%{version}.tar.gz
-License:        GPL-3.0-or-later AND (Apache-2.0 OR MIT) AND BSD-3-Clause AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND ISC AND MIT (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND Zlib
+Source1:        %{appid}.metainfo.xml
+SourceLicense:  GPL-3.0-or-later
+License:        (BSD-3-Clause OR MIT OR Apache-2.0) AND Unlicense AND Apache-2.0 AND MIT AND (MIT OR Apache-2.0 OR Zlib) AND BSD-2-Clause AND Zlib AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND GPL-3.0 AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND BSL-1.0 AND ISC AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
 Provides:       switcheroo-control
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  systemd-rpm-macros
@@ -20,6 +24,13 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %description
 %{summary}.
 
+%package        gui
+Summary:        GUI for cardwire
+Requires:       %{name} = %{evr}
+
+%description    gui
+%{summary}.
+
 %prep
 %autosetup
 %cargo_prep_online
@@ -32,8 +43,16 @@ install -Dm0755 target/rpm/cardwire %{buildroot}%{_bindir}/cardwire
 install -Dm0755 target/rpm/cardwired %{buildroot}%{_bindir}/cardwired
 install -Dm0644 assets/cardwired.service %{buildroot}%{_unitdir}/cardwired.service
 install -Dm0644 assets/com.github.opengamingcollective.cardwire.conf %{buildroot}%{_datadir}/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf
-	
+install -Dm755 target/release/cardwire-gui %{buildroot}%{_bindir}/cardwire-gui
+install -Dm644 assets/cardwire-gui.desktop %{buildroot}%{_appsdir}/cardwire-gui.desktop
+for icon in assets/icons/*.svg; do
+	install -Dm644 "$icon" %{buildroot}%{_scalableiconsdir}/$(basename "$icon")
+done
+
+%cargo_license_summary_online
 %{cargo_license_online} > LICENSE.dependencies
+
+%terra_appstream -o %{S:1}
 
 %post
 %systemd_post cardwired.service
@@ -50,8 +69,17 @@ install -Dm0644 assets/com.github.opengamingcollective.cardwire.conf %{buildroot
 %{_bindir}/cardwire
 %{_bindir}/cardwired
 %{_unitdir}/cardwired.service
-%{_datadir}/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf
+%config %{_datadir}/dbus-1/system.d/com.github.opengamingcollective.cardwire.conf
+
+%files gui
+%{_scalableiconsdir}/*.svg
+%{_bindir}/cardwire-gui
+%{_appsdir}/cardwire-gui.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Sat Aug 01 2026 Owen Zimmerman <owen@fyralabs.com>
+- Add cardwire-gui subpackage
+
 * Wed May 06 2026 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit

--- a/anda/system/cardwire/com.github.opengamingcollective.cardwire.metainfo.xml
+++ b/anda/system/cardwire/com.github.opengamingcollective.cardwire.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>com.github.opengamingcollective.cardwire</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <!-- Temporary until we have an icon -->
+  <icon type="local">/usr/share/icons/hicolor/scalable/apps/com.github.opengamingcollective.cardwire.tray.svg</icon>
+
+  <name>Cardwire</name>
+  <summary>A GPU Manager for linux that uses eBPF LSM hooks to block GPUs</summary>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/OpenGamingCollective/cardwire/metainfo-screenshot/assets/com.github.opengamingcollective.cardwire.screenshot.png</image>
+    </screenshot>
+  </screenshots>
+
+  <description>
+    <p>
+        cardwire GUI is a GPU manager for Linux using eBPF LSM hooks to block GPUs.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">cardwire-gui.desktop</launchable>
+
+  <url type="homepage">https://github.com/OpenGamingCollective/cardwire</url>
+  <provides>
+    <binary>cardwire-gui</binary>
+  </provides>
+
+  <keywords>
+    <keyword>GPU</keyword>
+    <keyword>GPU manager</keyword>
+    <keyword>eBPF LSM</keyword>
+    <keyword>asusctl</keyword>
+    <keyword>switcheroo-control</keyword>
+    <keyword>supergfxctl</keyword>
+  </keywords>
+
+  <releases>
+    <release version="0.11.1" />
+  </releases>
+</component>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (cardwire): add new cardwire gui package, some updates (#14833)](https://github.com/terrapkg/packages/pull/14833)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)