### PR TITLE
[el10] chore(noctalia-greeter): switch to release tags (#15092)

### DIFF
--- a/anda/desktops/noctalia-greeter/anda.hcl
+++ b/anda/desktops/noctalia-greeter/anda.hcl
@@ -2,7 +2,4 @@ project pkg {
   rpm {
     spec = "noctalia-greeter.spec"
   }
-  labels {
-    nightly = 1
-  }
 }

--- a/anda/desktops/noctalia-greeter/noctalia-greeter.spec
+++ b/anda/desktops/noctalia-greeter/noctalia-greeter.spec
@@ -1,17 +1,11 @@
-%global ver 1.2.1
-
-%global commit          bf5feefee3d90922952c1850eebdf93d1c0c7f01
-%global shortcommit     %(c=%{commit}; echo ${c:0:7})
-%global commitdate      20260808
-
 Name:   	noctalia-greeter
-Version:	%{ver}^%{commitdate}git.%{shortcommit}
-Release:	1%{?dist}
+Version:	1.2.1
+Release:	2%{?dist}
 Summary:	A minimal login greeter for greetd that matches the look and feel of Noctalia Shell.
 
 License:	MIT
 URL:		https://github.com/noctalia-dev/%{name}
-Source0:	%{url}/archive/%{commit}/%{name}-%{commit}.tar.gz
+Source0:	%{url}/archive/refs/tags/v%{version}.tar.gz
 
 BuildRequires:  dbus
 BuildRequires:  gcc-c++
@@ -47,7 +41,7 @@ Noctalia Greeter is the screen you see before your desktop session starts.
 It lets you pick a user, enter your password, choose a Wayland session, and pick a color scheme - with the same visual language as Noctalia Shell.
 
 %prep
-%autosetup -n noctalia-greeter-%{commit}
+%autosetup -n noctalia-greeter-%{version}
 
 %conf
 %meson -Db_pie=true
@@ -81,6 +75,9 @@ done
 %{_datadir}/polkit-1/actions/org.noctalia.greeter.apply-appearance.policy
 
 %changelog
+* Fri Jun 19 2026 Cypress Reed <cypress@fyralabs.com>
+- Switch to stable versioning from nightly git
+
 * Fri Jun 19 2026 Cypress Reed <cypress@fyralabs.com>
 - Update dependencies and files for built-in compositor
 

--- a/anda/desktops/noctalia-greeter/update.rhai
+++ b/anda/desktops/noctalia-greeter/update.rhai
@@ -1,6 +1,1 @@
-rpm.global("commit", gh_commit("noctalia-dev/noctalia-greeter"));
-if rpm.changed() {
-        rpm.global("ver", `(?m)^\s*version:\s*'([\d\.]+)',$`.find(gh_rawfile("noctalia-dev/noctalia-greeter", "main", "meson.build"), 1));
-        rpm.global("commitdate", date());
-        rpm.release();
-}
+rpm.version(gh_tag("noctalia-dev/noctalia-greeter"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(noctalia-greeter): switch to release tags (#15092)](https://github.com/terrapkg/packages/pull/15092)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)