### PR TITLE
[f45] add: birdtray and birdtray-nightly (#16241)

### DIFF
--- a/anda/misc/birdtray/nightly/anda.hcl
+++ b/anda/misc/birdtray/nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "birdtray-nightly.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/misc/birdtray/nightly/birdtray-nightly.spec
+++ b/anda/misc/birdtray/nightly/birdtray-nightly.spec
@@ -1,0 +1,40 @@
+%global commit bcceec6a1a56fa7acd19e1b6a93f430b5a566537
+%global commit_date 20260803
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%global ver 1.11.4
+
+Name:                  	birdtray-nightly
+Version:                %{ver}^%{commit_date}git.%{shortcommit}
+Release:                1%{?dist}
+Summary:                Mail system tray notification icon for Thunderbird (nightly)
+
+License:                GPL-3.0-or-later
+URL:                    https://github.com/gyunaev/birdtray
+Source0:                %{url}/archive/%{commit}/birdtray-%{commit}.tar.gz
+
+BuildRequires:          cmake-rpm-macros
+BuildRequires:          gcc-c++
+BuildRequires:          cmake(Qt6Core)
+BuildRequires:          cmake(Qt6Svg)
+BuildRequires:          cmake(Qt5X11Extras)
+BuildSystem:            cmake
+BuildOption(conf):      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+Packager:		Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%files
+%license LICENSE.txt
+%doc README.md
+%{_bindir}/birdtray
+%{_appsdir}/com.ulduzsoft.Birdtray.desktop
+%{_hicolordir}/*x*/apps/com.ulduzsoft.Birdtray.png
+%{_scalableiconsdir}/com.ulduzsoft.Birdtray.svg
+%{_metainfodir}/com.ulduzsoft.Birdtray.appdata.xml
+
+%changelog
+* Thu Aug 27 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit
+

--- a/anda/misc/birdtray/nightly/update.rhai
+++ b/anda/misc/birdtray/nightly/update.rhai
@@ -1,0 +1,6 @@
+rpm.global("ver" (gh("gyunaev/birdtray"));
+rpm.global("commit", gh_commit("gyunaev/birdtray"));
+if rpm.changed() {
+  rpm.release();
+  rpm.global("commit_date", date());
+}

--- a/anda/misc/birdtray/stable/anda.hcl
+++ b/anda/misc/birdtray/stable/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+    rpm {
+        spec = "birdtray.spec"
+    }
+}
+

--- a/anda/misc/birdtray/stable/birdtray.spec
+++ b/anda/misc/birdtray/stable/birdtray.spec
@@ -1,0 +1,34 @@
+Name:			birdtray
+Version:		1.11.4
+Release:        	1%{?dist}
+Summary:		Mail system tray notification icon for Thunderbird
+
+License:		GPL-3.0-or-later
+URL:			https://github.com/gyunaev/birdtray
+Source0:		%{url}/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires:		cmake-rpm-macros
+BuildRequires:		gcc-c++
+BuildRequires:		cmake(Qt5Core)
+BuildRequires:		cmake(Qt5Svg)
+BuildRequires:		cmake(Qt5X11Extras)
+BuildSystem:		cmake
+BuildOption(conf):	-DCMAKE_POLICY_VERSION_MINIMUM=3.5
+Packager:		Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%files
+%license LICENSE.txt
+%doc README.md
+%{_bindir}/birdtray
+%{_appsdir}/com.ulduzsoft.Birdtray.desktop
+%{_hicolordir}/*x*/apps/com.ulduzsoft.Birdtray.png
+%{_scalableiconsdir}/com.ulduzsoft.Birdtray.svg
+%{_metainfodir}/com.ulduzsoft.Birdtray.appdata.xml
+
+%changelog
+* Thu Aug 27 2026 Owen Zimmerman <owen@fyralabs.com> - 1.11.4-1
+- Initial commit
+

--- a/anda/misc/birdtray/stable/update.rhai
+++ b/anda/misc/birdtray/stable/update.rhai
@@ -1,0 +1,2 @@
+rpm.version(gh("gyunaev/birdtray"));
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: birdtray and birdtray-nightly (#16241)](https://github.com/terrapkg/packages/pull/16241)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)