### PR TITLE
[el10] feat: Update to the latest ogui patch set (#16163)

### DIFF
--- a/anda/games/opengamepadui/opengamepadui.spec
+++ b/anda/games/opengamepadui/opengamepadui.spec
@@ -2,7 +2,7 @@
 
 Name:           opengamepadui
 Version:        0.46.0
-Release:        10%{?dist}
+Release:        11%{?dist}
 Summary:        Open source gamepad-native game launcher and overlay
 
 License:        GPL-3.0-or-later


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat: Update to the latest ogui patch set (#16163)](https://github.com/terrapkg/packages/pull/16163)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)