### PR TITLE
[f43] feat: Update to the latest steamos-manager-powerstation (#16860)

### DIFF
--- a/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
+++ b/anda/games/steamos-manager-powerstation/steamos-manager-powerstation.spec
@@ -1,6 +1,6 @@
-%global commit 6067b61273f6462bbb8b854d2b8723094b45cb51
+%global commit 09d2a9d20ee878c7e665c87964beea35e0660b62
 %global shortcommit %{sub %{commit} 0 7}
-%global commitdate 20260910
+%global commitdate 20260911
 
 %global steamos_manager_systemd_user_units steamos-manager.service steamos-manager-configure-cecd.service steamos-manager-session-cleanup.service
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [feat: Update to the latest steamos-manager-powerstation (#16860)](https://github.com/terrapkg/packages/pull/16860)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)