### PR TITLE
[f43] fix (glass): glyph source (#15764)

### DIFF
--- a/anda/desktops/chasm/glass/glass.spec
+++ b/anda/desktops/chasm/glass/glass.spec
@@ -8,7 +8,7 @@ Summary:        Pure assembly terminal emulator
 License:        Unlicense
 URL:            https://github.com/isene/glass
 Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
-Source1:        https://github.com/isene/glyph/archive/refs/tags/v%{glyph_ver}.tar.gz
+Source1:        https://github.com/isene/glyph/archive/refs/tags/%{glyph_ver}.tar.gz
 BuildRequires:  nasm gcc
 BuildRequires:  make
 Requires:       xorg-x11-server-Xorg


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (glass): glyph source (#15764)](https://github.com/terrapkg/packages/pull/15764)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)