### PR TITLE
[f45] fix: pion (#14998)

### DIFF
--- a/anda/system/pion/pion.spec
+++ b/anda/system/pion/pion.spec
@@ -24,7 +24,7 @@ Binder IPC Linux userspace root service... Binder objects bound to files (like U
 %install
 install -Dm755 target/rpm/pion-binder   %{buildroot}%{_bindir}/pion-binder
 install -Dm644 dist/pion-binder.service %{buildroot}%{_unitdir}/pion-binder.service
-install -Dm644 dist/dev-binderfs.mount  %{buildroot}%{_unitdir}/dev-binderfs.mount
+install -Dm644 dist/dev-pionfs.mount  %{buildroot}%{_unitdir}/dev-pionfs.mount
 
 %post
 %systemd_post pion-binder.service
@@ -40,7 +40,7 @@ install -Dm644 dist/dev-binderfs.mount  %{buildroot}%{_unitdir}/dev-binderfs.mou
 %license LICENSE LICENSE.dependencies
 %{_bindir}/pion-binder
 %{_unitdir}/pion-binder.service
-%{_unitdir}/dev-binderfs.mount
+%{_unitdir}/dev-pionfs.mount
 
 %changelog
 * Tue Mar 17 2026 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: pion (#14998)](https://github.com/terrapkg/packages/pull/14998)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)