### PR TITLE
[el10] fix(steam): manual builds fail (#16763)

### DIFF
--- a/anda/games/steam/.gitignore
+++ b/anda/games/steam/.gitignore
@@ -6,3 +6,4 @@
 !anda.hcl
 !steam.spec
 !update.rhai
+!tmp


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix(steam): manual builds fail (#16763)](https://github.com/terrapkg/packages/pull/16763)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)