### PR TITLE
[el10] add AI policy checkbox to pull request template (#14887)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_package.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_package.md
@@ -10,6 +10,7 @@ Add any other context about the package submission here. Link to any relavent is
 **Checklist**
 - [] This package is maintained OR there is a valid reason to add it (e.g. python dependency)
 - [] I have tested at least the `x86_64` version of the package
-- [] I have read through any relevant [Terra](https://developer.fyralabs.com/terra) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
-- [] I have made sure there are no security issues with this package to the best of my ability
-- [] I have made sure this is not in Fedora (unless adding to the [extras repo](https://developer.fyralabs.com/terra/installing#extras)).
+- [] I have read through any relevant [Terra](https://docs.terrapkg.com/) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
+- [] I have ensured there are no security issues with this package to the best of my ability
+- [] I have ensured this is not in Fedora (unless adding to the [extras repo](https://docs.terrapkg.com/usage/installing/#extras))
+- [] I used an LLM. I used it ONLY to help debug issues, and not to generate the spec completely, in accordance with the [Terra AI policy](https://docs.terrapkg.com/policies#ai-policy)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add AI policy checkbox to pull request template (#14887)](https://github.com/terrapkg/packages/pull/14887)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)