### PR TITLE
[f44] add: xdg-desktop-portal-umbriel (#16152)

### DIFF
--- a/anda/desktops/umbriel/xdg-desktop-portal-umbriel-nightly/anda.hcl
+++ b/anda/desktops/umbriel/xdg-desktop-portal-umbriel-nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+  rpm {
+    spec = "xdg-desktop-portal-umbriel-nightly.spec"
+  }
+  labels {
+    nightly = 1
+  }
+}

--- a/anda/desktops/umbriel/xdg-desktop-portal-umbriel-nightly/update.rhai
+++ b/anda/desktops/umbriel/xdg-desktop-portal-umbriel-nightly/update.rhai
@@ -1,0 +1,6 @@
+rpm.global("commit", gh_commit("noctalia-dev/xdg-desktop-portal-umbriel"));
+if rpm.changed() {
+        // rpm.global("ver", gh("noctalia-dev/xdg-desktop-portal-umbriel"));
+        rpm.global("commitdate", date());
+        rpm.release();
+}

--- a/anda/desktops/umbriel/xdg-desktop-portal-umbriel-nightly/xdg-desktop-portal-umbriel-nightly.spec
+++ b/anda/desktops/umbriel/xdg-desktop-portal-umbriel-nightly/xdg-desktop-portal-umbriel-nightly.spec
@@ -1,0 +1,73 @@
+%global debug_package   %{nil}
+
+%global commit          515c9f70f13ba4b4b9e19930b3e899c4ac8a50a4
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global commitdate      20260824
+
+Name:   	xdg-desktop-portal-umbriel-nightly
+Version:	0^%{commitdate}git.%{shortcommit}
+Release:	1%{?dist}
+Summary:    An xdg-desktop-portal backend for the Umbriel compositor
+
+License:	MIT
+URL:		https://github.com/noctalia-dev/xdg-desktop-portal-umbriel
+Source0:	https://github.com/noctalia-dev/xdg-desktop-portal-umbriel/archive/%{commit}/xdg-desktop-portal-umbriel-%{commit}.tar.gz
+
+BuildRequires:  meson
+BuildRequires:  cmake
+BuildRequires:  gcc-c++
+BuildRequires:  git
+BuildRequires:  pkgconfig(sdbus-c++)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-protocols)
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(libpipewire-0.3)
+BuildRequires:  pkgconfig(cairo)
+BuildRequires:  pkgconfig(tomlplusplus)
+BuildRequires:  pkgconfig(gbm)
+BuildRequires:  pkgconfig(nlohmann_json)
+BuildRequires:  pkgconfig(gtk4)
+BuildRequires:  systemd-rpm-macros
+
+Packager:       Cypress Reed <cypress@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n xdg-desktop-portal-umbriel-%{commit}
+
+# Manually insert commit hash
+sed -i "s/'unknown'/'%{shortcommit}'/g" meson.build
+
+%conf
+%meson
+
+%build
+%meson_build
+
+%install
+%meson_install
+
+%post
+%systemd_user_post xdg-desktop-portal-umbriel.service
+
+%preun
+%systemd_user_preun xdg-desktop-portal-umbriel.service
+
+%postun
+%systemd_user_postun xdg-desktop-portal-umbriel.service
+
+%files
+%doc README.md
+%license LICENSE
+%{_userunitdir}/xdg-desktop-portal-umbriel.service
+%{_libexecdir}/umbriel-share-picker
+%{_libexecdir}/xdg-desktop-portal-umbriel
+%{_datadir}/dbus-1/services/org.freedesktop.impl.portal.desktop.umbriel.service
+%{_datadir}/xdg-desktop-portal/portals/umbriel.portal
+%config %{_datadir}/xdg-desktop-portal/umbriel-portals.conf
+
+%changelog
+* Mon Aug 24 2026 Cypress Reed <cypress@fyralabs.com>
+- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: xdg-desktop-portal-umbriel (#16152)](https://github.com/terrapkg/packages/pull/16152)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)