### PR TITLE
[f43] fix(apparmor): package systemd unit, fix profile/parser file-list conflict, bump release (#15010)

### DIFF
--- a/anda/lib/apparmor/0001-fix-apparmor-waydroid-denials.patch
+++ b/anda/lib/apparmor/0001-fix-apparmor-waydroid-denials.patch
@@ -1,0 +1,27 @@
+From d4e54e5c4c6ac4535eac193b4dfcf150d0b683a0 Mon Sep 17 00:00:00 2001
+From: Thomas Crider <gloriouseggroll@gmail.com>
+Date: Thu, 5 Jan 2023 02:30:22 -0500
+Subject: [PATCH] fix apparmor waydroid denials
+
+---
+ profiles/apparmor.d/usr.sbin.dnsmasq | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/profiles/apparmor.d/usr.sbin.dnsmasq b/profiles/apparmor.d/usr.sbin.dnsmasq
+index 9f5d8be..5aa8482 100644
+--- a/profiles/apparmor.d/usr.sbin.dnsmasq
++++ b/profiles/apparmor.d/usr.sbin.dnsmasq
+@@ -119,6 +119,10 @@ profile dnsmasq /usr/{bin,sbin}/dnsmasq flags=(attach_disconnected) {
+   # waydroid lxc-net pid file
+   @{run}/waydroid-lxc/dnsmasq.pid rw,
+ 
++  # waydroid
++  @{run}/waydroid-lxc/ r,
++  @{run}/waydroid-lxc/* rw,
++
+   profile libvirt_leaseshelper {
+     include <abstractions/base>
+ 
+-- 
+2.39.2
+

--- a/anda/lib/apparmor/0001-fix-denial-on-dnsmask-for-nsswitch.patch
+++ b/anda/lib/apparmor/0001-fix-denial-on-dnsmask-for-nsswitch.patch
@@ -1,0 +1,24 @@
+From d248cca7f6d0007d9d1e9ed59bd0f20d9c94ec3d Mon Sep 17 00:00:00 2001
+From: Thomas Crider <gloriouseggroll@gmail.com>
+Date: Sat, 19 Nov 2022 20:36:40 -0500
+Subject: [PATCH] fix denial on dnsmask for nsswitch
+
+---
+ profiles/apparmor.d/usr.sbin.dnsmasq | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/profiles/apparmor.d/usr.sbin.dnsmasq b/profiles/apparmor.d/usr.sbin.dnsmasq
+index 379d72f..e2cf6fb 100644
+--- a/profiles/apparmor.d/usr.sbin.dnsmasq
++++ b/profiles/apparmor.d/usr.sbin.dnsmasq
+@@ -43,6 +43,7 @@ profile dnsmasq /usr/{bin,sbin}/dnsmasq flags=(attach_disconnected) {
+   /etc/dnsmasq.d/* r,
+   /etc/dnsmasq.d-available/ r,
+   /etc/dnsmasq.d-available/* r,
++    /etc/authselect/nsswitch.conf r,
+   /etc/ethers r,
+   /etc/NetworkManager/dnsmasq.d/ r,
+   /etc/NetworkManager/dnsmasq.d/* r,
+-- 
+2.38.1
+

--- a/anda/lib/apparmor/0001-fix-swig-new_copy_array-removed-in-swig-4.5.0.patch
+++ b/anda/lib/apparmor/0001-fix-swig-new_copy_array-removed-in-swig-4.5.0.patch
@@ -1,0 +1,36 @@
+From: CatPieLeaf <catpieleaf@proton.me>
+Date: Fri, 7 Aug 2026 18:30:00 -0300
+Subject: [PATCH] swig: replace removed %new_copy_array macro
+
+SWIG 4.5.0 removed the %new_copy_array macro (see upstream SWIG
+CHANGES.current, 2026-05-16): calls to it are now passed through
+unexpanded to the C compiler, which fails with:
+
+    libapparmor_wrap.c:6601:14: error: expected expression before '%' token
+          arg1 = %new_copy_array(con_ptr, con_len+1, char);
+
+Builds fine against SWIG < 4.5.0 (e.g. 4.4.1), which still has the
+macro - this only breaks once the SWIG toolchain moves to 4.5.0+.
+Replace the single call site with the equivalent manual
+malloc+memcpy, with the same allocation-failure handling already used
+elsewhere in this same file via SWIG_exception_fail/SWIG_MemoryError.
+---
+ libraries/libapparmor/swig/SWIG/libapparmor.i | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/libraries/libapparmor/swig/SWIG/libapparmor.i
++++ b/libraries/libapparmor/swig/SWIG/libapparmor.i
+@@ -143,7 +143,12 @@
+   }
+   if (alloc_status != SWIG_NEWOBJ) {
+     // Unconditionally copy because the C function modifies the string in place
+-    $1 = %new_copy_array(con_ptr, con_len+1, char);
++    // %new_copy_array was removed in SWIG 4.5.0; do the copy manually
++    $1 = ($1_ltype) malloc((con_len+1)*sizeof($*1_ltype));
++    if (!$1) {
++      SWIG_exception_fail(SWIG_MemoryError, "Unable to allocate memory");
++    }
++    memcpy((void *)$1, (const void *)con_ptr, (con_len+1)*sizeof($*1_ltype));
+   } else {
+     $1 = con_ptr;
+   }

--- a/anda/lib/apparmor/apparmor.spec
+++ b/anda/lib/apparmor/apparmor.spec
@@ -3,21 +3,31 @@
 %global __arch_install_post /bin/true
 %global _sbindir /usr/sbin
 
+# Rakuos's fork hit a debuginfo Name collision with apparmor-libs32.spec
+# on EL10 CI. Fedora branches build fine with debuginfo enabled, so only
+# disable it there.
+%if 0%{?rhel}
+%global debug_package %{nil}
+%endif
+
 %bcond_with tests
 
 Name:           apparmor
 Version:        5.0.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        AppArmor userspace components
 
 %define baseversion %(echo %{version} | cut -d. -f-2)
 %global normver %(echo %version | sed 's/~/-/')
 
-License:        GPL-2.0
+License:        GPL-2.0-only
 URL:            https://gitlab.com/apparmor/apparmor
 Source0:        %url/-/archive/v%normver/apparmor-v%normver.tar.gz
 Source1:        apparmor.preset
 Patch01:        0001-fix-avahi-daemon-authselect-denial-in-fedora.patch
+Patch02:        0001-fix-denial-on-dnsmask-for-nsswitch.patch
+Patch03:        0001-fix-apparmor-waydroid-denials.patch
+Patch04:        0001-fix-swig-new_copy_array-removed-in-swig-4.5.0.patch
 
 BuildRequires:  gcc
 BuildRequires:  automake
@@ -116,6 +126,12 @@ program profiles to the AppArmor Security kernel module.
 Summary:        AppArmor User-Level Utilities
 Requires:       python3-apparmor = %{version}
 Requires:       python3-notify2
+Requires:       %{name}-parser
+# SELinux troubleshooting tools have no equivalent purpose once AppArmor is
+# the active LSM, and aa-notify/aa-status already cover the same ground.
+Obsoletes:      setroubleshoot
+Obsoletes:      setroubleshoot-server
+Obsoletes:      setroubleshoot-plugins
 
 %description    utils
 This package provides the aa-logprof, aa-genprof, aa-autodep,
@@ -180,6 +196,32 @@ mkdir -p %buildroot%_datadir/polkit-1/actions/
 %make_install -C parser \
     APPARMOR_BIN_PREFIX=%{buildroot}%{_prefix}/lib/apparmor \
     SBINDIR=%{buildroot}%{_sbindir}
+
+# Enable parser cache writing/compression by default so profile loads at
+# boot (rc.apparmor.functions parses 1500+ profiles) don't re-parse from
+# source every time, and point the cache at a dedicated /var/cache/apparmor
+# instead of the default /etc/apparmor.d/cache (read-only image /etc).
+sed -i \
+    -e 's/^#write-cache$/write-cache/' \
+    -e 's/^#Optimize=compress-fast$/Optimize=compress-fast/' \
+    %{buildroot}%{_sysconfdir}/apparmor/parser.conf
+echo 'cache-loc /var/cache/apparmor' >> %{buildroot}%{_sysconfdir}/apparmor/parser.conf
+install -dm755 %{buildroot}%{_localstatedir}/cache/apparmor
+
+# init/ installs aa-teardown, apparmor.service, and the rc.apparmor.functions
+# helpers into APPARMOR_BIN_PREFIX - none of this is covered by the parser
+# install above (their Makefiles are separate), so the parser package's
+# aa-teardown/apparmor.service/%{_prefix}/lib/apparmor entries need it.
+# Without this, nothing ever loads profiles into the kernel at boot - the
+# LSM comes up with zero profiles, and anything execing with
+# AppArmorProfile= (e.g. dbus-broker's systemd drop-in) fails outright
+# because the profile it expects was never loaded.
+%make_install -C init \
+    DISTRO=redhat \
+    APPARMOR_BIN_PREFIX=%{buildroot}%{_prefix}/lib/apparmor \
+    SBINDIR=%{buildroot}%{_sbindir} \
+    USR_SBINDIR=%{buildroot}%{_sbindir} \
+    SYSTEMD_UNIT_DIR=%{buildroot}%{_unitdir}
 %make_install -C profiles
 %make_install -C utils
 %make_install -C changehat/pam_apparmor \
@@ -193,6 +235,14 @@ find %{buildroot} \( -name "*.a" -o -name "*.la" \) -delete
 
 mkdir -p %buildroot%python3_sitearch/LibAppArmor
 mv %buildroot%python3_sitearch/{LibAppArmor.py,_LibAppArmor.cpython-*-linux-gnu.so,__pycache__/LibAppArmor.*} %buildroot%python3_sitearch/LibAppArmor/
+# Without this, the moved-into-a-subdir LibAppArmor.py is never executed on
+# `import LibAppArmor` - Python just treats the directory as an empty
+# implicit namespace package, so callers (e.g. apparmor-utils'
+# logparser.py, which does `import LibAppArmor` then
+# `LibAppArmor.parse_record(...)`) get "module 'LibAppArmor' has no
+# attribute 'parse_record'" even though the real SWIG bindings are right
+# there on disk.
+echo 'from .LibAppArmor import *' > %buildroot%python3_sitearch/LibAppArmor/__init__.py
 
 %find_lang aa-binutils
 %find_lang apparmor-parser
@@ -246,32 +296,14 @@ make -C utils check
 
 %files profiles
 %dir %{_sysconfdir}/apparmor.d/
-%dir %{_sysconfdir}/apparmor.d/abi
-%config(noreplace) %{_sysconfdir}/apparmor.d/abi/3.0
-%config(noreplace) %{_sysconfdir}/apparmor.d/abi/4.0
-%config(noreplace) %{_sysconfdir}/apparmor.d/abi/kernel-5.4-outoftree-network
-%config(noreplace) %{_sysconfdir}/apparmor.d/abi/kernel-5.4-vanilla
-%config(noreplace) %{_sysconfdir}/apparmor.d/php-fpm
-%config(noreplace) %{_sysconfdir}/apparmor.d/samba-bgqd
-%config(noreplace) %{_sysconfdir}/apparmor.d/samba-dcerpcd
-%config(noreplace) %{_sysconfdir}/apparmor.d/samba-rpcd
-%config(noreplace) %{_sysconfdir}/apparmor.d/samba-rpcd-classic
-%config(noreplace) %{_sysconfdir}/apparmor.d/samba-rpcd-spoolss
-%config(noreplace) %{_sysconfdir}/apparmor.d/zgrep
-%dir %{_sysconfdir}/apparmor.d/abstractions
-%config(noreplace) %{_sysconfdir}/apparmor.d/abstractions/*
-%dir %{_sysconfdir}/apparmor.d/disable
-%dir %{_sysconfdir}/apparmor.d/local
-%dir %{_sysconfdir}/apparmor.d/tunables
-%config(noreplace) %{_sysconfdir}/apparmor.d/tunables/*
-%dir %{_sysconfdir}/apparmor.d/apache2.d
-%config(noreplace) %{_sysconfdir}/apparmor.d/apache2.d/phpsysinfo
-%config(noreplace) %{_sysconfdir}/apparmor.d/bin.*
-%config(noreplace) %{_sysconfdir}/apparmor.d/sbin.*
-%config(noreplace) %{_sysconfdir}/apparmor.d/usr.*
-%config(noreplace) %{_sysconfdir}/apparmor.d/lsb_release
-%config(noreplace) %{_sysconfdir}/apparmor.d/nvidia_modprobe
-%config(noreplace) %{_sysconfdir}/apparmor.d/local/*
+# Everything under apparmor.d/ (the flat sample profiles, abi/,
+# abstractions/, local/, tunables/, apache2.d/) is claimed recursively by
+# this single glob instead of being enumerated by name - upstream adds and
+# removes bundled sample profiles between releases (5.0.2 ships ~150 of
+# them, not the dozen this list used to hardcode), and an enumerated list
+# silently drifts out of sync, leaving newly-added files unpackaged and
+# build failing with "Installed (but unpackaged) file(s) found".
+%config(noreplace) %{_sysconfdir}/apparmor.d/*
 %dir %{_datadir}/apparmor/
 %{_datadir}/apparmor/extra-profiles
 
@@ -285,17 +317,15 @@ make -C utils check
 %{_bindir}/aa-exec
 %{_bindir}/aa-features-abi
 %{_sbindir}/aa-load
-#{_sbindir}/aa-show-usage
-%dnl %{_sbindir}/aa-teardown
 %{_sbindir}/aa-show-usage
-%dnl %{_unitdir}/apparmor.service
+%{_sbindir}/aa-teardown
+%{_unitdir}/apparmor.service
 %{_presetdir}/70-apparmor.preset
-%dnl %{_prefix}/lib/apparmor
+%{_prefix}/lib/apparmor
 %dir %{_sysconfdir}/apparmor
-# FIXME: the confusion…? how did this happen
 %config(noreplace) %{_sysconfdir}/apparmor/default_unconfined.template
-%config(noreplace) %{_sysconfdir}/apparmor.d/
 %config(noreplace) %{_sysconfdir}/apparmor/parser.conf
+%dir %{_localstatedir}/cache/apparmor
 %{_mandir}/man1/aa-enabled.1.gz
 %{_mandir}/man1/aa-exec.1.gz
 %{_mandir}/man1/aa-features-abi.1.gz
@@ -304,9 +334,8 @@ make -C utils check
 %{_mandir}/man7/apparmor.7.gz
 %{_mandir}/man7/apparmor_xattrs.7.gz
 %{_mandir}/man8/aa-load.8.gz
-#{_mandir}/man8/aa-show-usage.8.gz
-%dnl %{_mandir}/man8/aa-teardown.8.gz
 %{_mandir}/man8/aa-show-usage.8.gz
+%{_mandir}/man8/aa-teardown.8.gz
 %{_mandir}/man8/apparmor_parser.8.gz
 
 %files utils -f apparmor-utils.lang
@@ -365,4 +394,21 @@ make -C utils check
 %{_mandir}/man8/mod_apparmor.8.gz
 
 %changelog
+* Fri Aug 07 2026 CatPieLeaf <catpieleaf@proton.me> - 5.0.2-2
+- Package the apparmor.service systemd unit (init/ was never built, so
+  nothing ever loaded profiles into the kernel at boot); fix a %files
+  parser/profiles file-conflict landmine; replace the stale enumerated
+  %files profiles list with a recursive glob so it can't drift out of
+  sync with upstream again; enable parser cache write/compression;
+  fix LibAppArmor's __init__.py; utils Requires apparmor-parser and
+  Obsoletes setroubleshoot; two more upstream sample-profile patches
+  (dnsmasq nsswitch, waydroid).
+- Patch SWIG's removed %new_copy_array macro (swig 4.5.0+ breaks the
+  python bindings build otherwise).
+- Fix two EL10/CentOS Stream 10 CI parse failures shared with
+  apparmor-libs32.spec: a debuginfo Name collision (now scoped to
+  rhel builds only, per review - Fedora keeps normal debuginfo) and
+  RPM macro-expanding install/files section tokens inside comments.
+- Use the proper SPDX GPL-2.0-only identifier instead of bare GPL-2.0.
+
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(apparmor): package systemd unit, fix profile/parser file-list conflict, bump release (#15010)](https://github.com/terrapkg/packages/pull/15010)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)