### PR TITLE
[f43] fix(terra-gpg-keys): Remove `%dir` (#15622)

### DIFF
--- a/anda/terra/gpg-keys/terra-gpg-keys.spec
+++ b/anda/terra/gpg-keys/terra-gpg-keys.spec
@@ -2,7 +2,7 @@
 
 Name:           terra-gpg-keys
 Version:        %{?fedora:%{fedora}}%{?rhel:%{rhel}}
-Release:        7%{?dist}
+Release:        8%{?dist}
 Summary:        GPG keys for Terra
 Requires:       filesystem >= 3.18-6
 
@@ -78,7 +78,6 @@ install -d -m 755 $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg
 install -m 644 %{_sourcedir}/RPM-GPG-KEY* $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/
 
 %files
-%dir %{_sysconfdir}/pki/rpm-gpg
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-*
 
 %changelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(terra-gpg-keys): Remove `%dir` (#15622)](https://github.com/terrapkg/packages/pull/15622)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)