### PR TITLE
[f44] feat: Update to the latest steamos-manager-powerstation (#14992)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit eda341d1135c17f9eb8acb618e5a77b03449bb30
+%global commit b624e9d6d5c89ac9a0988657aebb451e9526e4d9
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260804
+%global commitdate 20260805
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Update to the latest steamos-manager-powerstation (#14992)](https://github.com/terrapkg/packages/pull/14992)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)