### PR TITLE
[f45] feat: Update to the latest OGC gamescope (#16294)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -2,7 +2,7 @@
 
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
-%global gamescope_commit 55ac921a1afb346696b6f80541741d431b3eba29
+%global gamescope_commit 13e1dd1984f90c9f8e79ffdc98a8abfdc25455ca
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           terra-gamescope


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update to the latest OGC gamescope (#16294)](https://github.com/terrapkg/packages/pull/16294)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)