### PR TITLE
[f43] fix(devcontainer): drop stale vscode remoteUser (#14441)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,5 @@
         "redhat.vscode-xml"
       ]
     }
-  },
-  "remoteUser": "vscode",
-  "onCreateCommand": "sudo usermod -a -G mock vscode"
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(devcontainer): drop stale vscode remoteUser (#14441)](https://github.com/terrapkg/packages/pull/14441)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)