### PR TITLE
fix(noctalia-legacy): bluetooth endless discovery causes crash

### DIFF
--- a/anda/desktops/noctalia/legacy/noctalia-legacy-bluetooth-discovery.patch
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy-bluetooth-discovery.patch
@@ -31,7 +31,7 @@ index ee26af6476..3878421d83 100644
        }
        if (isDiscoverable && !showOnlyLists) {
 @@ -124,7 +122,7 @@ Item {
- 
+
    Component.onDestruction: {
      // Ensure scanning is stopped when component is closed
 -    if (isScanningActive && !showOnlyLists) {
@@ -45,17 +45,17 @@ index 9146763dd5..74d347257f 100644
 +++ b/Services/Networking/BluetoothService.qml
 @@ -53,7 +53,7 @@ Singleton {
    property bool pinRequired: false
- 
+
    // Internal variables
 -  property bool _discoveryWasRunning: false
 +  property bool _scanRequested: false
    property bool _ctlInit: false
    property var _autoConnectQueue: []
- 
+
 @@ -183,12 +183,12 @@ Singleton {
      }
    }
- 
+
 -  // Unify discovery controls
 -  function setScanActive(active) {
 +  function _applyScanRequest() {
@@ -70,7 +70,7 @@ index 9146763dd5..74d347257f 100644
 @@ -198,6 +198,12 @@ Singleton {
      }
    }
- 
+
 +  // Track whether the visible Bluetooth UI owns an active discovery request.
 +  function setScanActive(active) {
 +    root._scanRequested = active;
@@ -83,7 +83,7 @@ index 9146763dd5..74d347257f 100644
 @@ -368,12 +374,6 @@ Singleton {
      const intervalMs = Math.max(500, Number(root.connectRetryIntervalMs) | 0);
      const intervalSec = Math.max(1, Math.round(intervalMs / 1000));
- 
+
 -    // Temporarily pause discovery during pair/connect to reduce HCI churn
 -    root._discoveryWasRunning = root.scanningActive;
 -    if (root.scanningActive) {

--- a/anda/desktops/noctalia/legacy/noctalia-legacy-bluetooth-discovery.patch
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy-bluetooth-discovery.patch
@@ -1,0 +1,115 @@
+From a676e9586286d155a3e3c8129b4214a9847eff56 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gabriel=20Silva=20Gouv=C3=AAa?= <gouswat@gmail.com>
+Date: Tue, 25 Aug 2026 17:34:18 -0300
+Subject: [PATCH] fix(bluetooth): preserve discovery ownership through pairing
+
+---
+ .../Tabs/Connections/BluetoothSubTab.qml      |  8 +++----
+ Services/Networking/BluetoothService.qml      | 24 ++++++++-----------
+ 2 files changed, 13 insertions(+), 19 deletions(-)
+
+diff --git a/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml b/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
+index ee26af6476..3878421d83 100644
+--- a/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
++++ b/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
+@@ -105,15 +105,13 @@ Item {
+   function _updateScanningState() {
+     if (effectivelyVisible && BluetoothService.enabled && !showOnlyLists) {
+       Logger.d("BluetoothPrefs", "Panel/tab active");
+-      if (!isScanningActive) {
+-        BluetoothService.setScanActive(true);
+-      }
++      BluetoothService.setScanActive(true);
+       if (!Settings.data.network.disableDiscoverability && !isDiscoverable) {
+         BluetoothService.setDiscoverable(true);
+       }
+     } else {
+       Logger.d("BluetoothPrefs", "Panel/tab inactive");
+-      if (isScanningActive && !showOnlyLists) {
++      if (!showOnlyLists) {
+         BluetoothService.setScanActive(false);
+       }
+       if (isDiscoverable && !showOnlyLists) {
+@@ -124,7 +122,7 @@ Item {
+ 
+   Component.onDestruction: {
+     // Ensure scanning is stopped when component is closed
+-    if (isScanningActive && !showOnlyLists) {
++    if (!showOnlyLists) {
+       BluetoothService.setScanActive(false);
+     }
+     // Ensure discoverable is disabled when component is closed
+diff --git a/Services/Networking/BluetoothService.qml b/Services/Networking/BluetoothService.qml
+index 9146763dd5..74d347257f 100644
+--- a/Services/Networking/BluetoothService.qml
++++ b/Services/Networking/BluetoothService.qml
+@@ -53,7 +53,7 @@ Singleton {
+   property bool pinRequired: false
+ 
+   // Internal variables
+-  property bool _discoveryWasRunning: false
++  property bool _scanRequested: false
+   property bool _ctlInit: false
+   property var _autoConnectQueue: []
+ 
+@@ -183,12 +183,12 @@ Singleton {
+     }
+   }
+ 
+-  // Unify discovery controls
+-  function setScanActive(active) {
++  function _applyScanRequest() {
+     if (!adapter) {
+       Logger.d("Bluetooth", "Scan request ignored: adapter unavailable");
+       return;
+     }
++    const active = root._scanRequested && !pairingProcess.running;
+     try {
+       if (active || adapter.discovering) { // Only attempt to set if activating, or if deactivating and currently currently discovering
+         adapter.discovering = active;
+@@ -198,6 +198,12 @@ Singleton {
+     }
+   }
+ 
++  // Track whether the visible Bluetooth UI owns an active discovery request.
++  function setScanActive(active) {
++    root._scanRequested = active;
++    root._applyScanRequest();
++  }
++
+   // Toggle adapter discoverability (advertising visibility) via bluetoothctl
+   function setDiscoverable(state) {
+     if (!adapter) {
+@@ -368,12 +374,6 @@ Singleton {
+     const intervalMs = Math.max(500, Number(root.connectRetryIntervalMs) | 0);
+     const intervalSec = Math.max(1, Math.round(intervalMs / 1000));
+ 
+-    // Temporarily pause discovery during pair/connect to reduce HCI churn
+-    root._discoveryWasRunning = root.scanningActive;
+-    if (root.scanningActive) {
+-      root.setScanActive(false);
+-    }
+-
+     const scriptPath = Quickshell.shellDir + "/Scripts/python/src/network/bluetooth-pair.py";
+     pairingProcess.command = ["python3", scriptPath, String(addr), String(pairWait), String(attempts), String(intervalSec)];
+     pairingProcess.running = true;
+@@ -516,6 +516,7 @@ Singleton {
+   // Interactive pairing process
+   Process {
+     id: pairingProcess
++    onRunningChanged: root._applyScanRequest()
+     stdout: SplitParser {
+       onRead: data => {
+         Logger.d("Bluetooth", data);
+@@ -528,11 +529,6 @@ Singleton {
+     onExited: {
+       root.pinRequired = false;
+       Logger.i("Bluetooth", "Pairing process exited.");
+-      // Restore discovery if we paused it
+-      if (root._discoveryWasRunning) {
+-        root.setScanActive(true);
+-      }
+-      root._discoveryWasRunning = false;
+     }
+     environment: ({
+                     "LC_ALL": "C"

--- a/anda/desktops/noctalia/legacy/noctalia-legacy.spec
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy.spec
@@ -2,7 +2,7 @@
 
 Name:           noctalia-legacy
 Version:		4.7.7
-Release:        4%{?dist}
+Release:        3%{?dist}
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
@@ -27,8 +27,7 @@ Recommends:	    power-profiles-daemon
 Recommends:	    wlsunset
 Recommends:    	gpu-screen-recorder
 
-Provides:       noctalia-shell = %{version}-%{release}
-Obsoletes:      noctalia-shell < 5
+Obsoletes:      noctalia-shell <= 4.7.7-1
 
 Packager:       Cypress Reed <cypress@fyralabs.com>
 
@@ -54,7 +53,7 @@ echo "noctalia-shell has been renamed to noctalia"
 echo "noctalia v5 is coming soon! keep an eye out as this legacy package will become obsolete"
 
 %changelog
-* Tue Aug 25 2026 Gabriel Silva Gouvêa <gouswat@gmail.com> - 4.7.7-4
+* Tue Aug 25 2026 Gabriel Silva Gouvêa <gouswat@gmail.com>
 - Preserve Bluetooth discovery ownership when pairing finishes
 - Complete the transition from the former noctalia-shell package
 

--- a/anda/desktops/noctalia/legacy/noctalia-legacy.spec
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy.spec
@@ -8,7 +8,10 @@ Summary:        A Quickshell-based custom shell setup
 License:        MIT
 URL:            https://github.com/noctalia-dev/noctalia
 Source0:        https://github.com/noctalia-dev/noctalia/releases/download/v%{version}/noctalia-v%{version}.tar.gz
-Patch0:         https://github.com/gouveags/noctalia/commit/a676e9586286d155a3e3c8129b4214a9847eff56.patch
+# Downstream fix for https://github.com/terrapkg/packages/issues/16213.
+# Noctalia v4 is no longer maintained upstream. Original signed fix:
+# https://github.com/gouveags/noctalia/commit/a676e9586286d155a3e3c8129b4214a9847eff56
+Patch0:         noctalia-legacy-bluetooth-discovery.patch
 
 Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts

--- a/anda/desktops/noctalia/legacy/noctalia-legacy.spec
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy.spec
@@ -51,7 +51,7 @@ echo "noctalia-shell has been renamed to noctalia"
 echo "noctalia v5 is coming soon! keep an eye out as this legacy package will become obsolete"
 
 %changelog
-* Tue Aug 25 2026 Gabriel Silva Gouvêa <gabriel.gouvea@movedot.com> - 4.7.7-4
+* Tue Aug 25 2026 Gabriel Silva Gouvêa <gouswat@gmail.com> - 4.7.7-4
 - Preserve Bluetooth discovery ownership when pairing finishes
 - Complete the transition from the former noctalia-shell package
 

--- a/anda/desktops/noctalia/legacy/noctalia-legacy.spec
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy.spec
@@ -2,7 +2,7 @@
 
 Name:           noctalia-legacy
 Version:		4.7.7
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
@@ -24,7 +24,8 @@ Recommends:	    power-profiles-daemon
 Recommends:	    wlsunset
 Recommends:    	gpu-screen-recorder
 
-Obsoletes:      noctalia-shell <= 4.7.7-1
+Provides:       noctalia-shell = %{version}-%{release}
+Obsoletes:      noctalia-shell < 5
 
 Packager:       Cypress Reed <cypress@fyralabs.com>
 
@@ -50,8 +51,9 @@ echo "noctalia-shell has been renamed to noctalia"
 echo "noctalia v5 is coming soon! keep an eye out as this legacy package will become obsolete"
 
 %changelog
-* Tue Aug 25 2026 Gabriel Silva Gouvêa <gabriel.gouvea@movedot.com> - 4.7.7-3
+* Tue Aug 25 2026 Gabriel Silva Gouvêa <gabriel.gouvea@movedot.com> - 4.7.7-4
 - Preserve Bluetooth discovery ownership when pairing finishes
+- Complete the transition from the former noctalia-shell package
 
 * Thu Jun 04 2026 Cypress Reed <cypress@fyralabs.com>
 - Update email and name (was Willow Reed or Willow C Reed) (I'm official now!)

--- a/anda/desktops/noctalia/legacy/noctalia-legacy.spec
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy.spec
@@ -2,12 +2,13 @@
 
 Name:           noctalia-legacy
 Version:		4.7.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
 URL:            https://github.com/noctalia-dev/noctalia
 Source0:        https://github.com/noctalia-dev/noctalia/releases/download/v%{version}/noctalia-v%{version}.tar.gz
+Patch0:         https://github.com/gouveags/noctalia/commit/1ebba5f6a9822fbfa54f06cab8466c757e5a719a.patch
 
 Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts
@@ -31,7 +32,7 @@ Packager:       Cypress Reed <cypress@fyralabs.com>
 A beautiful, minimal desktop shell for Wayland that actually gets out of your way. Built on Quickshell with a warm lavender aesthetic that you can easily customize to match your vibe.
 
 %prep
-%autosetup -n noctalia-release
+%autosetup -n noctalia-release -p1
 
 %build
 
@@ -49,6 +50,9 @@ echo "noctalia-shell has been renamed to noctalia"
 echo "noctalia v5 is coming soon! keep an eye out as this legacy package will become obsolete"
 
 %changelog
+* Tue Aug 25 2026 Gabriel Silva Gouvêa <gabriel.gouvea@movedot.com> - 4.7.7-3
+- Preserve Bluetooth discovery ownership when pairing finishes
+
 * Thu Jun 04 2026 Cypress Reed <cypress@fyralabs.com>
 - Update email and name (was Willow Reed or Willow C Reed) (I'm official now!)
 

--- a/anda/desktops/noctalia/legacy/noctalia-legacy.spec
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy.spec
@@ -8,7 +8,7 @@ Summary:        A Quickshell-based custom shell setup
 License:        MIT
 URL:            https://github.com/noctalia-dev/noctalia
 Source0:        https://github.com/noctalia-dev/noctalia/releases/download/v%{version}/noctalia-v%{version}.tar.gz
-Patch0:         https://github.com/gouveags/noctalia/commit/1ebba5f6a9822fbfa54f06cab8466c757e5a719a.patch
+Patch0:         https://github.com/gouveags/noctalia/commit/a676e9586286d155a3e3c8129b4214a9847eff56.patch
 
 Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts


### PR DESCRIPTION
## What changed

This adds a downstream patch for Noctalia v4 that fixes Bluetooth crashing by keeping device discovery active even after pairing.

The patch makes Noctalia remember whether the Bluetooth panel still wants discovery instead of restoring scanning based only on whether it was active before pairing. Right now discovery keeps going endlessly until crash happens.

Detailed PR behavior:

- Stops discovery when the Bluetooth panel closes, including while pairing is still running.
- Restores discovery after pairing only when the panel still owns an active scan request.
- Adds the patch directly to the package so it can be reviewed and built without depending on an external fork.
- Completes the package transition using `Obsoletes` so existing `noctalia-shell` installations can receive the fixed `noctalia-legacy` package.

## Why

After updating Fedora, my Logitech MX Master 3S started disconnecting randomly when using an Intel Wireless-AC 9560 Bluetooth controller.

Testing against the real Bluetooth controller showed that Noctalia v4 could leave Bluetooth discovery running after its Bluetooth panel had already closed.

The problematic sequence was:

1. The Bluetooth panel started discovery.
2. Pairing temporarily paused discovery.
3. The panel was closed while pairing was still running.
4. Noctalia lost the information that the panel no longer wanted discovery.
5. When pairing finished, discovery was enabled again and remained active indefinitely.
6. Sustained discovery eventually caused the mouse connection to fail with an HCI `Connection Timeout (0x08)`.

Noctalia v4 is no longer receiving direct updates, so this downstream package is a useful place to ship the fix for people who still install the legacy version (myself included).

## Testing

- Reproduced the original failure against the physical Intel Bluetooth controller.
- Confirmed that sustained discovery could trigger the MX Master 3S connection timeout.
- Verified that closing the panel clears the logical discovery request.
- Verified that pairing temporarily pauses physical discovery without losing panel ownership.
- Verified that pairing completion does not restart discovery after the panel has closed.
- Built the binary RPM and source RPM successfully.
- Confirmed that the patch applies with `--fuzz=0`.
- Confirmed that the source RPM contains the vendored patch.
- Confirmed that the resulting binary payload matches the version tested on the hardware.
- Confirmed that the installed package passes `rpm -V`.

This closes [PR#16213](https://github.com/terrapkg/packages/issues/16213)