### PR TITLE
[f45] add: niri-autostart (#16654)

### DIFF
--- a/anda/desktops/niri/niri-autostart/anda.hcl
+++ b/anda/desktops/niri/niri-autostart/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "niri-autostart.spec"
+  }
+}

--- a/anda/desktops/niri/niri-autostart/niri-autostart.spec
+++ b/anda/desktops/niri/niri-autostart/niri-autostart.spec
@@ -1,0 +1,36 @@
+Name:           niri-autostart
+Version:        0.3.2
+Release:        1%{?dist}
+Summary:        Declarative autostart and layout restoration for niri
+SourceLicense:  GPL-3.0-or-later
+License:        %{SourceLicense} AND (Apache-2.0 OR MIT) AND MIT AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND Apache-2.0 AND (Unlicense OR MIT)
+URL:            https://github.com/partanskiy/niri-autostart
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+Packager:       Its-J <jonah@fyralabs.com>
+
+BuildRequires:  cargo-rpm-macros
+Requires:       niri
+
+%description
+%{summary}.
+
+%prep
+%autosetup -n %{name}-%{version}
+%cargo_prep_online
+
+%build
+%cargo_build
+
+%install
+install -Dm755 target/rpm/%{name} %{buildroot}%{_bindir}/%{name}
+%{cargo_license_online} > LICENSE.dependencies
+
+%files
+%license LICENSE
+%license LICENSE.dependencies
+%doc README.md
+%{_bindir}/%{name}
+
+%changelog
+* Sun Sep 06 2026 Its-J <jonah@fyralabs.com> - 0.3.2-1
+- Initial package

--- a/anda/desktops/niri/niri-autostart/update.rhai
+++ b/anda/desktops/niri/niri-autostart/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("partanskiy/niri-autostart"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: niri-autostart (#16654)](https://github.com/terrapkg/packages/pull/16654)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)