### PR TITLE
[f45] remove: kernel-p03-gcc (#15246)

### DIFF
--- a/anda/system/kernel-p03-gcc/anda.hcl
+++ b/anda/system/kernel-p03-gcc/anda.hcl
@@ -1,6 +1,0 @@
-project pkg {
-	arches = ["x86_64"]
-	rpm {
-		spec = "kernel-p03-gcc.spec"
-	}
-}

--- a/anda/system/kernel-p03-gcc/kernel-p03-gcc.spec
+++ b/anda/system/kernel-p03-gcc/kernel-p03-gcc.spec
@@ -1,7 +1,0 @@
-# %tag pins the exact linux-p03 release this build fetches - update.rhai
-# bumps it to the latest tag, and the %include below fetches from that
-# same tag (not main), so this file is never the source of truth for
-# anything except "which tag", and builds stay reproducible against a
-# fixed ref instead of whatever's currently on the moving main branch.
-%global tag 7.2.0-52.rc6.p03.14
-%include %(f=$(mktemp); curl -fsSL https://raw.githubusercontent.com/CatPieLeaf/linux-p03/%{tag}/sources/kernel-p03/kernel-p03-gcc.spec -o "$f"; echo "$f")

--- a/anda/system/kernel-p03-gcc/update.rhai
+++ b/anda/system/kernel-p03-gcc/update.rhai
@@ -1,4 +1,0 @@
-// Only bumps the cache-buster %tag so Andaman's diff-based updater
-// notices and rebuilds - the actual spec content is fetched live by
-// the %include in kernel-p03-gcc.spec.
-rpm.global("tag", gh("CatPieLeaf/linux-p03"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [remove: kernel-p03-gcc (#15246)](https://github.com/terrapkg/packages/pull/15246)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)