### PR TITLE
[f45] fix(weave): add weave-driver (#15888)

### DIFF
--- a/anda/langs/rust/weave/weave.spec
+++ b/anda/langs/rust/weave/weave.spec
@@ -1,12 +1,13 @@
 Name:           weave
 Version:        0.5.1
-Release:        1%?dist
+Release:        2%?dist
 Summary:        Entity-level git merge driver
 
 License:        ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (0BSD OR MIT OR Apache-2.0) AND Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-3-Clause AND BSL-1.0 AND CDLA-Permissive-2.0 AND ISC AND (ISC AND (Apache-2.0 OR ISC)) AND (ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)) AND MIT AND (MIT AND BSD-3-Clause) AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND MPL-2.0 AND Unicode-3.0 AND (Unlicense OR MIT) AND Zlib AND (Zlib OR Apache-2.0 OR MIT)
 URL:            https://ataraxy-labs.github.io/weave/
 Source0:        https://github.com/ataraxy-labs/weave/archive/refs/tags/v%version.tar.gz
 Packager:       madonuko <mado@fyralabs.com>
+Provides:       weave-driver = %evr
 
 BuildRequires:  rust-packaging
 BuildRequires:  pkgconfig(openssl)
@@ -28,8 +29,12 @@ cargo update
 
 
 %install
-cd crates/weave-cli
+pushd crates/weave-cli
 %cargo_install
+popd
+pushd crates/weave-driver
+%cargo_install
+popd
 
 
 #check
@@ -40,6 +45,7 @@ cd crates/weave-cli
 %license LICENSE-APACHE LICENSE-MIT LICENSE.dependencies
 %doc README.md
 %_bindir/weave
+%_bindir/weave-driver
 
 %changelog
 * Mon Jul 20 2026 madonuko <mado@fyralabs.com> - 0.3.6-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix(weave): add weave-driver (#15888)](https://github.com/terrapkg/packages/pull/15888)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)