### PR TITLE
[f44] chore (crystal): I can't spell (#16305)

### DIFF
--- a/anda/langs/crystal/crystal/crystal.spec
+++ b/anda/langs/crystal/crystal/crystal.spec
@@ -81,7 +81,7 @@ export PATH="%{_builddir}/crystal-%{bootstrap_version}-%{_arch}-alpine-linux-mus
 
 %changelog
 * Thu Jul 16 2026 Owen Zimmerman <owen@fyralabs.com> - 1.21.0-1 
-- Update for 1.21.0, use %%pkg_completions
+- Update for 1.21.0, use %%pkg_completion
 
 * Mon Nov 03 2025 Carl Hörberg <carl@84codes.com> -  1.18.2-2
 - Build from source, support multiple architectures.


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore (crystal): I can't spell (#16305)](https://github.com/terrapkg/packages/pull/16305)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)