### PR TITLE
[f44] fix: Update to latest steamos-manager-powerstation (#16802)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,4 +1,4 @@
-%global commit a3adfc356b4053c5f07d78ea3787ca359129b51a
+%global commit 6067b61273f6462bbb8b854d2b8723094b45cb51
 %global shortcommit %{sub %{commit} 0 7}
 %global commitdate 20260910
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: Update to latest steamos-manager-powerstation (#16802)](https://github.com/terrapkg/packages/pull/16802)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)