### PR TITLE
[f45] fix: tetra (#15070)

### DIFF
--- a/anda/system/tetra/tetra.spec
+++ b/anda/system/tetra/tetra.spec
@@ -63,7 +63,7 @@ install -Dm644 systemd/tetra.service %{buildroot}%{_unitdir}/tetra.service
 
 %files
 %license LICENSE LICENSE.dependencies
-%doc README.md SECURITY.md elements.md docs/*
+%doc README.md SECURITY.md docs/*
 %{_bindir}/tetra
 %{_unitdir}/tetra.service
 %{_datadir}/tetra/templates


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: tetra (#15070)](https://github.com/terrapkg/packages/pull/15070)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)