### PR TITLE
[el10] chore (cosmic-applet-package-updater): nightly label (#15875)

### DIFF
--- a/anda/desktops/cosmic/cosmic-applet-package-updater/anda.hcl
+++ b/anda/desktops/cosmic/cosmic-applet-package-updater/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "cosmic-applet-package-updater.spec"
 	}
+	labels {
+		nightly = 1
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (cosmic-applet-package-updater): nightly label (#15875)](https://github.com/terrapkg/packages/pull/15875)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)