### PR TITLE
[f45] fix: scroll (#15073)

### DIFF
--- a/anda/desktops/scroll/scroll.spec
+++ b/anda/desktops/scroll/scroll.spec
@@ -42,6 +42,7 @@ BuildRequires:  pkgconfig(libpcre2-8)
 BuildRequires:  pkgconfig(cairo)
 BuildRequires:  pkgconfig(pango)
 BuildRequires:  pkgconfig(gdk-pixbuf-2.0)
+BuildRequires:  readline-devel
 
 Provides:       sway-scroll
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: scroll (#15073)](https://github.com/terrapkg/packages/pull/15073)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)