### PR TITLE
[el10] fix: piclone (#15456)

### DIFF
--- a/anda/tools/piclone/piclone.spec
+++ b/anda/tools/piclone/piclone.spec
@@ -18,6 +18,7 @@ BuildRequires: intltool
 BuildRequires: vala
 BuildRequires: pkgconfig
 BuildRequires: gcc
+BuildRequires: pkgconfig(wayland-protocols)
 
 Requires: parted dosfstools e2fsprogs coreutils util-linux-core uuid dbus-x11 gtk3
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: piclone (#15456)](https://github.com/terrapkg/packages/pull/15456)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)