### PR TITLE
[el10] chore (opengamepadui): update spec (#14412)

### DIFF
--- a/anda/games/opengamepadui/opengamepadui.spec
+++ b/anda/games/opengamepadui/opengamepadui.spec
@@ -1,9 +1,11 @@
+%global debug_package %{nil}
+
 Name:           opengamepadui
 Version:        0.46.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Open source gamepad-native game launcher and overlay
 
-License:        GPLv3
+License:        GPL-3.0-or-later
 URL:            https://github.com/ShadowBlip/OpenGamepadUI
 Packager:       Cappy Ishihara <cappy@fyralabs.com>
 
@@ -41,45 +43,40 @@ Requires:       godot-runner
 Recommends:     inputplumber
 Recommends:     powerstation
 
-%global build_dir %{name}-%{version}
-
 %description
-Open Gamepad UI is a free and open source game launcher and overlay written using the Godot Game Engine 4 designed with a gamepad native experience in mind. Its goal is to provide an open and extendable foundation to launch and play games. It also implements a gamepad input system that can allow you to
-remap gamepad input to mouse and keyboard inputs.
+Open Gamepad UI is a free and open source game launcher and overlay
+written using the Godot Game Engine 4 designed with a gamepad native
+experience in mind. Its goal is to provide an open and extendable
+foundation to launch and play games. It also implements a gamepad
+input system that can allow you to remap
+gamepad input to mouse and keyboard inputs.
 
 %prep
 
 # We clone the repo from Git here because the build script requires
 # submodules to be present in the source directory.
-rm -rf %{build_dir}
-git clone %{url} %{build_dir} -b v%{version}
-cd %{build_dir}
-#git checkout tags/v%{version}
+# %git_clone %{url} v%{version}
+# %dnl git checkout tags/v%{version}
 # Temporary while some final issues are resolved, same version as above.
-git checkout pastaq/bazzite_crashes
+%git_clone %{url} pastaq/bazzite_crashes
 %patch 0 -p1
 
 %build
-cd %{build_dir}
-make import
+%make_build import
 %make_build
 
-
 %install
-cd %{build_dir}
 %make_install PREFIX=%{buildroot}%{_prefix} INSTALL_PREFIX=%{_prefix}
 
-
 %files
-%license %{build_dir}/LICENSE
-%doc %{build_dir}/docs/
+%license LICENSE
+%doc docs/
 %{_bindir}/opengamepadui
 %{_datadir}/opengamepadui/
 %{_datadir}/applications/opengamepadui.desktop
 %{_datadir}/icons/hicolor/scalable/apps/opengamepadui.svg
 %{_datadir}/polkit-1/actions/*
 %{_userunitdir}/*
-
 
 %changelog
 * Fri Jul 24 2026 HikariKnight <2557889+HikariKnight@users.noreply.github.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (opengamepadui): update spec (#14412)](https://github.com/terrapkg/packages/pull/14412)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)