### PR TITLE
[f44] chore(surface-control): switch from sed to using update.rhai for deleting the dash (#16840)

### DIFF
--- a/anda/system/linux-surface/surface-control/surface-control.spec
+++ b/anda/system/linux-surface/surface-control/surface-control.spec
@@ -1,10 +1,9 @@
 %global ver v0.5.0-1
-%global sanitized_ver %(echo %{ver} | sed 's/-/./')
 
 %define debug_package %{nil}
 
 Name:           surface-control
-Version:        %{sanitized_ver}
+Version:        0.5.0.1
 Release:        1%{?dist}
 Summary:        Control various aspects of Microsoft Surface devices from the shell
 

--- a/anda/system/linux-surface/surface-control/update.rhai
+++ b/anda/system/linux-surface/surface-control/update.rhai
@@ -1,1 +1,5 @@
-rpm.global("ver", gh("linux-surface/surface-control"));
+let v = gh("linux-surface/surface-control");
+rpm.global("ver", v);
+v.crop(1);
+v.replace("-", ".");
+rpm.version(v);


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [chore(surface-control): switch from sed to using update.rhai for deleting the dash (#16840)](https://github.com/terrapkg/packages/pull/16840)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)