### PR TITLE
[f43] fix(AI-POLICY.md): Link to the correct page (#16048)

### DIFF
--- a/AI-POLICY.md
+++ b/AI-POLICY.md
@@ -1,3 +1,3 @@
-Our AI/LLM policy can be found [here](https://docs.terrapkg.com/policies#ai-policy) in our docs.
+Our AI/LLM policy can be found [here](https://docs.terrapkg.com/contributing/policies#ai-policy) in our docs.
 
 TL;DR: Don't use an LLM to generate specs or GitHub comments/descriptions.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(AI-POLICY.md): Link to the correct page (#16048)](https://github.com/terrapkg/packages/pull/16048)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)