### PR TITLE
[f45] fix (rust-zoi-rs): license source and new summary/description (#15732)

### DIFF
--- a/anda/langs/rust/zoi/rust-zoi-rs.spec
+++ b/anda/langs/rust/zoi/rust-zoi-rs.spec
@@ -5,13 +5,13 @@
 
 Name:           rust-zoi-rs
 Version:        %(echo %crate_version | sed 's/-/~/g')
-Release:        1%?dist
-Summary:        Universal Package Manager & Environment Setup Tool
+Release:        2%?dist
+Summary:        Advanced Package Manager & Environment Orchestrator
 SourceLicense:  Apache-2.0
-License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 AND ISC) AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND BSL-1.0 AND CDLA-Permissive-2.0 AND ISC AND LGPL-2.0-or-later AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND MPL-2.0+ AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib
+License:        ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-3-Clause AND BSL-1.0 AND CDLA-Permissive-2.0 AND ISC AND (ISC AND (Apache-2.0 OR ISC)) AND (ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)) AND LGPL-2.0-or-later AND (LGPL-3.0-or-later OR MPL-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND MPL-2.0+ AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND bzip2-1.0.6
 URL:            https://crates.io/crates/zoi-rs
 Source0:        https://static.crates.io/crates/%{crate}/%{crate}-%{crate_version}.crate
-Source1:        https://gitlab.com/zillowe/zillwen/zusty/zoi/-/blob/main/LICENSE
+Source1:        https://gitlab.com/zillowe/zillwen/zusty/zoi/-/raw/Prod-Release-%crate_version/LICENSE
 BuildRequires:  cargo
 BuildRequires:  gcc-c++
 BuildRequires:  clang-devel
@@ -26,7 +26,9 @@ BuildRequires:  perl(Time::Piece)
 Packager:       madonuko <mado@fyralabs.com>
 
 %global _description %{expand:
-Universal Package Manager & Environment Setup Tool.}
+Zoi is an advanced package manager and environment orchestrator, designed to
+simplify package management and environment configuration across multiple
+operating systems.}
 
 %description %{_description}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix (rust-zoi-rs): license source and new summary/description (#15732)](https://github.com/terrapkg/packages/pull/15732)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)