### PR TITLE
[el10] fix: bpftune-gaming update.rhai (#16003)

### DIFF
--- a/anda/games/bpftune-gaming/anda.hcl
+++ b/anda/games/bpftune-gaming/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "bpftune-gaming.spec"
   }
+  labels {
+    nightly = 1
+  }
 }

--- a/anda/games/bpftune-gaming/update.rhai
+++ b/anda/games/bpftune-gaming/update.rhai
@@ -1,6 +1,6 @@
-rpm.global("ver", gh("KyleGospo/bpftune"));
 rpm.global("commit", gh_commit("KyleGospo/bpftune"));
 if rpm.changed() {
+    # rpm.global("ver", gh("KyleGospo/bpftune"));
     rpm.release();
     rpm.global("commit_date", date());
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: bpftune-gaming update.rhai (#16003)](https://github.com/terrapkg/packages/pull/16003)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)