### PR TITLE
[el10] fix: Add patch for issue that caused OGUI to never load under GNOME (#15216)

### DIFF
--- a/anda/games/opengamepadui/gnome.patch
+++ b/anda/games/opengamepadui/gnome.patch
@@ -1,0 +1,99 @@
+diff --git a/extensions/core/src/gamescope.rs b/extensions/core/src/gamescope.rs
+index a02b41a2..fa177b09 100644
+--- a/extensions/core/src/gamescope.rs
++++ b/extensions/core/src/gamescope.rs
+@@ -1,13 +1,23 @@
+ pub mod x11_client;
+ 
+-use std::collections::HashMap;
++use std::collections::{HashMap, HashSet};
+ use std::env;
++use std::sync::mpsc;
++use std::thread;
++use std::time::{Duration, Instant};
+ use x11_client::GamescopeXWayland;
+ 
++use gamescope_x11_client::atoms::GamescopeAtom;
++use gamescope_x11_client::xwayland::XWayland;
++
+ use godot::prelude::*;
+ 
+ use godot::classes::{Engine, Resource};
+ 
++/// How long to wait for an X11 display to connect
++/// before giving up on it.
++const DISPLAY_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
++
+ #[derive(GodotClass)]
+ #[class(base=Resource)]
+ pub struct GamescopeInstance {
+@@ -108,7 +118,7 @@ impl IResource for GamescopeInstance {
+         }
+ 
+         // Discover any gamescope instances
+-        let result = gamescope_x11_client::discover_gamescope_displays();
++        let result = discover_gamescope_displays();
+         let x11_displays = match result {
+             Ok(displays) => displays,
+             Err(e) => {
+@@ -160,3 +170,60 @@ impl IResource for GamescopeInstance {
+         }
+     }
+ }
++
++/// Returns the names of every X11 display that is a Gamescope XWayland
++fn discover_gamescope_displays() -> Result<Vec<String>, Box<dyn std::error::Error>> {
++    let mut seen = HashSet::new();
++    let displays = gamescope_x11_client::discover_x11_displays()?
++        .into_iter()
++        .filter(|display| seen.insert(display.clone()));
++
++    let probes: Vec<(String, mpsc::Receiver<bool>)> = displays
++        .map(|display| {
++            let (tx, rx) = mpsc::sync_channel(1);
++            let name = display.clone();
++            thread::spawn(move || {
++                let _ = tx.try_send(is_gamescope_display(&name));
++            });
++            (display, rx)
++        })
++        .collect();
++
++    let deadline = Instant::now() + DISPLAY_PROBE_TIMEOUT;
++    let mut gamescope_displays = Vec::new();
++    for (display, rx) in probes {
++        let remaining = deadline.saturating_duration_since(Instant::now());
++        match rx.recv_timeout(remaining) {
++            Ok(true) => gamescope_displays.push(display),
++            Ok(false) => (),
++            Err(_) => log::warn!("Display {display} did not respond in time; skipping it"),
++        }
++    }
++
++    Ok(gamescope_displays)
++}
++
++/// Connects to the given display and reports whether it is a Gamescope XWayland.
++fn is_gamescope_display(display: &str) -> bool {
++    let mut xwayland = XWayland::new(display.to_string());
++    if let Err(e) = xwayland.connect() {
++        log::debug!("Failed to connect to display {display}: {e:?}");
++        return false;
++    }
++
++    let root_window_id = match xwayland.get_root_window_id() {
++        Ok(root_window_id) => root_window_id,
++        Err(e) => {
++            log::debug!("Failed to get root window for display {display}: {e:?}");
++            return false;
++        }
++    };
++
++    match xwayland.has_xprop(root_window_id, GamescopeAtom::XwaylandServerId) {
++        Ok(is_gamescope) => is_gamescope,
++        Err(e) => {
++            log::debug!("Failed to query display {display}: {e:?}");
++            false
++        }
++    }
++}

--- a/anda/games/opengamepadui/opengamepadui.spec
+++ b/anda/games/opengamepadui/opengamepadui.spec
@@ -2,7 +2,7 @@
 
 Name:           opengamepadui
 Version:        0.46.0
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Open source gamepad-native game launcher and overlay
 
 License:        GPL-3.0-or-later
@@ -10,6 +10,7 @@ URL:            https://github.com/ShadowBlip/OpenGamepadUI
 Packager:       Cappy Ishihara <cappy@fyralabs.com>
 
 Patch0:         disable-manage-all.patch
+Patch1:         gnome.patch
 
 BuildRequires:  godot
 BuildRequires:  scons
@@ -60,6 +61,7 @@ gamepad input to mouse and keyboard inputs.
 # Temporary while some final issues are resolved, same version as above.
 %git_clone %{url} pastaq/bazzite_crashes
 %patch 0 -p1
+%patch 1 -p1
 
 %build
 %make_build import


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: Add patch for issue that caused OGUI to never load under GNOME (#15216)](https://github.com/terrapkg/packages/pull/15216)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)