### PR TITLE
[f44] fix(noctua): libcosmic export, install bullshit (#16852)

### DIFF
--- a/anda/desktops/cosmic/noctua/noctua-libcosmic-api.patch
+++ b/anda/desktops/cosmic/noctua/noctua-libcosmic-api.patch
@@ -1,0 +1,34 @@
+From 90bc3ba3453b0fa49681e427ef81d36d62f5996d Mon Sep 17 00:00:00 2001
+From: halfcyan <cypress@fyralabs.com>
+Date: Fri, 11 Sep 2026 06:10:02 +0200
+Subject: [PATCH] rename imports to iced
+
+---
+ ui/cosmic/src/app.rs | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/ui/cosmic/src/app.rs b/ui/cosmic/src/app.rs
+index 50e74cb..d708c52 100644
+--- a/ui/cosmic/src/app.rs
++++ b/ui/cosmic/src/app.rs
+@@ -7,7 +7,7 @@ use cosmic::cosmic_config::{self, CosmicConfigEntry};
+ use cosmic::iced::alignment::{Horizontal, Vertical};
+ use cosmic::iced::{Alignment, Length, Subscription};
+ use cosmic::widget::{self, about::About, icon, menu, nav_bar};
+-use cosmic::{iced_futures, prelude::*};
++use cosmic::{iced, prelude::*};
+ use futures_util::SinkExt;
+ use std::collections::HashMap;
+ use std::time::Duration;
+@@ -260,9 +260,9 @@ impl cosmic::Application for AppModel {
+         // Conditionally enables a timer that emits a message every second.
+         if self.watch_is_active {
+             subscriptions.push(Subscription::run(|| {
+-                iced_futures::stream::channel(
++                iced::stream::channel(
+                     1,
+-                    |mut emitter: iced_futures::futures::channel::mpsc::Sender<Message>| async move {
++                    |mut emitter: iced::futures::channel::mpsc::Sender<Message>| async move {
+                         let mut time = 1;
+                         let mut interval = tokio::time::interval(Duration::from_secs(1));
+ 

--- a/anda/desktops/cosmic/noctua/noctua.spec
+++ b/anda/desktops/cosmic/noctua/noctua.spec
@@ -13,6 +13,8 @@ License:        %{sourcelicense} AND (BSD-3-Clause OR MIT OR Apache-2.0) AND ((M
 
 URL:            https://codeberg.org/wfx/noctua
 Source0:        %{url}/archive/%{commit}.tar.gz
+Source1:        https://github.com/cosmic-utils/noctua/raw/refs/heads/main/LICENSE
+Patch0:         noctua-libcosmic-api.patch
 
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  gcc-c++
@@ -30,7 +32,7 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{summary}.
 
 %prep
-%autosetup -C
+%autosetup -C -p1
 %cargo_prep_online
 %cargo_license_summary_online
 
@@ -39,16 +41,18 @@ Packager:       Owen Zimmerman <owen@fyralabs.com>
 %{cargo_license_online} > LICENSE.dependencies
 
 %install
-install -Dm0755 target/rpm/noctua                                                   %{buildroot}%{_bindir}/noctua
-%desktop_file_install resources/org.codeberg.wfx.Noctua.desktop
-install -Dm0644 resources/org.codeberg.wfx.Noctua.metainfo.xml                      %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
-install -Dm0644 resources/icons/hicolor/scalable/apps/org.codeberg.wfx.Noctua.svg   %{buildroot}%{_scalableiconsdir}/%{appid}.svg
+install -Dm0755 target/rpm/noctua-cosmic                                            %{buildroot}%{_bindir}/noctua
+%desktop_file_install ui/cosmic/resources/app.desktop
+mv %{buildroot}%{_appsdir}/app.desktop %{buildroot}%{_appsdir}/%{appid}.desktop
+install -Dm0644 ui/cosmic/resources/app.metainfo.xml                      %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
+install -Dm0644 ui/cosmic/resources/icons/hicolor/scalable/apps/icon.svg   %{buildroot}%{_scalableiconsdir}/%{appid}.svg
+install -Dm0644 %{SOURCE1} LICENSE
 
 %terra_appstream
 
 %files
 %license LICENSE LICENSE.dependencies
-%doc README.md docs/*
+%doc README.md
 %{_bindir}/noctua
 %{_appsdir}/%{appid}.desktop
 %{_metainfodir}/%{appid}.metainfo.xml


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f44`:
 - [fix(noctua): libcosmic export, install bullshit (#16852)](https://github.com/terrapkg/packages/pull/16852)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)