### PR TITLE
[el10] feat: Update to the latest steamos-manager-powerstation (#15271)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit abb3e3933c3fd89193f1accd94e9dd5e28a22a0e
+%global commit d33fe1fa546f878e49487b559da36d7e88acb00e
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260809
+%global commitdate 20260810
 
 %global steamos_manager_systemd_user_units steamos-manager.service steamos-manager-configure-cecd.service steamos-manager-session-cleanup.service
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat: Update to the latest steamos-manager-powerstation (#15271)](https://github.com/terrapkg/packages/pull/15271)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)