### PR TITLE
[f43] add concurrency limits on update jobs (#16110)

### DIFF
--- a/.github/workflows/update-branch.yml
+++ b/.github/workflows/update-branch.yml
@@ -1,6 +1,11 @@
 name: Update per branch
 permissions:
   contents: read
+
+concurrency:
+  group: update-branch
+  cancel-in-progress: true
+
 on:
   schedule:
     - cron: "*/30 * * * *"

--- a/.github/workflows/update-comps.yml
+++ b/.github/workflows/update-comps.yml
@@ -2,6 +2,10 @@ name: Push comps updates
 permissions:
   contents: read
 
+concurrency:
+  group: update-comps
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -1,6 +1,11 @@
 name: Nightly Update
 permissions:
   contents: read
+
+concurrency:
+  group: update-nightly
+  cancel-in-progress: true
+
 on:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/update-weekly.yml
+++ b/.github/workflows/update-weekly.yml
@@ -1,6 +1,11 @@
 name: Weekly Update
 permissions:
   contents: read
+
+concurrency:
+  group: update-weekly
+  cancel-in-progress: true
+
 on:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,11 @@
 name: Update
 permissions:
   contents: read
+
+concurrency:
+  group: update
+  cancel-in-progress: true
+
 on:
   #schedule:
   #  - cron: "*/10 * * * *"


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add concurrency limits on update jobs (#16110)](https://github.com/terrapkg/packages/pull/16110)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)