### PR TITLE
[f45] fix(librepods): Version (#15687)

### DIFF
--- a/anda/apps/librepods/librepods.spec
+++ b/anda/apps/librepods/librepods.spec
@@ -1,12 +1,13 @@
+%global ver v0.2.5
 %global appid com.github.librepods
 
 Name:           librepods
 Summary:        AirPods liberated from Apple's ecosystem
-Version:        1.0.0.rc1
+Version:        %(echo "%{ver}" | sed 's/v//g;s/-hotfix//g')
 Release:        1%{?dist}
 License:        GPL-3.0-only
 URL:            https://github.com/kavishdevar/librepods
-Source0:        %url/archive/refs/tags/linux-v%version.tar.gz
+Source0:        %url/archive/refs/tags/%{ver}.tar.gz
 Source1:        com.github.librepods.metainfo.xml
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
@@ -15,6 +16,7 @@ BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  g++
 BuildRequires:  qt6-qtbase-devel
+BuildRequires:  qt6-qttools-devel
 BuildRequires:  qt6-qtconnectivity-devel
 BuildRequires:  qt6-qtmultimedia-devel
 BuildRequires:  qt6-qtdeclarative-devel
@@ -35,7 +37,7 @@ hearing aid, customized transparency mode, battery status, and more - all the
 premium features you paid for but Apple locked to their ecosystem.
 
 %prep
-%autosetup -n %{name}-linux-v%{version}
+%autosetup -C
 
 %conf
 pushd linux


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix(librepods): Version (#15687)](https://github.com/terrapkg/packages/pull/15687)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)