### PR TITLE
[f43] fix: Remove merged PRs from InputPlumber spec (#16775)

### DIFF
--- a/anda/games/inputplumber/inputplumber.spec
+++ b/anda/games/inputplumber/inputplumber.spec
@@ -9,9 +9,7 @@ URL:            https://github.com/ShadowBlip/InputPlumber
 Source0:        %{url}/archive/refs/tags/v%version.tar.gz
 Patch0:         make-install-dont-build.patch
 Patch1:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/644.patch
-Patch2:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/667.patch
-Patch3:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/687.patch
-Patch4:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/691.patch
+Patch2:         https://patch-diff.githubusercontent.com/raw/ShadowBlip/InputPlumber/pull/687.patch
 BuildRequires:  libevdev-devel libiio-devel git make cargo libudev-devel llvm-devel clang-devel
 BuildRequires:  rust-packaging cargo-rpm-macros mold rpm_macro(cargo_prep_online) systemd-rpm-macros
 Requires:       libevdev libiio


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix: Remove merged PRs from InputPlumber spec (#16775)](https://github.com/terrapkg/packages/pull/16775)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)