### PR TITLE
[el10] fix (zapret2): drop non-existent deps (#15243)

### DIFF
--- a/anda/misc/zapret2/zapret2.spec
+++ b/anda/misc/zapret2/zapret2.spec
@@ -2,7 +2,7 @@
 
 Name:    zapret2
 Version: 1.0.4
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A multi-platform Deep Packet Inspection (DPI) bypass tool
 License: MIT 
 Packager: madonuko <mado@fyralabs.com>
@@ -34,8 +34,6 @@ Suggests: curl
 Requires: ipset
 Requires: nftables
 # Subpackage dependencies.
-Requires: %{name}-nfqws
-Requires: %{name}-tpws
 
 %description
 A stand-alone (without 3rd party servers) DPI circumvention tool.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (zapret2): drop non-existent deps (#15243)](https://github.com/terrapkg/packages/pull/15243)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)