### PR TITLE
[f45] feat(ci): Run appstream and manifest jobs on arc-runner-set (#15379)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   manifest:
-    runs-on: ubuntu-24.04-arm
+    runs-on: arc-runner-set
     outputs:
       build_matrix: ${{ steps.generate_build_matrix.outputs.build_matrix }}
     container:
@@ -49,7 +49,7 @@ jobs:
 
   appstream:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
     container:
       image: ghcr.io/terrapkg/appstream-generator:main
     steps:


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat(ci): Run appstream and manifest jobs on arc-runner-set (#15379)](https://github.com/terrapkg/packages/pull/15379)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)