### PR TITLE
[el10] add: victor-mono-fonts (#16271)

### DIFF
--- a/anda/fonts/victor-mono/anda.hcl
+++ b/anda/fonts/victor-mono/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+	arches = ["x86_64"]
+	rpm {
+		spec = "victor-mono-fonts.spec"
+	}
+}

--- a/anda/fonts/victor-mono/update.rhai
+++ b/anda/fonts/victor-mono/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("rubjo/victor-mono"));

--- a/anda/fonts/victor-mono/victor-mono-fonts.spec
+++ b/anda/fonts/victor-mono/victor-mono-fonts.spec
@@ -1,0 +1,44 @@
+%global fontcontact victor.mono.font@gmail.com
+%global fontorg io.github.rubjo
+
+Version:        1.5.6
+Release:        1%{?dist}
+URL:            https://rubjo.github.io/victor-mono/
+Packager:       ammix <maxim@ammix.dev>
+
+%global fontlicense       OFL-1.1
+%global fontlicenses      LICENSE.txt
+%global fontdocs          README.md
+%global fontfamily        Victor Mono
+%global fontsummary       Free programming font with cursive italics and ligatures
+%global fonts             TTF/*.ttf
+%global fontdescription   %{expand:
+Victor Mono is a free programming font with semi-connected cursive italics and
+symbol ligatures.}
+
+Source0:        https://github.com/rubjo/victor-mono/raw/v%{version}/public/VictorMonoAll.zip
+Source1:        https://raw.githubusercontent.com/rubjo/victor-mono/v%{version}/README.md
+
+BuildRequires:  unzip
+BuildRequires:  rpm_macro(fontpkg)
+
+%fontpkg
+
+%prep
+%autosetup -c
+cp -p %{SOURCE1} README.md
+
+%build
+%fontbuild
+
+%install
+%fontinstall
+
+%check
+%fontcheck
+
+%fontfiles
+
+%changelog
+* Fri Aug 28 2026 ammix <maxim@ammix.dev> - 1.5.6-1
+- Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: victor-mono-fonts (#16271)](https://github.com/terrapkg/packages/pull/16271)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)