### PR TITLE
[f44] chore (rp-bookshelf): use %conf (#15367)

### DIFF
--- a/anda/apps/rp-bookshelf/rp-bookshelf.spec
+++ b/anda/apps/rp-bookshelf/rp-bookshelf.spec
@@ -12,11 +12,13 @@ Source0:        %url/archive/%commit.tar.gz
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 BuildRequires: meson
+BuildRequires: cmake
 BuildRequires: ninja-build
 BuildRequires: gtk3-devel
 BuildRequires: libcurl-devel
 BuildRequires: intltool
 BuildRequires: gcc
+BuildRequires: pkgconfig(wayland-protocols)
 
 Requires: libcurl gtk3
 
@@ -26,8 +28,10 @@ Requires: libcurl gtk3
 %prep
 %autosetup -n bookshelf-%commit
 
-%build
+%conf
 %meson
+
+%build
 %meson_build
 
 %install
@@ -38,10 +42,13 @@ Requires: libcurl gtk3
 %doc README
 %license debian/copyright
 %{_bindir}/rp-bookshelf
-%{_datadir}/icons/hicolor/16x16/apps/bookshelf.png
-%{_datadir}/icons/hicolor/24x24/apps/bookshelf.png
-%{_datadir}/icons/hicolor/32x32/apps/bookshelf.png
-%{_datadir}/icons/hicolor/48x48/apps/bookshelf.png
+%{_hicolordir}/16x16/apps/bookshelf.png
+%{_hicolordir}/24x24/apps/bookshelf.png
+%{_hicolordir}/32x32/apps/bookshelf.png
+%{_hicolordir}/48x48/apps/bookshelf.png
+%{_hicolordir}/64x64/apps/bookshelf.png
+%{_hicolordir}/96x96/apps/bookshelf.png
+%{_scalableiconsdir}/bookshelf.svg
 %{_datadir}/applications/rp-bookshelf.desktop
 %{_datadir}/rp-bookshelf/*
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (rp-bookshelf): use %conf (#15367)](https://github.com/terrapkg/packages/pull/15367)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)