### PR TITLE
[f45] build(deps): bump github/codeql-action/upload-sarif (#15924)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [build(deps): bump github/codeql-action/upload-sarif (#15924)](https://github.com/terrapkg/packages/pull/15924)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)