### PR TITLE
logitech-trueforce: fixup the ordering.

### DIFF
--- a/anda/apps/logi-wheel-gui/anda.hcl
+++ b/anda/apps/logi-wheel-gui/anda.hcl
@@ -3,4 +3,8 @@ project pkg {
   rpm {
     spec = "logi-wheel-gui.spec"
   }
+  labels {
+      updbranch = 1
+      mock = 1
+  }
 }

--- a/anda/lib/libtrueforce/anda.hcl
+++ b/anda/lib/libtrueforce/anda.hcl
@@ -4,7 +4,6 @@ project pkg {
     spec = "libtrueforce.spec"
   }
   labels {
-        updbranch = 1
         mock = 1
     }
 }

--- a/anda/lib/libtrueforce/libtrueforce.spec
+++ b/anda/lib/libtrueforce/libtrueforce.spec
@@ -10,7 +10,7 @@ URL:            https://github.com/mescon/logitech-trueforce-linux-driver
 Source0:        %{url}/archive/refs/tags/v%{repoversion}.tar.gz
 BuildRequires:  gcc
 BuildRequires:  make
-Requires:       logitech-trueforce
+Suggests:       logitech-trueforce
 Provides:       trueforce-sdk = %{evr}
 Packager:       Luan V. <luanv.oliveira@outlook.com>
 ExclusiveArch:  x86_64

--- a/anda/system/logitech-trueforce/akmod/anda.hcl
+++ b/anda/system/logitech-trueforce/akmod/anda.hcl
@@ -5,6 +5,5 @@ project pkg {
 	}
 	labels {
 		mock = 1
-		updbranch = 1
 	}
 }

--- a/anda/system/logitech-trueforce/dkms/anda.hcl
+++ b/anda/system/logitech-trueforce/dkms/anda.hcl
@@ -3,8 +3,4 @@ project pkg {
 	rpm {
 		spec = "dkms-logitech-trueforce.spec"
 	}
-	labels {
-		mock = 1
-		updbranch = 1
-	}
 }


### PR DESCRIPTION
all the driver components can be build in parallel with libtrueforce, the gui package though, depends on libtrueforce, so it should be built after it.

**What software is being packaged here?**
https://github.com/mescon/logitech-trueforce-linux-driver

**Describe the motivation**
right now, the hard pedency that libtrueforce has on the driver, makes the gui build fail since both the dkms and akmod don't get bumped on the same commit as the kmod-common.

fix by removing updbranch on the dkms and akmod packages, also, remove the hard dep on the driver for the library package as it is not realy necessary. 

**Additional context**
Add any other context about the package submission here. Link to any relavent issues.

**Checklist**
- [x] This package is maintained OR there is a valid reason to add it (e.g. python dependency)
- [x] I have tested at least the `x86_64` version of the package
- [x] I have read through any relevant [Terra](https://docs.terrapkg.com/) and [Fedora packaging](https://docs.fedoraproject.org/en-US/packaging-guidelines/) documentation/policies/guidelines
- [x] I have ensured there are no security issues with this package to the best of my ability
- [x] I have ensured this is not in Fedora (unless adding to the [extras repo](https://docs.terrapkg.com/usage/installing/#extras))
- [ ] I used an LLM
  - [ ] I used it in accordance with the [Terra AI policy](https://docs.terrapkg.com/policies#ai-policy)
  - [ ] I used it in a different way (please explain)
