### PR TITLE
[f45] add: lsfg-vk (#16851)

### DIFF
--- a/anda/misc/lsfg-vk/anda.hcl
+++ b/anda/misc/lsfg-vk/anda.hcl
@@ -1,0 +1,5 @@
+project pkg {
+  rpm {
+    spec = "lsfg-vk.spec"
+  }
+}

--- a/anda/misc/lsfg-vk/lsfg-vk.spec
+++ b/anda/misc/lsfg-vk/lsfg-vk.spec
@@ -1,0 +1,50 @@
+Name:           lsfg-vk
+Version:        2.0.0
+Release:        1%{?dist}
+Summary:        Lossless Scaling Frame Generation on Linux
+License:        CC-BY-NC-ND-4.0
+URL:            https://git.lsfg-vk.dev/lsfg-vk/
+Source0:        https://git.lsfg-vk.dev/lsfg-vk/snapshot/lsfg-vk-%{version}.tar.xz
+Packager:       Owen Zimmerman <owen@fyralabs.com>
+BuildRequires:  cmake
+BuildRequires:  qt6-qtbase-devel
+BuildRequires:  cmake(Qt6Quick)
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+
+%description
+%{summary}.
+
+%package    ui
+Summary:    UI for %{name}
+Requires:   %{name} = %{evr}
+
+%description ui
+%{summary}.
+
+%prep
+%autosetup -C
+
+%conf
+%cmake -DLSFGVK_BUILD_UI=ON
+
+%build
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%license LICENSE.txt
+%{_bindir}/lsfg-vk-cli
+%{_libdir}/liblsfg-vk-layer.so
+%{_datadir}/vulkan/implicit_layer.d/VkLayer_LSFGVK_frame_generation.json
+
+%files ui
+%{_bindir}/lsfg-vk-ui
+%{_appsdir}/gay.pancake.lsfg-vk-ui.desktop
+%{_hicolordir}/256x256/apps/gay.pancake.lsfg-vk-ui.png
+
+%changelog
+* Thu Sep 10 2026 Owen Zimmerman <owen@fyralabs.com> - 2.0.0-1
+- Initial commit

--- a/anda/misc/lsfg-vk/update.rhai
+++ b/anda/misc/lsfg-vk/update.rhai
@@ -1,0 +1,8 @@
+let tags = git_tags("https://git.lsfg-vk.dev/lsfg-vk.git");
+for tag in tags {
+    let v = tag;
+    if !v.contains("rc") {
+        rpm.version(v);
+        break;
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [add: lsfg-vk (#16851)](https://github.com/terrapkg/packages/pull/16851)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)