### PR TITLE
[f44] feat(ci): AppStream vetoes now count as CI failure, wrap CI output in (#15293)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -62,6 +62,7 @@ jobs:
         id: catalog
         # run appstream-builder, then add step summary
         run: |
+          set -o pipefail
           set -x
           appstream-builder -v \
             --packages-dir=artifacts/rpms \
@@ -94,11 +95,14 @@ jobs:
         if: steps.catalog.outcome == 'success'
         run: |
           if stat output/*.xml.gz &>/dev/null; then
-            echo "## AppStream Builder Log" >> $GITHUB_STEP_SUMMARY
+            echo "<details>" >> $GITHUB_STEP_SUMMARY
+            echo "<summary>AppStream Builder Log</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```log' >> $GITHUB_STEP_SUMMARY
             cat asb.log >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
             echo '---' >> $GITHUB_STEP_SUMMARY
           else
             echo "Nothing to do."
@@ -113,15 +117,19 @@ jobs:
           if stat output/*.xml.gz &>/dev/null; then
             if grep -q "veto" asb.log; then
               echo "::group::Vetoed packages"
-              echo "### Vetoed packages" >> $GITHUB_STEP_SUMMARY
+              echo "<details>" >> $GITHUB_STEP_SUMMARY
+              echo "<summary>Vetoed packages</summary>" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
               echo '```xml' >> $GITHUB_STEP_SUMMARY
               echo "$(grep -i 'veto' asb.log)" >> $GITHUB_STEP_SUMMARY
               echo '```' >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "</details>" >> $GITHUB_STEP_SUMMARY
               echo "::warning file=asb.log::Some packages were vetoed during AppStream generation. Please review the 'Vetoed packages' section in the summary for details."
               echo "::endgroup::"
             fi
-            echo "## Full Data Summary" >> $GITHUB_STEP_SUMMARY
+            echo "<details>" >> $GITHUB_STEP_SUMMARY
+            echo "<summary>Full Data Summary</summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Generated Appstream files:" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -133,6 +141,17 @@ jobs:
               echo '```' >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
             done
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
           else
             echo "No appstream files found." >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Fail on AppStream package failures
+        if: steps.report_summary.outcome == 'success'
+        run: |
+          for file in output/*.xml.gz; do
+            if zgrep -q '<veto>' "$file"; then
+              echo "::error file=$file::AppStream validation failed: package vetoes were found."
+              exit 1
+            fi
+          done


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat(ci): AppStream vetoes now count as CI failure, wrap CI output in (#15293)](https://github.com/terrapkg/packages/pull/15293)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)