### PR TITLE
[f44] fix(nct6687d-kmod): remove check for fedora to build akmod (#16182)

### DIFF
--- a/anda/system/nct6687d/akmod/nct6687d-kmod.spec
+++ b/anda/system/nct6687d/akmod/nct6687d-kmod.spec
@@ -2,10 +2,8 @@
 # is because akmods use the srpm to build the kmod package, and if the kmod package is included
 # in the main package, akmods will reinstall the userspace package every time the kernel is updated.
 
-%if 0%{?fedora}
 %global buildforkernels akmod
 %global debug_package %{nil}
-%endif
 
 %global commit 4864fd681346119cf17417f82934a8ce05d88ff6
 %global commitdate 20260816


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(nct6687d-kmod): remove check for fedora to build akmod (#16182)](https://github.com/terrapkg/packages/pull/16182)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)