### PR TITLE
[f44] feat: Update to the latest steamos-manager-powerstation (#16525)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit 25bff4c18dc646570915186d08ebaeb0c14c001f
+%global commit b2b641ed32587da7c4900c510fcbd8ca080d174f
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260823
+%global commitdate 20260903
 
 %global steamos_manager_systemd_user_units steamos-manager.service steamos-manager-configure-cecd.service steamos-manager-session-cleanup.service
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Update to the latest steamos-manager-powerstation (#16525)](https://github.com/terrapkg/packages/pull/16525)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)