### PR TITLE
[f43] chore: remove appormor-fedora (#15238)

### DIFF
--- a/anda/system/apparmor.d-fedora/anda.hcl
+++ b/anda/system/apparmor.d-fedora/anda.hcl
@@ -1,5 +1,0 @@
-project pkg {
-	rpm {
-		spec = "apparmor.d-fedora.spec"
-	}
-}

--- a/anda/system/apparmor.d-fedora/apparmor.d-fedora.spec
+++ b/anda/system/apparmor.d-fedora/apparmor.d-fedora.spec
@@ -1,8 +1,0 @@
-# %tag pins the exact apparmor.d-fedora release this build fetches -
-# update.rhai bumps it to the latest tag, and the %include below fetches
-# from that same tag (not main), so this file is never the source of
-# truth for anything except "which tag", and builds stay reproducible
-# against a fixed ref instead of whatever's currently on the moving
-# main branch.
-%global tag v0.4910.0-4
-%include %(f=$(mktemp); curl -fsSL https://raw.githubusercontent.com/CatPieLeaf/apparmor.d-fedora/%{tag}/dists/apparmor.d-fedora.spec -o "$f"; echo "$f")

--- a/anda/system/apparmor.d-fedora/update.rhai
+++ b/anda/system/apparmor.d-fedora/update.rhai
@@ -1,4 +1,0 @@
-// Only bumps the cache-buster %tag so Andaman's diff-based updater
-// notices and rebuilds - the actual spec content is fetched live by
-// the %include in apparmor.d-fedora.spec.
-rpm.global("tag", gh("CatPieLeaf/apparmor.d-fedora"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: remove appormor-fedora (#15238)](https://github.com/terrapkg/packages/pull/15238)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)