### PR TITLE
[f45] fix: Anki version typo (#15442)

### DIFF
--- a/anda/apps/anki-bin/anki-bin.spec
+++ b/anda/apps/anki-bin/anki-bin.spec
@@ -1,22 +1,23 @@
 %global xurl https://files.pythonhosted.org/packages/2d/cc/3d1fd48589b288347c7d8cc39018a61ec7ca704059c1185925657bd6e4f9/anki-26.8.1-cp310-abi3-manylinux_2_35_x86_64.whl
 %global aurl https://files.pythonhosted.org/packages/0a/bd/82f15738d7d356b69f708816ecb9699bf2dd4a9ead26d17ab4f1010f5607/anki-26.8.1-cp310-abi3-manylinux_2_35_aarch64.whl
 %global qurl https://files.pythonhosted.org/packages/a7/5f/7d08084d5c97b1bad03b9bd64d24246b0918e94faf22ddd5e76fa2e52f7f/aqt-26.8.1-py3-none-any.whl
+%global appid net.ankiweb.Anki
 
 Name:			anki-bin
-Version:		26.8.1
+Version:		26.08.1
 Release:		1%{?dist}
 Summary:		Flashcard program for using space repetition learning (Installed with wheel)
 License:		AGPL-3.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND BSD-3-Clause AND CC-BY-SA-3.0 AND CC-BY-3.0 AND Apache-2.0 AND CC-BY-2.5
 URL:			https://apps.ankiweb.net/
-BuildRequires:          python3-pip rpm_macro(fdupes) cargo
-Requires:               python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
-Requires:               python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
-Requires:               python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
-Requires:               python3-protobuf >= 4.21
-Requires:               libxcrypt-compat hicolor-icon-theme sox
-Requires:               (mpv or mpv-nightly)
+Packager:		madonuko <mado@fyralabs.com>
+BuildRequires:	python3-devel
+BuildRequires:	python3-pip rpm_macro(fdupes) cargo
+BuildRequires:	python3-sqlalchemy python3-simplejson python3-matplotlib python3-decorator python3-markdown python3-orjson
+BuildRequires:	python3-requests python3-pygame python3-beautifulsoup4 python3-httplib2 python3-pyaudio python3-jsonschema
+BuildRequires:	python3-flask-cors python3-protobuf python3-requests python3-waitress python3-pyqt6-webengine python3-send2trash
+Requires:		libxcrypt-compat hicolor-icon-theme sox
+Requires:		(mpv or mpv-nightly)
 
-ExclusiveArch:	        x86_64
 Conflicts:		anki
 %ifarch x86_64
 Source0:		%xurl
@@ -25,8 +26,8 @@ Source0:                %aurl
 %endif
 Source1:		%qurl
 Source2:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/runanki.py
-Source3:		https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.desktop
-Source4:                https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/bundle/lin/anki.png
+Source3:    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/installer/linux-template/%7B%7B%20cookiecutter.format%20%7D%7D/%7B%7B%20cookiecutter.app_name%20%7D%7D/anki.desktop
+Source4:    https://raw.githubusercontent.com/ankitects/anki/%{version}/qt/aqt/data/qt/icons/anki.png
 Source5:		https://raw.githubusercontent.com/ankitects/anki/%{version}/LICENSE
 Source6:		https://raw.githubusercontent.com/ankitects/anki/%{version}/README.md
 
@@ -40,37 +41,33 @@ Anki is based on a theory called spaced repetition.
 %build
 
 %install
-pip3 install --root=%{buildroot} %SOURCE0 %SOURCE1
+mkdir -p %_pyproject_wheeldir
+cp %{S:0} %{S:1} %_pyproject_wheeldir
+%pyproject_install
+%pyproject_save_files -D aqt '*aqt*'
+%pyproject_save_files -D anki '*anki*'
 install -Dm755 %{SOURCE2} "%{buildroot}/usr/bin/anki"
 install -Dm644 %{SOURCE3} "%{buildroot}/usr/share/applications/anki.desktop"
 install -Dm644 %{SOURCE4} "%{buildroot}/usr/share/pixmaps/anki.png"
 install -Dm644 %{SOURCE5} "%{buildroot}/%{_datadir}/licenses/%{name}/LICENSE"
 install -Dm644 %{SOURCE6} "%{buildroot}/%{_datadir}/doc/%{name}/README.md"
 
-cp -r %buildroot%_libdir/python3*/site-packages/{_aqt,anki*,aqt*} .
-rm -rf %buildroot{%_libdir,/usr/lib}/python3*/site-packages/*
-cp -r ./{_aqt,anki*,aqt*} %buildroot/usr/lib/python3*/site-packages/
-
-rm -rf %buildroot%_bindir/{distro,flask,jsonschema,markdown_py,normalizer,send2trash,waitress-serve}
-
-%fdupes %buildroot%_libdir/python*/site-packages/_aqt/data/
+%terra_appstream
 
 
-%files
+%files -f %{pyproject_files}-anki -f %{pyproject_files}-aqt
 %license LICENSE
 %doc README.md
 %_bindir/anki
-%_bindir/pyuic6
-%_bindir/pylupdate6
-/usr/lib/python*/site-packages/_aqt/
-/usr/lib/python*/site-packages/anki-%{version}.dist-info/
-/usr/lib/python*/site-packages/anki/
-/usr/lib/python*/site-packages/aqt-%{version}.dist-info/
-/usr/lib/python*/site-packages/aqt/
+%_bindir/ankiw
 %_datadir/applications/anki.desktop
 %_datadir/pixmaps/anki.png
+%_metainfodir/%appid.metainfo.xml
 
 %changelog
+* Thu Aug 13 2026 madonuko <madonuko@outlook.com> - 26.08.1-1
+- update sources and versioning
+
 * Fri Nov 10 2023 hazel-bunny <dabiswas112@gmail.com> - 23.10-2
 - Add python3-orjson and mpv as dependencies
 

--- a/anda/apps/anki-bin/update.rhai
+++ b/anda/apps/anki-bin/update.rhai
@@ -2,10 +2,10 @@ let aarch64_regex = `<a href="https://files\.pythonhosted\.org/packages/(..)/(..
 let html = get("https://pypi.org/project/anki/");
 let relevant = find(aarch64_regex, html, 0);
 let ver = find(aarch64_regex, relevant, 4);
-rpm.version(ver);
+rpm.global("aurl", find(`"(.+)"`, relevant, 1));
 if rpm.changed() {
+    rpm.version(gh("ankitects/anki"));
     rpm.release();
-    rpm.global("aurl", find(`"(.+)"`, relevant, 1));
     let cp = find(aarch64_regex, relevant, 5);
     let x86_64_regex = `<a href="https://files\.pythonhosted\.org/packages/(..)/(..)/(.{60})/anki-${ver}-cp${cp}-abi3-manylinux_.+?_x86_64.whl">`;
     let relevant1 = find(x86_64_regex, html, 0);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: Anki version typo (#15442)](https://github.com/terrapkg/packages/pull/15442)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)