### PR TITLE
[f45] fix: Bump bazzite-updater due to qt version bump (#16417)

### DIFF
--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -2,7 +2,7 @@
 
 Name:           bazzite-updater
 Version:        0.10.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Update your system
 
 License:        GPL-2.0-or-later AND BSD-3-Clause AND CC0-1.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: Bump bazzite-updater due to qt version bump (#16417)](https://github.com/terrapkg/packages/pull/16417)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)