### PR TITLE
[f43] chore: remove dead .crop(0) calls (#15179)

### DIFF
--- a/anda/system/hid-fanatecff/kmod-common/update.rhai
+++ b/anda/system/hid-fanatecff/kmod-common/update.rhai
@@ -2,7 +2,5 @@ rpm.global("commit", gh_commit("gotzl/hid-fanatecff"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commitdate", date());
-    let ver = gh("gotzl/hid-fanatecff");
-    ver.crop(0);
-    rpm.global("ver", ver);
+    rpm.global("ver", gh("gotzl/hid-fanatecff"));
 }

--- a/anda/system/hid-tmff2/kmod-common/update.rhai
+++ b/anda/system/hid-tmff2/kmod-common/update.rhai
@@ -2,7 +2,5 @@ rpm.global("commit", gh_commit("Kimplul/hid-tmff2"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commitdate", date());
-    let ver = gh("Kimplul/hid-tmff2");
-    ver.crop(0);
-    rpm.global("ver", ver);
+    rpm.global("ver", gh("Kimplul/hid-tmff2"));
 }

--- a/anda/system/t150-driver/kmod-common/update.rhai
+++ b/anda/system/t150-driver/kmod-common/update.rhai
@@ -2,7 +2,5 @@ rpm.global("commit", gh_commit("scarburato/t150_driver"));
 if rpm.changed() {
     rpm.release();
     rpm.global("commitdate", date());
-    let ver = gh("scarburato/t150_driver");
-    ver.crop(0);
-    rpm.global("ver", ver);
+    rpm.global("ver", gh("scarburato/t150_driver"));
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: remove dead .crop(0) calls (#15179)](https://github.com/terrapkg/packages/pull/15179)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)