### PR TITLE
[f45] fix(lily): Use `gh_tag()` (#15642)

### DIFF
--- a/anda/langs/lily/update.rhai
+++ b/anda/langs/lily/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("fascinatedbox/lily"));
+rpm.version(gh_tag("fascinatedbox/lily"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix(lily): Use `gh_tag()` (#15642)](https://github.com/terrapkg/packages/pull/15642)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)