### PR TITLE
[frawhide] fix(zenergy-kmod): remove check for fedora to build akmod (#16183)

### DIFF
--- a/anda/system/zenergy/akmod/zenergy-kmod.spec
+++ b/anda/system/zenergy/akmod/zenergy-kmod.spec
@@ -2,10 +2,8 @@
 # is because akmods use the srpm to build the kmod package, and if the kmod package is included
 # in the main package, akmods will reinstall the userspace package every time the kernel is updated.
 
-%if 0%{?fedora}
 %global buildforkernels akmod
 %global debug_package %{nil}
-%endif
 
 %global commit 58f2fda7184fbde95033f492f7c54990552ef86f
 %global commitdate 20250831


### PR DESCRIPTION
# Backport

This will backport the following commits from `el10` to `frawhide`:
 - [fix(zenergy-kmod): remove check for fedora to build akmod (#16183)](https://github.com/terrapkg/packages/pull/16183)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)