### PR TITLE
[f43] fix: rust-sheldon (#15457)

### DIFF
--- a/anda/tools/sheldon/sheldon.spec
+++ b/anda/tools/sheldon/sheldon.spec
@@ -15,6 +15,7 @@ Source:         %{terra_crates_source}
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  anda-srpm-macros
 BuildRequires:  pkgconfig(openssl)
+BuildRequires:  zlib-ng-compat-devel
 
 %global _description %{expand:
 Fast, configurable, shell plugin manager.}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: rust-sheldon (#15457)](https://github.com/terrapkg/packages/pull/15457)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)