### PR TITLE
[el10] chore (surface-control): still need this for the link (#16327)

### DIFF
--- a/anda/system/linux-surface/surface-control/surface-control.spec
+++ b/anda/system/linux-surface/surface-control/surface-control.spec
@@ -1,13 +1,16 @@
+%global ver 0.5.0-1
+%global sanitized_ver %(echo %{ver} | sed 's/-/./')
+
 %define debug_package %{nil}
 
 Name:           surface-control
-Version:        0.5.0.1
+Version:        %{sanitized_ver}
 Release:        1%{?dist}
 Summary:        Control various aspects of Microsoft Surface devices from the shell
 
 License:        MIT
 URL:            https://github.com/linux-surface/surface-control
-Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+Source0:        %{url}/archive/refs/tags/v%{ver}.tar.gz
 
 Requires:       dbus
 Requires:       libgcc

--- a/anda/system/linux-surface/surface-control/update.rhai
+++ b/anda/system/linux-surface/surface-control/update.rhai
@@ -1,1 +1,1 @@
-rpm.version(gh("linux-surface/surface-control"));
+rpm.global("ver", gh("linux-surface/surface-control"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [chore (surface-control): still need this for the link (#16327)](https://github.com/terrapkg/packages/pull/16327)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)