### PR TITLE
[el10] add: cosmic-ext-applet-system-monitor (#16431)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-applet-system-monitor/anda.hcl
+++ b/anda/desktops/cosmic/cosmic-ext-applet-system-monitor/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "cosmic-ext-applet-system-monitor.spec"
+  }
+}

--- a/anda/desktops/cosmic/cosmic-ext-applet-system-monitor/cosmic-ext-applet-system-monitor.spec
+++ b/anda/desktops/cosmic/cosmic-ext-applet-system-monitor/cosmic-ext-applet-system-monitor.spec
@@ -1,0 +1,45 @@
+%global appid dev.DBrox.CosmicSystemMonitor
+
+Name:           cosmic-ext-applet-system-monitor
+Version:        0.2.10
+Release:        1%{?dist}
+SourceLicense:  GPL-3.0-only
+License:        %{sourcelicense} AND (BSD-3-Clause OR MIT OR Apache-2.0) AND Apache-2.0 AND MIT AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND BSD-2-Clause AND Zlib AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND GPL-3.0 AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND (BSD-3-Clause OR Apache-2.0) AND BSL-1.0 AND ISC AND (MIT OR LGPL-3.0-or-later) AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
+Summary:        A highly configurable resource monitor applet for the COSMIC DE
+URL:            https://github.com/D-Brox/cosmic-ext-applet-system-monitor
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  rust-xkbcommon-devel
+BuildRequires:  systemd-devel
+Requires:       cosmic-osd
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -C
+%cargo_prep_online
+
+%build
+%cargo_build
+%cargo_license_summary_online
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+install -Dm0755 target/rpm/cosmic-ext-applet-system-monitor     %{buildroot}%{_bindir}/cosmic-ext-applet-system-monitor
+install -Dm0644 res/dev.DBrox.CosmicSystemMonitor.desktop       %{buildroot}%{_appsdir}/%{appid}.desktop
+install -Dm0644 res/dev.DBrox.CosmicSystemMonitor.metainfo.xml  %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
+install -Dm0644 res/dev.DBrox.CosmicSystemMonitor.svg           %{buildroot}%{_scalableiconsdir}/%{appid}.svg
+
+%files
+%doc README.md docs/*
+%license LICENSE
+%{_bindir}/cosmic-ext-applet-system-monitor
+%{_appsdir}/%{appid}.desktop
+%{_scalableiconsdir}/%{appid}.svg
+%{_metainfodir}/%{appid}.metainfo.xml
+
+%changelog
+* Wed Sep 02 2026 Owen Zimmerman <owen@fyralabs.com> - 0.2.10-1
+- Initial commit

--- a/anda/desktops/cosmic/cosmic-ext-applet-system-monitor/update.rhai
+++ b/anda/desktops/cosmic/cosmic-ext-applet-system-monitor/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("D-Brox/cosmic-ext-applet-system-monitor"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: cosmic-ext-applet-system-monitor (#16431)](https://github.com/terrapkg/packages/pull/16431)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)