### PR TITLE
[f45] docs: clean up redundant links, simplify some words, add support section (#16461)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ Our documentation can be found on our [docs site](https://docs.terrapkg.com).
 ## Searching Packages
 
 [pkgs.org](https://fedora.pkgs.org/rawhide/terra/) and [Repology](https://repology.org/) provide a list of the packages available in Terra.
+You can also `dnf search` for all packages, or search in graphical app stores for packages with [AppStream MetaData](https://www.freedesktop.org/software/appstream/docs/chap-AppStream-About.html) once you have Terra installed.
 
 ## Questions?
 
-Feel free to reach out by [joining our community](https://wiki.ultramarine-linux.org/en/community/community/). We're always happy to help!
+Feel free to reach out by joining our chats above, or opening a GitHub issue.
 
-- [Contribution Guide](https://docs.terrapkg.com/contributing/getting-started)
-- [FAQ](https://docs.terrapkg.com/reference/faq)
-- [Guidelines](https://docs.terrapkg.com/contributing/guidelines)
+## Support
+
+Maintaining Terra requires a ton of infrastructure, package maintainer, submission review, and software engineering work. If you would like to financially sponsor Terra, please go to [the Fyra Labs sponsor page](https://fyralabs.com/sponsor/) for an overview of how to do this, and thank you so much for helping us out!


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [docs: clean up redundant links, simplify some words, add support section (#16461)](https://github.com/terrapkg/packages/pull/16461)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)