### PR TITLE
[f43] fix (cosmic-ext-applet-cosmic-nightlight): package systemd service (#16914)

### DIFF
--- a/anda/desktops/cosmic/cosmic-ext-applet-cosmic-nightlight/cosmic-ext-applet-cosmic-nightlight.spec
+++ b/anda/desktops/cosmic/cosmic-ext-applet-cosmic-nightlight/cosmic-ext-applet-cosmic-nightlight.spec
@@ -2,7 +2,7 @@
 
 Name:           cosmic-ext-applet-cosmic-nightlight
 Version:        0.5.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 SourceLicense:  MPL-2.0
 License:	%{sourcelicense} AND (BSD-3-Clause OR MIT OR Apache-2.0) AND Apache-2.0 AND MIT AND (MIT OR Apache-2.0 OR Zlib) AND (0BSD OR MIT OR Apache-2.0) AND BSD-2-Clause AND Zlib AND MIT AND (Apache-2.0 OR GPL-2.0-only) AND ((MIT OR Apache-2.0) AND Unicode-3.0) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND Apache-2.0 AND MPL-2.0 AND (MIT OR Apache-2.0 OR CC0-1.0) AND Unicode-3.0 AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND CC0-1.0 AND (BSD-3-Clause OR Apache-2.0) AND BSL-1.0 AND ISC AND (MIT OR LGPL-3.0-or-later) AND GPL-3.0-only AND BSD-3-Clause AND (MIT OR Apache-2.0 OR LGPL-2.1-or-later) AND (Unlicense OR MIT)
 Summary:        Night-light / gamma utility for the COSMIC desktop (Pop!_OS), via DRM/KMS + polkit helper
@@ -10,6 +10,7 @@ URL:            https://github.com/cosmic-nightlight/cosmic-nightlight
 Source0:       	%{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires:  cargo-rpm-macros
 BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  systemd-rpm-macros
 Requires:       cosmic-osd
 Provides:	cosmic-nightlight
 Packager:       Owen Zimmerman <owen@fyralabs.com>
@@ -32,6 +33,16 @@ install -Dm644 data/io.github.cosmic_nightlight.settings.desktop			%{buildroot}%
 install -Dm644 data/io.github.cosmic_nightlight.metainfo.xml				%{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
 install -Dm644 data/icons/hicolor/scalable/apps/io.github.cosmic_nightlight.svg		%{buildroot}%{_scalableiconsdir}/%{appid}.svg
 install -Dm644 data/icons/hicolor/128x128/apps/io.github.cosmic_nightlight.png		%{buildroot}%{_hicolordir}/128x128/apps/%{appid}.png
+install -Dm644 systemd/cosmic-nightlight.service                                    %{buildroot}%{_userunitdir}/cosmic-nightlight.service
+
+%post
+%systemd_user_post cosmic-nightlight.service
+
+%preun
+%systemd_user_preun cosmic-nightlight.service
+
+%postun
+%systemd_user_postun_with_restart cosmic-nightlight.service
 
 %files
 %doc README.md
@@ -42,6 +53,7 @@ install -Dm644 data/icons/hicolor/128x128/apps/io.github.cosmic_nightlight.png		
 %{_metainfodir}/%{appid}.metainfo.xml
 %{_scalableiconsdir}/%{appid}.svg
 %{_hicolordir}/128x128/apps/%{appid}.png
+%{_userunitdir}/cosmic-nightlight.service
 
 %changelog
 * Thu Sep 10 2026 Owen Zimmerman <owen@fyralabs.com> - 0.5.0-1


### PR DESCRIPTION
# Backport

This will backport the following commits from `frawhide` to `f43`:
 - [fix (cosmic-ext-applet-cosmic-nightlight): package systemd service (#16914)](https://github.com/terrapkg/packages/pull/16914)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)