### PR TITLE
[el10] fix: cosmic-ext-applet-tailscale (#16544)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-applet-tailscale/cosmic-ext-applet-tailscale.spec
+++ b/anda/desktops/cosmic/cosmic-ext-applet-tailscale/cosmic-ext-applet-tailscale.spec
@@ -31,7 +31,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 
 %install
 install -Dm0755 target/rpm/gui-scale-applet                             %{buildroot}%{_bindir}/gui-scale-applet
-%destop_file_install data/com.bhh32.gui-scale-applet.desktop
+%desktop_file_install data/com.bhh32.gui-scale-applet.desktop
 install -Dm0644 data/com.bhh32.gui-scale-applet.metainfo.xml            %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
 install -Dm0644 data/icons/scalable/apps/com.bhh32.gui-scale-applet.png %{buildroot}%{_hicolordir}/256x256/apps/%{appid}.png
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: cosmic-ext-applet-tailscale (#16544)](https://github.com/terrapkg/packages/pull/16544)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)