### PR TITLE
[el10] fix: cardwire (#15506)

### DIFF
--- a/anda/system/cardwire/cardwire.spec
+++ b/anda/system/cardwire/cardwire.spec
@@ -1,6 +1,6 @@
 %global appid org.opengamingcollective.cardwire
 %bcond rust_nightly 1
-%global cardwire_toolchain nightly-2026-08-04
+%global cardwire_toolchain nightly-2026-08-12
 %define _cargo_home %{rpmbuilddir}%{?buildsubdir:/%{buildsubdir}}/.cargo
 %global _rustup_home %{rpmbuilddir}/.rustup
 %define __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTUP_HOME=%{_rustup_home} RUSTFLAGS='%{terra_rustflags}' %{_cargo_home}/cardwire-cargo
@@ -78,7 +78,7 @@ if test "\$1" = run && test "\$2" = %{cardwire_toolchain}; then
     shift 3
     exec %{_cargo_home}/cardwire-\$command "\$@"
 fi
-exec /usr/bin/rustup "\$@"
+exec %{_cargo_home}/bin/rustup "\$@"
 EOF
 chmod 0755 %{_cargo_home}/cardwire-cargo %{_cargo_home}/cardwire-rustc %{_cargo_home}/cardwire-rustdoc %{_cargo_home}/rustup
 # This pinned rust-src component may omit the lockfile required by -Z build-std.

--- a/anda/system/cardwire/update.rhai
+++ b/anda/system/cardwire/update.rhai
@@ -1,1 +1,5 @@
-rpm.version(gh("OpenGamingCollective/cardwire"));
+let v = gh("OpenGamingCollective/cardwire");
+rpm.version(v);
+if rpm.changed() {
+  rpm.global("cardwire_toolchain", `const\s+EBPF_NIGHTLY[^"]+"([^"]+)"`.find(gh_rawfile("OpenGamingCollective/cardwire", v, 1)));
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: cardwire (#15506)](https://github.com/terrapkg/packages/pull/15506)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)