### PR TITLE
[el10] add: cosmic-ext-applet-clipboard-manager (#15499)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-applet-clipboard-manager/anda.hcl
+++ b/anda/desktops/cosmic/cosmic-ext-applet-clipboard-manager/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+	rpm {
+		spec = "cosmic-ext-applet-clipboard-manager.spec"
+	}
+}

--- a/anda/desktops/cosmic/cosmic-ext-applet-clipboard-manager/cosmic-ext-applet-clipboard-manager.spec
+++ b/anda/desktops/cosmic/cosmic-ext-applet-clipboard-manager/cosmic-ext-applet-clipboard-manager.spec
@@ -1,0 +1,48 @@
+%global appid io.github.cosmic_utils.cosmic-ext-applet-clipboard-manager
+
+Name:           cosmic-ext-applet-clipboard-manager
+Version:        0.1.0
+Release:        1%{?dist}
+SourceLicense:  GPL-3.0-only
+License:        GPL-3.0-only AND (Apache-2.0 OR MIT) AND (Apache-2.0 OR BSL-1.0) AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND BSD-2-Clause AND Zlib AND MIT AND GPL-3.0 AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND (MIT OR Apache-2.0 OR CC0-1.0) AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND BSL-1.0 AND ISC AND BSD-3-Clause AND (Unlicense OR MIT)
+Summary:        Clipboard manager for COSMIC
+URL:            https://github.com/cosmic-utils/clipboard-manager
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+Source1:        io.github.cosmic_utils.cosmic-ext-applet-clipboard-manager.metainfo.xml
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  rust-xkbcommon-devel
+BuildRequires:  terra-appstream-helper
+Requires:       cosmic-osd
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -C
+%cargo_prep_online
+
+%build
+%cargo_build
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+install -Dm0755 target/rpm/cosmic-ext-applet-clipboard-manager  %{buildroot}%{_bindir}/cosmic-ext-applet-clipboard-manager
+install -Dm0644 res/desktop_entry.desktop                       %{buildroot}%{_appsdir}/%{appid}.desktop
+# Match the metainfo pulled from upstream
+install -Dm0644 res/app_icon.svg                                %{buildroot}%{_scalableiconsdir}/%{appid}-symbolic.svg
+
+%terra_appstream %{S:1}
+
+%files
+%doc README.md
+%license LICENSE LICENSE.dependencies
+%{_bindir}/cosmic-ext-applet-clipboard-manager
+%{_appsdir}/%{appid}.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_scalableiconsdir}/%{appid}-symbolic.svg
+
+%changelog
+* Fri Aug 14 2026 Owen Zimmerman <owen@fyralabs.com> - 0.1.0-1
+- Initial commit

