### PR TITLE
[f45] fix: rust-zoi-rs (#14895)

### DIFF
--- a/anda/langs/rust/zoi/rust-zoi-rs.spec
+++ b/anda/langs/rust/zoi/rust-zoi-rs.spec
@@ -10,9 +10,11 @@ Summary:        Universal Package Manager & Environment Setup Tool
 SourceLicense:  Apache-2.0
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND BSL-1.0 AND CDLA-Permissive-2.0 AND ISC AND LGPL-2.0-or-later AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND MPL-2.0+ AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib
 URL:            https://crates.io/crates/zoi-rs
-Source:         https://static.crates.io/crates/%{crate}/%{crate}-%{crate_version}.crate
+Source0:        https://static.crates.io/crates/%{crate}/%{crate}-%{crate_version}.crate
+Source1:        https://gitlab.com/zillowe/zillwen/zusty/zoi/-/blob/main/LICENSE
 BuildRequires:  cargo
 BuildRequires:  gcc-c++
+BuildRequires:  clang-devel
 BuildRequires:  rpm_macro(cargo_install)
 BuildRequires:  pkgconfig(openssl)
 BuildRequires:  perl(FindBin)
@@ -40,14 +42,9 @@ Requires:       git
 %files       -n %{crate}
 %license LICENSE
 %license LICENSE.dependencies
-%doc CHANGELOG.md
-%doc CODE_OF_CONDUCT.md
-%doc PACKAGING.md
 %doc README.md
-%doc RELEASE.md
-%doc SECURITY.md
 %{_bindir}/zoi
-%{_bindir}/zoi-mini
+%dnl %{_bindir}/zoi-mini
 
 %pkg_completion -Befz zoi -n %{crate}
 
@@ -80,6 +77,7 @@ use the "default" feature of the "%{crate}" crate.
 %prep
 %autosetup -n %{crate}-%{crate_version}
 %cargo_prep_online
+cp %{S:1} .
 
 %build
 %cargo_license_summary_online


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: rust-zoi-rs (#14895)](https://github.com/terrapkg/packages/pull/14895)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)