### PR TITLE
[f45] chore (bacon): fix license and remove %autochangelog (#16919)

### DIFF
--- a/anda/langs/rust/bacon/rust-bacon.spec
+++ b/anda/langs/rust/bacon/rust-bacon.spec
@@ -6,15 +6,15 @@
 
 Name:           rust-bacon
 Version:        3.25.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Background rust compiler
 Packager:       Olivia <git@olivia.sh>
 
-License:        AGPL-3.0
+License:        AGPL-3.0-or-later
 URL:            https://crates.io/crates/bacon
 Source:         %{terra_crates_source}
 
-BuildRequires:  anda-srpm-macros 
+BuildRequires:  anda-srpm-macros
 BuildRequires:  mold
 BuildRequires:  cargo-rpm-macros >= 24
 BuildRequires:  alsa-lib-devel
@@ -133,5 +133,3 @@ use the "sound" feature of the "%{crate}" crate.
 %changelog
 * Sun Jul 19 2026 Olivia <git@olivia.sh> - 3.24.0-2
 - Update packager
-
-%autochangelog


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f45`:
 - [chore (bacon): fix license and remove %autochangelog (#16919)](https://github.com/terrapkg/packages/pull/16919)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)