### PR TITLE
[f44] fix: pyvcd (#15294)

### DIFF
--- a/anda/langs/python/pyvcd/pyvcd.spec
+++ b/anda/langs/python/pyvcd/pyvcd.spec
@@ -18,6 +18,7 @@ BuildRequires:  python3-setuptools_scm
 BuildRequires:  python3-pip
 BuildRequires:  python3-devel
 BuildRequires:  python3-installer
+BuildRequires:  python3-uv-build
 BuildRequires:  git
 
 Packager:	    Owen Zimmerman <owen@fyralabs.com>
@@ -44,7 +45,7 @@ Provides:       pyvcd
 %pyproject_save_files vcd
 
 %files -n python3-%{pypi_name} -f %{pyproject_files}
-%doc README.rst CODE_OF_CONDUCT.md CHANGELOG.rst
+%doc README.rst CHANGELOG.rst
 %license LICENSE.txt
 %python3_sitelib/pyvcd-%version.dist-info/*
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: pyvcd (#15294)](https://github.com/terrapkg/packages/pull/15294)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)