### PR TITLE
[f45] add: chatterino7 and chatterino7-nightly (#16667)

### DIFF
--- a/anda/apps/chatterino7/nightly/anda.hcl
+++ b/anda/apps/chatterino7/nightly/anda.hcl
@@ -1,0 +1,8 @@
+project pkg {
+    rpm {
+        spec = "chatterino7-nightly.spec"
+    }
+    labels {
+        nightly = 1
+    }
+}

--- a/anda/apps/chatterino7/nightly/chatterino7-nightly.spec
+++ b/anda/apps/chatterino7/nightly/chatterino7-nightly.spec
@@ -1,0 +1,86 @@
+%global appid com.chatterino.chatterino
+%global appstream_component desktop-application
+%global name_pretty Chatterino7
+
+%global ver 7.5.5
+%global commit 5a77ec758b7f02af47cac92d3ed92d5947ffad33
+%global shortcommit %{sub %{commit} 1 7}
+%global commit_date 20260903
+
+Name:           chatterino7-nightly
+Version:        %{ver}^%{commit_date}git.%{shortcommit}
+Release:        1%{?dist}
+Summary:        Twitch chat client with 7TV subscriber features
+
+License:        MIT AND BSD-3-Clause AND BSL-1.0 AND LicenseRef-fourtf-chatterino-sound-license
+URL:            https://github.com/SevenTV/chatterino7
+Source0:        %{url}/archive/%{commit}/chatterino7-%{commit}.tar.gz
+
+Packager:       ammix <maxim@ammix.dev>
+
+BuildRequires:  anda-srpm-macros
+BuildRequires:  terra-appstream-helper
+BuildRequires:  gcc-c++
+BuildRequires:  git-core
+BuildRequires:  cmake
+BuildRequires:  ninja-build
+BuildRequires:  desktop-file-utils
+BuildRequires:  boost-devel
+BuildRequires:  cmake(Qt6Concurrent)
+BuildRequires:  cmake(Qt6Core)
+BuildRequires:  cmake(Qt6Gui)
+BuildRequires:  cmake(Qt6Network)
+BuildRequires:  cmake(Qt6NetworkPrivate)
+BuildRequires:  cmake(Qt6Svg)
+BuildRequires:  cmake(Qt6Widgets)
+BuildRequires:  cmake(Qt6WidgetsPrivate)
+BuildRequires:  cmake(RapidJSON)
+BuildRequires:  miniaudio-devel
+BuildRequires:  pkgconfig(libnotify)
+BuildRequires:  pkgconfig(openssl)
+
+Requires:       hicolor-icon-theme
+Requires:       qt6-qtimageformats
+Requires:       kf6-kimageformats
+
+Conflicts:      chatterino
+Conflicts:      chatterino7
+
+%description
+Chatterino7 is a fork of Chatterino 2 with 7TV name paints, personal emotes,
+animated profile avatars and higher-resolution emotes.
+
+%prep
+%git_clone %{url} %{commit}
+
+%conf
+%cmake -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DUSE_SYSTEM_MINIAUDIO=ON \
+    -DCHATTERINO_NO_AVIF_PLUGIN=ON \
+    -DCHATTERINO_UPDATER=OFF \
+    -DCHATTERINO_NIGHTLY_BUILD=ON \
+    -DSKIP_JSON_GENERATION=ON
+
+%build
+%cmake_build
+
+%install
+%cmake_install
+%terra_appstream
+
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/com.chatterino.chatterino.desktop
+
+%files
+%license LICENSE LICENSES
+%license resources/licenses lib/sol2/LICENSE.txt
+%doc README.md CHANGELOG.c7.md
+%{_bindir}/chatterino
+%{_appsdir}/com.chatterino.chatterino.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_hicolordir}/256x256/apps/com.chatterino.chatterino.png
+
+%changelog
+* Sun Sep 06 2026 ammix <maxim@ammix.dev>
+- Initial package

