### PR TITLE
[f43] template: clarify llm policy (#16436)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_package.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_package.md
@@ -13,4 +13,6 @@ Add any other context about the package submission here. Link to any relavent is
 - [] I have read through any relevant [Terra](https://docs.terrapkg.com/) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
 - [] I have ensured there are no security issues with this package to the best of my ability
 - [] I have ensured this is not in Fedora (unless adding to the [extras repo](https://docs.terrapkg.com/usage/installing/#extras))
-- [] I used an LLM. I used it ONLY to help debug issues, and not to generate the spec completely, in accordance with the [Terra AI policy](https://docs.terrapkg.com/policies#ai-policy)
+- [] I used an LLM
+  - [] I used it in accordance with the [Terra AI policy](https://docs.terrapkg.com/policies#ai-policy)
+  - [] I used it in a different way (please explain)


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [template: clarify llm policy (#16436)](https://github.com/terrapkg/packages/pull/16436)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)