### PR TITLE
[f43] fix(ci): Runner name (#15435)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
   manifest:
     outputs:
       build_matrix: ${{ steps.parsing.outputs.build_matrix }}
-    runs-on: runner-arc-set
+    runs-on: arc-runner-set
     container:
       image: ghcr.io/terrapkg/builder:frawhide
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(ci): Runner name (#15435)](https://github.com/terrapkg/packages/pull/15435)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)