### PR TITLE
[f43] fix: rio (#15303)

### DIFF
--- a/anda/devs/rio/rio.spec
+++ b/anda/devs/rio/rio.spec
@@ -71,6 +71,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %files devel
 %{_libdir}/librio_backend.so
 %{_libdir}/libsugarloaf.so
+%{_libdir}/liblibrio_wasm.so
 
 %changelog
 * Mon May 5 2025 Gilver E. <rockgrub@disroot.org> - 0.2.13-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: rio (#15303)](https://github.com/terrapkg/packages/pull/15303)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)