### PR TITLE
[el10] fix bazel for non-rawhide (#16745)

### DIFF
--- a/anda/buildsys/bazel/anda.hcl
+++ b/anda/buildsys/bazel/anda.hcl
@@ -5,6 +5,6 @@ project pkg {
   }
   rpm {
     spec = "bazel.spec"
-    extra_repos = ["https://packages.adoptium.net/artifactory/rpm/fedora/rawhide/\\$basearch"]
+    extra_repos = ["https://packages.adoptium.net/artifactory/rpm/fedora/\\$releasever/\\$basearch"]
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `f45` to `el10`:
 - [fix bazel for non-rawhide (#16745)](https://github.com/terrapkg/packages/pull/16745)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)