### PR TITLE
[f45] feat: Update to the latest steamos-manager-powerstation (#16788)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,4 +1,4 @@
-%global commit 66d246d1ac2e3f4c27115ffd63ffdace3901a291
+%global commit a3adfc356b4053c5f07d78ea3787ca359129b51a
 %global shortcommit %{sub %{commit} 0 7}
 %global commitdate 20260910
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [feat: Update to the latest steamos-manager-powerstation (#16788)](https://github.com/terrapkg/packages/pull/16788)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)