### PR TITLE
[f44] chore (.gitignore): add **/*.cabal (#15415)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 anda-build/
 **/*.tar*
+**/*.cabal
 **/*.crate
 **/*.zip
 **/*.minisig


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (.gitignore): add **/*.cabal (#15415)](https://github.com/terrapkg/packages/pull/15415)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)