--- a/anda/desktops/cosmic/cosmic-ext-applet-clipboard-manager/io.github.cosmic_utils.cosmic-ext-applet-clipboard-manager.metainfo.xml
+++ b/anda/desktops/cosmic/cosmic-ext-applet-clipboard-manager/io.github.cosmic_utils.cosmic-ext-applet-clipboard-manager.metainfo.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines -->
+
+<component type="desktop-application">
+    <id>io.github.cosmic_utils.cosmic-ext-applet-clipboard-manager</id>
+
+    <name>Clipboard Manager</name>
+    <name xml:lang="cs">Manažer schránky</name>
+    <name xml:lang="de">Zwischenablage Verwaltung</name>
+    <name xml:lang="hu">Vágólapkezelő</name>
+    <name xml:lang="ru">Менеджер буфера обмена</name>
+    <name xml:lang="uk">Буфер обміну</name>
+    <name xml:lang="fr">Presse-papier</name>
+    <summary>A wayland clipboard manager</summary>
+    <summary xml:lang="cs">Manažer schránky pro Wayland</summary>
+    <summary xml:lang="de">Eine Zwischenablage Verwaltung für Wayland</summary>
+    <summary xml:lang="hu">Wayland vágólapkezelő</summary>
+    <summary xml:lang="ru">Менеджер буфера обмена для Wayland</summary>
+    <summary xml:lang="uk">Віджет буфера обміну для Wayland</summary>
+    <summary xml:lang="fr">Gestionnaire de presse-papier pour wayland</summary>
+
+    <metadata_license>MIT</metadata_license>
+    <project_license>GPL-3.0-only</project_license>
+
+    <project_group>COSMIC</project_group>
+
+    <developer id="tld.vendor">
+        <name>wiiznokes</name>
+    </developer>
+
+
+    <icon type="stock">io.github.cosmic_utils.cosmic-ext-applet-clipboard-manager-symbolic</icon>
+
+    <url type="homepage">
+        https://github.com/cosmic-utils/clipboard-manager</url>
+    <url type="bugtracker">
+        https://github.com/cosmic-utils/clipboard-manager/issues</url>
+    <url type="contribute">
+        https://github.com/cosmic-utils/clipboard-manager</url>
+    <url type="translate">
+        https://github.com/cosmic-utils/clipboard-manager/tree/master/i18n</url>
+
+    <content_rating type="oars-1.1" />
+
+
+    <description>
+        <p>Clipboard Manager cosmic applet with support for images and other mime types. Only work
+            on Wayland using the data control protocol.</p>
+        <p xml:lang="cs">COSMIC applet manažera schránky s podporou pro obrázky a další mime typy.
+            Funguje na Waylandu za pomoci data control protokolu.</p>
+        <p xml:lang="de">COSMIC applet mit support für bilder und andere mime typen.
+            Funktioniert nur in Wayland mit dem Datenkontrollprotokoll (data control protocol).</p>    <!--the contents in the parenthesis are for better understanding while troubleshooting-->
+        <p xml:lang="hu">Vágólapkezelő COSMIC kisalkalmazás, amely támogatja a képeket és más MIME-típusokat. 
+           Csak Waylanden működik az adatvezérlő protokoll használatával.</p>
+        <p xml:lang="ru">Апплет буфера обмена COSMIC с поддержкой изображений и других типов MIME. 
+           Работает только в Wayland с использованием протокола управления данными.</p>
+        <p xml:lang="uk">Віджет буфера обміну COSMIC із підтримкою зображень та інших типів MIME. 
+           працює лише в середовищі Wayland і використовує протокол керування даними.</p>
+       <p xml:lang="fr">Un applet de gestion du presse-papier pour le bureau COSMIC avec support des images et autres types de médias. 
+       Uniquement compatible avec Wayland via le protocole de contrôle des données. (data control protocol)</p> <!--I decided to follow the lead of the DE translator : including limited English in parenthesis for ease of troubleshooting -->
+    </description>
+
+
+    <launchable type="desktop-id">
+        io.github.cosmic_utils.cosmic-ext-applet-clipboard-manager.desktop</launchable>
+    <screenshots>
+        <screenshot type="default">
+            <image>
+                https://media.githubusercontent.com/media/cosmic-utils/clipboard-manager/master/res/screenshots/main_popup.png</image>
+            <caption>The applet.</caption>
+            <caption xml:lang="cs">Ukázka appletu.</caption>
+            <caption xml:lang="de">Das Applet.</caption>
+            <caption xml:lang="hu">A kisalkalmazás.</caption>
+            <caption xml:lang="ru">Апплет.</caption>
+            <caption xml:lang="uk">Віджет.</caption>
+            <caption xml:lang="fr">L'applet.</caption>
+        </screenshot>
+    </screenshots>
+
+    <provides>
+        <id>com.system76.CosmicApplet</id>
+        <binaries>
+            <binary>cosmic-ext-applet-clipboard-manager</binary>
+        </binaries>
+    </provides>
+
+    <categories>
+        <category>Utility</category>
+    </categories>
+
+    <releases>
+        <release version="0.1.0" date="2025-07-20">
+        </release>
+    </releases>
+</component>

--- a/anda/desktops/cosmic/cosmic-ext-applet-clipboard-manager/update.rhai
+++ b/anda/desktops/cosmic/cosmic-ext-applet-clipboard-manager/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh_tag("cosmic-utils/clipboard-manager"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: cosmic-ext-applet-clipboard-manager (#15499)](https://github.com/terrapkg/packages/pull/15499)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)