### PR TITLE
[f44] fix(python-mpv-jsonipc): source url changed (#15774)

### DIFF
--- a/anda/langs/python/python-mpv-jsonipc/python-mpv-jsonipc.spec
+++ b/anda/langs/python/python-mpv-jsonipc/python-mpv-jsonipc.spec
@@ -7,7 +7,7 @@ Release:		1%{?dist}
 Summary:		Python API to MPV using JSON IPC
 License:		Apache-2.0
 URL:			https://github.com/iwalton3/python-mpv-jsonipc
-Source0:		%{pypi_source}
+Source0:		%{pypi_source python_mpv_jsonipc}
 BuildArch:      noarch
 
 BuildRequires:  python3-devel
@@ -28,7 +28,7 @@ Provides:       python-mpv-jsonipc
 %_desc
 
 %prep
-%autosetup -n %{pypi_name}-%{version}
+%autosetup -n python_mpv_jsonipc-%{version}
 
 %build
 %pyproject_wheel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(python-mpv-jsonipc): source url changed (#15774)](https://github.com/terrapkg/packages/pull/15774)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)