### PR TITLE
fix(ghostty-tip): Reverse update script logic

### DIFF
--- a/anda/devs/ghostty/tip/update.rhai
+++ b/anda/devs/ghostty/tip/update.rhai
@@ -1,9 +1,11 @@
 let r = get("https://api.github.com/repos/ghostty-org/ghostty/releases/83450291").json();
-rpm.global("commit", r.target_commitish);
+let d = sh(`date -d "${r.created_at}" "+%Y%m%d%H%M"`, #{"stdout": "piped"}).ctx.stdout;
+
+d.pop();
+rpm.version(d);
+
 if rpm.changed() {
-    let d = sh(`date -d "${r.created_at}" "+%Y%m%d%H%M"`, #{"stdout": "piped"}).ctx.stdout;
-    d.pop();
-    rpm.version(d);
+    rpm.global("commit", r.target_commitish);
     let z = get(`https://raw.githubusercontent.com/ghostty-org/ghostty/refs/heads/main/build.zig.zon`);
     let v = find("\\.version = \"([\\d.]+)-dev\"", z, 1);
     rpm.global("ver", v);


### PR DESCRIPTION
The original logic tracked the commit because that was how `-nightly` worked, this tracks the release date instead which should, in theory, only update when a new release artifact actually pushes. All the Ghostty builds which failed due to the tarball not being present never bumped the version, so it seems like this logic will result in less of a race condition.