### PR TITLE
[f44] feat: Bump mesa for 26.2.2 (#16418)

### DIFF
--- a/anda/lib/mesa/mesa.spec
+++ b/anda/lib/mesa/mesa.spec
@@ -87,7 +87,7 @@ Summary:        Mesa graphics libraries
 %global ver 26.2.2
 Epoch:          1
 Version:        %{lua:ver = string.gsub(rpm.expand("%{ver}"), "-", "~"); print(ver)}
-Release:        5%{?dist}
+Release:        1%{?dist}
 Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
 License:        MIT AND BSD-3-Clause AND SGI-B-2.0
 URL:            https://mesa3d.org
@@ -119,9 +119,6 @@ Source15:       https://static.crates.io/crates/rustc-hash/rustc-hash-%{rustc_ha
 Patch30:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/tags/%{ver}/limiter.patch
 Patch31:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/tags/%{ver}/radv-defaults.patch
 Patch32:        https://raw.githubusercontent.com/OpenGamingCollective/mesa/refs/tags/%{ver}/vram-overcommit.patch
-
-# https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/44102
-Patch33:        44102.patch
 
 BuildRequires:  meson >= 1.3.0
 BuildRequires:  gcc


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Bump mesa for 26.2.2 (#16418)](https://github.com/terrapkg/packages/pull/16418)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)