### PR TITLE
[f43] fix: umbriel-nightly (#16716)

### DIFF
--- a/anda/desktops/umbriel/nightly/umbriel-nightly.spec
+++ b/anda/desktops/umbriel/nightly/umbriel-nightly.spec
@@ -6,11 +6,12 @@
 
 Name:   	umbriel-nightly
 Version:	0^%{commitdate}git.%{shortcommit}
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	A work-in-progress Wayland compositor designed for daily use, with scrolling and dwindle layouts, per-output workspaces, window rules, blur, shadows, and fluid animations
 
 License:	MIT
 URL:		https://github.com/noctalia-dev/umbriel
+Source0:    https://github.com/noctalia-dev/umbriel/archive/%{commit}.tar.gz
 
 BuildRequires:  wlroots-devel >= 0.20
 BuildRequires:  meson
@@ -27,7 +28,6 @@ BuildRequires:  pkgconfig(jemalloc)
 BuildRequires:  pkgconfig(wayland-client)
 BuildRequires:  pkgconfig(wayland-protocols)
 BuildRequires:  pkgconfig(xkbcommon)
-BuildRequires:  pkgconfig(scenefx-0.5)
 BuildRequires:  pkgconfig(cairo)
 BuildRequires:  pkgconfig(pangocairo)
 
@@ -40,10 +40,10 @@ Packager:       Cypress Reed <cypress@fyralabs.com>
 %{summary}.
 
 %prep
-%git_clone %{url}.git %{commit}
+%autosetup -n umbriel-%{commit}
 
 %conf
-%meson
+%meson --buildtype=release
 
 %build
 %meson_build
@@ -74,5 +74,8 @@ Packager:       Cypress Reed <cypress@fyralabs.com>
 %{_datadir}/umbriel/shaders/squash.glsl
 
 %changelog
+* Mon Sep 07 2026 Cypress Reed <cypress@fyralabs.com>
+- No more submodule needed, remove system scenefx requirement
+
 * Mon Aug 24 2026 Cypress Reed <cypress@fyralabs.com>
 - Initial package


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: umbriel-nightly (#16716)](https://github.com/terrapkg/packages/pull/16716)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)