### PR TITLE
[f45] chore: Bump gamescope release (#15570)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -7,7 +7,7 @@
 
 Name:           terra-gamescope
 Version:        137.%{short_commit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Micro-compositor for video games on Wayland
 
 License:        BSD


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore: Bump gamescope release (#15570)](https://github.com/terrapkg/packages/pull/15570)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)