--- a/anda/apps/chatterino7/nightly/update.rhai
+++ b/anda/apps/chatterino7/nightly/update.rhai
@@ -1,0 +1,6 @@
+rpm.global("ver", gh("SevenTV/chatterino7").sub_string(1));
+rpm.global("commit", gh_commit("SevenTV/chatterino7"));
+if rpm.changed() {
+    rpm.release();
+    rpm.global("commit_date", date());
+}

--- a/anda/apps/chatterino7/stable/anda.hcl
+++ b/anda/apps/chatterino7/stable/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "chatterino7.spec"
+    }
+}

--- a/anda/apps/chatterino7/stable/chatterino7.spec
+++ b/anda/apps/chatterino7/stable/chatterino7.spec
@@ -1,0 +1,82 @@
+%global appid com.chatterino.chatterino
+%global appstream_component desktop-application
+%global name_pretty Chatterino7
+
+Name:           chatterino7
+Version:        7.5.5
+Release:        1%{?dist}
+Summary:        Twitch chat client with 7TV subscriber features
+
+License:        MIT AND BSD-3-Clause AND BSL-1.0 AND LicenseRef-fourtf-chatterino-sound-license
+URL:            https://github.com/SevenTV/chatterino7
+Source0:        %{url}/archive/v%{version}/chatterino7-%{version}.tar.gz
+
+Packager:       ammix <maxim@ammix.dev>
+
+BuildRequires:  anda-srpm-macros
+BuildRequires:  terra-appstream-helper
+BuildRequires:  gcc-c++
+BuildRequires:  git-core
+BuildRequires:  cmake
+BuildRequires:  ninja-build
+BuildRequires:  desktop-file-utils
+BuildRequires:  boost-devel
+BuildRequires:  cmake(Qt6Concurrent)
+BuildRequires:  cmake(Qt6Core)
+BuildRequires:  cmake(Qt6Gui)
+BuildRequires:  cmake(Qt6Network)
+BuildRequires:  cmake(Qt6NetworkPrivate)
+BuildRequires:  cmake(Qt6Svg)
+BuildRequires:  cmake(Qt6Widgets)
+BuildRequires:  cmake(Qt6WidgetsPrivate)
+BuildRequires:  cmake(Qt6Keychain)
+BuildRequires:  cmake(RapidJSON)
+BuildRequires:  miniaudio-devel
+BuildRequires:  pkgconfig(libnotify)
+BuildRequires:  pkgconfig(openssl)
+
+Requires:       hicolor-icon-theme
+Requires:       qt6-qtimageformats
+Requires:       kf6-kimageformats
+
+Conflicts:      chatterino
+Conflicts:      chatterino7-nightly
+
+%description
+Chatterino7 is a fork of Chatterino 2 with 7TV name paints, personal emotes,
+animated profile avatars and higher-resolution emotes.
+
+%prep
+%git_clone %{url} v%{version}
+
+%conf
+%cmake -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DUSE_SYSTEM_QTKEYCHAIN=ON \
+    -DUSE_SYSTEM_MINIAUDIO=ON \
+    -DCHATTERINO_NO_AVIF_PLUGIN=ON \
+    -DCHATTERINO_UPDATER=OFF \
+    -DSKIP_JSON_GENERATION=ON
+
+%build
+%cmake_build
+
+%install
+%cmake_install
+%terra_appstream
+
+%check
+%desktop_file_validate %{buildroot}%{_appsdir}/com.chatterino.chatterino.desktop
+
+%files
+%license LICENSE LICENSES
+%license resources/licenses lib/sol2/LICENSE.txt
+%doc README.md CHANGELOG.c7.md
+%{_bindir}/chatterino
+%{_appsdir}/com.chatterino.chatterino.desktop
+%{_metainfodir}/%{appid}.metainfo.xml
+%{_hicolordir}/256x256/apps/com.chatterino.chatterino.png
+
+%changelog
+* Sun Sep 06 2026 ammix <maxim@ammix.dev>
+- Initial package

--- a/anda/apps/chatterino7/stable/update.rhai
+++ b/anda/apps/chatterino7/stable/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("SevenTV/chatterino7"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: chatterino7 and chatterino7-nightly (#16667)](https://github.com/terrapkg/packages/pull/16667)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)