### PR TITLE
[f44] fix: plumeimpactor (#16526)

### DIFF
--- a/anda/apps/plumeimpactor/plumeimpactor.spec
+++ b/anda/apps/plumeimpactor/plumeimpactor.spec
@@ -38,7 +38,7 @@ done
 
 %files
 %doc README.md SECURITY.md
-%license LICENSE LICENSE_ELLEKIT
+%license LICENSE
 %{_bindir}/plumeimpactor
 %{_hicolordir}/*x*/apps/%{appid}.png
 %{_appsdir}/%{appid}.desktop


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: plumeimpactor (#16526)](https://github.com/terrapkg/packages/pull/16526)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)