### PR TITLE
[f43] Add cosmic-ext-applet-sysinfo (#15598)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/anda.hcl
+++ b/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "cosmic-ext-applet-sysinfo.spec"
+  }
+}

--- a/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/cosmic-ext-applet-sysinfo.spec
+++ b/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/cosmic-ext-applet-sysinfo.spec
@@ -1,0 +1,50 @@
+%global ver 0.4.0
+%global commitdate 20260814
+%global commit f66e0c7b133bf4249d23ab7483693cedca46ad19
+%global shortcommit %{sub %{commit} 0 7}
+%global appid io.github.cosmic_utils.sysinfo-applet
+
+Name:           cosmic-ext-applet-sysinfo
+Version:        %{ver}^%{commitdate}.git%{shortcommit}
+Release:        1%{?dist}
+Summary:        Simple system info applet for cosmic
+
+SourceLicense:  GPL-3.0-or-later
+License:        %{sourcelicense} AND (ISC AND (Apache-2.0 OR ISC)) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND (Apache-2.0 OR ISC OR MIT) AND Apache-2.0 AND MIT AND (Zlib OR Apache-2.0 OR M) AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND CDLA-Permissive-2.0 AND BSD-2-Clause AND Zlib AND (ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)) AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND GPL-3.0 AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND (BSD-3-Clause OR Apache-2.0) AND BSL-1.0 AND ISC AND (MIT OR LGPL-3.0-or-later) AND GPL-3.0-only AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
+URL:            https://github.com/cosmic-utils/cosmic-ext-applet-sysinfo
+Source0:        %{url}/archive/%{commit}.tar.gz
+
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(xkbcommon)
+Requires:       cosmic-osm
+
+Packager:       Olivia <git@olivia.sh>
+
+%description
+Simple system info applet for cosmic.
+
+%prep
+%autosetup -n %{name}-%{commit}
+%cargo_prep_online
+%cargo_license_summary_online
+
+%build
+%cargo_build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+%__install -Dm 755 target/rpm/%{name} %{buildroot}%{_bindir}/%{name}
+%__install -Dm 644 data/%{appid}-symbolic.svg %{buildroot}%{_scalableiconsdir}/%{appid}-symbolic.svg
+%__install -Dm 644 data/%{appid}.desktop %{buildroot}%{_appsdir}/%{appid}.desktop
+
+%files
+%license LICENSE LICENSE.dependencies
+%doc README.md
+%{_bindir}/%{name}
+%{_scalableiconsdir}/%{appid}-symbolic.svg
+%{_appsdir}/%{appid}.desktop
+
+%changelog
+* Mon Aug 17 2026 Olivia <git@olivia.sh>
+- Initial package

--- a/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/update.rhai
+++ b/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/update.rhai
@@ -1,0 +1,11 @@
+let repo = "cosmic-utils/cosmic-ext-applet-sysinfo";
+let commit = gh_commit(repo);
+rpm.global("commit", commit);
+
+if rpm.changed() {
+    let cargo_toml = gh_rawfile(repo, commit, "Cargo.toml");
+
+    rpm.release();
+    rpm.global("commit_date", date());
+    rpm.global("ver", find(`version = "([\d.]+)"`, cargo_toml, 1));
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [Add cosmic-ext-applet-sysinfo (#15598)](https://github.com/terrapkg/packages/pull/15598)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)