### PR TITLE
fix(bruno): build the new bruno-sqlite workspace

### DIFF
--- a/anda/devs/bruno/bruno.spec
+++ b/anda/devs/bruno/bruno.spec
@@ -43,6 +43,7 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 %{__npm} run build:bruno-requests
 %{__npm} run build:schema-types
 %{__npm} run build:bruno-filestore
+%{__npm} run build:bruno-sqlite
 %{__npm} run sandbox:bundle-libraries --workspace=packages/bruno-js
 
 %{__npm} run build:web


### PR DESCRIPTION
Owen noticed on Discord that bruno went red after #14631 was merged, so here's the fix.

The updater bumped it to 4.1.0 a few minutes after the merge, and that build fails on every branch and both arches:

```
× Module not found: Can't resolve '@usebruno/sqlite/web'
  in packages/bruno-app/src/pages/Main.js:8
```

4.1.0 adds a new workspace, `packages/bruno-sqlite`, and `bruno-app` imports it now. The spec's `%build` section follows the build order from upstream's [scripts/setup.js](https://github.com/usebruno/bruno/blob/v4.1.0/scripts/setup.js#L111), where `build:bruno-sqlite` was added right after `build:bruno-filestore`, so the spec just needs the same line in the same spot.

Nothing else was needed for it: it's plain TypeScript built with rollup, no native dependencies, and its `generate` step only writes files into the source tree. I left `Release` at 1 since 4.1.0-1 never built successfully.

Failed run: https://github.com/terrapkg/packages/actions/runs/33567519316

One thing that might look confusing when you go through the logs: the 4.0.0 build right after the merge is red as well, but for an unrelated reason. The RPM built and uploaded fine there, and only the `createrepo_c` run on the `terrarawhide-source` metadata failed.
