### PR TITLE
[f45] fix: rp-appset (#16326)

### DIFF
--- a/anda/apps/rp-appset/rp-appset.spec
+++ b/anda/apps/rp-appset/rp-appset.spec
@@ -29,8 +29,10 @@ Provides:       rp-appset
 %prep
 %autosetup -n appset-%commit
 
-%build
+%conf
 %meson
+
+%build
 %meson_build
 
 %install
@@ -43,10 +45,11 @@ Provides:       rp-appset
 %license debian/copyright
 %{_datadir}/rpcc/ui/pipanel.ui
 %{_libdir}/rpcc/librpcc_pipanel.so
-%{_iconsdir}/hicolor/24x24/apps/appset-desktop.png
-%{_iconsdir}/hicolor/24x24/apps/appset-taskbar.png
-%{_iconsdir}/hicolor/32x32/apps/appset-desktop.png
-%{_iconsdir}/hicolor/32x32/apps/appset-taskbar.png
+%{_iconsdir}/hicolor/*x*/apps/appset-taskbar.png
+%{_iconsdir}/hicolor/*x*/apps/appset-desktop.png
+
+%{_scalableiconsdir}/appset-desktop.svg
+%{_scalableiconsdir}/appset-taskbar.svg
 
 %changelog
 * Sat Oct 25 2025 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: rp-appset (#16326)](https://github.com/terrapkg/packages/pull/16326)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)