### PR TITLE
[f43] add: kernel-p03, kernel-p03-gcc (#14936)

### DIFF
--- a/anda/system/kernel-p03-gcc/anda.hcl
+++ b/anda/system/kernel-p03-gcc/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "kernel-p03-gcc.spec"
+	}
+}

--- a/anda/system/kernel-p03-gcc/kernel-p03-gcc.spec
+++ b/anda/system/kernel-p03-gcc/kernel-p03-gcc.spec
@@ -1,0 +1,7 @@
+# %tag below is only a cache-buster for Andaman's diff-based updater -
+# the actual build content is fetched fresh from
+# https://github.com/CatPieLeaf/linux-p03/blob/main/sources/kernel-p03/kernel-p03-gcc.spec
+# at parse time, so this file is never the source of truth for anything
+# except "did the tag change".
+%global tag 7.1.5-201.p03.10
+%include %(f=$(mktemp); curl -fsSL https://raw.githubusercontent.com/CatPieLeaf/linux-p03/main/sources/kernel-p03/kernel-p03-gcc.spec -o "$f"; echo "$f")

--- a/anda/system/kernel-p03-gcc/update.rhai
+++ b/anda/system/kernel-p03-gcc/update.rhai
@@ -1,0 +1,4 @@
+// Only bumps the cache-buster %tag so Andaman's diff-based updater
+// notices and rebuilds - the actual spec content is fetched live by
+// the %include in kernel-p03-gcc.spec.
+rpm.global("tag", gh("CatPieLeaf/linux-p03"));

--- a/anda/system/kernel-p03/anda.hcl
+++ b/anda/system/kernel-p03/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "kernel-p03.spec"
+	}
+}

--- a/anda/system/kernel-p03/kernel-p03.spec
+++ b/anda/system/kernel-p03/kernel-p03.spec
@@ -1,0 +1,7 @@
+# %tag below is only a cache-buster for Andaman's diff-based updater -
+# the actual build content is fetched fresh from
+# https://github.com/CatPieLeaf/linux-p03/blob/main/sources/kernel-p03/kernel-p03.spec
+# at parse time, so this file is never the source of truth for anything
+# except "did the tag change".
+%global tag 7.1.5-201.p03.10
+%include %(f=$(mktemp); curl -fsSL https://raw.githubusercontent.com/CatPieLeaf/linux-p03/main/sources/kernel-p03/kernel-p03.spec -o "$f"; echo "$f")

--- a/anda/system/kernel-p03/update.rhai
+++ b/anda/system/kernel-p03/update.rhai
@@ -1,0 +1,4 @@
+// Only bumps the cache-buster %tag so Andaman's diff-based updater
+// notices and rebuilds - the actual spec content is fetched live by
+// the %include in kernel-p03.spec.
+rpm.global("tag", gh("CatPieLeaf/linux-p03"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: kernel-p03, kernel-p03-gcc (#14936)](https://github.com/terrapkg/packages/pull/14936)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)