### PR TITLE
[f45] fix (cosmic-ext-applet-sysinfo): requires (#15726)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/cosmic-ext-applet-sysinfo.spec
+++ b/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/cosmic-ext-applet-sysinfo.spec
@@ -6,7 +6,7 @@
 
 Name:           cosmic-ext-applet-sysinfo
 Version:        %{ver}^%{commitdate}.git%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Simple system info applet for cosmic
 
 SourceLicense:  GPL-3.0-or-later
@@ -17,7 +17,7 @@ Source0:        %{url}/archive/%{commit}.tar.gz
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(xkbcommon)
-Requires:       cosmic-osm
+Requires:       cosmic-osd
 
 Packager:       Olivia <git@olivia.sh>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix (cosmic-ext-applet-sysinfo): requires (#15726)](https://github.com/terrapkg/packages/pull/15726)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)