### PR TITLE
[f45] add: gpu-screen-recorder-notification (#15834)

### DIFF
--- a/anda/multimedia/gpu-screen-recorder-notification/anda.hcl
+++ b/anda/multimedia/gpu-screen-recorder-notification/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "gpu-screen-recorder-notification.spec"
+  }
+}

--- a/anda/multimedia/gpu-screen-recorder-notification/ci_setup.rhai
+++ b/anda/multimedia/gpu-screen-recorder-notification/ci_setup.rhai
@@ -1,0 +1,1 @@
+sh("dnf in -y 'rpm_macro(buildsystem_meson_conf)'", #{});

--- a/anda/multimedia/gpu-screen-recorder-notification/gpu-screen-recorder-notification.spec
+++ b/anda/multimedia/gpu-screen-recorder-notification/gpu-screen-recorder-notification.spec
@@ -1,0 +1,41 @@
+Name:           gpu-screen-recorder-notification
+Version:        1.3.4
+Release:        1%{?dist}
+Summary:        Notification in the style of ShadowPlay
+
+License:        GPL-3.0-or-later
+
+URL:            https://git.dec05eba.com/%{name}/about
+
+Source:         https://dec05eba.com/snapshot/%{name}.git.%{version}.tar.gz
+
+BuildRequires:  gcc gcc-c++
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xrandr)
+BuildRequires:  pkgconfig(xrender)
+BuildRequires:  pkgconfig(xext)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-egl)
+BuildRequires:  pkgconfig(wayland-scanner)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  pkgconfig(gl)
+BuildRequires:  pkgconfig(glx)
+BuildRequires:  pkgconfig(egl)
+BuildRequires:  pkgconfig(pango)
+BuildRequires:  rpm_macro(buildsystem_meson_conf)
+BuildSystem:    meson
+
+Packager:       madonuko <mado@fyralabs.com>
+
+%description
+%summary.
+
+%files
+%license LICENSE
+%doc README.md
+%_bindir/gsr-notify
+%_datadir/gsr-notify
+
+%changelog
+* Tue Aug 18 2026 madonuko <mado@fyralabs.com> - 1.3.4-1
+- Initial package

--- a/anda/multimedia/gpu-screen-recorder-notification/update.rhai
+++ b/anda/multimedia/gpu-screen-recorder-notification/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(find_all(`/gpu-screen-recorder-notification/tag/\?h=([\d.]+)`, get(`https://git.dec05eba.com/gpu-screen-recorder-notification/refs/`))[0][1]);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: gpu-screen-recorder-notification (#15834)](https://github.com/terrapkg/packages/pull/15834)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)