### PR TITLE
chore (t3code-nightly): remove nightly label

### DIFF
--- a/anda/devs/t3code/nightly/anda.hcl
+++ b/anda/devs/t3code/nightly/anda.hcl
@@ -3,7 +3,4 @@ project pkg {
 	rpm {
 		spec = "t3code-nightly.spec"
 	}
-	labels {
-	  nightly = 1
-	}
 }


### PR DESCRIPTION
This package updates multiple times a day, and is marketed as a 'nightly' version, so we should keep the name but let it update every time there is a new commit