### PR TITLE
[f44] feat: Update ScopeBuddy to 1.5.0 (#14912)

### DIFF
--- a/anda/games/ScopeBuddy/ScopeBuddy.spec
+++ b/anda/games/ScopeBuddy/ScopeBuddy.spec
@@ -1,6 +1,6 @@
 Name:           ScopeBuddy
 Version:        1.5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A manager script to make gamescope easier to use on desktop
 License:        Apache-2.0
 URL:            https://github.com/OpenGamingCollective/ScopeBuddy
@@ -9,6 +9,7 @@ BuildArch:      noarch
 
 Requires:       bash
 Requires:       perl
+Requires:       awk
 Requires:       (gamescope or terra-gamescope)
 Suggests:       (kscreen-doctor or gnome-randr)
 Suggests:       jq


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Update ScopeBuddy to 1.5.0 (#14912)](https://github.com/terrapkg/packages/pull/14912)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)