### PR TITLE
[f45] fix: Update patch set for inputplumber (#16452)

### DIFF
--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -2,15 +2,15 @@
 
 Name:           inputplumber
 Version:        0.79.0
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:        Open source input router and remapper daemon for Linux
 License:        GPL-3.0-or-later
 URL:            https://github.com/ShadowBlip/InputPlumber
 Source0:        %{url}/archive/refs/tags/v%version.tar.gz
 Patch0:         make-install-dont-build.patch
 Patch1:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/644.patch
-Patch2:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/653.patch
-Patch3:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/656.patch
+Patch2:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/667.patch
+Patch3:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/687.patch
 BuildRequires:  libevdev-devel libiio-devel git make cargo libudev-devel llvm-devel clang-devel
 BuildRequires:  rust-packaging cargo-rpm-macros mold rpm_macro(cargo_prep_online) systemd-rpm-macros
 Requires:       libevdev libiio
@@ -25,7 +25,7 @@ can be used to combine any number of input devices (like gamepads, mice, and
 keyboards) and translate their input to a variety of virtual device formats.
 
 %prep
-%autosetup -n InputPlumber-%version -p1
+%autosetup -n InputPlumber-%version -S git_am -p1
 %cargo_prep_online
 
 %build

--- a/anda/games/inputplumber/make-install-dont-build.patch
+++ b/anda/games/inputplumber/make-install-dont-build.patch
@@ -1,3 +1,5 @@
+From: Terra <terra@fyralabs.com>
+Subject: [PATCH] make install not depend on build
 --- a/Makefile	2025-05-21 22:56:09.064696169 -0500
 +++ b/Makefile	2025-05-21 23:14:40.494058939 -0500
 @@ -41,8 +41,8 @@


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: Update patch set for inputplumber (#16452)](https://github.com/terrapkg/packages/pull/16452)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)