### PR TITLE
[f45] fix: Add support for more GPD devices to InputPlumber (#15098)

### DIFF
--- a/anda/games/inputplumber/644.patch
+++ b/anda/games/inputplumber/644.patch
@@ -1,0 +1,570 @@
+From d21ec02cfb699cd041196354f5aa75a52d22ba68 Mon Sep 17 00:00:00 2001
+From: "Derek J. Clark" <derekjohn.clark@gmail.com>
+Date: Sat, 8 Aug 2026 12:47:41 -0700
+Subject: [PATCH] fix(Hardware Support) Improve support for GPD Win 4 - Adds
+ support for 2023 (7640u/7840u) versions - Adds back paddle support. GPD Win
+ 4devices use the same back paddle   device as the win mini. - All devices
+ have a dedicated guide button. Remove the QAM mapping to   allow full support
+ of both paddles. (Win Mini, Win 4) - Generalize the driver name for the GPD
+ paddle device.
+
+---
+ .../capability_maps/gpd_type3.yaml            | 44 ++++++++++++-
+ .../capability_maps/gpd_type4.yaml            | 63 -------------------
+ .../inputplumber/devices/50-gpd_win4.yaml     | 23 ++++++-
+ .../inputplumber/devices/50-gpd_win5.yaml     |  2 +-
+ .../inputplumber/devices/50-gpd_winmini.yaml  |  3 -
+ .../{gpd_win_mini => gpd_device}/event.rs     |  0
+ .../hid_report.rs                             |  0
+ .../macro_keyboard_driver.rs                  |  0
+ .../{gpd_win_mini => gpd_device}/mod.rs       |  0
+ .../touchpad_driver.rs                        |  0
+ src/drivers/mod.rs                            |  2 +-
+ src/input/source/hidraw.rs                    | 41 ++++++------
+ ...acro_keyboard.rs => gpd_macro_keyboard.rs} | 36 +++++------
+ ...d_win_mini_touchpad.rs => gpd_touchpad.rs} | 62 +++++++++---------
+ 14 files changed, 127 insertions(+), 149 deletions(-)
+ delete mode 100644 rootfs/usr/share/inputplumber/capability_maps/gpd_type4.yaml
+ rename src/drivers/{gpd_win_mini => gpd_device}/event.rs (100%)
+ rename src/drivers/{gpd_win_mini => gpd_device}/hid_report.rs (100%)
+ rename src/drivers/{gpd_win_mini => gpd_device}/macro_keyboard_driver.rs (100%)
+ rename src/drivers/{gpd_win_mini => gpd_device}/mod.rs (100%)
+ rename src/drivers/{gpd_win_mini => gpd_device}/touchpad_driver.rs (100%)
+ rename src/input/source/hidraw/{gpd_win_mini_macro_keyboard.rs => gpd_macro_keyboard.rs} (69%)
+ rename src/input/source/hidraw/{gpd_win_mini_touchpad.rs => gpd_touchpad.rs} (69%)
+
+diff --git a/rootfs/usr/share/inputplumber/capability_maps/gpd_type3.yaml b/rootfs/usr/share/inputplumber/capability_maps/gpd_type3.yaml
+index 3fde9148..88d5bfbf 100644
+--- a/rootfs/usr/share/inputplumber/capability_maps/gpd_type3.yaml
++++ b/rootfs/usr/share/inputplumber/capability_maps/gpd_type3.yaml
+@@ -13,10 +13,48 @@ id: gpd3
+ 
+ # List of mapped events that are activated by a specific set of activation keys.
+ mapping:
+-  - name: Quick Access
++  - name: Left Paddle
+     source_events:
+-      - gamepad:
+-          button: RightPaddle1
++      - keyboard: KeyF14
++    target_event:
++      gamepad:
++        button: LeftPaddle1
++  - name: Right Paddle
++    source_events:
++      - keyboard: KeyF15
++    target_event:
++      gamepad:
++        button: RightPaddle1
++  - name: Mode Switch
++    source_events:
++      - keyboard: KeyF13
++    target_event:
++      gamepad:
++        button: QuickAccess
++  - name: Home
++    source_events:
++      - keyboard: KeyLeftMeta
++      - keyboard: KeyD
++    target_event:
++      gamepad:
++        button: Guide
++  - name: Home (Long Press)
++    source_events:
++      - keyboard: KeyTab
++    target_event:
++      gamepad:
++        button: Guide
++  - name: Keyboard
++    source_events:
++      - keyboard: KeyLeftMeta
++      - keyboard: KeyLeftCtrl
++      - keyboard: KeyO
++    target_event:
++      gamepad:
++        button: Keyboard
++  - name: Keyboard (Long Press)
++    source_events:
++      - keyboard: KeyDelete
+     target_event:
+       gamepad:
+         button: QuickAccess
+diff --git a/rootfs/usr/share/inputplumber/capability_maps/gpd_type4.yaml b/rootfs/usr/share/inputplumber/capability_maps/gpd_type4.yaml
+deleted file mode 100644
+index 89694dd8..00000000
+--- a/rootfs/usr/share/inputplumber/capability_maps/gpd_type4.yaml
++++ /dev/null
+@@ -1,63 +0,0 @@
+-# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v1.json
+-# Schema version number
+-version: 1
+-
+-# The type of configuration schema
+-kind: CapabilityMap
+-
+-# Name for the device event map
+-name: GPD Type 4
+-
+-# Unique identifier of the capability mapping
+-id: gpd4
+-
+-# List of mapped events that are activated by a specific set of activation keys.
+-mapping:
+-  - name: Left Paddle
+-    source_events:
+-      - keyboard: KeyF14
+-    target_event:
+-      gamepad:
+-        button: LeftPaddle1
+-  - name: Right Paddle
+-    source_events:
+-      - keyboard: KeyF15
+-    target_event:
+-      gamepad:
+-        button: RightPaddle1
+-  - name: Mode Switch
+-    source_events:
+-      - keyboard: KeyF13
+-    target_event:
+-      gamepad:
+-        button: QuickAccess
+-  - name: Home
+-    source_events:
+-      - keyboard: KeyLeftMeta
+-      - keyboard: KeyD
+-    target_event:
+-      gamepad:
+-        button: Guide
+-  - name: Home (Long Press)
+-    source_events:
+-      - keyboard: KeyTab
+-    target_event:
+-      gamepad:
+-        button: Guide
+-  - name: Keyboard
+-    source_events:
+-      - keyboard: KeyLeftMeta
+-      - keyboard: KeyLeftCtrl
+-      - keyboard: KeyO
+-    target_event:
+-      gamepad:
+-        button: Keyboard
+-  - name: Keyboard (Long Press)
+-    source_events:
+-      - keyboard: KeyDelete
+-    target_event:
+-      gamepad:
+-        button: QuickAccess
+-
+-# List of events to filter from the source devices
+-filtered_events: []
+diff --git a/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml b/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
+index 93994267..6374008e 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
+@@ -22,6 +22,12 @@ matches:
+ # One or more source devices to combine into a single virtual device. The events
+ # from these devices will be watched and translated according to the key map.
+ source_devices:
++  # Back paddles
++  - group: keyboard
++    hidraw:
++      vendor_id: 0x2f24
++      product_id: 0x0135
++      interface_num: 1
+   # GPD Win4 2022 (6800U)
+   - group: gamepad
+     evdev:
+@@ -29,6 +35,7 @@ source_devices:
+       phys_path: usb-0000:73:00.3-4.1/input0
+       handler: event*
+   - group: keyboard
++    blocked: true
+     evdev:
+       name: "  Mouse for Windows"
+       handler: event*
+@@ -40,6 +47,18 @@ source_devices:
+         x: [-1, 0, 0]
+         y: [0, -1, 0]
+         z: [0, 0, 1]
++  # GPD Win4 2023 (7640u/7840u)
++  - group: gamepad
++    evdev:
++      name: "Microsoft X-Box 360 pad"
++      phys_path: usb-0000:63:00.3-4.1/input0
++      handler: event*
++  - group: keyboard
++    blocked: true
++    evdev:
++      name: "  Mouse for Windows"
++      handler: event*
++      phys_path: usb-0000:63:00.3-3.2/input1
+   # GPD Win4 2025 (HX 370)
+   - group: gamepad
+     evdev:
+@@ -47,6 +66,7 @@ source_devices:
+       phys_path: usb-0000:66:00.0-2.1/input0
+       handler: event*
+   - group: keyboard
++    blocked: true
+     evdev:
+       name: "  Mouse for Windows"
+       handler: event*
+@@ -71,6 +91,3 @@ target_devices:
+   - xbox-elite
+   - mouse
+   - keyboard
+-
+-# The ID of a device event mapping in the 'event_maps' folder
+-capability_map_id: gpd3
+diff --git a/rootfs/usr/share/inputplumber/devices/50-gpd_win5.yaml b/rootfs/usr/share/inputplumber/devices/50-gpd_win5.yaml
+index e5949af3..5945b276 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-gpd_win5.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-gpd_win5.yaml
+@@ -65,4 +65,4 @@ target_devices:
+   - keyboard
+ 
+ # The ID of a device event mapping in the 'event_maps' folder
+-capability_map_id: gpd4
++capability_map_id: gpd3
+diff --git a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+index 2fc42d62..a90650c3 100644
+--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
++++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+@@ -70,6 +70,3 @@ target_devices:
+   - mouse
+   - keyboard
+   - touchpad
+-
+-# The ID of a device event mapping in the 'event_maps' folder
+-capability_map_id: gpd3
+diff --git a/src/drivers/gpd_win_mini/event.rs b/src/drivers/gpd_device/event.rs
+similarity index 100%
+rename from src/drivers/gpd_win_mini/event.rs
+rename to src/drivers/gpd_device/event.rs
+diff --git a/src/drivers/gpd_win_mini/hid_report.rs b/src/drivers/gpd_device/hid_report.rs
+similarity index 100%
+rename from src/drivers/gpd_win_mini/hid_report.rs
+rename to src/drivers/gpd_device/hid_report.rs
+diff --git a/src/drivers/gpd_win_mini/macro_keyboard_driver.rs b/src/drivers/gpd_device/macro_keyboard_driver.rs
+similarity index 100%
+rename from src/drivers/gpd_win_mini/macro_keyboard_driver.rs
+rename to src/drivers/gpd_device/macro_keyboard_driver.rs
+diff --git a/src/drivers/gpd_win_mini/mod.rs b/src/drivers/gpd_device/mod.rs
+similarity index 100%
+rename from src/drivers/gpd_win_mini/mod.rs
+rename to src/drivers/gpd_device/mod.rs
+diff --git a/src/drivers/gpd_win_mini/touchpad_driver.rs b/src/drivers/gpd_device/touchpad_driver.rs
+similarity index 100%
+rename from src/drivers/gpd_win_mini/touchpad_driver.rs
+rename to src/drivers/gpd_device/touchpad_driver.rs
+diff --git a/src/drivers/mod.rs b/src/drivers/mod.rs
+index 7a8477ec..adef2133 100644
+--- a/src/drivers/mod.rs
++++ b/src/drivers/mod.rs
+@@ -1,7 +1,7 @@
+ pub mod dualsense;
+ pub mod flydigi_vader_4_pro;
+ pub mod fts3528;
+-pub mod gpd_win_mini;
++pub mod gpd_device;
+ pub mod horipad_steam;
+ pub mod iio_imu;
+ pub mod lego;
+diff --git a/src/input/source/hidraw.rs b/src/input/source/hidraw.rs
+index 92a7b003..d40e770c 100644
+--- a/src/input/source/hidraw.rs
++++ b/src/input/source/hidraw.rs
+@@ -2,8 +2,8 @@ pub mod blocked;
+ pub mod dualsense;
+ pub mod flydigi_vader_4_pro;
+ pub mod fts3528;
+-pub mod gpd_win_mini_macro_keyboard;
+-pub mod gpd_win_mini_touchpad;
++pub mod gpd_macro_keyboard;
++pub mod gpd_touchpad;
+ pub mod horipad_steam;
+ pub mod legion_go;
+ pub mod legion_go2;
+@@ -34,9 +34,8 @@ use crate::{
+ 
+ use self::{
+     blocked::BlockedHidrawDevice, dualsense::DualSenseController, flydigi_vader_4_pro::Vader4Pro,
+-    fts3528::Fts3528Touchscreen, gpd_win_mini_macro_keyboard::GpdWinMiniMacroKeyboard,
+-    gpd_win_mini_touchpad::GpdWinMiniTouchpad, horipad_steam::HoripadSteam,
+-    legion_go::LegionGoController, legion_go2::LegionGo2Controller,
++    fts3528::Fts3528Touchscreen, gpd_macro_keyboard::GpdMacroKeyboard, gpd_touchpad::GpdTouchpad,
++    horipad_steam::HoripadSteam, legion_go::LegionGoController, legion_go2::LegionGo2Controller,
+     legos_imu::LegionSImuController, legos_touchpad::LegionSTouchpadController,
+     legos_xinput::LegionSXInputController, opineo::OrangePiNeoTouchpad, oxp_hid::OxpHid,
+     rog_ally::RogAlly, steam_deck::DeckController, xpad_uhid::XpadUhid, zotac_zone::ZotacZone,
+@@ -48,8 +47,8 @@ enum DriverType {
+     Blocked,
+     DualSense,
+     Fts3528Touchscreen,
+-    GpdWinMiniMacroKeyboard,
+-    GpdWinMiniTouchpad,
++    GpdMacroKeyboard,
++    GpdTouchpad,
+     HoripadSteam,
+     LegionGo,
+     LegionGo2,
+@@ -73,8 +72,8 @@ pub enum HidRawDevice {
+     Blocked(SourceDriver<BlockedHidrawDevice>),
+     DualSense(SourceDriver<DualSenseController>),
+     Fts3528Touchscreen(SourceDriver<Fts3528Touchscreen>),
+-    GpdWinMiniMacroKeyboard(SourceDriver<GpdWinMiniMacroKeyboard>),
+-    GpdWinMiniTouchpad(SourceDriver<GpdWinMiniTouchpad>),
++    GpdWinMiniMacroKeyboard(SourceDriver<GpdMacroKeyboard>),
++    GpdWinMiniTouchpad(SourceDriver<GpdTouchpad>),
+     HoripadSteam(SourceDriver<HoripadSteam>),
+     LegionGo(SourceDriver<LegionGoController>),
+     LegionGo2(SourceDriver<LegionGo2Controller>),
+@@ -456,14 +455,14 @@ impl HidRawDevice {
+                 );
+                 Ok(Self::ZotacZone(source_device))
+             }
+-            DriverType::GpdWinMiniTouchpad => {
+-                let device = GpdWinMiniTouchpad::new(device_info.clone())?;
++            DriverType::GpdTouchpad => {
++                let device = GpdTouchpad::new(device_info.clone())?;
+                 let source_device =
+                     SourceDriver::new(composite_device, device, device_info.into(), conf);
+                 Ok(Self::GpdWinMiniTouchpad(source_device))
+             }
+-            DriverType::GpdWinMiniMacroKeyboard => {
+-                let device = GpdWinMiniMacroKeyboard::new(device_info.clone())?;
++            DriverType::GpdMacroKeyboard => {
++                let device = GpdMacroKeyboard::new(device_info.clone())?;
+                 let source_device =
+                     SourceDriver::new(composite_device, device, device_info.into(), conf);
+                 Ok(Self::GpdWinMiniMacroKeyboard(source_device))
+@@ -616,20 +615,20 @@ impl HidRawDevice {
+         }
+ 
+         // GPD Win Mini
+-        if vid == drivers::gpd_win_mini::touchpad_driver::VID
+-            && pid == drivers::gpd_win_mini::touchpad_driver::PID
+-            && iid == drivers::gpd_win_mini::touchpad_driver::IID
++        if vid == drivers::gpd_device::touchpad_driver::VID
++            && pid == drivers::gpd_device::touchpad_driver::PID
++            && iid == drivers::gpd_device::touchpad_driver::IID
+         {
+             log::info!("Detected GPD Win Mini Touchpad");
+-            return DriverType::GpdWinMiniTouchpad;
++            return DriverType::GpdTouchpad;
+         }
+ 
+-        if vid == drivers::gpd_win_mini::macro_keyboard_driver::VID
+-            && pid == drivers::gpd_win_mini::macro_keyboard_driver::PID
+-            && iid == drivers::gpd_win_mini::macro_keyboard_driver::IID
++        if vid == drivers::gpd_device::macro_keyboard_driver::VID
++            && pid == drivers::gpd_device::macro_keyboard_driver::PID
++            && iid == drivers::gpd_device::macro_keyboard_driver::IID
+         {
+             log::info!("Detected GPD Win Mini Macro keyboard");
+-            return DriverType::GpdWinMiniMacroKeyboard;
++            return DriverType::GpdMacroKeyboard;
+         }
+ 
+         if vid == drivers::ultimate_2::VID && pid == drivers::ultimate_2::PID {
+diff --git a/src/input/source/hidraw/gpd_win_mini_macro_keyboard.rs b/src/input/source/hidraw/gpd_macro_keyboard.rs
+similarity index 69%
+rename from src/input/source/hidraw/gpd_win_mini_macro_keyboard.rs
+rename to src/input/source/hidraw/gpd_macro_keyboard.rs
+index 16c26dfd..2867506c 100644
+--- a/src/input/source/hidraw/gpd_win_mini_macro_keyboard.rs
++++ b/src/input/source/hidraw/gpd_macro_keyboard.rs
+@@ -1,30 +1,28 @@
+ use std::{error::Error, fmt::Debug};
+ 
+ use crate::{
+-    drivers::gpd_win_mini::{
+-        event, macro_keyboard_driver::MacroKeyboardDriver
+-    },
++    drivers::gpd_device::{event, macro_keyboard_driver::MacroKeyboardDriver},
+     input::{
+         capability::{Capability, Gamepad, GamepadButton},
+         event::{native::NativeEvent, value::InputValue},
+-        source::{InputError, SourceInputDevice, SourceOutputDevice}
++        source::{InputError, SourceInputDevice, SourceOutputDevice},
+     },
+     udev::device::UdevDevice,
+ };
+ 
+ /// GPD Win Mini macro keyboard source device implementation
+-pub struct GpdWinMiniMacroKeyboard {
++pub struct GpdMacroKeyboard {
+     driver: MacroKeyboardDriver,
+ }
+ 
+-impl GpdWinMiniMacroKeyboard {
++impl GpdMacroKeyboard {
+     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
+         let driver = MacroKeyboardDriver::new(device_info)?;
+         Ok(Self { driver })
+     }
+ }
+ 
+-impl SourceInputDevice for GpdWinMiniMacroKeyboard {
++impl SourceInputDevice for GpdMacroKeyboard {
+     fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+         let events = self.driver.poll()?;
+         let native_events = translate_events(events);
+@@ -36,9 +34,9 @@ impl SourceInputDevice for GpdWinMiniMacroKeyboard {
+     }
+ }
+ 
+-impl SourceOutputDevice for GpdWinMiniMacroKeyboard {}
++impl SourceOutputDevice for GpdMacroKeyboard {}
+ 
+-impl Debug for GpdWinMiniMacroKeyboard {
++impl Debug for GpdMacroKeyboard {
+     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+         f.debug_struct("GpdWinMiniMacroKeyboard").finish()
+     }
+@@ -57,18 +55,14 @@ fn translate_events(events: Vec<event::Event>) -> Vec<NativeEvent> {
+ fn translate_event(event: event::Event) -> NativeEvent {
+     match event {
+         event::Event::GamepadButton(button) => match button {
+-            event::GamepadButtonEvent::L4(value) => {
+-                NativeEvent::new(
+-                    Capability::Gamepad(Gamepad::Button(GamepadButton::LeftPaddle1)),
+-                    InputValue::Bool(value.pressed)
+-                )
+-            },
+-            event::GamepadButtonEvent::R4(value) => {
+-                NativeEvent::new(
+-                    Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle1)),
+-                    InputValue::Bool(value.pressed)
+-                )
+-            },
++            event::GamepadButtonEvent::L4(value) => NativeEvent::new(
++                Capability::Gamepad(Gamepad::Button(GamepadButton::LeftPaddle1)),
++                InputValue::Bool(value.pressed),
++            ),
++            event::GamepadButtonEvent::R4(value) => NativeEvent::new(
++                Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle1)),
++                InputValue::Bool(value.pressed),
++            ),
+         },
+         _ => NativeEvent::new(Capability::NotImplemented, InputValue::None),
+     }
+diff --git a/src/input/source/hidraw/gpd_win_mini_touchpad.rs b/src/input/source/hidraw/gpd_touchpad.rs
+similarity index 69%
+rename from src/input/source/hidraw/gpd_win_mini_touchpad.rs
+rename to src/input/source/hidraw/gpd_touchpad.rs
+index f65876f6..5910e7da 100644
+--- a/src/input/source/hidraw/gpd_win_mini_touchpad.rs
++++ b/src/input/source/hidraw/gpd_touchpad.rs
+@@ -1,30 +1,34 @@
+ use std::{error::Error, fmt::Debug};
+ 
+ use crate::{
+-    drivers::gpd_win_mini::{
+-        event, touchpad_driver::{self, TouchpadDriver}
++    drivers::gpd_device::{
++        event,
++        touchpad_driver::{self, TouchpadDriver},
+     },
+     input::{
+         capability::{Capability, Gamepad, GamepadTrigger, Touch, TouchButton, Touchpad},
+-        event::{native::NativeEvent, value::{InputValue, normalize_unsigned_value}},
+-        source::{InputError, SourceInputDevice, SourceOutputDevice}
++        event::{
++            native::NativeEvent,
++            value::{normalize_unsigned_value, InputValue},
++        },
++        source::{InputError, SourceInputDevice, SourceOutputDevice},
+     },
+     udev::device::UdevDevice,
+ };
+ 
+ /// GPD Win Mini source device implementation
+-pub struct GpdWinMiniTouchpad {
++pub struct GpdTouchpad {
+     driver: TouchpadDriver,
+ }
+ 
+-impl GpdWinMiniTouchpad {
++impl GpdTouchpad {
+     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
+         let driver = TouchpadDriver::new(device_info)?;
+         Ok(Self { driver })
+     }
+ }
+ 
+-impl SourceInputDevice for GpdWinMiniTouchpad {
++impl SourceInputDevice for GpdTouchpad {
+     fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+         let events = self.driver.poll()?;
+         let native_events = translate_events(events);
+@@ -36,9 +40,9 @@ impl SourceInputDevice for GpdWinMiniTouchpad {
+     }
+ }
+ 
+-impl SourceOutputDevice for GpdWinMiniTouchpad {}
++impl SourceOutputDevice for GpdTouchpad {}
+ 
+-impl Debug for GpdWinMiniTouchpad {
++impl Debug for GpdTouchpad {
+     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+         f.debug_struct("GpdWinMiniTouchpad").finish()
+     }
+@@ -77,12 +81,10 @@ fn normalize_axis_value(event: event::TouchAxisEvent) -> InputValue {
+ /// maximum axis ranges.
+ fn normalize_trigger_value(event: event::TriggerEvent) -> InputValue {
+     match event {
+-        event::TriggerEvent::PadForce(value) => {
+-            InputValue::Float(normalize_unsigned_value(
+-                value.value as f64,
+-                touchpad_driver::PAD_FORCE_MAX
+-            ))
+-        }
++        event::TriggerEvent::PadForce(value) => InputValue::Float(normalize_unsigned_value(
++            value.value as f64,
++            touchpad_driver::PAD_FORCE_MAX,
++        )),
+     }
+ }
+ 
+@@ -98,27 +100,21 @@ fn translate_events(events: Vec<event::Event>) -> Vec<NativeEvent> {
+ /// Translate the given touchpad event into a native event
+ fn translate_event(event: event::Event) -> NativeEvent {
+     match event {
+-        event::Event::TouchAxis(axis) => {
+-            NativeEvent::new(
+-                Capability::Touchpad(Touchpad::RightPad(Touch::Motion)),
+-                normalize_axis_value(axis)
+-            )
+-        },
++        event::Event::TouchAxis(axis) => NativeEvent::new(
++            Capability::Touchpad(Touchpad::RightPad(Touch::Motion)),
++            normalize_axis_value(axis),
++        ),
+         event::Event::TouchButton(button) => match button {
+-            event::TouchButtonEvent::Left(value) => {
+-                NativeEvent::new(
+-                    Capability::Touchpad(Touchpad::RightPad(Touch::Button(TouchButton::Press))),
+-                    InputValue::Bool(value.pressed),
+-                )
+-            },
++            event::TouchButtonEvent::Left(value) => NativeEvent::new(
++                Capability::Touchpad(Touchpad::RightPad(Touch::Button(TouchButton::Press))),
++                InputValue::Bool(value.pressed),
++            ),
+         },
+         event::Event::Trigger(trigg) => match trigg.clone() {
+-            event::TriggerEvent::PadForce(_) => {
+-                NativeEvent::new(
+-                    Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTouchpadForce)),
+-                    normalize_trigger_value(trigg),
+-                )
+-            },
++            event::TriggerEvent::PadForce(_) => NativeEvent::new(
++                Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTouchpadForce)),
++                normalize_trigger_value(trigg),
++            ),
+         },
+         _ => NativeEvent::new(Capability::NotImplemented, InputValue::None),
+     }

--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -2,12 +2,13 @@
 
 Name:           inputplumber
 Version:        0.78.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Open source input router and remapper daemon for Linux
 License:        GPL-3.0-or-later
 URL:            https://github.com/ShadowBlip/InputPlumber
 Source0:        %{url}/archive/refs/tags/v%version.tar.gz
 Patch0:         make-install-dont-build.patch
+Patch1:         644.patch
 BuildRequires:  libevdev-devel libiio-devel git make cargo libudev-devel llvm-devel clang-devel
 BuildRequires:  rust-packaging cargo-rpm-macros mold rpm_macro(cargo_prep_online) systemd-rpm-macros
 Requires:       libevdev libiio
@@ -22,7 +23,7 @@ can be used to combine any number of input devices (like gamepads, mice, and
 keyboards) and translate their input to a variety of virtual device formats.
 
 %prep
-%autosetup -n InputPlumber-%version
+%autosetup -n InputPlumber-%version -p1
 %cargo_prep_online
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: Add support for more GPD devices to InputPlumber (#15098)](https://github.com/terrapkg/packages/pull/15098)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)