### PR TITLE
[f44] fix: protonplus (#15196)

### DIFF
--- a/anda/games/protonplus/protonplus.spec
+++ b/anda/games/protonplus/protonplus.spec
@@ -2,12 +2,11 @@
 
 Name:           protonplus
 Version:        0.6.2
-%global downloadver %(echo %{version} | sed -E 's/\.([^.]*)$/-\1/')
 Release:        1%{?dist}
 Summary:        A modern compatibility tools manager
 License:        GPL-3.0-or-later
 URL:            https://github.com/Vysp3r/ProtonPlus
-Source0:        %{url}/archive/refs/tags/v%{downloadver}.tar.gz
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 BuildRequires:  meson


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: protonplus (#15196)](https://github.com/terrapkg/packages/pull/15196)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)