### PR TITLE
[f45] chore (bsc): make x86_64 only (#16593)

### DIFF
--- a/anda/buildsys/bsc/anda.hcl
+++ b/anda/buildsys/bsc/anda.hcl
@@ -1,4 +1,5 @@
 project pkg {
+		arches = ["x86_64"]
 	rpm {
 		spec = "bsc.spec"
 	}

--- a/anda/buildsys/bsc/bsc.spec
+++ b/anda/buildsys/bsc/bsc.spec
@@ -22,6 +22,7 @@ BuildRequires:  flex
 BuildRequires:  bison
 BuildRequires:  zlib-ng-compat-devel
 BuildRequires:  tcl-devel
+ExclusiveArch:  x86_64
 
 # For check
 BuildRequires:  binutils


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (bsc): make x86_64 only (#16593)](https://github.com/terrapkg/packages/pull/16593)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)