### PR TITLE
[el10] fix: asusctl (#15489)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -62,6 +62,9 @@ install -D -m 0644 rog-anime/data/diagonal-template.png %{buildroot}%{_docdir}/%
 %desktop_file_validate %{buildroot}%{_appsdir}/%{appid}.desktop
 mkdir -p %{buildroot}%{_sysconfdir}/asusd
 
+
+%find_lang rog-control-center
+
 %files
 %doc README.md CHANGELOG.md
 %license LICENSE
@@ -101,7 +104,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/asusd
 %postun
 %systemd_postun_with_restart %{asus_system_units}
 
-%files rog-gui
+%files rog-gui -f rog-control-center.lang
 %{_bindir}/rog-control-center
 %{_appsdir}/%{appid}.desktop
 %{_hicolordir}/512x512/apps/rog-control-center.png


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: asusctl (#15489)](https://github.com/terrapkg/packages/pull/15489)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)