### PR TITLE
[f43] chore: make HolyC woke (#15009)

### DIFF
--- a/anda/langs/holyc/holyc/holyc.spec
+++ b/anda/langs/holyc/holyc/holyc.spec
@@ -27,11 +27,13 @@ sed -i 's|git rev-parse main|git rev-parse HEAD|g' CMakeLists.txt
 # Make the binary correctly report its installed location as /usr/bin instead of /usr
 sed -i 's|binary: %%s/hcc|binary: %%s/bin/hcc|g' cli.c
 
-%build
+%conf
 %cmake \
   -DCMAKE_BUILD_TYPE="Release" \
   -DHCC_LINK_SQLITE3="1" \
   -DHCC_ENABLE_JIT="ON"
+
+%build
 %cmake_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: make HolyC woke (#15009)](https://github.com/terrapkg/packages/pull/15009)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)