### PR TITLE
fix(steam): manual builds fail

### DIFF
--- a/anda/games/steam/.gitignore
+++ b/anda/games/steam/.gitignore
@@ -6,3 +6,4 @@
 !anda.hcl
 !steam.spec
 !update.rhai
+!tmp


### PR DESCRIPTION
with the power of being awesome i have detected that the manual build matrix runner tries to detect directories by using a touch/git strategy and not whitelisting tmp means everything breaks
