### PR TITLE
[f44] fix(librepods): Update script again (#15681)

### DIFF
--- a/anda/apps/librepods/update.rhai
+++ b/anda/apps/librepods/update.rhai
@@ -1,7 +1,8 @@
 let tag = gh("kavishdevar/librepods");
-if `[\d.]+-alpha.*`.find_all(tag).len == 0 && `[\d.]+-rc\.\d+`.find_all(tag).len == 0 && `nightly-.*`.find_all(tag).len == 0 {
-  if tag.ends_with("-hotfix") {
-    tag.crop(7);
-  }
-  rpm.version(tag);
+if `[\d.]+-alpha.*`.find_all(tag).len == 0 && `[\d.]+-rc.*`.find_all(tag).len == 0 && `nightly-.*`.find_all(tag).len == 0 {
+  rpm.global("ver", tag);
+}
+
+if rpm.changed() {
+  rpm.release();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(librepods): Update script again (#15681)](https://github.com/terrapkg/packages/pull/15681)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)