### PR TITLE
[f43] feat: Update to the latest steamos-manager-powerstation (#15954)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit 238a1413b3bd9888b1c4d9fd592e8111326549d2
+%global commit 5438d605296ae5b5ecc031760cc80d5f4675f7d8
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260810
+%global commitdate 20260819
 
 %global steamos_manager_systemd_user_units steamos-manager.service steamos-manager-configure-cecd.service steamos-manager-session-cleanup.service
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update to the latest steamos-manager-powerstation (#15954)](https://github.com/terrapkg/packages/pull/15954)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)