### PR TITLE
[f44] fix: Drop legacy desktop files for ogui session that could confuse steamos-manager (#16451)

### DIFF
--- a/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
+++ b/anda/games/gamescope-session-ogui-steam/gamescope-session-ogui-steam.spec
@@ -6,7 +6,7 @@
 
 Name:           gamescope-session-ogui-steam
 Version:        0~%{commit_date}git.%{shortcommit}
-Release:        1%?dist
+Release:        2%?dist
 Summary:        gamescope-session-steam
 License:        GPL-3.0-only
 URL:            https://github.com/OpenGamingCollective/gamescope-session-ogui-steam
@@ -27,16 +27,12 @@ Gamescope Session for OpenGamepadUI in overlay mode with Steam
 %install
 install -Dpm0755 -t "%buildroot%_datadir/gamescope-session-plus/sessions.d/" ".%_datadir/gamescope-session-plus/sessions.d/ogui-steam"
 install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session-ogui-steam.desktop"
-install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamescope-session-steam-plus.desktop"
-install -Dpm0644 -t "%buildroot%_datadir/wayland-sessions/" ".%_datadir/wayland-sessions/gamepadui-with-qam-session.desktop"
 
 %files
 %doc README.md
 %license LICENSE
 %{_datadir}/gamescope-session-plus/sessions.d/ogui-steam
 %{_datadir}/wayland-sessions/gamescope-session-ogui-steam.desktop
-%{_datadir}/wayland-sessions/gamescope-session-steam-plus.desktop
-%{_datadir}/wayland-sessions/gamepadui-with-qam-session.desktop
 
 %changelog
 * Mon Feb 02 2026 Tulip Blossom <tulilirockz@outlook.com> - 20231030.6835776-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: Drop legacy desktop files for ogui session that could confuse steamos-manager (#16451)](https://github.com/terrapkg/packages/pull/16451)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)