### PR TITLE
[f45] chore (t3code-nightly): go back to using nightly tag (#16575)

### DIFF
--- a/anda/devs/t3code/nightly/anda.hcl
+++ b/anda/devs/t3code/nightly/anda.hcl
@@ -3,4 +3,7 @@ project pkg {
 	rpm {
 		spec = "t3code-nightly.spec"
 	}
+	labels {
+		nightly = 1
+	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (t3code-nightly): go back to using nightly tag (#16575)](https://github.com/terrapkg/packages/pull/16575)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)