### PR TITLE
[f43] fix: fprintd-clients update.rhai (#16002)

### DIFF
--- a/anda/multimedia/gpu-screen-recorder-ui/gpu-screen-recorder-ui.spec
+++ b/anda/multimedia/gpu-screen-recorder-ui/gpu-screen-recorder-ui.spec
@@ -1,5 +1,5 @@
 Name:           gpu-screen-recorder-ui
-Version:        1.9.3
+Version:        1.13.5
 Release:        1%{?dist}
 Summary:        A fullscreen overlay UI for GPU Screen Recorder in the style of ShadowPlay
 

--- a/anda/multimedia/gpu-screen-recorder-ui/test.rhai
+++ b/anda/multimedia/gpu-screen-recorder-ui/test.rhai
@@ -1,0 +1,2 @@
+let tags = git_tags("https://repo.dec05eba.com/gpu-screen-recorder-ui");
+print(tags[tags.len()-1]);

--- a/anda/system/fprintd-clients/fprintd-clients.spec
+++ b/anda/system/fprintd-clients/fprintd-clients.spec
@@ -1,6 +1,6 @@
 Name:           fprintd-clients
-Version:        
-Release:        1%{?dist}
+Version:        1.90.1
+Release:        2%{?dist}
 Summary:        D-Bus service to access fingerprint readers
 License:        GPL-2.0-or-later
 URL:            https://gitlab.freedesktop.org/uunicorn/fprintd

--- a/anda/system/fprintd-clients/update.rhai
+++ b/anda/system/fprintd-clients/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gitlab("gitlab.freedesktop.org", "6774"));
+rpm.version(gitlab_tag("gitlab.freedesktop.org", "6774"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: fprintd-clients update.rhai (#16002)](https://github.com/terrapkg/packages/pull/16002)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)