### PR TITLE
[f44] add: boards (#16441)

### DIFF
--- a/anda/desktops/cosmic/boards/anda.hcl
+++ b/anda/desktops/cosmic/boards/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+	rpm {
+		spec = "boards.spec"
+	}
+	labels {
+		nightly = 1
+	}
+}

--- a/anda/desktops/cosmic/boards/boards.spec
+++ b/anda/desktops/cosmic/boards/boards.spec
@@ -1,0 +1,54 @@
+%global ver 0.1.0
+%global commitdate 20260714
+%global commit 2adfe6b2be0e0517243b39f7450fd4ade8853830
+%global shortcommit %{sub %{commit} 0 7}
+%global appid dev.edfloreshz.Boards
+
+Name:           boards
+Version:        %{ver}^%{commitdate}.git%{shortcommit}
+Release:        1%{?dist}
+Summary:        Boards is a Trello like application for COSMIC
+
+SourceLicense:  GPL-3.0-only
+License:        %{sourcelicense} AND (BSD-3-Clause OR MIT OR Apache-2.0) AND Apache-2.0 AND MIT AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND BSD-2-Clause AND Zlib AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND GPL-3.0 AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND (MIT OR Apache-2.0 OR CC0-1.0) AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND (BSD-3-Clause OR Apache-2.0) AND BSL-1.0 AND ISC AND (MIT OR LGPL-3.0-or-later) AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
+
+URL:            https://github.com/cosmic-utils/boards
+Source0:        %{url}/archive/%{commit}.tar.gz
+
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  desktop-file-utils
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -C
+%cargo_prep_online
+%cargo_license_summary_online
+
+%build
+%cargo_build
+%{cargo_license_online} > LICENSE.dependencies
+
+%install
+install -Dm0755 target/rpm/boards                               %{buildroot}%{_bindir}/boards
+install -Dm644  resources/app.desktop                           %{buildroot}%{_appsdir}/%{appid}.desktop
+install -Dm0644 resources/app.metainfo.xml                      %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
+install -Dm0644 resources/icons/hicolor/scalable/apps/icon.svg  %{buildroot}%{_scalableiconsdir}/%{appid}.svg
+
+%terra_appstream
+
+%files
+%license LICENSE LICENSE.dependencies
+%doc README.md
+%{_bindir}/boards
+%{_appsdir}/%{appid}.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_scalableiconsdir}/%{appid}.svg
+
+%changelog
+* Wed Sep 02 2026 Owen Zimmerman <owen@fyralabs.com>
+- Initial commit

--- a/anda/desktops/cosmic/boards/update.rhai
+++ b/anda/desktops/cosmic/boards/update.rhai
@@ -1,0 +1,11 @@
+let repo = "cosmic-utils/boards";
+let commit = gh_commit(repo);
+rpm.global("commit", commit);
+
+if rpm.changed() {
+    let cargo_toml = gh_rawfile(repo, commit, "Cargo.toml");
+
+    rpm.release();
+    rpm.global("commit_date", date());
+    rpm.global("ver", find(`version = "([\d.]+)"`, cargo_toml, 1));
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [add: boards (#16441)](https://github.com/terrapkg/packages/pull/16441)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)