### PR TITLE
[el10] fix: Use tagged releases of terra-gamescope/ogc gamescope (#16815)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -1,17 +1,16 @@
 %global libliftoff_minver 0.4.1
 
 %global _default_patch_fuzz 2
-%global build_timestamp %(date +"%Y%m%d")
-%global gamescope_commit 77e6ea94dbc3feca4b95daef433d6238a9efdd68
-%define short_commit %(echo %{gamescope_commit} | cut -c1-8)
+%global ver 3.16.28-ogc1
 
 Name:           terra-gamescope
-Version:        137.%{short_commit}
+Version:        3.16.28^1
 Release:        1%?dist
-Summary:        Micro-compositor for video games on Wayland
+Summary:        OGC fork of the Micro-compositor for video games on Wayland
 
 License:        BSD-2-Clause
 URL:            https://github.com/OpenGamingCollective/gamescope
+Packager:       Kyle Gospodnetich <me@kylegospodneti.ch>
 
 Provides:       gamescope = %{version}-%{release}
 Conflicts:      gamescope
@@ -100,6 +99,8 @@ BuildRequires:  pkgconfig(xwayland)
 
 %description
 %{name} is the micro-compositor optimized for running video games on Wayland.
+This version is a fork by the OpenGamingCollective that improves support for
+additional hardware.
 
 %package libs
 Summary:	libs for %{name}
@@ -108,10 +109,7 @@ Requires: terra-gamescope = %{evr}
 %summary
 
 %prep
-%setup -Tc
-git clone %{url}.git $PWD
-git checkout %{gamescope_commit}
-git submodule update --init --recursive
+%git_clone %{url} %{ver}
 mkdir -p pkgconfig
 cp %{SOURCE0} pkgconfig/stb.pc
 

--- a/anda/games/terra-gamescope/update.rhai
+++ b/anda/games/terra-gamescope/update.rhai
@@ -1,6 +1,5 @@
-if rpm.changed() {
-    rpm.release();
-    let v = gh_commit("OpenGamingCollective/gamescope");
-    v.crop(1);
-    rpm.global("gamescope_commit", v);
-}
+let v = gh_tag("OpenGamingCollective/gamescope");
+
+rpm.global("ver", v);
+v.replace("-ogc", "^");
+rpm.version(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `el10`:
 - [fix: Use tagged releases of terra-gamescope/ogc gamescope (#16815)](https://github.com/terrapkg/packages/pull/16815)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)