### PR TITLE
add: apparmor.d-fedora

### DIFF
--- a/anda/system/apparmor.d-fedora/anda.hcl
+++ b/anda/system/apparmor.d-fedora/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "apparmor.d-fedora.spec"
+	}
+}

--- a/anda/system/apparmor.d-fedora/apparmor.d-fedora.spec
+++ b/anda/system/apparmor.d-fedora/apparmor.d-fedora.spec
@@ -1,0 +1,7 @@
+# %tag below is only a cache-buster for Andaman's diff-based updater -
+# the actual build content is fetched fresh from
+# https://github.com/CatPieLeaf/apparmor.d-fedora/blob/main/dists/apparmor.d-fedora.spec
+# at parse time, so this file is never the source of truth for anything
+# except "did the tag change".
+%global tag v0.4910.0-2
+%include %(f=$(mktemp); curl -fsSL https://raw.githubusercontent.com/CatPieLeaf/apparmor.d-fedora/main/dists/apparmor.d-fedora.spec -o "$f"; echo "$f")

--- a/anda/system/apparmor.d-fedora/update.rhai
+++ b/anda/system/apparmor.d-fedora/update.rhai
@@ -1,0 +1,4 @@
+// Only bumps the cache-buster %tag so Andaman's diff-based updater
+// notices and rebuilds - the actual spec content is fetched live by
+// the %include in apparmor.d-fedora.spec.
+rpm.global("tag", gh("CatPieLeaf/apparmor.d-fedora"));


### PR DESCRIPTION
Terra packaging for CatPieLeaf/apparmor.d-fedora. Dumb-fetch spec: the real build content is pulled live from the repo's main branch at parse time via %include, so this file is never a diverging local copy. update.rhai only bumps a cache-buster %tag global to trigger Andaman's diff-based rebuild when a new release tag is published.