### PR TITLE
[f45] fix: swayfx (#14978)

### DIFF
--- a/anda/desktops/swayfx/swayfx.spec
+++ b/anda/desktops/swayfx/swayfx.spec
@@ -33,7 +33,7 @@ BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-cursor)
 BuildRequires:  pkgconfig(wayland-server) >= 1.21.0
 BuildRequires:  pkgconfig(wayland-protocols) >= 1.24
-BuildRequires:  pkgconfig(scenefx-0.4)
+BuildRequires:  pkgconfig(scenefx-0.5)
 BuildRequires:  pkgconfig(wlroots-0.19)
 BuildRequires:  pkgconfig(xcb)
 BuildRequires:  pkgconfig(xcb-icccm)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: swayfx (#14978)](https://github.com/terrapkg/packages/pull/14978)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)