### PR TITLE
[el10] chore(.backportrc.json): Add f45 (#15624)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
   "repoOwner": "terrapkg",
   "repoName": "packages",
   "resetAuthor": true,
-  "targetBranchChoices": ["frawhide", "f44", "f43", "el10"],
+  "targetBranchChoices": ["frawhide", "f45", "f44", "f43", "el10"],
   "branchLabelMapping": {
     "^sync-(.+)$": "$1"
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore(.backportrc.json): Add f45 (#15624)](https://github.com/terrapkg/packages/pull/15624)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)