### PR TITLE
[f45] fix: socktop (#16125)

### DIFF
--- a/anda/apps/socktop/socktop.spec
+++ b/anda/apps/socktop/socktop.spec
@@ -1,13 +1,9 @@
-%global ver v1.60.2
-%global download_ver %(echo %{ver} | sed 's/v//g')
-%global sanitized_ver %(echo %{ver} | sed 's/-//g')
-
 Name:           socktop
-Version:        %sanitized_ver
+Version:        1.60.2
 Release:        1%?dist
 Summary:        socktop is a remote system monitor with a rich TUI interface
 URL:            https://github.com/jasonwitty/socktop
-Source0:        %{url}/archive/refs/tags/%{ver}.tar.gz
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 License:        MIT
 BuildRequires:  rust libdrm-devel systemd-rpm-macros cargo-rpm-macros
 Requires:       libdrm
@@ -18,7 +14,7 @@ socktop is a remote system monitor with a rich TUI interface, inspired by `top` 
 that communicates with a lightweight remote agent over WebSockets.
 
 %prep
-%autosetup -n %{name}-%{download_ver}
+%autosetup -n %{name}-%{version}
 %cargo_prep_online
 
 %build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: socktop (#16125)](https://github.com/terrapkg/packages/pull/16125)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)