### PR TITLE
[f43] feat: Update gamescope-session to the latest version (#14961)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,8 +1,8 @@
 %define debug_package %nil
 
-%global commit 153e1f0ce0a669814ad242593121330d76a61b0e
+%global commit 4cf5e0e13368f65e7bfd6e8c3c8d1511f089438c
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260801
+%global commit_date 20260804
 
 Name:           gamescope-session
 Version:        0~%{commit_date}git.%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update gamescope-session to the latest version (#14961)](https://github.com/terrapkg/packages/pull/14961)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)