### PR TITLE
[f45] fix: Add upstream patch for rendering issues in gamescope (#16347)

### DIFF
--- a/anda/lib/mesa/44102.patch
+++ b/anda/lib/mesa/44102.patch
@@ -1,0 +1,29 @@
+From c5d2bd44d5e09cb5218c80ed50f172bf88fe918a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Ol=C5=A1=C3=A1k?= <maraeo@gmail.com>
+Date: Sun, 30 Aug 2026 04:05:25 -0400
+Subject: [PATCH] radv: fix RADV_FORCE_VRS (Persona 3 Reload)
+
+This field affects register programming and shouldn't be set when there is
+no per-vertex VRS export.
+
+Fixes: 743b466c724 - radv: disallow force_vrs_per_vertex with FragCoord when using GPL & ESO
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/work_items/16187
+---
+ src/amd/vulkan/radv_pipeline_graphics.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/amd/vulkan/radv_pipeline_graphics.c b/src/amd/vulkan/radv_pipeline_graphics.c
+index 710280b7a220..d8eb9e8a5a2d 100644
+--- a/src/amd/vulkan/radv_pipeline_graphics.c
++++ b/src/amd/vulkan/radv_pipeline_graphics.c
+@@ -2765,6 +2765,7 @@ radv_graphics_shaders_compile(const struct radv_compiler_info *compiler_info, st
+          }
+       } else if (fs_stage && fs_stage->info.ps.disallow_force_vrs_per_vertex) {
+          stages[i].info.force_vrs_per_vertex = false;
++         stages[i].info.outinfo.writes_primitive_shading_rate = false;
+       }
+       break;
+    }
+-- 
+GitLab
+

--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -87,7 +87,7 @@ Summary:        Mesa graphics libraries
 %global ver 26.2.1
 Epoch:          1
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        4%{?dist}
+Release:        5%{?dist}
 Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            https://mesa3d.org
@@ -119,6 +119,9 @@ Source15:       https://static.crates.io/crates/rustc-hash/rustc-hash-%{rustc_ha
 Patch30:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/tags/%{ver}/limiter.patch
 Patch31:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/tags/%{ver}/radv-defaults.patch
 Patch32:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/tags/%{ver}/vram-overcommit.patch
+
+# https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/44102
+Patch33:        44102.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: Add upstream patch for rendering issues in gamescope (#16347)](https://github.com/terrapkg/packages/pull/16347)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)