### PR TITLE
[f43] fix (piclone): use %find_lang and %conf (#15505)

### DIFF
--- a/anda/tools/piclone/piclone.spec
+++ b/anda/tools/piclone/piclone.spec
@@ -36,14 +36,18 @@ bootable card with an image of the source device.
 %prep
 %autosetup -n piclone-%commit
 
-%build
+%conf
 %meson
+
+%build
 %meson_build
 
 %install
 %meson_install
 
-%files
+%find_lang %{name}
+
+%files -f %{name}.lang
 %doc README
 %license debian/copyright
 %{_bindir}/piclone


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (piclone): use %find_lang and %conf (#15505)](https://github.com/terrapkg/packages/pull/15505)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)