### PR TITLE
[f45] chore (flashprog): add update.rhai (#14894)

### DIFF
--- a/anda/tools/flashprog/update.rhai
+++ b/anda/tools/flashprog/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(sourcearcade("flashprog"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (flashprog): add update.rhai (#14894)](https://github.com/terrapkg/packages/pull/14894)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)