### PR TITLE
[f45] feat: Update bazzite-portal to 0.2.4 (#14871)

### DIFF
--- a/anda/apps/bazzite-portal/bazzite-portal.spec
+++ b/anda/apps/bazzite-portal/bazzite-portal.spec
@@ -1,5 +1,5 @@
 Name:           bazzite-portal
-Version:        0.2.3
+Version:        0.2.4
 Release:        1%{?dist}
 Summary:        Bazzite Portal is a tabbed frontend for curated script execution, with a focus on distro specific QOL shortcuts
 URL:            https://github.com/ublue-os/yafti-gtk


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update bazzite-portal to 0.2.4 (#14871)](https://github.com/terrapkg/packages/pull/14871)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)