### PR TITLE
[f43] fix: klassy (#15737)

### DIFF
--- a/anda/themes/klassy/klassy.spec
+++ b/anda/themes/klassy/klassy.spec
@@ -130,12 +130,17 @@ popd
 %{_datadir}/icons/hicolor/
 %{_datadir}/icons/%{name}/
 %{_datadir}/icons/%{name}-dark/
-%{_datadir}/plasma/desktoptheme/kite-*/
+%{_datadir}/config.kcfg/klassy.kcfg
+%{_datadir}/config.kcfg/klassy-decoration.kcfg
 
 %{_kf6_datadir}/kstyle/themes/%{name}.themerc
 
 %{_kf6_datadir}/plasma/layout-templates/org.kde.klassy.*
 %{_kf6_datadir}/plasma/look-and-feel/org.kde.klassy*
+
+%{_datadir}/config.kcfg/klassy.kcfg
+%{_datadir}/plasma/desktoptheme/klassy-dark/*
+%{_datadir}/plasma/desktoptheme/klassy-light/*
 
 %changelog
 %autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: klassy (#15737)](https://github.com/terrapkg/packages/pull/15737)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)