### PR TITLE
[el10] feat: Update steamos-manager-powerstation to the latest version (#15011)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit b624e9d6d5c89ac9a0988657aebb451e9526e4d9
+%global commit b689b2027cb0fe361b4df60e8f16c57bdc1bbd45
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260805
+%global commitdate 20260807
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat: Update steamos-manager-powerstation to the latest version (#15011)](https://github.com/terrapkg/packages/pull/15011)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)