### PR TITLE
[f44] fix: quickjs-ng (#14959)

### DIFF
--- a/anda/lib/quickjs-ng/quickjs-ng.spec
+++ b/anda/lib/quickjs-ng/quickjs-ng.spec
@@ -41,8 +41,10 @@ Example files for %{name}
 %prep
 %autosetup -p1 -n quickjs-%{version}
 
-%build
+%conf
 %cmake
+
+%build
 %cmake_build
 
 %install
@@ -54,9 +56,8 @@ rm %{buildroot}%{_docdir}/quickjs/LICENSE
 %license LICENSE
 %{_bindir}/qjs
 %{_bindir}/qjsc
-%{_mandir}/man1/qjs.1/qjs.man.*
-%{_mandir}/man1/qjsc.1/qjsc.man.*
-
+%{_mandir}/man1/qjs.1.*
+%{_mandir}/man1/qjsc.1.*
 
 %files examples
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: quickjs-ng (#14959)](https://github.com/terrapkg/packages/pull/14959)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)