### PR TITLE
[f45] chore (t3code-nightly): remove nightly label (#16529)

### DIFF
--- a/anda/devs/t3code/nightly/anda.hcl
+++ b/anda/devs/t3code/nightly/anda.hcl
@@ -3,7 +3,4 @@ project pkg {
 	rpm {
 		spec = "t3code-nightly.spec"
 	}
-	labels {
-	  nightly = 1
-	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (t3code-nightly): remove nightly label (#16529)](https://github.com/terrapkg/packages/pull/16529)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)