### PR TITLE
[f45] feat: Update to the latest OGC steamos-manager (#16636)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit b2b641ed32587da7c4900c510fcbd8ca080d174f
+%global commit f5e4aaf35b2f96c7f0a8f96ae2f6823febe5adf7
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260903
+%global commitdate 20260906
 
 %global steamos_manager_systemd_user_units steamos-manager.service steamos-manager-configure-cecd.service steamos-manager-session-cleanup.service
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update to the latest OGC steamos-manager (#16636)](https://github.com/terrapkg/packages/pull/16636)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)