### PR TITLE
feat(ci): add offline label (and also use it for taisei)

### DIFF
--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -85,7 +85,7 @@ jobs:
           dnf5 builddep -y ${dir}/*.spec
 
       - name: Build with Andaman
-        run: anda build -D "vendor Terra" -D "__python %{__python3}" ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
+        run: anda build -D "vendor Terra" -D "__python %{__python3}" ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }} ${{ matrix.pkg.labels.offline == '1' && '--no-network' || '' }}
 
       - name: Report Cache Summary
         if: steps.sccache.outcome == 'success'

--- a/anda/games/taisei/anda.hcl
+++ b/anda/games/taisei/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "taisei.spec"
 	}
+	labels {
+		offline = 1
+	}
 }


### PR DESCRIPTION
Adds a label for the CI to build packages with no networking.

This feature is opt-in by default (I think, please someone double check that I'm not insane) so to allow a maintainer to choose if a given app has network access during the build process, preventing any potential artifacts from being downloaded from the net.

Included in this PR is another commit that adds the offline label to my `taisei` package which I know with certainty will never need internet access during the build.