### PR TITLE
[f44] wl-kmod: sync patches with rpmfusion for kernels 7.2+ (#16128)

### DIFF
--- a/anda/system/wl-kmod/wl-kmod-038_kernel_7.2_adaptation_remove_strncpy_function.patch
+++ b/anda/system/wl-kmod/wl-kmod-038_kernel_7.2_adaptation_remove_strncpy_function.patch
@@ -1,0 +1,94 @@
+From c0025504abc2234f687a69a4cbbd05c800c61474 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Thu, 23 Jul 2026 19:27:26 +0200
+Subject: [PATCH] linux_osl.c and wl_linux.c: adapt compatibility with kernel
+ >= 7.2.x remove strncpy kernel function - Related to commit "Remove
+ strncpy()" (Kees Cook, 19 Jun 2026)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ src/shared/linux_osl.c | 11 +++++++++++
+ src/wl/sys/wl_linux.c  | 14 +++++++++++++-
+ 2 files changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/linux_osl.c b/src/shared/linux_osl.c
+index 1ac2074..bfb3622 100644
+--- a/src/shared/linux_osl.c
++++ b/src/shared/linux_osl.c
+@@ -475,8 +475,13 @@ osl_debug_malloc(osl_t *osh, uint size, int line, const char* file)
+ 	if (!basename)
+ 		basename = file;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
++	// Related to commit "Remove strncpy()" (Kees Cook, 19 Jun 2026)
++	strscpy(p->file, basename, BCM_MEM_FILENAME_LEN);
++#else
+ 	strncpy(p->file, basename, BCM_MEM_FILENAME_LEN);
+ 	p->file[BCM_MEM_FILENAME_LEN - 1] = '\0';
++#endif
+ 
+ 	if (osh) {
+ 		p->prev = NULL;
+@@ -872,7 +877,13 @@ osl_strcpy(char *d, const char *s)
+ char*
+ osl_strncpy(char *d, const char *s, uint n)
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
++	// Related to commit "Remove strncpy()" (Kees Cook, 19 Jun 2026)
++	strscpy_pad(d, s, n);
++	return (d);
++#else
+ 	return (strncpy(d, s, n));
++#endif
+ }
+ 
+ char*
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index b0cb8b7..74c1937 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -1328,8 +1328,13 @@ wl_alloc_linux_if(wl_if_t *wlif)
+ 	bzero(dev, sizeof(struct net_device));
+ 	ether_setup(dev);
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
++	// Related to commit "Remove strncpy()" (Kees Cook, 19 Jun 2026)
++	strscpy(dev->name, intf_name, IFNAMSIZ);
++#else
+ 	strncpy(dev->name, intf_name, IFNAMSIZ-1);
+ 	dev->name[IFNAMSIZ-1] = '\0';
++#endif
+ 
+ 	priv_link = MALLOC(wl->osh, sizeof(priv_link_t));
+ 	if (!priv_link) {
+@@ -1550,8 +1555,13 @@ wl_get_driver_info(struct net_device *dev, struct ethtool_drvinfo *info)
+ #endif
+ 	bzero(info, sizeof(struct ethtool_drvinfo));
+ 	snprintf(info->driver, sizeof(info->driver), "wl%d", wl->pub->unit);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
++	// Related to commit "Remove strncpy()" (Kees Cook, 19 Jun 2026)
++	strscpy(info->version, EPI_VERSION_STR, sizeof(info->version));
++#else
+ 	strncpy(info->version, EPI_VERSION_STR, sizeof(info->version));
+ 	info->version[(sizeof(info->version))-1] = '\0';
++#endif
+ }
+ 
+ static int
+@@ -3069,7 +3079,9 @@ _wl_add_monitor_if(wl_task_t *task)
+ 	}
+ 
+ 	ASSERT(strlen(wlif->name) > 0);
+-#if __GNUC__ < 8
++#if __GNUC__ < 8 && LINUX_VERSION_CODE < KERNEL_VERSION(7, 2, 0)
++	// Test on kernel lower than 7.2 is related to commit "Remove strncpy()"
++	// (Kees Cook, 19 Jun 2026)
+ 	strncpy(wlif->dev->name, wlif->name, strlen(wlif->name));
+ #else
+ 	// Should have been:
+-- 
+2.55.0
+

--- a/anda/system/wl-kmod/wl-kmod.spec
+++ b/anda/system/wl-kmod/wl-kmod.spec
@@ -10,7 +10,7 @@
 
 Name:       wl-kmod
 Version:    6.30.223.271
-Release:    7%{?dist}
+Release:    8%{?dist}
 Summary:    Kernel module for Broadcom wireless devices
 Group:      System Environment/Kernel
 License:    Redistributable, no modification permitted
@@ -54,6 +54,7 @@ Patch32:    wl-kmod-034_kernel_6.15_adaptation_replace_del_timer_with_timer_dele
 Patch33:    wl-kmod-035_kernel_6.17_adaptation_fix_functions_prototypes.patch
 Patch34:    wl-kmod-036_kernel_7.1_adaptation_replace_net_device_struct_with_wireless_dev_struct.patch
 Patch35:    wl-kmod-037_kernel_6.13_remove_flush_scheduled_work.patch
+Patch36:    wl-kmod-038_kernel_7.2_adaptation_remove_strncpy_function.patch
 ExclusiveArch:  i686 x86_64
 BuildRequires:  kmodtool
 BuildRequires:  elfutils-libelf-devel
@@ -115,6 +116,7 @@ pushd %{name}-%{version}-src
 %patch -P 33 -p1 -b .kernel_6.17_adaptation
 %patch -P 34 -p1 -b .kernel_7.1_adaptation
 %patch -P 35 -p1 -b .flush_scheduled_work
+%patch -P 36 -p1 -b .kernel_7.2_adaptation
 
 # Manual patching to build for RHEL - inspired by CentOS wl-kmod.spec
 # Actually works for RHEL 6.x and 7.x
@@ -378,6 +380,10 @@ pushd %{name}-%{version}-src
    %{__sed} -i  's/ >= KERNEL_VERSION(6, 14, 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
    %{__sed} -i  's/ >= KERNEL_VERSION(6, 17, 0)/ >= KERNEL_VERSION(5, 14, 0)/g' src/wl/sys/wl_cfg80211_hybrid.c
   %endif
+  %if %{kvr} >= 687
+   #  Apply to EL 9.8 point release and later
+   #   >  No changes currently needed for EL 9.8 point release
+  %endif
  %endif
 %endif
 %if 0%{?rhel} == 10
@@ -414,7 +420,11 @@ done
 %build
 for kernel_version in %{?kernel_versions}; do
  pushd _kmod_build_${kernel_version%%___*}
+%if 0%{?rhel} >= 10
+ make -C ${kernel_version##*___} M=`pwd` objtool=/usr/bin/true modules
+%else
  make -C ${kernel_version##*___} M=`pwd` modules
+%endif
  popd
 done
 
@@ -431,4 +441,5 @@ chmod 0755 $RPM_BUILD_ROOT%{kmodinstdir_prefix}*%{kmodinstdir_postfix}/* || :
 %{?akmod_install}
 
 %changelog
-%autochangelog
+* Mon Aug 24 2026 LionHeartP <LionHeartP@proton.me> - 6.30.223.271-8
+- Sync changes from rpmfusion: Add new patch for kernel 7.2+, adjust rhel >=10 build command and prepare section for EL>=9.8


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [wl-kmod: sync patches with rpmfusion for kernels 7.2+ (#16128)](https://github.com/terrapkg/packages/pull/16128)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)