### PR TITLE
[f43] chore (ci): change bootstrap name (#15408)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,4 +1,4 @@
-name: Bootstrap Andaman and Subatomic
+name: Bootstrap Core Terra Packages
 permissions:
   contents: read
   attestations: write


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (ci): change bootstrap name (#15408)](https://github.com/terrapkg/packages/pull/15408)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)