### PR TITLE
[f45] chore (noctalia-qs): rebuild for new qt version (#16403)

### DIFF
--- a/anda/desktops/noctalia/qs/noctalia-qs.spec
+++ b/anda/desktops/noctalia/qs/noctalia-qs.spec
@@ -2,7 +2,7 @@
 
 Name:	       noctalia-qs
 Version:       0.0.12
-Release:       5%{?dist}
+Release:       6%{?dist}
 Summary:       Flexible QtQuick based desktop shell toolkit
 License:       LGPL-3.0-only AND GPL-3.0-only
 URL:	       https://github.com/noctalia-dev/noctalia-qs


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (noctalia-qs): rebuild for new qt version (#16403)](https://github.com/terrapkg/packages/pull/16403)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)