### PR TITLE
[f43] chore (SwayOSD): use %conf (#15364)

### DIFF
--- a/anda/desktops/sway/swayosd/swayosd.spec
+++ b/anda/desktops/sway/swayosd/swayosd.spec
@@ -45,8 +45,10 @@ Provides:       swayosd
 %prep
 %autosetup -n SwayOSD-%{version}
 
-%build
+%conf
 %meson
+
+%build
 %meson_build
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (SwayOSD): use %conf (#15364)](https://github.com/terrapkg/packages/pull/15364)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)