### PR TITLE
[el10] feat: Update gamescope-session to the latest version (#16038)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,8 +1,8 @@
 %define debug_package %nil
 
-%global commit 5c8f1a54646030b30b7fdf821e09d5f127b23415
+%global commit 39c835136c242df16693431a55f1340280844e48
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260819
+%global commit_date 20260820
 
 Name:           gamescope-session
 Version:        0~%{commit_date}git.%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat: Update gamescope-session to the latest version (#16038)](https://github.com/terrapkg/packages/pull/16038)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)