### PR TITLE
[f44] feat: Bump release of inputplumber to grab the latest patches (#15755)

### DIFF
--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -2,7 +2,7 @@
 
 Name:           inputplumber
 Version:        0.78.0
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Open source input router and remapper daemon for Linux
 License:        GPL-3.0-or-later
 URL:            https://github.com/ShadowBlip/InputPlumber


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Bump release of inputplumber to grab the latest patches (#15755)](https://github.com/terrapkg/packages/pull/15755)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)