### PR TITLE
fix(ente): use git_tags()

### DIFF
--- a/anda/apps/ente/cli/update.rhai
+++ b/anda/apps/ente/cli/update.rhai
@@ -1,10 +1,7 @@
-let tagobjs = get("https://api.github.com/repos/ente-io/ente/tags").json_arr();
-for tagobj in tagobjs {
-  if tagobj.name.starts_with("cli-v") {
-    rpm.global("tag", tagobj.name);
-    if rpm.changed() {
-      rpm.release();
-      break;
-    }
-  }
+let stable_tag = `^cli-v\d+\.\d+\.\d+$`;
+let tags = git_tags("https://github.com/ente-io/ente")
+  .filter(|tag| stable_tag.find_all(tag).len == 1);
+rpm.global("tag", tags[tags.len - 1]);
+if rpm.changed() {
+  rpm.release();
 }

--- a/anda/apps/ente/ensu/update.rhai
+++ b/anda/apps/ente/ensu/update.rhai
@@ -1,10 +1,7 @@
-let tagobjs = get("https://api.github.com/repos/ente-io/ente/tags").json_arr();
-for tagobj in tagobjs {
-  if tagobj.name.starts_with("ensu-v") {
-    rpm.global("tag", tagobj.name);
-    if rpm.changed() {
-      rpm.release();
-      break;
-    }
-  }
+let stable_tag = `^ensu-v\d+\.\d+\.\d+$`;
+let tags = git_tags("https://github.com/ente-io/ente")
+  .filter(|tag| stable_tag.find_all(tag).len == 1);
+rpm.global("tag", tags[tags.len - 1]);
+if rpm.changed() {
+  rpm.release();
 }


### PR DESCRIPTION
Needs an Anda release with [FyraLabs/anda#505](https://github.com/FyraLabs/anda/pull/505). 

Both update scripts work locally.
The current (frawhide) update scripts don't actually seem to find anything, so both packages are quite a few versions behind. Should we bump them manually once, or just wait for the updater?