### PR TITLE
[f44] add: colorls (#15832)

### DIFF
--- a/anda/langs/ruby/colorls/anda.hcl
+++ b/anda/langs/ruby/colorls/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "colorls.spec"
+  }
+}

--- a/anda/langs/ruby/colorls/colorls.spec
+++ b/anda/langs/ruby/colorls/colorls.spec
@@ -1,0 +1,35 @@
+%define debug_package %nil
+%global gem_name colorls
+
+Name:           colorls
+Version:        1.5.0
+Release:        1%?dist
+Summary:        A Ruby gem that beautifies the terminal's ls command, with color and font-awesome icons
+License:        MIT
+URL:            https://github.com/athityakumar/colorls
+Source0:        https://rubygems.org/downloads/colorls-1.5.0.gem
+BuildRequires:  rubygems-devel
+
+%description
+A Ruby script that colorizes the ls output with color and icons.
+
+%pkg_completion -z
+
+%prep
+%autosetup
+
+%build
+gem build ../%{gem_name}-%{version}.gemspec
+
+%gem_install
+
+%install
+install -Dm755 exe/colorls -t %buildroot%_bindir
+install -Dm644 man/colorls.1 -t %buildroot%_mandir/man1
+install -Dm755 zsh/_colorls -t %buildroot%zsh_completions_dir
+
+%files
+%doc README.md
+%license LICENSE.md
+%_bindir/colorls
+%_mandir/man1/colorls.1.*

--- a/anda/langs/ruby/colorls/update.rhai
+++ b/anda/langs/ruby/colorls/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gems("colorls"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: colorls (#15832)](https://github.com/terrapkg/packages/pull/15832)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)