### PR TITLE
[f43] fix: zen-browser (#16768)

### DIFF
--- a/anda/apps/zen-browser/update.rhai
+++ b/anda/apps/zen-browser/update.rhai
@@ -1,3 +1,4 @@
 let v = gh("zen-browser/desktop");
-ver.truncate(v.len - 1);
+rpm.global("download_ver", v);
+v.truncate(v.len - 1);
 rpm.version(v);

--- a/anda/apps/zen-browser/zen-browser.spec
+++ b/anda/apps/zen-browser/zen-browser.spec
@@ -5,9 +5,10 @@
 %global zen_app_name    zen
 %global zendir          %{_libdir}/%{zen_app_name}
 %global brandingdir     browser/branding/release
+%global download_ver    1.21.16b
 
 # Fedora rustc gives more than one valid target triple.
-# `x86_64-oe-linux-gnu` and `x86_64-unknown-linux-gnu` both agree with 
+# `x86_64-oe-linux-gnu` and `x86_64-unknown-linux-gnu` both agree with
 # `x86_64-pc-linux-gnu` and so the mozilla build system just stops.
 # Just Fedora Things:tm:
 %global rust_triple     %{_arch}-unknown-linux-gnu
@@ -37,7 +38,7 @@ Summary:        Calm and private web browser that is built on Firefox
 License:        MPL-2.0
 URL:            https://zen-browser.app
 
-Source0:        %{giturl}/releases/download/%{version}/zen.source.tar.zst
+Source0:        %{giturl}/releases/download/%{download_ver}/zen.source.tar.zst
 Source1:        zen.sh.in
 Source2:        %{appid}.desktop
 Source3:        zen-browser-default-prefs.js


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: zen-browser (#16768)](https://github.com/terrapkg/packages/pull/16768)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)