### PR TITLE
[f45] fix: signal-desktop (#16466)

### DIFF
--- a/anda/apps/signal-desktop/signal-desktop.spec
+++ b/anda/apps/signal-desktop/signal-desktop.spec
@@ -76,6 +76,7 @@ echo "Electron Builder" > %{rpmbuilddir}/webapp-tool.txt
 mv ./packages/mute-state-change/LICENSE ./packages/mute-state-change/LICENSE.mute-state-change
 mv ./packages/windows-ucv/LICENSE ./packages/mute-state-change/LICENSE.windows-ucv
 mv ./packages/types/LICENSE ./packages/mute-state-change/LICENSE.types
+mv ./packages/lame/LICENSE ./packages/mute-state-change/LICENSE.lame
 %electron_install -i signal -l -I build/icons/png
 
 %desktop_file_install %{SOURCE1}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: signal-desktop (#16466)](https://github.com/terrapkg/packages/pull/16466)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)