### PR TITLE
[el10] chore (dart): build debuginfo package (#16195)

### DIFF
--- a/anda/langs/dart/dart.spec
+++ b/anda/langs/dart/dart.spec
@@ -1,4 +1,4 @@
-%define debug_package %{nil}
+%undefine _debugsource_packages
 
 Name: dart
 Version: 3.13.2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (dart): build debuginfo package (#16195)](https://github.com/terrapkg/packages/pull/16195)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)