### PR TITLE
[f43] chore: Add Epoch: 1 to terra-gamescope (#16845)

### DIFF
--- a/anda/games/terra-gamescope/terra-gamescope.spec
+++ b/anda/games/terra-gamescope/terra-gamescope.spec
@@ -6,6 +6,7 @@
 Name:           terra-gamescope
 Version:        3.16.28^1
 Release:        1%?dist
+Epoch:          1
 Summary:        OGC fork of the Micro-compositor for video games on Wayland
 
 License:        BSD-2-Clause


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [chore: Add Epoch: 1 to terra-gamescope (#16845)](https://github.com/terrapkg/packages/pull/16845)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)