### PR TITLE
chore(cardwire): conflict with switcheroo-control

### DIFF
--- a/anda/system/cardwire/cardwire.spec
+++ b/anda/system/cardwire/cardwire.spec
@@ -2,7 +2,7 @@
 
 Name:           cardwire
 Version:        0.11.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A GPU Manager for linux that uses eBPF LSM hooks to block GPUs
 URL:            https://opengamingcollective.github.io/cardwire/
 Source0:        https://github.com/OpenGamingCollective/cardwire/archive/refs/tags/v%{version}.tar.gz
@@ -10,6 +10,7 @@ Source1:        %{appid}.metainfo.xml
 SourceLicense:  GPL-3.0-or-later
 License:        (BSD-3-Clause OR MIT OR Apache-2.0) AND Unlicense AND Apache-2.0 AND MIT AND (MIT OR Apache-2.0 OR Zlib) AND BSD-2-Clause AND Zlib AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND GPL-3.0 AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND BSL-1.0 AND ISC AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
 Provides:       switcheroo-control
+Conflicts:      switcheroo-control
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  systemd-devel


### PR DESCRIPTION
Cardwire implements the switcheroo-control dbus interface but has restrictions that switcheroo-control does not have i.e. the 2 GPU limit making it not a drop-in replacement.