### PR TITLE
[f45] fix(zigstream-ng): shebangs (#15955)

### DIFF
--- a/anda/langs/python/zipstream-ng/zipstream-ng.spec
+++ b/anda/langs/python/zipstream-ng/zipstream-ng.spec
@@ -35,6 +35,7 @@ Provides:       zipstream-ng
 %autosetup -n zipstream-ng-%{version}
 
 %build
+sed 's@/usr/bin/env python@/usr/bin/python3@g' -i src/*/*.py
 %pyproject_wheel
 
 %install


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix(zigstream-ng): shebangs (#15955)](https://github.com/terrapkg/packages/pull/15955)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)