### PR TITLE
[f45] fix: transformers (#16493)

### DIFF
--- a/anda/langs/python/transformers/transformers.spec
+++ b/anda/langs/python/transformers/transformers.spec
@@ -3,7 +3,7 @@
 
 Name:			python-%{pypi_name}
 Version:		5.16.1
-Release:		1%{?dist}
+Release:		2%{?dist}
 Summary:		The model-definition framework for state-of-the-art machine learning models
 License:		Apache-2.0
 URL:			https://huggingface.co/docs/transformers/index
@@ -31,6 +31,7 @@ Summary:        %{summary}
 
 %pyproject_patch_dependency huggingface-hub:drop_constraints
 %pyproject_patch_dependency tokenizers:drop_constraints
+%pyproject_patch_dependency safetensors:drop_constraints
 
 %build
 %pyproject_wheel


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: transformers (#16493)](https://github.com/terrapkg/packages/pull/16493)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)