### PR TITLE
[el10] feat: Update to the latest steamos-manager-powerstation (#15276)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,4 +1,4 @@
-%global commit d33fe1fa546f878e49487b559da36d7e88acb00e
+%global commit 238a1413b3bd9888b1c4d9fd592e8111326549d2
 %global shortcommit %{sub %{commit} 0 7}
 %global commitdate 20260810
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat: Update to the latest steamos-manager-powerstation (#15276)](https://github.com/terrapkg/packages/pull/15276)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)