### PR TITLE
[f43] fix: ttop (#15593)

### DIFF
--- a/anda/apps/ttop/ttop.spec
+++ b/anda/apps/ttop/ttop.spec
@@ -7,6 +7,7 @@ URL:            https://github.com/inv2004/ttop
 Source0:		%url/archive/refs/tags/v%version.tar.gz
 BuildRequires:  anda-srpm-macros
 BuildRequires:  nim
+BuildRequires:  openssl-devel
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: ttop (#15593)](https://github.com/terrapkg/packages/pull/15593)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)