### PR TITLE
chore: fix hid-tmff2 compilation

### DIFF
--- a/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
+++ b/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
@@ -34,9 +34,6 @@ Akmods modules for the akmod-%{name} package.
 echo hid-tmff-new > %{name}.conf
 
 %install
-# UDev rules:
-install -Dpm644 udev/99-thrustmaster.rules -t %{buildroot}%{_udevrulesdir}/
-
 # Akmods modules
 install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
 


### PR DESCRIPTION
The udev rules were removed, so this package fails on compilation