### PR TITLE
[f43] add: yaml-language-server (#15825)

### DIFF
--- a/anda/langs/yaml/yaml-language-server/anda.hcl
+++ b/anda/langs/yaml/yaml-language-server/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "yaml-language-server.spec"
+  }
+}

--- a/anda/langs/yaml/yaml-language-server/update.rhai
+++ b/anda/langs/yaml/yaml-language-server/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(npm("yaml-language-server"));

--- a/anda/langs/yaml/yaml-language-server/yaml-language-server.spec
+++ b/anda/langs/yaml/yaml-language-server/yaml-language-server.spec
@@ -1,0 +1,37 @@
+%define debug_package %nil
+%global npm_name yaml-language-server
+
+Name:           %npm_name
+Version:        1.24.0
+Release:        1%?dist
+Summary:        YAML language server
+License:        MIT AND BSD-3-Clause AND ISC
+SourceLicense:  MIT
+URL:            https://github.com/redhat-developer/yaml-language-server
+Packager:       madonuko <mado@fyralabs.com>
+BuildRequires:  nodejs-packaging
+BuildRequires:  nodejs-npm
+BuildRequires:  nodejs-license-checker
+
+%description
+Provides YAML language features over the Language Server Protocol (LSP), including validation, completion, hover, formatting, document symbols, and schema-based intelligence.
+
+%prep
+%npm_prep
+
+%build
+%npm_license_summary
+%npm_license -o LICENSE.modules
+
+%install
+%npm_install
+
+%files
+%doc README.md
+%license LICENSE LICENSE.modules
+%nodejs_sitelib/%npm_name/
+%_bindir/%npm_name
+
+%changelog
+* Tue Aug 18 2026 madonuko <mado@fyralabs.com> - 1.24.0-1
+- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: yaml-language-server (#15825)](https://github.com/terrapkg/packages/pull/15825)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)