### PR TITLE
[f45] fix(vesktop): detect metainfo in update script (#15779)

### DIFF
--- a/anda/apps/vesktop/update.rhai
+++ b/anda/apps/vesktop/update.rhai
@@ -1,1 +1,10 @@
-rpm.version(gh_tag("Vencord/Vesktop"));
+let v = gh_tag("Vencord/Vesktop");
+let url = `dev.vencord.Vesktop.metainfo.xml`
+
+if get(`https://github.com/Vencord/Vesktop/releases/expanded_assets/${v}`).contains(url) {
+  rpm.version(v);
+} else {
+  print(`vesktop: ${v} (waiting for ${url})`);
+  terminate();
+}
+

--- a/anda/multimedia/openutau/update.rhai
+++ b/anda/multimedia/openutau/update.rhai
@@ -4,6 +4,6 @@ let url = `OpenUtau-linux-x64.tar.gz`;
 if get(`https://github.com/stakira/OpenUtau/releases/expanded_assets/${v}`).contains(url) {
   rpm.global("ver", v);
 } else {
-  print(`openutau: ${v} (waiting for bundle)`);
+  print(`openutau: ${v} (waiting for ${url})`);
   terminate();
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix(vesktop): detect metainfo in update script (#15779)](https://github.com/terrapkg/packages/pull/15779)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)