### PR TITLE
fix(jujutsu): drop stale dependencies

### DIFF
--- a/anda/tools/jujutsu/jujutsu.spec
+++ b/anda/tools/jujutsu/jujutsu.spec
@@ -5,7 +5,7 @@
 
 Name:           jujutsu
 Version:        0.44.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Git-compatible DVCS that is both simple and powerful
 License:        Apache-2.0 AND CC-BY-4.0
 URL:            https://www.jj-vcs.dev/latest/
@@ -16,8 +16,6 @@ BuildRequires:  gnupg
 BuildRequires:  gpgme
 BuildRequires:  openssh
 Requires:       glibc
-Requires:       libgit2
-Requires:       libssh2
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
@@ -113,5 +111,8 @@ rm -rf %{buildroot}%{_pkgdocdir}/images
 %doc %{_pkgdocdir}
 
 %changelog
+* Sat Aug 29 2026 ammix <maxim@ammix.dev>
+- Drop stale libgit2 and libssh2 dependencies
+
 * Tue Dec 16 2025 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit


### PR DESCRIPTION
Hi! So I was packaging jjui and noticed that the jujutsu installation failed on rawhide, because the libgit2 packages are now versioned in Fedora. But since [libgit2 and libssh2 aren't actually dependencies of Jujutsu anymore](https://github.com/jj-vcs/jj/commit/7bcc5cca8f8688da8aae286f95938d7eccfbebe4), we can safely drop them here.