### PR TITLE
[f43] chore (asusctl): build debuginfo packages (#15498)

### DIFF
--- a/anda/system/asusctl/asusctl.spec
+++ b/anda/system/asusctl/asusctl.spec
@@ -1,4 +1,3 @@
-%global debug_package %{nil}
 %global appid org.opengamingcollective.rog-control-center
 
 %global asus_system_units asusd.service asus-shutdown.service


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (asusctl): build debuginfo packages (#15498)](https://github.com/terrapkg/packages/pull/15498)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)