### PR TITLE
[f45] feat: Update to the latest steamos-manager-powerstation (#15133)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit cb38d0a3ad24bf995abe59abcd0b0a79fa8bd35f
+%global commit abb3e3933c3fd89193f1accd94e9dd5e28a22a0e
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260808
+%global commitdate 20260809
 
 %global steamos_manager_systemd_user_units steamos-manager.service steamos-manager-configure-cecd.service steamos-manager-session-cleanup.service
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update to the latest steamos-manager-powerstation (#15133)](https://github.com/terrapkg/packages/pull/15133)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)