### PR TITLE
[f45] fix: Add selinux rules for ds-inhibit feature of steamos-manager (#15899)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -6,7 +6,7 @@
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          1%{?dist}
+Release:          3%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager

--- a/anda/games/steamos-manager-powerstation/steamos_manager.te
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.te
@@ -1,4 +1,4 @@
-policy_module(steamos_manager, 1.0.5)
+policy_module(steamos_manager, 1.0.6)
 
 ########################################
 # Init
@@ -83,6 +83,9 @@ kernel_read_system_state(steamos_manager_t)
 # Read /proc/{pid}/comm, environ, stat, fd/ for display sleep inhibition
 domain_read_all_domains_state(steamos_manager_t)
 
+# ds-inhibit walks /proc/{pid}/fd/
+allow steamos_manager_t self:capability { dac_read_search sys_ptrace };
+
 ########################################
 # Tracefs and debugfs
 ########################################
@@ -123,14 +126,7 @@ optional_policy(`
 	allow steamos_manager_t uinput_device_t:chr_file { open read write ioctl getattr };
 ')
 
-# /dev/hidraw* — DualSense controller inhibitor
-optional_policy(`
-	gen_require(`
-		type hidraw_device_t;
-	')
-	allow steamos_manager_t hidraw_device_t:chr_file { open read write getattr ioctl watch watch_reads };
-')
-
+# /dev/hidraw* — DualSense controller inhibitor.
 optional_policy(`
 	gen_require(`
 		type usb_device_t;
@@ -143,18 +139,30 @@ dev_rw_input_dev(steamos_manager_t)
 dev_getattr_all_chr_files(steamos_manager_t)
 dev_getattr_all_blk_files(steamos_manager_t)
 
+gen_require(`
+	type devpts_t;
+')
+allow steamos_manager_t devpts_t:dir getattr;	# /dev/pts
+
+optional_policy(`
+	gen_require(`
+		type mqueue_spool_t;
+	')
+	allow steamos_manager_t mqueue_spool_t:dir getattr;	# /dev/mqueue
+')
+
 optional_policy(`
 	gen_require(`
 		type hugetlbfs_t;
 	')
-	allow steamos_manager_t hugetlbfs_t:dir getattr;
+	allow steamos_manager_t hugetlbfs_t:dir getattr;	# /dev/hugepages
 ')
 
 optional_policy(`
 	gen_require(`
 		type proc_kcore_t;
 	')
-	allow steamos_manager_t proc_kcore_t:file getattr;
+	allow steamos_manager_t proc_kcore_t:file getattr;	# /dev/core -> /proc/kcore
 ')
 
 # Udev events via netlink socket


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: Add selinux rules for ds-inhibit feature of steamos-manager (#15899)](https://github.com/terrapkg/packages/pull/15899)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)