### PR TITLE
[f43] chore (surface-control): I guess the version string from github works (#16321)

### DIFF
--- a/anda/system/linux-surface/surface-control/surface-control.spec
+++ b/anda/system/linux-surface/surface-control/surface-control.spec
@@ -1,6 +1,3 @@
-%global ver 0.5.0-1
-%global sanitized_ver %(echo %{ver} | sed 's/-/./')
-
 %define debug_package %{nil}
 
 Name:           surface-control
@@ -10,7 +7,7 @@ Summary:        Control various aspects of Microsoft Surface devices from the sh
 
 License:        MIT
 URL:            https://github.com/linux-surface/surface-control
-Source0:        %{url}/archive/refs/tags/v%{ver}.tar.gz
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 
 Requires:       dbus
 Requires:       libgcc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (surface-control): I guess the version string from github works (#16321)](https://github.com/terrapkg/packages/pull/16321)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)