### PR TITLE
[f44] feat: Update to the latest gamescope-session (#14913)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,6 +1,6 @@
 %define debug_package %nil
 
-%global commit 2de366835f64145e027645f76ab33e72132da860
+%global commit 153e1f0ce0a669814ad242593121330d76a61b0e
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260801
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Update to the latest gamescope-session (#14913)](https://github.com/terrapkg/packages/pull/14913)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)