### PR TITLE
[el10] fix: minimon-applet (#16069)

### DIFF
--- a/anda/desktops/cosmic/minimon-applet/minimon-applet.spec
+++ b/anda/desktops/cosmic/minimon-applet/minimon-applet.spec
@@ -22,7 +22,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{summary}.
 
 %prep
-%autosetup
+%autosetup -C
 %cargo_prep_online
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: minimon-applet (#16069)](https://github.com/terrapkg/packages/pull/16069)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)