### PR TITLE
[el10] add: libunrar and libunrar-devel (#16257)

### DIFF
--- a/anda/tools/unrar/unrar.spec
+++ b/anda/tools/unrar/unrar.spec
@@ -1,6 +1,6 @@
 Name:           unrar
 Version:        7.2.7
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Utility for extracting, testing and viewing RAR archives
 
 License:        LicenseRef-unrar AND BSD-2-Clause AND CC0-1.0 AND LicenseRef-Fedora-Public-Domain
@@ -18,19 +18,47 @@ BuildRequires:  make
 The unrar utility is a freeware program for extracting, testing and
 viewing the contents of archives created with the RAR archiver.
 
+%package -n libunrar
+Summary:        Library for extracting RAR archives
+
+%description -n libunrar
+The libunrar library allows applications linking against it to extract
+files from RAR archives.
+
+%package -n libunrar-devel
+Summary:        Development files for libunrar
+Requires:       libunrar%{?_isa} = %{version}-%{release}
+
+%description -n libunrar-devel
+The libunrar-devel package contains the headers needed to develop
+applications that use libunrar.
+
 %prep
 %autosetup -n %{name}
 
 %build
 %set_build_flags
+CXXFLAGS="$CXXFLAGS -std=c++11 -Wno-parentheses -Wno-switch -Wno-sign-compare -Wno-class-memaccess -Wno-unused-variable -Wno-unused-function -Wno-dangling-else"
 %make_build -f makefile unrar \
-    CXXFLAGS="$CXXFLAGS -std=c++11 -Wno-parentheses -Wno-switch -Wno-sign-compare -Wno-class-memaccess -Wno-unused-variable -Wno-unused-function -Wno-dangling-else" \
+    CXXFLAGS="$CXXFLAGS" \
+    LDFLAGS="$LDFLAGS -pthread" \
+    STRIP=:
+rm -f *.o
+%make_build -f makefile lib \
+    CXXFLAGS="$CXXFLAGS -fPIC -DPIC" \
     LDFLAGS="$LDFLAGS -pthread" \
     STRIP=:
 
 %install
 install -Dpm 0755 unrar %{buildroot}%{_bindir}/unrar
 install -Dpm 0644 %{SOURCE1} %{buildroot}%{_mandir}/man1/unrar.1
+install -Dpm 0755 libunrar.so %{buildroot}%{_libdir}/libunrar.so
+install -dpm 0755 %{buildroot}%{_includedir}/unrar
+install -pm 0644 *.hpp %{buildroot}%{_includedir}/unrar/
+install -Dpm 0644 /dev/null %{buildroot}%{_rpmmacrodir}/macros.unrar
+echo "%%unrar_version %{version}" > %{buildroot}%{_rpmmacrodir}/macros.unrar
+
+%ldconfig_scriptlets -n libunrar
 
 %files
 %license license.txt acknow.txt
@@ -38,6 +66,19 @@ install -Dpm 0644 %{SOURCE1} %{buildroot}%{_mandir}/man1/unrar.1
 %{_bindir}/unrar
 %{_mandir}/man1/unrar.1*
 
+%files -n libunrar
+%license license.txt acknow.txt
+%doc readme.txt
+%{_libdir}/libunrar.so
+
+%files -n libunrar-devel
+%doc readme.txt
+%{_includedir}/unrar/
+%{_rpmmacrodir}/macros.unrar
+
 %changelog
+* Thu Aug 27 2026 ammix <maxim@ammix.dev> - 7.2.7-2
+- Add libunrar and libunrar-devel subpackages
+
 * Thu Aug 27 2026 ammix <maxim@ammix.dev> - 7.2.7-1
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: libunrar and libunrar-devel (#16257)](https://github.com/terrapkg/packages/pull/16257)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)