### PR TITLE
[el10] fix: umbriel-nightly (#16611)

### DIFF
--- a/anda/desktops/umbriel/nightly/umbriel-nightly.spec
+++ b/anda/desktops/umbriel/nightly/umbriel-nightly.spec
@@ -70,6 +70,8 @@ Packager:       Cypress Reed <cypress@fyralabs.com>
 %{_userunitdir}/umbriel.service
 %{_userunitdir}/umbriel-session.target
 %{_userunitdir}/umbriel-shutdown.target
+%{_datadir}/umbriel/shaders/reveal.glsl
+%{_datadir}/umbriel/shaders/squash.glsl
 
 %changelog
 * Mon Aug 24 2026 Cypress Reed <cypress@fyralabs.com>


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: umbriel-nightly (#16611)](https://github.com/terrapkg/packages/pull/16611)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)