### PR TITLE
[f45] fix: arduino-flasher-cli (#15357)

### DIFF
--- a/anda/tools/arduino-flasher-cli/anda.hcl
+++ b/anda/tools/arduino-flasher-cli/anda.hcl
@@ -1,5 +1,4 @@
 project pkg {
-  arches = ["x86_64"]
 	rpm {
 		spec = "arduino-flasher-cli.spec"
 	}

--- a/anda/tools/arduino-flasher-cli/arduino-flasher-cli.spec
+++ b/anda/tools/arduino-flasher-cli/arduino-flasher-cli.spec
@@ -9,16 +9,20 @@ CLI tool to flash UNO Q boards with the latest Arduino Linux image.}
 %global golicenses      LICENSE license_header.tpl
 %global godocs          README.md
 
+%ifarch x86_64
+%global arch amd64
+%elifarch aarch64
+%global arch arm64
+%endif
+
 Name:           arduino-flasher-cli
 Release:        1%{?dist}
 Summary:        CLI tool to flash UNO Q boards with the latest Arduino Linux image
-License:        GPL-3.0-only
+License:        GPL-3.0-or-later
 URL:            %{gourl}
 Source0:        %{gosource}
 Source1:        https://raw.githubusercontent.com/arduino/arduino-flasher-cli/refs/heads/main/README.md
-BuildRequires:  anda-srpm-macros qdl
-ExclusiveArch:  x86_64
-
+BuildRequires:  qdl
 %description %{common_description}
 
 %gopkg
@@ -27,19 +31,20 @@ ExclusiveArch:  x86_64
 %goprep
 
 %build
-mkdir -p updater/artifacts/resources_linux_amd64
-cp %{_bindir}/qdl updater/artifacts/resources_linux_amd64/qdl
+mkdir -p internal/updater/artifacts/resources_linux_%{arch}
+cp %{_bindir}/qdl internal/updater/artifacts/resources_linux_%{arch}/qdl
 %define gomodulesmode GO111MODULE=on
-%gobuild -o %{gobuilddir}/bin/arduino-cli %{goipath}
+%gobuild -o %{gobuilddir}/cmd/arduino-flasher-cli %{goipath}/cmd/arduino-flasher-cli
 
 %install
 cp %{S:1} README.md
-install -Dm755 %{gobuilddir}/bin/arduino-cli -t %buildroot%{_bindir}
+ls -laH %{gobuilddir}/cmd/
+install -Dm755 %{gobuilddir}/cmd/arduino-flasher-cli -t %buildroot%{_bindir}
 
 %files
 %license LICENSE
 %doc README.md
-%{_bindir}/arduino-cli
+%{_bindir}/arduino-flasher-cli
 
 %changelog
 * Fri Nov 14 2025 Jaiden Riordan <jade@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: arduino-flasher-cli (#15357)](https://github.com/terrapkg/packages/pull/15357)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)