### PR TITLE
[f43] feat: Update to the latest ryzen_smu, drop patches (#15527)

### DIFF
--- a/anda/system/ryzen-smu/akmod/ryzen_smu-kmod.spec
+++ b/anda/system/ryzen-smu/akmod/ryzen_smu-kmod.spec
@@ -7,20 +7,18 @@
 %global debug_package %{nil}
 %endif
 
-%global commit 1be4fb1cd9d60b5ddefc2a4201a898766a731400
-%global commitdate 20260626
+%global commit d2983668300dd2a598e5a7dc40e71ce0678cc270
+%global commitdate 20260815
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global modulename ryzen_smu
 
 Name:           %{modulename}-kmod
 Version:        0.1.7^%{commitdate}git.%{shortcommit}
-Release:        3%{?dist}
+Release:        1%{?dist}
 Summary:        Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen processors
 License:        GPL-2.0-only
 URL:            https://github.com/amkillam/ryzen_smu
 Source0:        %{url}/archive/%{commit}.tar.gz#/%{modulename}-%{shortcommit}.tar.gz
-# https://github.com/amkillam/ryzen_smu/pull/53
-Patch0:         https://patch-diff.githubusercontent.com/raw/amkillam/ryzen_smu/pull/53.patch
 BuildRequires:  gcc
 BuildRequires:  make
 BuildRequires:  kmodtool
@@ -48,7 +46,6 @@ Use at your own risk.
 kmodtool --target %{_target_cpu} --repo terrapkg.com --kmodname %{modulename} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
 
 %setup -q -c -n %{modulename}-%{commit}
-%patch -P 0 -p1 -d %{modulename}-%{commit}
 
 for kernel_version  in %{?kernel_versions} ; do
   cp -a %{modulename}-%{commit} _kmod_build_${kernel_version%%___*}

--- a/anda/system/ryzen-smu/dkms/dkms-ryzen_smu.spec
+++ b/anda/system/ryzen-smu/dkms/dkms-ryzen_smu.spec
@@ -1,18 +1,16 @@
-%global commit 1be4fb1cd9d60b5ddefc2a4201a898766a731400
+%global commit d2983668300dd2a598e5a7dc40e71ce0678cc270
 %global debug_package %{nil}
 %global modulename ryzen_smu
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260626
+%global commitdate 20260815
 
 Name:           dkms-%{modulename}
 Version:        0.1.7^%{commitdate}git.%{shortcommit}
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen processors
 License:        GPL-2.0-only
 URL:            https://github.com/amkillam/ryzen_smu
 Source:         %{url}/archive/%{commit}.tar.gz
-# https://github.com/amkillam/ryzen_smu/pull/53
-Patch0:         https://patch-diff.githubusercontent.com/raw/amkillam/ryzen_smu/pull/53.patch
 BuildRequires:  sed
 BuildRequires:  systemd-rpm-macros
 Requires:       %{modulename} = %{?epoch:%{epoch}:}%{version}

--- a/anda/system/ryzen-smu/kmod-common/ryzen_smu.spec
+++ b/anda/system/ryzen-smu/kmod-common/ryzen_smu.spec
@@ -1,10 +1,10 @@
-%global commit 1be4fb1cd9d60b5ddefc2a4201a898766a731400
+%global commit d2983668300dd2a598e5a7dc40e71ce0678cc270
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commitdate 20260626
+%global commitdate 20260815
 
 Name:           ryzen_smu
 Version:        0.1.7^%{commitdate}git.%{shortcommit}
-Release:        3%{?dist}
+Release:        1%{?dist}
 Summary:        Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen processors
 License:        GPL-2.0-only
 URL:            https://github.com/amkillam/ryzen_smu


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update to the latest ryzen_smu, drop patches (#15527)](https://github.com/terrapkg/packages/pull/15527)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)