### PR TITLE
[f44] fix: t3code-nightly version format (#15173)

### DIFF
--- a/anda/devs/t3code/nightly/update.rhai
+++ b/anda/devs/t3code/nightly/update.rhai
@@ -1,6 +1,8 @@
-rpm.global("latest_stable_version", gh("pingdotgg/t3code"));
 rpm.global("commit", gh_commit("pingdotgg/t3code"));
 if rpm.changed() {
+  let ver = gh("pingdotgg/t3code");
+  ver.crop(1);
+  rpm.global("latest_stable_version", ver);
   rpm.release();
   rpm.global("commit_date", date());
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: t3code-nightly version format (#15173)](https://github.com/terrapkg/packages/pull/15173)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)