### PR TITLE
[f45] fix: faugus-launcher (#16247)

### DIFF
--- a/anda/games/faugus-launcher/faugus-launcher.spec
+++ b/anda/games/faugus-launcher/faugus-launcher.spec
@@ -9,7 +9,7 @@ Source0:        https://github.com/Faugus/faugus-launcher/archive/refs/tags/%{ve
 Packager:       Caio Bruno <cbrunofb@gmail.com>
 
 BuildArch:      noarch
-BuildRequires:  meson gtk-update-icon-cache python3-devel
+BuildRequires:  meson gtk-update-icon-cache python3-devel gettext
 Requires:       python3-gobject python3-requests python3-pillow python3-vdf python3-psutil python3-dbus gtk4 libadwaita libmanette python3-icoextract
 Recommends:     mangohud
 Recommends:     (falcond or gamemode)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: faugus-launcher (#16247)](https://github.com/terrapkg/packages/pull/16247)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)