### PR TITLE
[f45] build(deps): bump actions/attest-build-provenance from 4.1.1 to 4.2.2 (#15358)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -96,7 +96,7 @@ jobs:
           curl -H "Authorization: Bearer ${{ secrets.MADOGUCHI_JWT }}" https://madoguchi.fyralabs.com/v4/repos/terra${{ matrix.version }} -X PUT -H "Content-Type: application/json" -d '{"gh":"https://github.com/terrapkg/packages/tree/${{ matrix.version }}","link":"https://repos.fyralabs.com/terra${{ matrix.version }}/"}' --fail-with-body
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             anda-build/rpm/rpms/*

--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Attest build provenance
         if: inputs.publish
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             anda-build/rpm/rpms/*


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [build(deps): bump actions/attest-build-provenance from 4.1.1 to 4.2.2 (#15358)](https://github.com/terrapkg/packages/pull/15358)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)