### PR TITLE
[el10] fix(noctalia-legacy): bluetooth endless discovery causes crash (#16215)

### DIFF
--- a/anda/desktops/noctalia/legacy/noctalia-legacy-bluetooth-discovery.patch
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy-bluetooth-discovery.patch
@@ -1,0 +1,115 @@
+From a676e9586286d155a3e3c8129b4214a9847eff56 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gabriel=20Silva=20Gouv=C3=AAa?= <gouswat@gmail.com>
+Date: Tue, 25 Aug 2026 17:34:18 -0300
+Subject: [PATCH] fix(bluetooth): preserve discovery ownership through pairing
+
+---
+ .../Tabs/Connections/BluetoothSubTab.qml      |  8 +++----
+ Services/Networking/BluetoothService.qml      | 24 ++++++++-----------
+ 2 files changed, 13 insertions(+), 19 deletions(-)
+
+diff --git a/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml b/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
+index ee26af6476..3878421d83 100644
+--- a/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
++++ b/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
+@@ -105,15 +105,13 @@ Item {
+   function _updateScanningState() {
+     if (effectivelyVisible && BluetoothService.enabled && !showOnlyLists) {
+       Logger.d("BluetoothPrefs", "Panel/tab active");
+-      if (!isScanningActive) {
+-        BluetoothService.setScanActive(true);
+-      }
++      BluetoothService.setScanActive(true);
+       if (!Settings.data.network.disableDiscoverability && !isDiscoverable) {
+         BluetoothService.setDiscoverable(true);
+       }
+     } else {
+       Logger.d("BluetoothPrefs", "Panel/tab inactive");
+-      if (isScanningActive && !showOnlyLists) {
++      if (!showOnlyLists) {
+         BluetoothService.setScanActive(false);
+       }
+       if (isDiscoverable && !showOnlyLists) {
+@@ -124,7 +122,7 @@ Item {
+
+   Component.onDestruction: {
+     // Ensure scanning is stopped when component is closed
+-    if (isScanningActive && !showOnlyLists) {
++    if (!showOnlyLists) {
+       BluetoothService.setScanActive(false);
+     }
+     // Ensure discoverable is disabled when component is closed
+diff --git a/Services/Networking/BluetoothService.qml b/Services/Networking/BluetoothService.qml
+index 9146763dd5..74d347257f 100644
+--- a/Services/Networking/BluetoothService.qml
++++ b/Services/Networking/BluetoothService.qml
+@@ -53,7 +53,7 @@ Singleton {
+   property bool pinRequired: false
+
+   // Internal variables
+-  property bool _discoveryWasRunning: false
++  property bool _scanRequested: false
+   property bool _ctlInit: false
+   property var _autoConnectQueue: []
+
+@@ -183,12 +183,12 @@ Singleton {
+     }
+   }
+
+-  // Unify discovery controls
+-  function setScanActive(active) {
++  function _applyScanRequest() {
+     if (!adapter) {
+       Logger.d("Bluetooth", "Scan request ignored: adapter unavailable");
+       return;
+     }
++    const active = root._scanRequested && !pairingProcess.running;
+     try {
+       if (active || adapter.discovering) { // Only attempt to set if activating, or if deactivating and currently currently discovering
+         adapter.discovering = active;
+@@ -198,6 +198,12 @@ Singleton {
+     }
+   }
+
++  // Track whether the visible Bluetooth UI owns an active discovery request.
++  function setScanActive(active) {
++    root._scanRequested = active;
++    root._applyScanRequest();
++  }
++
+   // Toggle adapter discoverability (advertising visibility) via bluetoothctl
+   function setDiscoverable(state) {
+     if (!adapter) {
+@@ -368,12 +374,6 @@ Singleton {
+     const intervalMs = Math.max(500, Number(root.connectRetryIntervalMs) | 0);
+     const intervalSec = Math.max(1, Math.round(intervalMs / 1000));
+
+-    // Temporarily pause discovery during pair/connect to reduce HCI churn
+-    root._discoveryWasRunning = root.scanningActive;
+-    if (root.scanningActive) {
+-      root.setScanActive(false);
+-    }
+-
+     const scriptPath = Quickshell.shellDir + "/Scripts/python/src/network/bluetooth-pair.py";
+     pairingProcess.command = ["python3", scriptPath, String(addr), String(pairWait), String(attempts), String(intervalSec)];
+     pairingProcess.running = true;
+@@ -516,6 +516,7 @@ Singleton {
+   // Interactive pairing process
+   Process {
+     id: pairingProcess
++    onRunningChanged: root._applyScanRequest()
+     stdout: SplitParser {
+       onRead: data => {
+         Logger.d("Bluetooth", data);
+@@ -528,11 +529,6 @@ Singleton {
+     onExited: {
+       root.pinRequired = false;
+       Logger.i("Bluetooth", "Pairing process exited.");
+-      // Restore discovery if we paused it
+-      if (root._discoveryWasRunning) {
+-        root.setScanActive(true);
+-      }
+-      root._discoveryWasRunning = false;
+     }
+     environment: ({
+                     "LC_ALL": "C"

--- a/anda/desktops/noctalia/legacy/noctalia-legacy.spec
+++ b/anda/desktops/noctalia/legacy/noctalia-legacy.spec
@@ -2,12 +2,16 @@
 
 Name:           noctalia-legacy
 Version:		4.7.7
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        A Quickshell-based custom shell setup
 
 License:        MIT
 URL:            https://github.com/noctalia-dev/noctalia
 Source0:        https://github.com/noctalia-dev/noctalia/releases/download/v%{version}/noctalia-v%{version}.tar.gz
+# Downstream fix for https://github.com/terrapkg/packages/issues/16213.
+# Noctalia v4 is no longer maintained upstream. Original signed fix:
+# https://github.com/gouveags/noctalia/commit/a676e9586286d155a3e3c8129b4214a9847eff56
+Patch0:         noctalia-legacy-bluetooth-discovery.patch
 
 Requires:	    brightnessctl
 Requires:    	dejavu-sans-fonts
@@ -31,7 +35,7 @@ Packager:       Cypress Reed <cypress@fyralabs.com>
 A beautiful, minimal desktop shell for Wayland that actually gets out of your way. Built on Quickshell with a warm lavender aesthetic that you can easily customize to match your vibe.
 
 %prep
-%autosetup -n noctalia-release
+%autosetup -n noctalia-release -p1
 
 %build
 
@@ -49,6 +53,10 @@ echo "noctalia-shell has been renamed to noctalia"
 echo "noctalia v5 is coming soon! keep an eye out as this legacy package will become obsolete"
 
 %changelog
+* Tue Aug 25 2026 Gabriel Silva Gouvêa <gouswat@gmail.com>
+- Preserve Bluetooth discovery ownership when pairing finishes
+- Complete the transition from the former noctalia-shell package
+
 * Thu Jun 04 2026 Cypress Reed <cypress@fyralabs.com>
 - Update email and name (was Willow Reed or Willow C Reed) (I'm official now!)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(noctalia-legacy): bluetooth endless discovery causes crash (#16215)](https://github.com/terrapkg/packages/pull/16215)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)