### PR TITLE
[f44] feat(ci): Do manifest on runner-arc-set for manual builds (#15426)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
   manifest:
     outputs:
       build_matrix: ${{ steps.parsing.outputs.build_matrix }}
-    runs-on: ubuntu-24.04-arm
+    runs-on: runner-arc-set
     container:
       image: ghcr.io/terrapkg/builder:f44
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat(ci): Do manifest on runner-arc-set for manual builds (#15426)](https://github.com/terrapkg/packages/pull/15426)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)