### PR TITLE
add: apparmor-libs32, a 32-bit multilib companion for apparmor-libs/-devel

### DIFF
--- a/anda/lib/apparmor-libs32/anda.hcl
+++ b/anda/lib/apparmor-libs32/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64", "i686"]
+	rpm {
+		spec = "apparmor-libs32.spec"
+	}
+}

--- a/anda/lib/apparmor-libs32/apparmor-libs32.spec
+++ b/anda/lib/apparmor-libs32/apparmor-libs32.spec
@@ -6,6 +6,10 @@
 # executables" autoconf sanity check before anything of ours even runs.
 %undefine _annotated_build
 
+# Shares Name: apparmor with the main spec - caused a debuginfo Name
+# collision on Rakuos's fork of this spec. Disabled defensively.
+%global debug_package %{nil}
+
 Name:           apparmor
 Version:        5.0.2
 Release:        1%{?dist}

--- a/anda/lib/apparmor-libs32/apparmor-libs32.spec
+++ b/anda/lib/apparmor-libs32/apparmor-libs32.spec
@@ -22,6 +22,8 @@ BuildRequires:  gcc
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  autoconf-archive
+BuildRequires:  flex
+BuildRequires:  bison
 BuildRequires:  gawk
 BuildRequires:  which
 BuildRequires:  libzstd-devel

--- a/anda/lib/apparmor-libs32/apparmor-libs32.spec
+++ b/anda/lib/apparmor-libs32/apparmor-libs32.spec
@@ -18,9 +18,10 @@ Summary:        AppArmor userspace components (32-bit multilib libs)
 %define baseversion %(echo %{version} | cut -d. -f-2)
 %global normver %(echo %version | sed 's/~/-/')
 
-License:        GPL-2.0
+License:        GPL-2.0-only
 URL:            https://gitlab.com/apparmor/apparmor
 Source0:        %url/-/archive/v%normver/apparmor-v%normver.tar.gz
+Packager:       CatPieLeaf <catpieleaf@proton.me>
 
 BuildRequires:  gcc
 BuildRequires:  automake

--- a/anda/lib/apparmor-libs32/apparmor-libs32.spec
+++ b/anda/lib/apparmor-libs32/apparmor-libs32.spec
@@ -1,0 +1,85 @@
+%global __arch_install_post /bin/true
+
+# The annobin gcc plugin (baked into %%{optflags}/CFLAGS via
+# -specs=.../redhat-annobin-cc1) isn't built for i686 multilib, so with it
+# active a plain `-m32` compile fails at the "C compiler cannot create
+# executables" autoconf sanity check before anything of ours even runs.
+%undefine _annotated_build
+
+Name:           apparmor
+Version:        5.0.2
+Release:        1%{?dist}
+Summary:        AppArmor userspace components (32-bit multilib libs)
+
+%define baseversion %(echo %{version} | cut -d. -f-2)
+%global normver %(echo %version | sed 's/~/-/')
+
+License:        GPL-2.0
+URL:            https://gitlab.com/apparmor/apparmor
+Source0:        %url/-/archive/v%normver/apparmor-v%normver.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  automake
+BuildRequires:  libtool
+BuildRequires:  autoconf-archive
+BuildRequires:  gawk
+BuildRequires:  which
+BuildRequires:  libzstd-devel
+
+%description
+This is a trimmed-down i686 multilib-companion build of apparmor: just
+libraries/libapparmor (the shared library + headers), with no python
+bindings, parser, utils, pam, or httpd module. Those subpackages are
+x86_64-only and are built from the full apparmor.spec instead - this
+spec exists only so the i686 cross-build doesn't have to drag in
+httpd-devel/pam-devel/etc. for pieces nobody uploads as i686.
+
+%package      libs
+Summary:      AppArmor library (32-bit)
+
+%description  libs
+32-bit multilib companion of apparmor-libs.
+
+%package       devel
+Summary:       AppArmor development libraries and header files (32-bit)
+Requires:      %{name}-libs%{?_isa} = %{version}-%{release}
+
+%description    devel
+32-bit multilib companion of apparmor-devel.
+
+%prep
+%autosetup -n %name-v%normver
+
+%conf
+pushd libraries/libapparmor
+./autogen.sh
+# Built inside a real i686 arch mock chroot (native i686 gcc, no -m32/
+# multilib hack needed) - plain %%configure is a native build here.
+%configure || \
+  { cat config.log; exit 1; }
+popd
+
+%build
+pushd libraries/libapparmor
+%make_build VERSION=%normver
+popd
+
+%install
+%make_install -C libraries/libapparmor
+find %{buildroot} \( -name "*.a" -o -name "*.la" \) -delete
+
+%files libs
+%license LICENSE
+%{_libdir}/libapparmor.so.*
+
+%files devel
+%{_libdir}/libapparmor.so
+%{_includedir}/aalogparse
+%{_includedir}/sys/apparmor*
+%{_libdir}/pkgconfig/libapparmor.pc
+%{_mandir}/man2/aa_*.2.gz
+%{_mandir}/man3/aa_*.3.gz
+
+%changelog
+* Fri Aug 07 2026 CatPieLeaf <catpieleaf@proton.me>
+- Initial package - 32-bit multilib companion of apparmor-libs/apparmor-devel

