### PR TITLE
[f43] feat(ci): add offline label (and also use it for taisei) (#15925)

### DIFF
--- a/.github/workflows/json-build.yml
+++ b/.github/workflows/json-build.yml
@@ -85,7 +85,7 @@ jobs:
           dnf5 builddep -y ${dir}/*.spec
 
       - name: Build with Andaman
-        run: anda build -D "vendor Terra" -D "__python %{__python3}" ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }}
+        run: anda build -D "vendor Terra" -D "__python %{__python3}" ${{ matrix.pkg.pkg }} -c terra-${{ matrix.version }}-${{ matrix.pkg.arch }} ${{ !matrix.pkg.labels.mock == '1' && '-rrpmbuild' || '' }} ${{ matrix.pkg.labels.offline == '1' && '--no-network' || '' }}
 
       - name: Report Cache Summary
         if: steps.sccache.outcome == 'success'

--- a/anda/games/taisei/anda.hcl
+++ b/anda/games/taisei/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
 	rpm {
 		spec = "taisei.spec"
 	}
+	labels {
+		offline = 1
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat(ci): add offline label (and also use it for taisei) (#15925)](https://github.com/terrapkg/packages/pull/15925)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)