### PR TITLE
[f43] fix (cosmic-ext-applet-sysinfo): nightly label (#15839)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/anda.hcl
+++ b/anda/desktops/cosmic/cosmic-ext-applet-sysinfo/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "cosmic-ext-applet-sysinfo.spec"
   }
+	labels {
+		nightly = 1
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (cosmic-ext-applet-sysinfo): nightly label (#15839)](https://github.com/terrapkg/packages/pull/15839)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)