### PR TITLE
[f43] fix: coolercontrol alert symbolic icon name (#16643)

### DIFF
--- a/anda/apps/coolercontrol/coolercontrol.spec
+++ b/anda/apps/coolercontrol/coolercontrol.spec
@@ -9,7 +9,7 @@ for background device management, as well as a GUI to expertly customize your se
 
 Name:           coolercontrol
 Version:        5.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Cooling device control for Linux
 ExclusiveArch:  x86_64 aarch64
 License:        GPL-3.0-or-later
@@ -92,7 +92,7 @@ desktop-file-install --dir=%buildroot%_datadir/applications packaging/metadata/%
 install -Dpm644 packaging/metadata/%rdnn.svg %buildroot%_iconsdir/hicolor/scalable/apps/%rdnn.svg
 install -Dpm644 packaging/metadata/%rdnn-alert.svg %buildroot%_iconsdir/hicolor/scalable/apps/%rdnn-alert.svg
 install -Dpm644 packaging/metadata/%rdnn-symbolic.svg %buildroot%_iconsdir/hicolor/symbolic/apps/%rdnn-symbolic.svg
-install -Dpm644 packaging/metadata/%rdnn-symbolic-alert.svg %buildroot%_iconsdir/hicolor/symbolic/apps/%rdnn-symbolic-alert.svg
+install -Dpm644 packaging/metadata/%rdnn-alert-symbolic.svg %buildroot%_iconsdir/hicolor/symbolic/apps/%rdnn-alert-symbolic.svg
 install -Dpm644 packaging/metadata/%rdnn.png %buildroot%_iconsdir/hicolor/256x256/apps/%rdnn.png
 install -Dpm644 packaging/metadata/%rdnn-alert.png %buildroot%_iconsdir/hicolor/256x256/apps/%rdnn-alert.png
 for f in packaging/systemd/*.service; do
@@ -124,7 +124,7 @@ appstream-util validate-relax --nonet %buildroot%_metainfodir/%rdnn.metainfo.xml
 %_iconsdir/hicolor/*/apps/%rdnn.*
 %_iconsdir/hicolor/*/apps/%rdnn-alert.*
 %_iconsdir/hicolor/*/apps/%rdnn-symbolic.svg
-%_iconsdir/hicolor/*/apps/%rdnn-symbolic-alert.svg
+%_iconsdir/hicolor/*/apps/%rdnn-alert-symbolic.svg
 
 %files -n coolercontrold
 %doc coolercontrold/README.md
@@ -134,6 +134,9 @@ appstream-util validate-relax --nonet %buildroot%_metainfodir/%rdnn.metainfo.xml
 %_unitdir/coolercontrold.service
 
 %changelog
+* Sun Sep 06 2026 Guy Boldon <gb@guyboldon.com> - 5.0.0-2
+- Use fixed symbolic icon name
+
 * Sat Feb 28 2026 Guy Boldon <gb@guyboldon.com> - 3.1.1-2
 - Updated dependencies and build to match current version
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: coolercontrol alert symbolic icon name (#16643)](https://github.com/terrapkg/packages/pull/16643)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)