### PR TITLE
[f44] fix(librepods): Update version sorting (#15649)

### DIFF
--- a/anda/apps/librepods/update.rhai
+++ b/anda/apps/librepods/update.rhai
@@ -1,4 +1,7 @@
-let tags = json_arr(get("https://api.github.com/repos/kavishdevar/librepods/tags"));
-let tag = tags.find(|t| t.name.starts_with("linux-v"));
-tag.name.crop(7);
-rpm.version(tag.name);
+let tag = gh("kavishdevar/librepods");
+if `[\d.]+-alpha.*`.find_all(tag).len == 0 && `[\d.]+-rc\.\d+`.find_all(tag).len == 0 && `nightly-.*`.find_all(tag).len == 0 {
+  if tag.ends_with("-hotfix") {
+    tag.crop(7);
+  }
+  rpm.version(tag);
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(librepods): Update version sorting (#15649)](https://github.com/terrapkg/packages/pull/15649)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)