### PR TITLE
[f43] add: plasma-applet-tdp-control (#16642)

### DIFF
--- a/anda/desktops/kde/plasma-applet-tdp-control/anda.hcl
+++ b/anda/desktops/kde/plasma-applet-tdp-control/anda.hcl
@@ -1,0 +1,6 @@
+project pkg {
+        arches = ["aarch64"]
+    rpm {
+        spec = "plasma-applet-tdp-control.spec"
+    }
+}

--- a/anda/desktops/kde/plasma-applet-tdp-control/plasma-applet-tdp-control.spec
+++ b/anda/desktops/kde/plasma-applet-tdp-control/plasma-applet-tdp-control.spec
@@ -1,0 +1,40 @@
+%global appid org.opengamingcollective.tdpcontrol
+
+Name:           plasma-applet-tdp-control
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        A Plasma applet for steamos-manager's performance profile, TDP limit and manual GPU clock
+License:        GPL-3.0-or-later
+URL:            https://github.com/OpenGamingCollective/plasma-applet-tdp-control
+Source0:        %{url}/archive/refs/tags/%{version}.tar.gz
+
+BuildRequires:  make
+Requires:       plasma-workspace
+Requires:       plasma-desktop
+Requires:       steamos-manager
+
+BuildArch:      noarch
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+%description
+%{summary}.
+
+%prep
+%autosetup -C
+
+%build
+%make_build plasmoid
+
+%install
+mkdir -p %{buildroot}%{_datadir}/plasma/plasmoids/org.opengamingcollective.tdpcontrol
+cp -r package/* %{buildroot}%{_datadir}/plasma/plasmoids/org.opengamingcollective.tdpcontrol/
+
+%files
+%license LICENSE
+%doc README.md
+%{_datadir}/plasma/plasmoids/org.opengamingcollective.tdpcontrol/*
+
+%changelog
+* Sun Sep 06 2026 Owen Zimmerman <owen@fyralabs.com> - VERSION-RELEASE
+- Initial commit

--- a/anda/desktops/kde/plasma-applet-tdp-control/update.rhai
+++ b/anda/desktops/kde/plasma-applet-tdp-control/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("OpenGamingCollective/plasma-applet-tdp-control"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [add: plasma-applet-tdp-control (#16642)](https://github.com/terrapkg/packages/pull/16642)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)