### PR TITLE
[el10] feat: Update to the latest gamescope-session from OGC (#16809)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,8 +1,8 @@
 %define debug_package %nil
 
-%global commit 1ddd3a95c296a31a3b7bafd3f402a597091a64f4
+%global commit baeb6bc06642211ea1929ba432bcaf9b85b9ae4a
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20260905
+%global commit_date 20260910
 
 Name:           gamescope-session
 Version:        0~%{commit_date}git.%{shortcommit}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [feat: Update to the latest gamescope-session from OGC (#16809)](https://github.com/terrapkg/packages/pull/16809)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)