### PR TITLE
[el10] fix(ci): Add terra-gpg-keys to bootstrap (#15403)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -41,11 +41,15 @@ jobs:
           export PATH=$PATH:/github/home/.cargo/bin
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           anda build -D "vendor Terra" -rrpmbuild anda/terra/mock-configs/pkg
+
       - name: Install terra-mock-configs
         run: dnf install -y anda-build/rpm/rpms/terra-mock-configs*.rpm
 
       - name: Build anda-srpm-macros
         run: anda build -D "vendor Terra" -rrpmbuild anda/terra/srpm-macros/pkg
+
+      - name: Build terra-gpg-keys
+        run: anda build -D "vendor Terra" -rrpmbuild anda/terra/gpg-keys/pkg
 
       - name: Build terra-release
         run: anda build -D "vendor Terra" -rrpmbuild anda/terra/release/pkg


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(ci): Add terra-gpg-keys to bootstrap (#15403)](https://github.com/terrapkg/packages/pull/15403)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)