### PR TITLE
[f44] fix(ghostty-tip): Reverse update script logic (#15956)

### DIFF
--- a/anda/devs/ghostty/tip/update.rhai
+++ b/anda/devs/ghostty/tip/update.rhai
@@ -1,9 +1,11 @@
 let r = get("https://api.github.com/repos/ghostty-org/ghostty/releases/83450291").json();
-rpm.global("commit", r.target_commitish);
+let d = sh(`date -d "${r.created_at}" "+%Y%m%d%H%M"`, #{"stdout": "piped"}).ctx.stdout;
+
+d.pop();
+rpm.version(d);
+
 if rpm.changed() {
-    let d = sh(`date -d "${r.created_at}" "+%Y%m%d%H%M"`, #{"stdout": "piped"}).ctx.stdout;
-    d.pop();
-    rpm.version(d);
+    rpm.global("commit", r.target_commitish);
     let z = get(`https://raw.githubusercontent.com/ghostty-org/ghostty/refs/heads/main/build.zig.zon`);
     let v = find("\\.version = \"([\\d.]+)-dev\"", z, 1);
     rpm.global("ver", v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(ghostty-tip): Reverse update script logic (#15956)](https://github.com/terrapkg/packages/pull/15956)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)