### PR TITLE
[f44] add: tidal-hifi (#15735)

### DIFF
--- a/anda/apps/tidal-hifi/anda.hcl
+++ b/anda/apps/tidal-hifi/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "tidal-hifi.spec"
+  }
+}

--- a/anda/apps/tidal-hifi/tidal-hifi.spec
+++ b/anda/apps/tidal-hifi/tidal-hifi.spec
@@ -1,0 +1,39 @@
+%global debug_package %{nil}
+
+Name:           tidal-hifi
+Version:        8.1.3
+Release:        1%?dist
+Summary:        The web version of Tidal running in electron with hifi support thanks to widevine
+%electronmeta
+License:        MIT AND %electron_license
+URL:            https://github.com/Mastermindzh/tidal-hifi
+Source0:        %url/archive/refs/tags/%version.tar.gz
+Packager:       madonuko <mado@fyralabs.com>
+
+BuildRequires:  nodejs-packaging
+
+%description
+The web version of TIDAL running in electron with Hi-Fi (High & Max) support thanks to widevine.
+
+%prep
+%autosetup
+
+%build
+%npm_build -r compile -BC ./build/electron-builder.base.yml
+
+%install
+%electron_install
+
+# Do not ship an absolute symlink from /usr/bin.
+rm -f %{buildroot}%{_bindir}/%{name}
+ln -s ../%{_lib}/%{name}/%{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/%{name}
+%{_libdir}/%{name}
+
+%changelog
+* Mon Aug 17 2026 madonuko <mado@fyralabs.com>
+- Initial package

--- a/anda/apps/tidal-hifi/update.rhai
+++ b/anda/apps/tidal-hifi/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("Mastermindzh/tidal-hifi"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: tidal-hifi (#15735)](https://github.com/terrapkg/packages/pull/15735)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)