### PR TITLE
[f44] add: apparmor.d-fedora (#14937)

### DIFF
--- a/anda/system/apparmor.d-fedora/anda.hcl
+++ b/anda/system/apparmor.d-fedora/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "apparmor.d-fedora.spec"
+	}
+}

--- a/anda/system/apparmor.d-fedora/apparmor.d-fedora.spec
+++ b/anda/system/apparmor.d-fedora/apparmor.d-fedora.spec
@@ -1,0 +1,7 @@
+# %tag below is only a cache-buster for Andaman's diff-based updater -
+# the actual build content is fetched fresh from
+# https://github.com/CatPieLeaf/apparmor.d-fedora/blob/main/dists/apparmor.d-fedora.spec
+# at parse time, so this file is never the source of truth for anything
+# except "did the tag change".
+%global tag v0.4910.0-2
+%include %(f=$(mktemp); curl -fsSL https://raw.githubusercontent.com/CatPieLeaf/apparmor.d-fedora/main/dists/apparmor.d-fedora.spec -o "$f"; echo "$f")

--- a/anda/system/apparmor.d-fedora/update.rhai
+++ b/anda/system/apparmor.d-fedora/update.rhai
@@ -1,0 +1,4 @@
+// Only bumps the cache-buster %tag so Andaman's diff-based updater
+// notices and rebuilds - the actual spec content is fetched live by
+// the %include in apparmor.d-fedora.spec.
+rpm.global("tag", gh("CatPieLeaf/apparmor.d-fedora"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: apparmor.d-fedora (#14937)](https://github.com/terrapkg/packages/pull/14937)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)