### PR TITLE
[el10] fix(ghostty): Improper `%dir` use (#15659)

### DIFF
--- a/anda/devs/ghostty/stable/ghostty.spec
+++ b/anda/devs/ghostty/stable/ghostty.spec
@@ -4,7 +4,7 @@
 
 Name:           ghostty
 Version:        1.3.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A fast, native terminal emulator written in Zig.
 License:        MIT AND MPL-2.0 AND OFL-1.1 AND (WTFPL OR CC0-1.0) AND Apache-2.0
 URL:            https://ghostty.org/
@@ -198,7 +198,7 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{name}
 %license LICENSE
 %{_bindir}/%{name}
 %{_datadir}/applications/%{appid}.desktop
-%dir %{_datadir}/%{name}
+%{_datadir}/%{name}
 %{_datadir}/%{name}/doc
 %{_datadir}/metainfo/%{appid}.metainfo.xml
 %{_datadir}/dbus-1/services/%{appid}.service
@@ -250,7 +250,7 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{name}
 %{_datadir}/bat/syntaxes/%{name}.sublime-syntax
 
 %files shell-integration
-%dir %{_datadir}/%{name}/shell-integration
+%{_datadir}/%{name}/shell-integration
 %{_datadir}/%{name}/shell-integration/bash/bash-preexec.sh
 %{_datadir}/%{name}/shell-integration/bash/%{name}.bash
 %{_datadir}/%{name}/shell-integration/elvish/lib/%{name}-integration.elv


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(ghostty): Improper `%dir` use (#15659)](https://github.com/terrapkg/packages/pull/15659)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)