### PR TITLE
[f44] chore(andax): Update EPEL Bodhi branch to 10.4 (#16158)

### DIFF
--- a/andax/bump_extras.rhai
+++ b/andax/bump_extras.rhai
@@ -33,7 +33,7 @@ fn as_bodhi_ver(branch) {
     if branch.starts_with("el") {
         branch.crop(2);
         if branch == "10" {
-            return "EPEL-10.3";
+            return "EPEL-10.4";
         }
         return `EPEL-${release}`;
     } else if branch == "frawhide" {


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(andax): Update EPEL Bodhi branch to 10.4 (#16158)](https://github.com/terrapkg/packages/pull/16158)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)