### PR TITLE
[el10] fix (glass): glyph ver update script (#15709)

### DIFF
--- a/anda/desktops/chasm/glass/update.rhai
+++ b/anda/desktops/chasm/glass/update.rhai
@@ -1,2 +1,2 @@
 rpm.version(gh("isene/glass"));
-rpm.global(gh("isene/glyph"));
+rpm.global("glyph_ver", gh("isene/glyph"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (glass): glyph ver update script (#15709)](https://github.com/terrapkg/packages/pull/15709)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)