### PR TITLE
[f45] fix (uupd): call correct systemd unit in post macros (#16616)

### DIFF
--- a/anda/system/uupd/uupd.spec
+++ b/anda/system/uupd/uupd.spec
@@ -1,6 +1,6 @@
 Name:           uupd
 Version:        1.4.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Centralized update service/checker made for Universal Blue
 License:        Apache-2.0
 URL:            https://github.com/ublue-os/uupd
@@ -31,10 +31,10 @@ install -Dpm0644 -t %{buildroot}%{_unitdir}/ %{name}.service %{name}.timer
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/polkit-1/rules.d/ %{name}.rules
 
 %post
-%systemd_post %{name}.timer
+%systemd_post %{name}.service
 
 %preun
-%systemd_preun %{name}.timer
+%systemd_preun %{name}.service
 
 %files
 %license LICENSE


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [fix (uupd): call correct systemd unit in post macros (#16616)](https://github.com/terrapkg/packages/pull/16616)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)