### PR TITLE
[f43] fix (librepods): icon and files (#15692)

### DIFF
--- a/anda/apps/librepods/com.github.librepods.metainfo.xml
+++ b/anda/apps/librepods/com.github.librepods.metainfo.xml
@@ -3,9 +3,7 @@
   <id>com.github.librepods</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
-  <icon
-        type="remote"
-    >https://github.com/kavishdevar/librepods/blob/main/linux/assets/librepods.png</icon>
+  <icon type="stock">librepods</icon>
 
   <name>librepods</name>
   <summary>AirPods liberated from Apple's ecosystem</summary>

--- a/anda/apps/librepods/librepods.spec
+++ b/anda/apps/librepods/librepods.spec
@@ -50,7 +50,6 @@ pushd linux
 popd
 
 %install
-install -Dm644 linux-rust/assets/icon.png %{buildroot}%{_iconsdir}/hicolor/512x512/apps/librepods.png
 pushd linux
 %cmake_install
 popd
@@ -60,9 +59,11 @@ popd
 %doc README.md linux/README.md CHANGELOG.md
 %license LICENSE
 %{_bindir}/librepods
+%{_bindir}/librepods-ctl
 %{_appsdir}/me.kavishdevar.librepods.desktop
 %{_metainfodir}/com.github.librepods.metainfo.xml
-%{_hicolordir}/512x512/apps/librepods.png
+%{_scalableiconsdir}/librepods.svg
+%{_datadir}/librepods/translations/librepods_tr.qm
 
 %changelog
 * Wed Nov 19 2025 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (librepods): icon and files (#15692)](https://github.com/terrapkg/packages/pull/15692)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)