### PR TITLE
[f45] fix: pi-top-Python-SDK (#15455)

### DIFF
--- a/anda/tools/pi-top-Python-SDK/pi-top-Python-SDK.spec
+++ b/anda/tools/pi-top-Python-SDK/pi-top-Python-SDK.spec
@@ -223,7 +223,7 @@ pushd packages/system
 %pyproject_install
 popd
 
-rm -rf %{buildroot}/usr/lib/python3.14/site-packages/pitop/protoplus/
+rm -rf %{buildroot}%{python3_sitelib}/pitop/protoplus/
 
 %files -n python3-%{pypi_name}
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: pi-top-Python-SDK (#15455)](https://github.com/terrapkg/packages/pull/15455)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)