### PR TITLE
[f44] feat: Update to latest OGC gamescope-session (#16816)

### DIFF
--- a/anda/games/gamescope-session/gamescope-session.spec
+++ b/anda/games/gamescope-session/gamescope-session.spec
@@ -1,6 +1,6 @@
 %define debug_package %nil
 
-%global commit baeb6bc06642211ea1929ba432bcaf9b85b9ae4a
+%global commit f4ed6312b7038fb42264044bb271e40ab1993171
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global commit_date 20260910
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [feat: Update to latest OGC gamescope-session (#16816)](https://github.com/terrapkg/packages/pull/16816)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)