### PR TITLE
[f43] fix(bruno): build the new bruno-sqlite workspace (#16402)

### DIFF
--- a/anda/devs/bruno/bruno.spec
+++ b/anda/devs/bruno/bruno.spec
@@ -43,6 +43,7 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 %{__npm} run build:bruno-requests
 %{__npm} run build:schema-types
 %{__npm} run build:bruno-filestore
+%{__npm} run build:bruno-sqlite
 %{__npm} run sandbox:bundle-libraries --workspace=packages/bruno-js
 
 %{__npm} run build:web


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix(bruno): build the new bruno-sqlite workspace (#16402)](https://github.com/terrapkg/packages/pull/16402)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)