### PR TITLE
[f45] fix(ghostty-tip): Improper `%dir` use (#15663)

### DIFF
--- a/anda/devs/ghostty/tip/ghostty-tip.spec
+++ b/anda/devs/ghostty/tip/ghostty-tip.spec
@@ -244,7 +244,7 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 %license LICENSE
 %{_bindir}/%{base_name}
 %{_datadir}/applications/%{appid}.desktop
-%dir %{_datadir}/%{base_name}
+%{_datadir}/%{base_name}
 %{_datadir}/%{base_name}/doc
 %{_datadir}/metainfo/%{appid}.metainfo.xml
 %{_datadir}/dbus-1/services/%{appid}.service
@@ -296,7 +296,7 @@ rm -rf %{buildroot}%{_datadir}/terminfo/g/%{base_name}
 %{_datadir}/bat/syntaxes/%{base_name}.sublime-syntax
 
 %files shell-integration
-%dir %{_datadir}/%{base_name}/shell-integration
+%{_datadir}/%{base_name}/shell-integration
 %{_datadir}/%{base_name}/shell-integration/bash/bash-preexec.sh
 %{_datadir}/%{base_name}/shell-integration/bash/%{base_name}.bash
 %{_datadir}/%{base_name}/shell-integration/elvish/lib/%{base_name}-integration.elv


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix(ghostty-tip): Improper `%dir` use (#15663)](https://github.com/terrapkg/packages/pull/15663)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)