### PR TITLE
[el10] fix(colorls): packager (#15865)

### DIFF
--- a/anda/langs/ruby/colorls/colorls.spec
+++ b/anda/langs/ruby/colorls/colorls.spec
@@ -3,10 +3,11 @@
 
 Name:           colorls
 Version:        1.5.0
-Release:        1%?dist
+Release:        2%?dist
 Summary:        A Ruby gem that beautifies the terminal's ls command, with color and font-awesome icons
 License:        MIT
 URL:            https://github.com/athityakumar/colorls
+Packager:       madonuko <mado@fyralabs.com>
 Source0:        https://rubygems.org/downloads/colorls-1.5.0.gem
 BuildRequires:  rubygems-devel
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(colorls): packager (#15865)](https://github.com/terrapkg/packages/pull/15865)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)