### PR TITLE
[f44] fix (resources): remove https:// from update.rhai (#14889)

### DIFF
--- a/anda/apps/resources/update.rhai
+++ b/anda/apps/resources/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gitlab_tag("https://gitlab.gnome.org", "39041"));
+rpm.version(gitlab_tag("gitlab.gnome.org", "39041"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix (resources): remove https:// from update.rhai (#14889)](https://github.com/terrapkg/packages/pull/14889)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)