### PR TITLE
[f45] fix(ghostty-tip): Missing semicolon in update script (#15636)

### DIFF
--- a/anda/devs/ghostty/tip/update.rhai
+++ b/anda/devs/ghostty/tip/update.rhai
@@ -2,7 +2,7 @@ let r = get("https://api.github.com/repos/ghostty-org/ghostty/releases/83450291"
 rpm.global("commit", r.target_commitish);
 if rpm.changed() {
     let d = sh(`date -d "${r.created_at}" "+%Y%m%d%H%M"`, #{"stdout": "piped"}).ctx.stdout;
-    d.pop()
+    d.pop();
     rpm.version(d);
     let z = get(`https://raw.githubusercontent.com/ghostty-org/ghostty/refs/heads/main/build.zig.zon`);
     let v = find("\\.version = \"([\\d.]+)-dev\"", z, 1);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix(ghostty-tip): Missing semicolon in update script (#15636)](https://github.com/terrapkg/packages/pull/15636)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)