### PR TITLE
fix: bazzite-updater

### DIFF
--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -40,6 +40,7 @@ Requires:       kf6-kirigami%{?_isa}
 Requires:       kf6-kirigami-addons%{?_isa}
 Requires:       kf6-qqc2-desktop-style%{?_isa}
 Requires:       qqc2-breeze-style%{?_isa}
+Requires:       qt6-qtimageformats%{?_isa}
 Requires:       qt6-controllable%{?_isa}
 Requires:       hicolor-icon-theme
 Requires:       systemd%{?_isa} >= 258

--- a/anda/apps/bazzite-updater/bazzite-updater.spec
+++ b/anda/apps/bazzite-updater/bazzite-updater.spec
@@ -2,7 +2,7 @@
 
 Name:           bazzite-updater
 Version:        0.10.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Update your system
 
 License:        GPL-2.0-or-later AND BSD-3-Clause AND CC0-1.0


### PR DESCRIPTION
Adds qt6-qtimageformats. If this package is not present at runtime and the configured RSS feed attempts to load certain image formats (such as webp), it can cause the app to crash and will not display these image formats.