### PR TITLE
[el10] add: speedtest-go (#16652)

### DIFF
--- a/anda/tools/speedtest-go/anda.hcl
+++ b/anda/tools/speedtest-go/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+    rpm {
+        spec = "speedtest-go.spec"
+    }
+}

--- a/anda/tools/speedtest-go/speedtest-go.spec
+++ b/anda/tools/speedtest-go/speedtest-go.spec
@@ -1,0 +1,42 @@
+%global goipath github.com/showwin/speedtest-go
+Version:        1.8.3
+
+%gometa -f
+
+Name:           speedtest-go
+Release:        1%{?dist}
+Summary:        CLI and Go API to Test Internet Speed using speedtest.net
+
+License:        MIT
+URL:            https://github.com/showwin/speedtest-go
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
+
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+
+BuildRequires:  golang
+BuildRequires:  gcc
+BuildRequires:  go-rpm-macros
+
+%description
+%{summary}.
+
+%gopkg
+
+%prep
+%autosetup -C
+
+%build
+%define gomodulesmode GO111MODULE=on
+%gobuild -o %{gobuilddir}/ %{goipath}/
+
+%install
+install -Dm 0755 %{gobuilddir}/speedtest-go %{buildroot}%{_bindir}/speedtest-go
+
+%files
+%license LICENSE
+%doc README.md docs/*
+%{_bindir}/speedtest-go
+
+%changelog
+* Sun Sep 06 2026 Owen Zimmerman <owen@fyralabs.com> - 1.8.3-1
+- Initial commit

--- a/anda/tools/speedtest-go/update.rhai
+++ b/anda/tools/speedtest-go/update.rhai
@@ -1,0 +1,1 @@
+rpm.version(gh("showwin/speedtest-go"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [add: speedtest-go (#16652)](https://github.com/terrapkg/packages/pull/16652)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)