### PR TITLE
[f43] libtrueforce: fix update script (#16710)

### DIFF
--- a/anda/lib/libtrueforce/libtrueforce.spec
+++ b/anda/lib/libtrueforce/libtrueforce.spec
@@ -1,4 +1,4 @@
-%global repoversion v0.40.0
+%global repoversion 0.40.0
 
 Name:           libtrueforce
 Version:        1.3.11^%{repoversion}

--- a/anda/lib/libtrueforce/update.rhai
+++ b/anda/lib/libtrueforce/update.rhai
@@ -1,1 +1,5 @@
-rpm.global("repoversion", gh("mescon/logitech-trueforce-linux-driver"));
+let version = gh("mescon/logitech-trueforce-linux-driver");
+if version.starts_with("v") {
+	version.crop(1);
+}
+rpm.global("repoversion", version);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [libtrueforce: fix update script (#16710)](https://github.com/terrapkg/packages/pull/16710)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)