### PR TITLE
[f45] fix: gradle (#15004)

### DIFF
--- a/anda/buildsys/gradle/gradle.spec
+++ b/anda/buildsys/gradle/gradle.spec
@@ -7,8 +7,8 @@ Source0:		https://github.com/gradle/gradle/archive/refs/tags/v%{version}.tar.gz
 Packager:		madonuko <mado@fyralabs.com>
 License:		Apache-2.0
 Requires:		java coreutils findutils sed which bash
-BuildRequires:	java-21-openjdk-devel asciidoc xmlto groovy unzip git
-BuildRequires:  temurin-17-jdk temurin-17-jre anda-srpm-macros
+BuildRequires:	java-25-openjdk-devel asciidoc xmlto groovy unzip git
+BuildRequires:  temurin-17-jdk temurin-17-jre temurin-8-jdk anda-srpm-macros
 BuildArch:		noarch
 Recommends:		gradle-doc gradle-src
 
@@ -34,7 +34,6 @@ export GRADLE_HOME=/usr/share/java/gradle
 EOF
 
 %build
-export PATH="/usr/lib/jvm/java-21-openjdk/bin:${PATH}"
 ./gradlew installAll --parallel \
 	-Porg.gradle.java.installations.auto-download=false \
 	-PfinalRelease=true \


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: gradle (#15004)](https://github.com/terrapkg/packages/pull/15004)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)