### PR TITLE
[f45] feat: Update to the latest gamescope-session-powerstation (#15097)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,12 +1,12 @@
-%global commit b689b2027cb0fe361b4df60e8f16c57bdc1bbd45
+%global commit cb38d0a3ad24bf995abe59abcd0b0a79fa8bd35f
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260807
+%global commitdate 20260808
 
 %global steamos_manager_systemd_user_units steamos-manager.service steamos-manager-configure-cecd.service steamos-manager-session-cleanup.service
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          4%{?dist}
+Release:          1%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update to the latest gamescope-session-powerstation (#15097)](https://github.com/terrapkg/packages/pull/15097)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)