### PR TITLE
[f45] fix (porffor): add nightly label (#16202)

### DIFF
--- a/anda/langs/js/porffor/anda.hcl
+++ b/anda/langs/js/porffor/anda.hcl
@@ -2,4 +2,7 @@ project pkg {
   rpm {
     spec = "porffor.spec"
   }
+  labels {
+    nightly = 1
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix (porffor): add nightly label (#16202)](https://github.com/terrapkg/packages/pull/16202)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)