### PR TITLE
[el10] add: porffor (#15821)

### DIFF
--- a/anda/langs/js/porffor/anda.hcl
+++ b/anda/langs/js/porffor/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "porffor.spec"
+  }
+}

--- a/anda/langs/js/porffor/porffor.spec
+++ b/anda/langs/js/porffor/porffor.spec
@@ -1,0 +1,49 @@
+%global commit 747d551844750fc5ed32cf88cdf0b3854aee267e
+%global commit_date 20260812
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           porffor-nightly
+Version:        0~%{commit_date}git.%{shortcommit}
+Release:        1%?dist
+Summary:        An ahead-of-time JavaScript compiler
+License:        MIT
+URL:            https://porffor.dev/
+Source0:		    https://github.com/CanadaHonk/porffor/archive/%commit/porffor-%commit.tar.gz
+Packager:       madonuko <mado@fyralabs.com>
+Provides:       porffor = %evr
+Provides:       porf = %evr
+BuildRequires:  clang mold compiler-rt llvm
+BuildRequires:  nodejs
+
+%description
+Porffor is a 100% AOT compiled JS engine/runtime. There is nothing interpreted or compiled just-in-time. Porffor compiles JS to C (with an IR inbetween).
+
+%prep
+%autosetup -n porffor-%commit
+
+%build
+node selfhosted/build.mjs
+./porf c --compress-data selfhosted/bundle.js -o selfhosted/stage1.c
+
+clang -O0 -fuse-ld=mold -fno-sanitize=undefined -w \
+  -fprofile-instr-generate=release.profraw \
+  selfhosted/stage1.c -o pgo-porf -lm
+./pgo-porf c selfhosted/bundle.js -o selfhosted/stage2.c
+llvm-profdata merge -o release.profdata release.profraw
+
+clang %build_cflags -fuse-ld=mold \
+  -fprofile-instr-use=release.profdata \
+  -mllvm -force-attribute=porf_strict_eq:noinline \
+  selfhosted/stage1.c -o porf -lm
+
+%install
+install -Dpm755 porf -t %buildroot%_bindir
+
+%files
+%doc README.md
+%license LICENSE
+%_bindir/porf
+
+%changelog
+* Tue Aug 18 2026 madonuko <mado@fyralabs.com> - 0~20260812git.747d551-1
+- Initial package

--- a/anda/langs/js/porffor/update.rhai
+++ b/anda/langs/js/porffor/update.rhai
@@ -1,0 +1,5 @@
+rpm.global("commit", gh_commit("CanadaHonk/porffor"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: porffor (#15821)](https://github.com/terrapkg/packages/pull/15821)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)