### PR TITLE
[f43] fix: discord-openasar (#16235)

### DIFF
--- a/anda/apps/discord-openasar/discord-openasar.spec
+++ b/anda/apps/discord-openasar/discord-openasar.spec
@@ -7,7 +7,7 @@
 
 Name:           discord-openasar
 Version:        1.0.155
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A snappier Discord rewrite with features like further customization and theming
 License:        MIT AND https://discord.com/terms
 URL:            https://github.com/GooseMod/OpenAsar
@@ -44,11 +44,12 @@ ln -s %_datadir/discord-openasar/discord.png %{buildroot}%{_datadir}/pixmaps/dis
 mkdir -p %{buildroot}%{_datadir}/discord-openasar/resources
 cp -v %{SOURCE1} %{buildroot}%{_datadir}/discord-openasar/resources/app.asar
 chmod o+w %{buildroot}%{_datadir}/discord-openasar/resources -R
-ln -s %_datadir/discord-openasar/Discord %buildroot%_bindir/discord-openasar
-
+ln -s %_datadir/discord-openasar/discord %buildroot%_bindir/discord-openasar
+ln -s %_datadir/discord-openasar/updater_bootstrap %buildroot%_bindir/updater_bootstrap
 
 %files
 %_bindir/discord-openasar
+%{_bindir}/updater_bootstrap
 %{_datadir}/discord-openasar/
 %{_datadir}/applications/discord-openasar.desktop
 %{_datadir}/pixmaps/discord-openasar.png


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: discord-openasar (#16235)](https://github.com/terrapkg/packages/pull/16235)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)