--- a/anda/lib/apparmor-libs32/apparmor-libs32.spec
+++ b/anda/lib/apparmor-libs32/apparmor-libs32.spec
@@ -55,7 +55,11 @@ pushd libraries/libapparmor
 ./autogen.sh
 # Built inside a real i686 arch mock chroot (native i686 gcc, no -m32/
 # multilib hack needed) - plain %%configure is a native build here.
-%configure || \
+# --disable-man-pages: podchecker (perl-Pod-Checker) isn't guaranteed on
+# every builder image, and man pages are arch-independent content already
+# owned by the main apparmor-devel package - shipping them again here would
+# just be a duplicate-file install conflict for no reason.
+%configure --disable-man-pages || \
   { cat config.log; exit 1; }
 popd
 
@@ -77,8 +81,6 @@ find %{buildroot} \( -name "*.a" -o -name "*.la" \) -delete
 %{_includedir}/aalogparse
 %{_includedir}/sys/apparmor*
 %{_libdir}/pkgconfig/libapparmor.pc
-%{_mandir}/man2/aa_*.2.gz
-%{_mandir}/man3/aa_*.3.gz
 
 %changelog
 * Fri Aug 07 2026 CatPieLeaf <catpieleaf@proton.me>

--- a/anda/lib/apparmor-libs32/update.rhai
+++ b/anda/lib/apparmor-libs32/update.rhai
@@ -1,0 +1,3 @@
+let v = gitlab_tag("4484878");
+v.replace("-", "~");
+rpm.version(v);


### PR DESCRIPTION
Adds `anda/lib/apparmor-libs32/` (new Anda project, own `anda.hcl`/
`update.rhai`): a trimmed i686 multilib companion carrying just
`libraries/libapparmor` (the shared lib + devel headers, no python
bindings/parser/utils/pam/httpd module).

Why this is needed: a systemd built with AppArmor support (meson
`-Dapparmor=enabled`) links `systemd-libs`/PID1 against `libapparmor.so.1`.
On a multilib x86_64 system, the `systemd-libs.i686` package (pulled in by
32-bit apps/games, e.g. Steam/Proton/Wine) then also needs a matching
`libapparmor.so.1.i686` to satisfy that same dependency - upstream
apparmor never publishes one. Without it, installing/updating
`systemd-libs.i686` alongside an AppArmor-enabled `systemd-libs` fails to
resolve. This package is Terra's/Rakuos's own build of that missing i686
companion, not something 32-bit apps need to link directly themselves.

Ported from Rakuos's `apparmor-libs32.spec` (same rationale documented in
their `.gitlab-ci.yml`), adapted to Terra's version (5.0.2) and Anda's
native per-arch build mechanism (`arches = ["x86_64", "i686"]`) instead of
a hand-rolled mock target_arch build. `update.rhai` mirrors the main
`apparmor` package's so both stay version-synced automatically.