### PR TITLE
[el10] fix: gpu-screen-recorder-ui (#16072)

### DIFF
--- a/anda/multimedia/gpu-screen-recorder-ui/gpu-screen-recorder-ui.spec
+++ b/anda/multimedia/gpu-screen-recorder-ui/gpu-screen-recorder-ui.spec
@@ -10,6 +10,7 @@ URL:            https://git.dec05eba.com/%{name}/about
 Source:         https://dec05eba.com/snapshot/%{name}.git.%{version}.tar.gz
 
 BuildRequires:  meson gcc gcc-c++
+BuildRequires:  desktop-file-utils
 BuildRequires:  pkgconfig(x11)
 BuildRequires:  pkgconfig(xrandr)
 BuildRequires:  pkgconfig(xrender)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: gpu-screen-recorder-ui (#16072)](https://github.com/terrapkg/packages/pull/16072)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)