### PR TITLE
[el10] chore(gamescope-session): Recommend cardwire or switcheroo-control (#14949)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -6,13 +6,13 @@
 
 Name:           gamescope-session
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        4%?dist
+Release:        5%?dist
 Summary:        Gamescope session based on Valve's gamescope
 License:        MIT
 URL:            https://github.com/OpenGamingCollective/gamescope-session
 Source0:        %url/archive/%commit.tar.gz
 Requires:       gamescope
-Recommends:     cardwire
+Recommends:     (cardwire or switcheroo-control)
 BuildRequires:  systemd-rpm-macros
 Packager:       Tulip Blossom <tulilirockz@outlook.com>
 BuildArch:      noarch


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(gamescope-session): Recommend cardwire or switcheroo-control (#14949)](https://github.com/terrapkg/packages/pull/14949)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)