### PR TITLE
fix: allow SteamOS Manager to control scx service

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -6,7 +6,7 @@
 
 Name:             steamos-manager-powerstation
 Version:          0~%{commitdate}.git%{shortcommit}
-Release:          3%{?dist}
+Release:          4%{?dist}
 Summary:          SteamOS Manager is a system daemon that aims to abstract Steam's interactions with the operating system
 License:          MIT AND (MIT OR Apache-2.0) AND Unicode-3.0 AND (Apache-2.0 OR BSL-1.0) AND Apache-2.0 OR MIT AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ISC AND (LGPL-2.1 OR MIT OR Apache-2.0) AND MIT AND (MIT OR Apache-2.0) AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT) AND (Zlib OR Apache-2.0 OR MIT)
 URL:              https://github.com/OpenGamingCollective/steamos-manager

--- a/anda/games/steamos-manager-powerstation/steamos_manager.te
+++ b/anda/games/steamos-manager-powerstation/steamos_manager.te
@@ -1,4 +1,4 @@
-policy_module(steamos_manager, 1.0.6)
+policy_module(steamos_manager, 1.0.7)
 
 ########################################
 # Init
@@ -26,7 +26,7 @@ init_status(steamos_manager_t)
 gen_require(`
 	type systemd_unit_file_t;
 ')
-allow steamos_manager_t systemd_unit_file_t:service status;
+allow steamos_manager_t systemd_unit_file_t:service { start stop status };
 
 ########################################
 # Process permissions


### PR DESCRIPTION
SteamOS Manager exposes `lavd` through `steamosctl` when `scx_lavd` is installed, but the packaged SELinux policy only permits querying systemd services. Starting the scheduler is therefore denied on enforcing systems.

Reproduced on Bazzite 44 with `steamos-manager-powerstation-0~20260819.git5438d60-3.fc44`:

```
$ steamosctl set-cpu-scheduler lavd
Error: org.freedesktop.DBus.Error.AccessDenied: SELinux policy denies access
```

The audit event identifies the missing permission:

```
scontext=system_u:system_r:steamos_manager_t:s0
tcontext=system_u:object_r:systemd_unit_file_t:s0
tclass=service
denied { start }
path="/usr/lib/systemd/system/scx_loader.service"
```

This change aligns the existing rule with its comment by granting the start/stop permissions needed by `CpuSchedulerManager::set_cpu_scheduler`, then bumps the policy module and RPM release.

Validation:
- `git diff --check`
- Compiled `steamos_manager.pp` successfully in an ephemeral Fedora 44 container using `selinux-policy-devel`.
