### PR TITLE
[el10] chore: Fix hid-tmff2 (#16033)

### DIFF
--- a/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
+++ b/anda/system/hid-tmff2/kmod-common/hid-tmff2.spec
@@ -34,16 +34,12 @@ Akmods modules for the akmod-%{name} package.
 echo hid-tmff-new > %{name}.conf
 
 %install
-# UDev rules:
-install -Dpm644 udev/99-thrustmaster.rules -t %{buildroot}%{_udevrulesdir}/
-
 # Akmods modules
 install -Dm644 %{name}.conf -t %{buildroot}%{_modulesloaddir}
 
 %files
 %license LICENSE
 %doc README.md
-%{_udevrulesdir}/99-thrustmaster.rules
 
 %files akmod-modules
 %{_modulesloaddir}/%{name}.conf


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore: Fix hid-tmff2 (#16033)](https://github.com/terrapkg/packages/pull/16033)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)