### PR TITLE
[f45] add: gpu-screen-recorder-ui (#15833)

### DIFF
--- a/anda/multimedia/gpu-screen-recorder-ui/anda.hcl
+++ b/anda/multimedia/gpu-screen-recorder-ui/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "gpu-screen-recorder-ui.spec"
+  }
+}

--- a/anda/multimedia/gpu-screen-recorder-ui/ci_setup.rhai
+++ b/anda/multimedia/gpu-screen-recorder-ui/ci_setup.rhai
@@ -1,0 +1,1 @@
+sh("dnf in -y 'rpm_macro(buildsystem_meson_conf)'", #{});

--- a/anda/multimedia/gpu-screen-recorder-ui/gpu-screen-recorder-ui.spec
+++ b/anda/multimedia/gpu-screen-recorder-ui/gpu-screen-recorder-ui.spec
@@ -1,0 +1,63 @@
+Name:           gpu-screen-recorder-ui
+Version:        1.13.5
+Release:        1%{?dist}
+Summary:        A fullscreen overlay UI for GPU Screen Recorder in the style of ShadowPlay
+
+License:        GPL-3.0-or-later
+
+URL:            https://git.dec05eba.com/%{name}/about
+
+Source:         https://dec05eba.com/snapshot/%{name}.git.%{version}.tar.gz
+
+BuildRequires:  meson gcc gcc-c++
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xrandr)
+BuildRequires:  pkgconfig(xrender)
+BuildRequires:  pkgconfig(xcomposite)
+BuildRequires:  pkgconfig(xfixes)
+BuildRequires:  pkgconfig(xext)
+BuildRequires:  pkgconfig(xi)
+BuildRequires:  pkgconfig(xcursor)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-egl)
+BuildRequires:  pkgconfig(wayland-scanner)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(gl)
+BuildRequires:  pkgconfig(glx)
+BuildRequires:  pkgconfig(egl)
+BuildRequires:  kernel-headers
+BuildRequires:  pkgconfig(libpulse)
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(dbus-1)
+BuildRequires:  pkgconfig(pango)
+BuildRequires:  pkgconfig(libcap)
+BuildRequires:  rpm_macro(buildsystem_meson_conf)
+BuildSystem:    meson
+
+Packager:       madonuko <mado@fyralabs.com>
+
+%description
+%summary.
+
+%post
+setcap cap_setuid+ep /usr/bin/gsr-global-hotkeys
+
+%files
+%license LICENSE
+%doc README.md
+%_appsdir/gpu-screen-recorder.desktop
+%_bindir/gsr-game-tracker
+%_bindir/gsr-global-hotkeys
+%_bindir/gsr-gnome-helper
+%_bindir/gsr-kwin-helper
+%_bindir/gsr-ui
+%_bindir/gsr-ui-cli
+%_bindir/gsr-wayland-bridge
+%_datadir/gsr-ui
+%_hicolordir/*/apps/gpu-screen-recorder.png
+%_mandir/man1/gsr-ui-cli.1.*
+%_mandir/man1/gsr-ui.1.*
+
+%changelog
+* Tue Aug 18 2026 madonuko <mado@fyralabs.com> - 1.13.5-1
+- Initial package

--- a/anda/multimedia/gpu-screen-recorder-ui/update.rhai
+++ b/anda/multimedia/gpu-screen-recorder-ui/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(find_all(`/gpu-screen-recorder-ui/tag/\?h=([\d.]+)`, get(`https://git.dec05eba.com/gpu-screen-recorder-ui/refs/`))[0][1]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: gpu-screen-recorder-ui (#15833)](https://github.com/terrapkg/packages/pull/15833)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)