### PR TITLE
[f43] fix: protonplus (#15132)

### DIFF
--- a/anda/games/protonplus/protonplus.spec
+++ b/anda/games/protonplus/protonplus.spec
@@ -2,14 +2,16 @@
 
 Name:           protonplus
 Version:        0.6.1.1
+%global downloadver %(echo %{version} | sed -E 's/\.([^.]*)$/-\1/')
 Release:        1%{?dist}
 Summary:        A modern compatibility tools manager
 License:        GPL-3.0-or-later
 URL:            https://github.com/Vysp3r/ProtonPlus
-Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+Source0:        %{url}/archive/refs/tags/v%{downloadver}.tar.gz
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 BuildRequires:  meson
+BuildRequires:  cmake
 BuildRequires:  ninja-build
 BuildRequires:  gcc
 BuildRequires:  vala
@@ -19,6 +21,9 @@ BuildRequires:  pkgconfig(json-glib-1.0)
 BuildRequires:  pkgconfig(libsoup-3.0)
 BuildRequires:  pkgconfig(gee-0.8)
 BuildRequires:  pkgconfig(libarchive)
+BuildRequires:  pkgconfig(sdl3)
+BuildRequires:  pkgconfig(libnotify)
+BuildRequires:  pkgconfig(appstream)
 BuildRequires:  desktop-file-utils
 
 Provides:       ProtonPlus
@@ -29,7 +34,7 @@ It allows you to easily manage and update various compatibility
 tools like Proton, Wine, DXVK, and VKD3D across different launchers.
 
 %prep
-%autosetup -n ProtonPlus-%{version}
+%autosetup -C
 
 %conf
 %meson


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: protonplus (#15132)](https://github.com/terrapkg/packages/pull/15132)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)