### PR TITLE
[f44] feat: Update steamos-manager-powerstation to the latest version (#14966)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit e01df05e47f4b45f55a90e8c8bf3b08e65300b9e
+%global commit eda341d1135c17f9eb8acb618e5a77b03449bb30
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260730
+%global commitdate 20260804
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Update steamos-manager-powerstation to the latest version (#14966)](https://github.com/terrapkg/packages/pull/14966)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)