### PR TITLE
[f45] fix: rpinters (#16527)

### DIFF
--- a/anda/apps/rpinters/rpinters.spec
+++ b/anda/apps/rpinters/rpinters.spec
@@ -39,6 +39,7 @@ BuildRequires: pkgconfig(gsettings-desktop-schemas)
 %license debian/copyright
 %{_datadir}/rpcc/ui/%{name}.ui
 %{_libdir}/rpcc/librpcc_rpinters.so
+%{_datadir}/polkit-1/rules.d/10-rpinters.rules
 
 %changelog
 * Fri Aug 08 2025 Owen Zimmerman <owen@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix: rpinters (#16527)](https://github.com/terrapkg/packages/pull/16527)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)