### PR TITLE
[el10] fix: panel-modeler (#16000)

### DIFF
--- a/anda/tools/panel-modeler/panel-modeler.spec
+++ b/anda/tools/panel-modeler/panel-modeler.spec
@@ -1,46 +1,65 @@
+%global appid dev.willowidk.panel-modeler
+
 Name:   	panel-modeler
-Version:	1.0.0
+Version:	2.1.2
 Release:	1%{?dist}
 Summary:	Photovoltaic decay modeling through PVWatts
 
 License:	MIT
-URL:		https://github.com/halfcyan/panel-modeler
-Source0:	https://github.com/halfcyan/panel-modeler/archive/refs/tags/v%{version}.tar.gz
+URL:		https://tangled.org/willowidk.dev/panel-modeler
+Source0:	https://tangled.org/willowidk.dev/panel-modeler/archive/refs/tags/v%{version}.tar.gz
 
 BuildRequires:  meson
 BuildRequires:  clang
 BuildRequires:  mold
 BuildRequires:  ninja-build
+BuildRequires:  qt6-qtbase-devel
+BuildRequires:  desktop-file-utils
+BuildRequires:  libappstream-glib
 
 Packager:       Cypress Reed <cypress@fyralabs.com>
 
 %description
-A C++ command-line program that predicts the future power output of solar
+A C++ command-line and GUI program that predicts the future power output of solar
 panels based on their specifications (reference power, temperature derating
-coefficient, and decay rate). Given a location's average irradiance and
+coefficient, and decay rate), along with the number of panels in an array. Given a location's average irradiance and
 temperature over a year, it calculates the expected power output a given
 number of years into the future.
 
 The program takes two command-line arguments — an input file and an output
 file, both in CSV format.
 
+%pkg_completion -bfz
+
 %prep
-%autosetup
+%autosetup -n panel-modeler-v%{version}
 
 %conf
-%meson --native-file clang.ini
+%meson --native-file clang.ini -Dqt=enabled
 
 %build
 %meson_build
 
 %install
-install -Dm0755 %{_vpath_builddir}/%{name} %{buildroot}%{_bindir}/%{name}
+%meson_install
+
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/%{name}.desktop
 
 %files
 %license LICENSE
-%doc README.md
 %{_bindir}/%{name}
+%{_bindir}/%{name}-gui
+%{_datadir}/panel-modeler/
+%{_docdir}/panel-modeler/
+%{_appsdir}/%{name}.desktop
+%{_scalableiconsdir}/%{name}.svg
+%{_metainfodir}/%{appid}.metainfo.xml
 
 %changelog
+* Thu Aug 20 2026 Cypress Reed <cypress@fyralabs.com>
+- Add bash/zsh/fish completions and .desktop file and appstream metainfo
+- Add packages required for v2.1.0
+
 * Thu Jul 30 2026 Cypress Reed <cypress@fyralabs.com>
 - Initial package

--- a/anda/tools/panel-modeler/update.rhai
+++ b/anda/tools/panel-modeler/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("halfcyan/panel-modeler"))
+rpm.version(tangled("willowidk.dev/panel-modeler"))


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: panel-modeler (#16000)](https://github.com/terrapkg/packages/pull/16000)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)