### PR TITLE
[el10] fix(awww): hardcode obsolete (#15949)

### DIFF
--- a/anda/desktops/waylands/awww/awww.spec
+++ b/anda/desktops/waylands/awww/awww.spec
@@ -1,6 +1,6 @@
 Name:           awww
 Version:        0.12.1
-Release:        2%?dist
+Release:        3%?dist
 Summary:        Wallpaper daemon for Wayland
 SourceLicense:  GPL-3.0-only
 License:        (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-3-Clause AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (MIT OR Zlib OR Apache-2.0) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
@@ -15,7 +15,7 @@ BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols)
 
-Obsoletes:      swww < %{evr}
+Obsoletes:      swww < 0.11.2-2
 
 %description
 awww is a wallpaper daemon for Wayland that is controlled


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(awww): hardcode obsolete (#15949)](https://github.com/terrapkg/packages/pull/15949)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)