### PR TITLE
[f44] chore(openscad-nightly): add experimental build option (#16352)

### DIFF
--- a/anda/tools/openscad/nightly/openscad-nightly.spec
+++ b/anda/tools/openscad/nightly/openscad-nightly.spec
@@ -6,7 +6,7 @@
 %global realname openscad
 Name:           %{realname}-nightly
 Version:        %{latest_stable_version}^%{commit_date}git.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        The Programmers Solid 3D CAD Modeller
 # OpenSCAD is GPL-2.0-only WITH CGAL-linking-exception
 # Appdata file is CC0-1.0
@@ -98,7 +98,8 @@ git submodule update --init --recursive
     -DUSE_BUILTIN_CLIPPER2:BOOL=OFF \
     -DUSE_CCACHE:BOOL=OFF \
     -DUSE_BUILTIN_MANIFOLD:BOOL=OFF \
-    -DUSE_BUILTIN_OPENCSG:BOOL=OFF
+    -DUSE_BUILTIN_OPENCSG:BOOL=OFF \
+    -DEXPERIMENTAL:BOOL=ON
 
 %build
 %cmake_build
@@ -138,5 +139,8 @@ rm -rf %{buildroot}%{_datadir}/%{realname}/fonts
 %{_datadir}/%{realname}/libraries/MCAD
 
 %changelog
+* Mon Aug 31 2026 Jan200101 <sentrycraft123@gmail.com> - 2021.01^20260830git.36a2927-2
+- add EXPERIMENTAL build option
+
 * Wed Aug 19 2026 Jan200101 <sentrycraft123@gmail.com> - 0~20260819git.1ee676b-1
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(openscad-nightly): add experimental build option (#16352)](https://github.com/terrapkg/packages/pull/16352)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)