### PR TITLE
[f43] fix (anki-bin): drop anda.hcl x86 only build (#15603)

### DIFF
--- a/anda/apps/anki-bin/anda.hcl
+++ b/anda/apps/anki-bin/anda.hcl
@@ -1,5 +1,4 @@
 project pkg {
-	arches = ["x86_64"]
 	rpm {
 		spec = "anki-bin.spec"
 	}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (anki-bin): drop anda.hcl x86 only build (#15603)](https://github.com/terrapkg/packages/pull/15603)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)