### PR TITLE
fix: bazzite-updater

### DIFF
--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -1,7 +1,7 @@
 %global appid io.github.rfrench3.bazzite-updater
 
 Name:           bazzite-updater
-Version:        0.9.1
+Version:        0.9.2
 Release:        1%{?dist}
 Summary:        Update your system
 

--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -1,7 +1,7 @@
 %global appid io.github.rfrench3.bazzite-updater
 
 Name:           bazzite-updater
-Version:        0.9.2
+Version:        0.9.4
 Release:        1%{?dist}
 Summary:        Update your system
 


### PR DESCRIPTION
I'm not fully sure what the issue is yet, but bazzite-updater for the `f44` branch is not being updated beyond 0.9.1 even though there are new releases. When I try to install it on Fedora 44, it fails with the repeated error `Downloading successful, but checksum doesn't match. ...`

I believe this happened because a new release (0.9.2) occurred ~1 minute after the PR for a new dependency was accepted. the `frawhide` branch is successfully updating for the new releases, but even now it seems to be not updating the f44 version. I'll make an issue with more details, will this PR force it to build the right version on `f44`?