### PR TITLE
[f44] fix: libcuobjclient (#16799)

### DIFF
--- a/anda/devs/cuda/libcuobjclient/libcuobjclient.spec
+++ b/anda/devs/cuda/libcuobjclient/libcuobjclient.spec
@@ -65,6 +65,7 @@ sed -i \
 %doc README cuObjRDMADESCRprotocolformat.pdf
 %{_includedir}/cuobjclient.h
 %{_includedir}/cuobjtelem.h
+%{_includedir}/cuobjextrc_types.h
 %{_libdir}/libcuobjclient.so
 %{_libdir}/pkgconfig/cuobjclient.pc
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix: libcuobjclient (#16799)](https://github.com/terrapkg/packages/pull/16799)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)