### PR TITLE
[f43] fix(komikku): bdep pkgconfig(gtksourceview-5) (#15786)

### DIFF
--- a/anda/apps/komikku/komikku.spec
+++ b/anda/apps/komikku/komikku.spec
@@ -27,6 +27,7 @@ BuildRequires:  cmake
 BuildRequires:  pkgconfig(gobject-introspection-1.0) >= 1.35.9
 BuildRequires:  pkgconfig(gtk4) >= %{gtk4_version}
 BuildRequires:  pkgconfig(libadwaita-1) >= %{libadwaita_version}
+BuildRequires:  pkgconfig(gtksourceview-5)
 
 Requires:       hicolor-icon-theme
 Requires:       gtk4 >= %{gtk4_version}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(komikku): bdep pkgconfig(gtksourceview-5) (#15786)](https://github.com/terrapkg/packages/pull/15786)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)