### PR TITLE
[f44] chore (rio): use %pkg_devel_files (#15314)

### DIFF
--- a/anda/devs/rio/rio.spec
+++ b/anda/devs/rio/rio.spec
@@ -34,11 +34,7 @@ Packager:      Gilver E. <roachy@fyralabs.com>
 %description %_description
 
 %package       devel
-Summary:       Development files for Rio
-Requires:      %{name} = %{version}-%{release}
-
-%description   devel
-This package contains the development libraries for Rio.
+%pkg_devel_files
 
 %prep
 %autosetup -n %{name}-%{version}
@@ -67,11 +63,6 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %{_datadir}/applications/%{name}.desktop
 %{_iconsdir}/hicolor/scalable/apps/%{name}.svg
 %{_metainfodir}/%{appid}.metainfo.xml
-
-%files devel
-%{_libdir}/librio_backend.so
-%{_libdir}/libsugarloaf.so
-%{_libdir}/liblibrio_wasm.so
 
 %changelog
 * Mon May 5 2025 Gilver E. <rockgrub@disroot.org> - 0.2.13-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (rio): use %pkg_devel_files (#15314)](https://github.com/terrapkg/packages/pull/15314)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)