### PR TITLE
[f45] add: mercury-cli (#15468)

### DIFF
--- a/anda/tools/mercury-cli/anda.hcl
+++ b/anda/tools/mercury-cli/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "mercury-cli.spec"
+	}
+}

--- a/anda/tools/mercury-cli/mercury-cli.spec
+++ b/anda/tools/mercury-cli/mercury-cli.spec
@@ -1,0 +1,43 @@
+%global goipath github.com/MercuryTechnologies/mercury-cli
+Version:        0.11.0
+
+%gometa -f
+
+Name:           mercury-cli
+Release:        1%{?dist}
+Summary:        A multi-shell completion binary
+
+License:        Apache-2.0
+URL:            https://github.com/MercuryTechnologies/mercury-cli
+Source0:        %{url}/archive/refs/tags/v%version.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+Requires:       glibc
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%autosetup -C
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/cmd/mercury %{goipath}/cmd/mercury
+
+%install
+install -Dm 0755 %{gobuilddir}/cmd/mercury %{buildroot}%{_bindir}/mercury-cli
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/mercury-cli
+
+%changelog
+* Thu Aug 13 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/tools/mercury-cli/update.rhai
+++ b/anda/tools/mercury-cli/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("MercuryTechnologies/mercury-cli"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: mercury-cli (#15468)](https://github.com/terrapkg/packages/pull/15468)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)