### PR TITLE
[f43] fix: brew-proxy (#16467)

### DIFF
--- a/anda/system/brew-proxy/brew-proxy.spec
+++ b/anda/system/brew-proxy/brew-proxy.spec
@@ -143,6 +143,7 @@ fi
 %{_datadir}/polkit-1/actions/%{proxy_dbus_name}.policy
 %{_datadir}/polkit-1/rules.d/%{proxy_dbus_name}.rules
 %{_environmentdir}/30-%{name}.conf
+%{_tmpfilesdir}/brew-proxy.conf
 
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.bz2


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: brew-proxy (#16467)](https://github.com/terrapkg/packages/pull/16467)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)