### PR TITLE
[el10] fix(jujutsu): drop stale dependencies (#16285)

### DIFF
--- a/anda/tools/jujutsu/jujutsu.spec
+++ b/anda/tools/jujutsu/jujutsu.spec
@@ -5,7 +5,7 @@
 
 Name:           jujutsu
 Version:        0.44.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Git-compatible DVCS that is both simple and powerful
 License:        Apache-2.0 AND CC-BY-4.0
 URL:            https://www.jj-vcs.dev/latest/
@@ -16,8 +16,6 @@ BuildRequires:  gnupg
 BuildRequires:  gpgme
 BuildRequires:  openssh
 Requires:       glibc
-Requires:       libgit2
-Requires:       libssh2
 
 Packager:       Owen Zimmerman <owen@fyralabs.com>
 
@@ -113,5 +111,8 @@ rm -rf %{buildroot}%{_pkgdocdir}/images
 %doc %{_pkgdocdir}
 
 %changelog
+* Sat Aug 29 2026 ammix <maxim@ammix.dev>
+- Drop stale libgit2 and libssh2 dependencies
+
 * Tue Dec 16 2025 Owen Zimmerman <owen@fyralabs.com>
 - Initial commit


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(jujutsu): drop stale dependencies (#16285)](https://github.com/terrapkg/packages/pull/16285)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)