### PR TITLE
[el10] fix (proton-vpn): bump release when there's a new metainfo commit (#16393)

### DIFF
--- a/anda/apps/proton-vpn/update.rhai
+++ b/anda/apps/proton-vpn/update.rhai
@@ -1,3 +1,9 @@
-rpm.version(gh_tag("ProtonVPN/proton-vpn-gtk-app"));
+import "andax/spec.rhai" as spec;
 
 rpm.global("metainfo_commit", gh_commit("flathub/com.protonvpn.www"));
+if rpm.changed() {
+  let rel = spec::get_release(rpm).parse_int();
+  rpm.release(rel + 1);
+}
+
+rpm.version(gh_tag("ProtonVPN/proton-vpn-gtk-app"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix (proton-vpn): bump release when there's a new metainfo commit (#16393)](https://github.com/terrapkg/packages/pull/16393)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)