### PR TITLE
[f43] chore (MareTF): remove double cmake call (#16383)

### DIFF
--- a/anda/tools/MareTF/MareTF.spec
+++ b/anda/tools/MareTF/MareTF.spec
@@ -31,8 +31,7 @@ BuildRequires:  vulkan-headers
 %cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DMARETF_BUILD_INSTALLER=ON \
-    -DCPACK_GENERATOR=RPM \
-    -DMARETF_BUILD_INSTALLER=ON
+    -DCPACK_GENERATOR=RPM
 
 %build
 %cmake_build


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore (MareTF): remove double cmake call (#16383)](https://github.com/terrapkg/packages/pull/16383)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)