### PR TITLE
[f43] feat: Update to the latest OGC gamescope (#16498)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -2,7 +2,7 @@
 
 %global _default_patch_fuzz 2
 %global build_timestamp %(date +"%Y%m%d")
-%global gamescope_commit 13e1dd1984f90c9f8e79ffdc98a8abfdc25455ca
+%global gamescope_commit 77e6ea94dbc3feca4b95daef433d6238a9efdd68
 %define short_commit %(echo %{gamescope_commit} | cut -c1-8)
 
 Name:           terra-gamescope


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update to the latest OGC gamescope (#16498)](https://github.com/terrapkg/packages/pull/16498)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)