### PR TITLE
[el10] fix: Arctis-Sound-Manager (#14897)

### DIFF
--- a/anda/apps/Arctis-Sound-Manager/Arctis-Sound-Manager.spec
+++ b/anda/apps/Arctis-Sound-Manager/Arctis-Sound-Manager.spec
@@ -135,6 +135,7 @@ install -Dm644 debian/asm-first-run.desktop \
 %{_bindir}/asm-gui
 %{_bindir}/asm-router
 %{_bindir}/asm-setup
+%{_bindir}/asm-stream-guard
 %{_udevrulesdir}/91-steelseries-arctis.rules
 %{_userunitdir}/arctis-manager.service
 %{_userunitdir}/arctis-video-router.service


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: Arctis-Sound-Manager (#14897)](https://github.com/terrapkg/packages/pull/14897)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)