### PR TITLE
[f45] fix (darkly): remove -devel package (#15944)

### DIFF
--- a/anda/themes/darkly/darkly.spec
+++ b/anda/themes/darkly/darkly.spec
@@ -1,6 +1,6 @@
 Name:           darkly
 Version:        0.5.38
-Release:        1%{?dist}
+Release:        2%{?dist}
 License:        GPL-2.0-or-later
 Summary:        Forked from the lightly theme, this style brings a fresh and unique look to your applications
 URL:            https://github.com/Bali10050/Darkly
@@ -40,14 +40,6 @@ Requires:       kf6-plasma
 %description
 %{summary}.
 
-%package devel
-Summary:       Development files for %{name}
-Requires:      %{name} = %{evr}
-
-%description   devel
-This package contains the development libraries for %{name}.
-
-
 %prep
 %autosetup -n Darkly-%{version}
 
@@ -72,8 +64,6 @@ This package contains the development libraries for %{name}.
 %{_datadir}/kservices6/darklydecorationconfig.desktop
 %{_datadir}/kstyle/themes/darkly.themerc
 %{_datadir}/plasma/desktoptheme/darkly/*
-
-%files devel
 %{_libdir}/cmake/Darkly/
 %{_qt6_plugindir}/kstyle_config/darklystyleconfig.so
 %{_qt6_plugindir}/org.kde.kdecoration3/org.kde.darkly.so


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix (darkly): remove -devel package (#15944)](https://github.com/terrapkg/packages/pull/15944)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)