### PR TITLE
[f45] fix: proton-vpn (#14958)

### DIFF
--- a/anda/apps/proton-vpn/proton-vpn.spec
+++ b/anda/apps/proton-vpn/proton-vpn.spec
@@ -23,6 +23,7 @@ BuildRequires:  gtk3
 BuildRequires:  libnotify
 BuildRequires:  python3-proton-vpn-api-core
 BuildRequires:  librsvg2
+BuildRequires:  gettext
 
 Requires:       gtk3
 Requires:       libnotify


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: proton-vpn (#14958)](https://github.com/terrapkg/packages/pull/14958)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)