### PR TITLE
[el10] chore(zig-master): Bump Fedora compat version (#15520)

### DIFF
--- a/anda/langs/zig/master/zig-master.spec
+++ b/anda/langs/zig/master/zig-master.spec
@@ -2,7 +2,7 @@
 %global         zig_arches x86_64 aarch64 riscv64 %{mips64}
 # Signing key from https://ziglang.org/download/
 %global         public_key RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
-%if 0%{?fedora} >= 46
+%if 0%{?fedora} >= 47
 %define         llvm_compat 22
 %endif
 %global         llvm_version 22.0.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(zig-master): Bump Fedora compat version (#15520)](https://github.com/terrapkg/packages/pull/15520)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)